### PR TITLE
Change attestation topic name

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandler.java
@@ -84,7 +84,7 @@ public class SingleAttestationTopicHandler implements Eth2TopicHandler<Attestati
 
   @Override
   public String getTopicName() {
-    return "committee_index" + subnetId + "_beacon_attestation";
+    return "beacon_attestation_" + subnetId;
   }
 
   @Override

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -63,7 +63,7 @@ public class AttestationGossipManagerTest {
   @BeforeEach
   public void setup() {
     BeaconChainUtil.create(0, recentChainData).initializeStorage();
-    doReturn(topicChannel).when(gossipNetwork).subscribe(contains("committee_index"), any());
+    doReturn(topicChannel).when(gossipNetwork).subscribe(contains("beacon_attestation"), any());
     attestationGossipManager =
         new AttestationGossipManager(gossipEncoding, attestationSubnetSubscriptions);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
@@ -92,9 +92,9 @@ public class AttestationSubnetSubscriptionsTest {
 
     TopicChannel topicChannel1 = mock(TopicChannel.class);
     TopicChannel topicChannel2 = mock(TopicChannel.class);
-    when(gossipNetwork.subscribe(contains("committee_index" + subnetId1), any()))
+    when(gossipNetwork.subscribe(contains("beacon_attestation_1" + subnetId1), any()))
         .thenReturn(topicChannel1);
-    when(gossipNetwork.subscribe(contains("committee_index" + subnetId2), any()))
+    when(gossipNetwork.subscribe(contains("beacon_attestation_2" + subnetId2), any()))
         .thenReturn(topicChannel2);
 
     subnetSubscriptions.subscribeToSubnetId(subnetId1);
@@ -102,8 +102,8 @@ public class AttestationSubnetSubscriptionsTest {
 
     verifyNoInteractions(topicChannel2);
 
-    verify(gossipNetwork).subscribe(argThat(i -> i.contains("committee_index" + subnetId1)), any());
-    verify(gossipNetwork).subscribe(argThat(i -> i.contains("committee_index" + subnetId2)), any());
+    verify(gossipNetwork).subscribe(argThat(i -> i.contains("beacon_attestation_1" + subnetId1)), any());
+    verify(gossipNetwork).subscribe(argThat(i -> i.contains("beacon_attestation_2" + subnetId2)), any());
 
     assertThat(subnetSubscriptions.getChannel(attestation1)).isEqualTo(Optional.of(topicChannel1));
     assertThat(subnetSubscriptions.getChannel(attestation2)).isEqualTo(Optional.of(topicChannel2));
@@ -114,7 +114,7 @@ public class AttestationSubnetSubscriptionsTest {
     final Attestation attestation = dataStructureUtil.randomAttestation();
     final int subnetId = computeSubnetId(attestation);
     TopicChannel topicChannel = mock(TopicChannel.class);
-    when(gossipNetwork.subscribe(contains("committee_index" + subnetId), any()))
+    when(gossipNetwork.subscribe(contains("beacon_attestation_" + subnetId), any()))
         .thenReturn(topicChannel);
 
     subnetSubscriptions.subscribeToSubnetId(subnetId);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationSubnetSubscriptionsTest.java
@@ -102,8 +102,10 @@ public class AttestationSubnetSubscriptionsTest {
 
     verifyNoInteractions(topicChannel2);
 
-    verify(gossipNetwork).subscribe(argThat(i -> i.contains("beacon_attestation_1" + subnetId1)), any());
-    verify(gossipNetwork).subscribe(argThat(i -> i.contains("beacon_attestation_2" + subnetId2)), any());
+    verify(gossipNetwork)
+        .subscribe(argThat(i -> i.contains("beacon_attestation_1" + subnetId1)), any());
+    verify(gossipNetwork)
+        .subscribe(argThat(i -> i.contains("beacon_attestation_2" + subnetId2)), any());
 
     assertThat(subnetSubscriptions.getChannel(attestation1)).isEqualTo(Optional.of(topicChannel1));
     assertThat(subnetSubscriptions.getChannel(attestation2)).isEqualTo(Optional.of(topicChannel2));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -124,6 +124,6 @@ public class SingleAttestationTopicHandlerTest {
         new SingleAttestationTopicHandler(
             gossipEncoding, forkInfo, 0, attestationValidator, gossipedAttestationConsumer);
     assertThat(topicHandler.getTopic())
-        .isEqualTo("/eth2/11223344/committee_index0_beacon_attestation/ssz_snappy");
+        .isEqualTo("/eth2/11223344/beacon_attestation_0/ssz_snappy");
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -123,7 +123,6 @@ public class SingleAttestationTopicHandlerTest {
     final SingleAttestationTopicHandler topicHandler =
         new SingleAttestationTopicHandler(
             gossipEncoding, forkInfo, 0, attestationValidator, gossipedAttestationConsumer);
-    assertThat(topicHandler.getTopic())
-        .isEqualTo("/eth2/11223344/beacon_attestation_0/ssz_snappy");
+    assertThat(topicHandler.getTopic()).isEqualTo("/eth2/11223344/beacon_attestation_0/ssz_snappy");
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Changes attestation topic name as part of v0.12 spec update

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.