### PR TITLE
Move to JUnit5

### DIFF
--- a/artemis/build.gradle
+++ b/artemis/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
   testImplementation 'com.squareup.okhttp3:okhttp'
   testImplementation 'org.awaitility:awaitility'
-  testImplementation 'org.mockito:mockito-core'
 
   test {
     testLogging.showStandardStreams = true

--- a/build.gradle
+++ b/build.gradle
@@ -214,8 +214,12 @@ subprojects {
     testImplementation sourceSets.testSupport.output
     integrationTestImplementation sourceSets.testSupport.output
 
-    testImplementation 'junit:junit'
     testImplementation 'org.assertj:assertj-core'
+    testImplementation 'net.consensys.cava:cava-junit'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   }
 
   task integrationTest(type: Test, dependsOn:["compileTestJava"]){

--- a/errorprone-checks/build.gradle
+++ b/errorprone-checks/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   annotationProcessor 'com.google.auto.service:auto-service'
 
   testImplementation 'com.google.errorprone:error_prone_test_helpers'
+  testImplementation 'junit:junit:4.12'
 
   epJavac 'com.google.errorprone:error_prone_check_api'
 }

--- a/errorprone-checks/src/test/java/tech/pegasys/errorpronechecks/DoNotInvokeMessageDigestDirectlyTest.java
+++ b/errorprone-checks/src/test/java/tech/pegasys/errorpronechecks/DoNotInvokeMessageDigestDirectlyTest.java
@@ -14,26 +14,26 @@
 package tech.pegasys.errorpronechecks;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class DoNotInvokeMessageDigestDirectlyTest {
+class DoNotInvokeMessageDigestDirectlyTest {
 
   private CompilationTestHelper compilationHelper;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     compilationHelper =
         CompilationTestHelper.newInstance(DoNotInvokeMessageDigestDirectly.class, getClass());
   }
 
   @Test
-  public void doNotInvokeMessageDigestDirectlyPositiveCases() {
+  void doNotInvokeMessageDigestDirectlyPositiveCases() {
     compilationHelper.addSourceFile("DoNotInvokeMessageDigestDirectlyPositiveCases.java").doTest();
   }
 
   @Test
-  public void doNotInvokeMessageDigestDirectlyNegativeCases() {
+  void doNotInvokeMessageDigestDirectlyNegativeCases() {
     compilationHelper.addSourceFile("DoNotInvokeMessageDigestDirectlyNegativeCases.java").doTest();
   }
 }

--- a/errorprone-checks/src/test/java/tech/pegasys/errorpronechecks/DoNotReturnNullOptionalsTest.java
+++ b/errorprone-checks/src/test/java/tech/pegasys/errorpronechecks/DoNotReturnNullOptionalsTest.java
@@ -14,26 +14,26 @@
 package tech.pegasys.errorpronechecks;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class DoNotReturnNullOptionalsTest {
+class DoNotReturnNullOptionalsTest {
 
   private CompilationTestHelper compilationHelper;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     compilationHelper =
         CompilationTestHelper.newInstance(DoNotReturnNullOptionals.class, getClass());
   }
 
   @Test
-  public void doNotReturnNullPositiveCases() {
+  void doNotReturnNullPositiveCases() {
     compilationHelper.addSourceFile("DoNotReturnNullOptionalsPositiveCases.java").doTest();
   }
 
   @Test
-  public void doNotReturnNullNegativeCases() {
+  void doNotReturnNullNegativeCases() {
     compilationHelper.addSourceFile("DoNotReturnNullOptionalsNegativeCases.java").doTest();
   }
 }

--- a/ethereum/beaconchain/build.gradle
+++ b/ethereum/beaconchain/build.gradle
@@ -18,15 +18,6 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   runtime 'org.apache.logging.log4j:log4j-core'
 
-  testImplementation 'org.mockito:mockito-core'
-
-  integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.mockito:mockito-core'
-  integrationTestImplementation 'junit:junit'
-
-  testSupportImplementation 'org.assertj:assertj-core'
-  testSupportImplementation 'org.mockito:mockito-core'
-  testSupportImplementation 'junit:junit'
   test {
     testLogging.showStandardStreams = true
   }

--- a/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/datastructures/beaconchainoperations/DepositInputTest.java
+++ b/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/datastructures/beaconchainoperations/DepositInputTest.java
@@ -13,17 +13,17 @@
 
 package tech.pegasys.artemis.datastructures.beaconchainoperations;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class DepositInputTest {
+class DepositInputTest {
 
   @Test
-  public void rountripSSZ() {
+  void rountripSSZ() {
     DepositInput di =
         new DepositInput(
             Bytes32.random(),

--- a/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/datastructures/beaconchainstate/ValidatorRegistryDeltaBlockTest.java
+++ b/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/datastructures/beaconchainstate/ValidatorRegistryDeltaBlockTest.java
@@ -13,18 +13,18 @@
 
 package tech.pegasys.artemis.datastructures.beaconchainstate;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.primitives.UnsignedLong;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ValidatorRegistryDeltaBlockTest {
+class ValidatorRegistryDeltaBlockTest {
 
   @Test
-  public void roundtripSSZ() {
+  void roundtripSSZ() {
     ValidatorRegistryDeltaBlock block =
         new ValidatorRegistryDeltaBlock(
             UnsignedLong.valueOf(123),

--- a/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
+++ b/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/BeaconStateTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.artemis.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static tech.pegasys.artemis.Constants.ACTIVATION;
 import static tech.pegasys.artemis.Constants.ACTIVE;
 import static tech.pegasys.artemis.Constants.ACTIVE_PENDING_EXIT;
@@ -28,7 +29,6 @@ import static tech.pegasys.artemis.state.BeaconState.BeaconStateHelperFunctions.
 
 import com.google.common.primitives.UnsignedLong;
 import com.google.gson.Gson;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,8 +37,9 @@ import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.crypto.Hash;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Test;
+import net.consensys.cava.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.beaconchainoperations.AttestationData;
 import tech.pegasys.artemis.datastructures.beaconchainoperations.LatestBlockRoots;
 import tech.pegasys.artemis.datastructures.beaconchainstate.ForkData;
@@ -46,11 +47,8 @@ import tech.pegasys.artemis.datastructures.beaconchainstate.ShardCommittee;
 import tech.pegasys.artemis.datastructures.beaconchainstate.ValidatorRecord;
 import tech.pegasys.artemis.datastructures.beaconchainstate.Validators;
 
-public class BeaconStateTest {
-
-  static {
-    Security.addProvider(new BouncyCastleProvider());
-  }
+@ExtendWith(BouncyCastleExtension.class)
+class BeaconStateTest {
 
   private BeaconState newState() {
     // Initialize state
@@ -170,8 +168,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void
-      processDepositValidatorPubkeysDoesNotContainPubkeyAndMinEmptyValidatorIndexIsNegative() {
+  void processDepositValidatorPubkeysDoesNotContainPubkeyAndMinEmptyValidatorIndexIsNegative() {
     BeaconState state = newState();
     assertThat(
             state.process_deposit(
@@ -186,7 +183,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void processDepositValidatorPubkeysDoesNotContainPubkey() {
+  void processDepositValidatorPubkeysDoesNotContainPubkey() {
     BeaconState state = newState();
     assertThat(
             state.process_deposit(
@@ -201,7 +198,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void processDepositValidatorPubkeysContainsPubkey() {
+  void processDepositValidatorPubkeysContainsPubkey() {
     BeaconState state = newState();
 
     double oldBalance = state.getValidator_balances().get(2);
@@ -220,8 +217,8 @@ public class BeaconStateTest {
     assertThat(state.getValidator_balances().get(2)).isEqualTo(oldBalance + 100.0);
   }
 
-  @Test(expected = AssertionError.class)
-  public void getAttestationParticipantsSizesNotEqual() {
+  @Test
+  void getAttestationParticipantsSizesNotEqual() {
     AttestationData attestationData =
         new AttestationData(
             0,
@@ -234,11 +231,15 @@ public class BeaconStateTest {
             Bytes32.ZERO);
     byte[] participation_bitfield = Bytes32.ZERO.toArrayUnsafe();
 
-    BeaconState.get_attestation_participants(newState(), attestationData, participation_bitfield);
+    assertThrows(
+        AssertionError.class,
+        () ->
+            BeaconState.get_attestation_participants(
+                newState(), attestationData, participation_bitfield));
   }
 
   @Test
-  public void getAttestationParticipantsReturnsEmptyArrayList() {
+  void getAttestationParticipantsReturnsEmptyArrayList() {
     AttestationData attestationData =
         new AttestationData(
             0,
@@ -260,7 +261,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void getAttestationParticipantsSuccessful() {
+  void getAttestationParticipantsSuccessful() {
     BeaconState state = newState();
     ArrayList<ShardCommittee> shard_committee = state.getShard_committees_at_slots().get(64);
     shard_committee.add(
@@ -289,7 +290,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void activateValidatorNotPendingActivation() {
+  void activateValidatorNotPendingActivation() {
     BeaconState state = newState();
     int validator_index = 0;
 
@@ -299,7 +300,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void activateValidator() {
+  void activateValidator() {
     BeaconState state = newState();
     int validator_index = 0;
 
@@ -318,7 +319,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void initiateValidatorExitNotActive() {
+  void initiateValidatorExitNotActive() {
     BeaconState state = newState();
     int validator_index = 0;
 
@@ -328,7 +329,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void initiateValidatorExit() {
+  void initiateValidatorExit() {
     BeaconState state = newState();
     int validator_index = 2;
 
@@ -345,7 +346,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void exitValidatorPrevStatusExitedWithPenaltyNewStatusExitedWithoutPenalty() {
+  void exitValidatorPrevStatusExitedWithPenaltyNewStatusExitedWithoutPenalty() {
     BeaconState state = newState();
     int validator_index = 4;
 
@@ -355,7 +356,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void exitValidatorPrevStatusExitedWithoutPenaltyNewStatusExitedWithoutPenalty() {
+  void exitValidatorPrevStatusExitedWithoutPenaltyNewStatusExitedWithoutPenalty() {
     BeaconState state = newState();
     int validator_index = 3;
 
@@ -372,7 +373,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void exitValidatorPrevStatusExitedWithoutPenaltyNewStatusExitedWithPenalty() {
+  void exitValidatorPrevStatusExitedWithoutPenaltyNewStatusExitedWithPenalty() {
     BeaconState state = newState();
     int validator_index = 3;
 
@@ -389,7 +390,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void exitValidatorPrevStatusDidNotExitNewStatusExitedWithPenalty() {
+  void exitValidatorPrevStatusDidNotExitNewStatusExitedWithPenalty() {
     BeaconState state = newState();
     int validator_index = 2;
 
@@ -406,7 +407,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void exitValidatorPrevStatusDidNotExitNewStatusExitedWithoutPenalty() {
+  void exitValidatorPrevStatusDidNotExitNewStatusExitedWithoutPenalty() {
     BeaconState state = newState();
     int validator_index = 0;
 
@@ -425,7 +426,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void deepCopyBeaconState() {
+  void deepCopyBeaconState() {
     BeaconState state = newState();
     BeaconState deepCopy = BeaconState.deepCopy(state);
 
@@ -475,13 +476,15 @@ public class BeaconStateTest {
     return Hash.keccak256(bytes);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void failsWhenInvalidArgumentsBytes3ToInt() {
-    bytes3ToInt(Bytes.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 0}), -1);
+  @Test
+  void failsWhenInvalidArgumentsBytes3ToInt() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> bytes3ToInt(Bytes.wrap(new byte[] {(byte) 0, (byte) 0, (byte) 0}), -1));
   }
 
   @Test
-  public void convertBytes3ToInt() {
+  void convertBytes3ToInt() {
     // Smoke Tests
     // Test that MSB [00000001][00000000][11110000] LSB == 65656
     assertThat(bytes3ToInt(Bytes.wrap(new byte[] {(byte) 1, (byte) 0, (byte) 120}), 0))
@@ -508,7 +511,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void testShuffle() {
+  void testShuffle() {
     List<Integer> input = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     ArrayList<Integer> sample = new ArrayList<>(input);
 
@@ -518,16 +521,16 @@ public class BeaconStateTest {
     assertThat(actual).isEqualTo(expected);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void failsWhenInvalidArgumentTestSplit() {
+  @Test
+  void failsWhenInvalidArgumentTestSplit() {
     List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7);
     ArrayList<Integer> sample = new ArrayList<>(input);
 
-    split(sample, -1);
+    assertThrows(IllegalArgumentException.class, () -> split(sample, -1));
   }
 
   @Test
-  public void splitReturnsOneSmallerSizedSplit() {
+  void splitReturnsOneSmallerSizedSplit() {
     List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7);
     ArrayList<Integer> sample = new ArrayList<>(input);
 
@@ -545,7 +548,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void splitReturnsTwoSmallerSizedSplits() {
+  void splitReturnsTwoSmallerSizedSplits() {
     List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6);
     ArrayList<Integer> sample = new ArrayList<>(input);
 
@@ -563,7 +566,7 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void splitReturnsEquallySizedSplits() {
+  void splitReturnsEquallySizedSplits() {
     List<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8);
     ArrayList<Integer> sample = new ArrayList<>(input);
 
@@ -581,21 +584,21 @@ public class BeaconStateTest {
   }
 
   @Test
-  public void clampReturnsMinVal() {
+  void clampReturnsMinVal() {
     int actual = clamp(3, 5, 0);
     int expected = 3;
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test
-  public void clampReturnsMaxVal() {
+  void clampReturnsMaxVal() {
     int actual = clamp(3, 5, 6);
     int expected = 5;
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test
-  public void clampReturnsX() {
+  void clampReturnsX() {
     int actual = clamp(3, 5, 4);
     int expected = 4;
     assertThat(actual).isEqualTo(expected);

--- a/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/StateTransitionTest.java
+++ b/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/StateTransitionTest.java
@@ -24,25 +24,22 @@ import static tech.pegasys.artemis.Constants.LATEST_RANDAO_MIXES_LENGTH;
 import static tech.pegasys.artemis.Constants.PENDING_ACTIVATION;
 
 import com.google.common.primitives.UnsignedLong;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.Collections;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
 import net.consensys.cava.crypto.Hash;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Test;
+import net.consensys.cava.junit.BouncyCastleExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.artemis.datastructures.beaconchainblocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.beaconchainstate.ShardCommittee;
 import tech.pegasys.artemis.datastructures.beaconchainstate.ValidatorRecord;
 import tech.pegasys.artemis.state.util.SlotProcessorUtil;
 
-public class StateTransitionTest {
-
-  static {
-    Security.addProvider(new BouncyCastleProvider());
-  }
+@ExtendWith(BouncyCastleExtension.class)
+class StateTransitionTest {
 
   private BeaconState newState() {
     // Initialize state
@@ -111,7 +108,7 @@ public class StateTransitionTest {
   }
 
   @Test
-  public void testUpdateProposerRandaoLayer() {
+  void testUpdateProposerRandaoLayer() {
     // initialize state and state transition objects
     BeaconState state = newState();
     state.setSlot(4);
@@ -154,7 +151,7 @@ public class StateTransitionTest {
   }
 
   @Test
-  public void testUpdateLatestRandaoMixes() {
+  void testUpdateLatestRandaoMixes() {
     BeaconState state = newState();
     state.setLatest_randao_mixes(
         new ArrayList<Bytes32>(Collections.nCopies(LATEST_RANDAO_MIXES_LENGTH, Bytes32.ZERO)));
@@ -175,7 +172,7 @@ public class StateTransitionTest {
   }
 
   @Test
-  public void testUpdateRecentBlockHashes() throws StateTransitionException {
+  void testUpdateRecentBlockHashes() throws StateTransitionException {
     BeaconState state = newState();
     ArrayList<ArrayList<ShardCommittee>> shard_committees_at_slots =
         new ArrayList<ArrayList<ShardCommittee>>();

--- a/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/util/ValidatorsUtilTest.java
+++ b/ethereum/beaconchain/src/test/java/tech/pegasys/artemis/state/util/ValidatorsUtilTest.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.artemis.state.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.pegasys.artemis.Constants.ACTIVE_PENDING_EXIT;
 import static tech.pegasys.artemis.Constants.EXITED_WITHOUT_PENALTY;
 
@@ -25,37 +25,37 @@ import java.util.Arrays;
 import net.consensys.cava.bytes.Bytes;
 import net.consensys.cava.bytes.Bytes32;
 import net.consensys.cava.bytes.Bytes48;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import tech.pegasys.artemis.datastructures.beaconchainstate.ValidatorRecord;
 import tech.pegasys.artemis.datastructures.beaconchainstate.Validators;
 
-public class ValidatorsUtilTest {
-  public static final double DOUBLE_ASSERTION_DELTA = 0.0d;
-  public static final double DEFAULT_BALANCE = 0.0d;
+class ValidatorsUtilTest {
+  private static final double DOUBLE_ASSERTION_DELTA = 0.0d;
+  private static final double DEFAULT_BALANCE = 0.0d;
   private int validatorSizeExpected = 0;
   private double effectiveBalanceExpected = 0.0d;
   private double balance;
   private Validators validatorRecordTest;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     validatorSizeExpected = 0;
     effectiveBalanceExpected = 0.0d;
     balance = 0.0d;
     validatorRecordTest = null;
   }
 
-  @After
-  public void teardown() {
+  @AfterEach
+  void teardown() {
     validatorSizeExpected = 0;
     effectiveBalanceExpected = 0.0d;
     validatorRecordTest = null;
   }
 
   @Test
-  public void assert_get_zero_as_effective_balance_for_nullValidators() {
+  void assert_get_zero_as_effective_balance_for_nullValidators() {
     // when
     double effectiveBalanceActual = ValidatorsUtil.get_effective_balance(null);
 
@@ -64,7 +64,7 @@ public class ValidatorsUtilTest {
   }
 
   @Test
-  public void
+  void
       assert_get_zero_as_effective_balance_for_validators_with_singleValidatorRecord_and_zero_balance() {
     // given
     validatorRecordTest =
@@ -79,7 +79,7 @@ public class ValidatorsUtilTest {
   }
 
   @Test
-  public void
+  void
       assert_get_nonZero_as_effective_balance_for_validators_with_singleValidatorRecord_and_nonZero_balance() {
     // given
     balance = 112.32d;
@@ -95,7 +95,7 @@ public class ValidatorsUtilTest {
   }
 
   @Test
-  public void
+  void
       assert_get_nonZero_value_as_effective_balance_for_validators_with_multipleValidatorRecords() {
     // given
     double validatorRecordBal1 = 112.32d;
@@ -114,7 +114,7 @@ public class ValidatorsUtilTest {
   }
 
   @Test
-  public void assert_get_active_validator_indices() {
+  void assert_get_active_validator_indices() {
     // given
     validatorRecordTest =
         getValidatorsList(
@@ -133,7 +133,7 @@ public class ValidatorsUtilTest {
   }
 
   @Test
-  public void assert_that_inactive_validators_are_excluded_for_get_active_validator_indices() {
+  void assert_that_inactive_validators_are_excluded_for_get_active_validator_indices() {
     // given
     validatorRecordTest =
         getValidatorsList(
@@ -152,7 +152,7 @@ public class ValidatorsUtilTest {
   }
 
   @Test
-  public void assert_get_active_validator_indices_for_all_inactive_validators_scenario() {
+  void assert_get_active_validator_indices_for_all_inactive_validators_scenario() {
     // given
     validatorRecordTest =
         getValidatorsList(
@@ -171,7 +171,7 @@ public class ValidatorsUtilTest {
   }
 
   @Test
-  public void assert_get_active_validator_indices_as_emptyList_for_nullInput() {
+  void assert_get_active_validator_indices_as_emptyList_for_nullInput() {
     // given
     validatorSizeExpected = 0;
 
@@ -183,7 +183,7 @@ public class ValidatorsUtilTest {
     assertEquals(validatorSizeExpected, activeValidatorsActual.size());
   }
 
-  public ValidatorRecord getAValidatorRecordTestDataFromParameters(
+  ValidatorRecord getAValidatorRecordTestDataFromParameters(
       Bytes48 pubkey,
       Bytes32 withdrawalCredentials,
       Bytes32 randaoCommitment,
@@ -210,7 +210,7 @@ public class ValidatorsUtilTest {
     return validatorRecord;
   }
 
-  public ValidatorRecord getDefaultValidatorRecordWithStatus(
+  ValidatorRecord getDefaultValidatorRecordWithStatus(
       int pubKeyInt, int statusAsInt, double balance) {
     Bytes32 withdrawal_credentials = Bytes32.ZERO;
     Bytes32 randaoCommitment = Bytes32.ZERO;
@@ -234,7 +234,7 @@ public class ValidatorsUtilTest {
         balance);
   }
 
-  public Validators getValidatorsList(ValidatorRecord... validatorRecords) {
+  Validators getValidatorsList(ValidatorRecord... validatorRecords) {
     return new Validators(Arrays.asList(validatorRecords));
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -34,7 +34,15 @@ dependencyManagement {
     dependency 'io.vertx:vertx-unit:3.5.4'
     dependency 'io.vertx:vertx-web:3.5.4'
 
-    dependency 'junit:junit:4.12'
+
+    dependencySet(group: 'net.consensys.cava', version: '1.0.0-425F50-snapshot') {
+      entry 'cava-bytes'
+      entry 'cava-crypto'
+      entry 'cava-junit'
+      entry 'cava-ssz'
+      entry 'cava-toml'
+      entry 'cava-units'
+    }
 
     dependency 'org.apache.logging.log4j:log4j-api:2.11.1'
     dependency 'org.apache.logging.log4j:log4j-core:2.11.1'
@@ -46,18 +54,15 @@ dependencyManagement {
 
     dependency 'org.bouncycastle:bcprov-jdk15on:1.60'
 
-    dependencySet(group: 'net.consensys.cava', version: '1.0.0-79E441-snapshot') {
-      entry 'cava-bytes'
-      entry 'cava-crypto'
-      entry 'cava-units'
-      entry 'cava-ssz'
-      entry 'cava-toml'
-    }
 
     dependency 'org.java-websocket:Java-WebSocket:1.3.8'
 
-    dependency 'org.mockito:mockito-core:2.23.4'
-
+    dependencySet(group: 'org.junit.jupiter', version: '5.3.2') {
+      entry 'junit-jupiter-api'
+      entry 'junit-jupiter-engine'
+      entry 'junit-jupiter-params'
+    }
+    
     dependency 'org.openjdk.jmh:jmh-core:1.21'
 
     dependency 'org.rocksdb:rocksdbjni:5.15.10'

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -16,16 +16,6 @@ dependencies {
 
   implementation 'org.apache.logging.log4j:log4j-api'
   runtime 'org.apache.logging.log4j:log4j-core'
-
-  testImplementation 'org.mockito:mockito-core'
-
-  integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.mockito:mockito-core'
-  integrationTestImplementation 'junit:junit'
-
-  testSupportImplementation 'org.assertj:assertj-core'
-  testSupportImplementation 'org.mockito:mockito-core'
-  testSupportImplementation 'junit:junit'
 }
 
 configurations { testArtifacts }

--- a/services/beaconchain/build.gradle
+++ b/services/beaconchain/build.gradle
@@ -18,15 +18,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   runtime 'org.apache.logging.log4j:log4j-core'
 
-  testImplementation 'org.mockito:mockito-core'
-
-  integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.mockito:mockito-core'
-  integrationTestImplementation 'junit:junit'
-
-  testSupportImplementation 'org.assertj:assertj-core'
-  testSupportImplementation 'org.mockito:mockito-core'
-  testSupportImplementation 'junit:junit'
+  testSupportImplementation 'io.vertx:vertx-core'
 }
 
 configurations { testArtifacts }

--- a/services/beaconnode/build.gradle
+++ b/services/beaconnode/build.gradle
@@ -13,16 +13,6 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
   runtime 'org.apache.logging.log4j:log4j-core'
-
-  testImplementation 'org.mockito:mockito-core'
-
-  integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.mockito:mockito-core'
-  integrationTestImplementation 'junit:junit'
-
-  testSupportImplementation 'org.assertj:assertj-core'
-  testSupportImplementation 'org.mockito:mockito-core'
-  testSupportImplementation 'junit:junit'
 }
 
 configurations { testArtifacts }

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -12,16 +12,6 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
   runtime 'org.apache.logging.log4j:log4j-core'
-
-  testImplementation 'org.mockito:mockito-core'
-
-  integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.mockito:mockito-core'
-  integrationTestImplementation 'junit:junit'
-
-  testSupportImplementation 'org.assertj:assertj-core'
-  testSupportImplementation 'org.mockito:mockito-core'
-  testSupportImplementation 'junit:junit'
 }
 
 configurations { testArtifacts }

--- a/services/chainstorage/build.gradle
+++ b/services/chainstorage/build.gradle
@@ -12,16 +12,6 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
   runtime 'org.apache.logging.log4j:log4j-core'
-
-  testImplementation 'org.mockito:mockito-core'
-
-  integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.mockito:mockito-core'
-  integrationTestImplementation 'junit:junit'
-
-  testSupportImplementation 'org.assertj:assertj-core'
-  testSupportImplementation 'org.mockito:mockito-core'
-  testSupportImplementation 'junit:junit'
 }
 
 configurations { testArtifacts }

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -10,9 +10,5 @@ dependencies {
   api 'org.bouncycastle:bcprov-jdk15on'
 
   implementation 'com.google.guava:guava'
-  implementation 'io.vertx:vertx-core'
-  implementation 'io.netty:netty-common'
-  implementation 'net.consensys.cava:cava-units'
-
-  testImplementation 'org.mockito:mockito-core'
+  implementation 'net.consensys.cava:cava-bytes'
 }


### PR DESCRIPTION
Move all tests to JUnit5. Keep assertJ for assertions in existing tests.

As a result of moving to JUnit5:
* Use BouncyCastleExtension to make sure BouncyCastle is registered as a security provider
* Use package-visible methods and classes everywhere
* Replace expected exceptions with assertThrows
