### PR TITLE
refactor multiPublishingBeaconNodeApi

### DIFF
--- a/validator/relaypublisher/src/main/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingBeaconNodeApi.java
+++ b/validator/relaypublisher/src/main/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingBeaconNodeApi.java
@@ -14,64 +14,26 @@
 package tech.pegasys.teku.validator.relaypublisher;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
-import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
-import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
-import tech.pegasys.teku.validator.api.AttesterDuties;
-import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
-import tech.pegasys.teku.validator.api.ProposerDuties;
-import tech.pegasys.teku.validator.api.SendSignedBlockResult;
-import tech.pegasys.teku.validator.api.SubmitDataError;
-import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
-import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
 import tech.pegasys.teku.validator.eventadapter.InProcessBeaconNodeApi;
 import tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi;
 
-public class MultiPublishingBeaconNodeApi implements BeaconNodeApi, ValidatorApiChannel {
-  @SuppressWarnings("PrivateStaticFinalLoggers")
-  private final Logger logger;
+public class MultiPublishingBeaconNodeApi implements BeaconNodeApi {
 
   private final BeaconNodeApi delegate;
-  private final List<AdditionalPublisherApi> additionalPublisherApis;
+  private final ValidatorApiChannel validatorApiChannel;
 
   MultiPublishingBeaconNodeApi(
-      final BeaconNodeApi delegate,
-      final List<AdditionalPublisherApi> additionalPublishingApis,
-      final Logger logger) {
+      final BeaconNodeApi delegate, final ValidatorApiChannel validatorApiChannel) {
     this.delegate = delegate;
-    this.additionalPublisherApis = additionalPublishingApis;
-    this.logger = logger;
-  }
-
-  MultiPublishingBeaconNodeApi(
-      final BeaconNodeApi delegate, List<AdditionalPublisherApi> additionalPublishingApis) {
-    this(delegate, additionalPublishingApis, LogManager.getLogger());
+    this.validatorApiChannel = validatorApiChannel;
   }
 
   public static BeaconNodeApi create(
@@ -82,7 +44,7 @@ public class MultiPublishingBeaconNodeApi implements BeaconNodeApi, ValidatorApi
       final boolean useIndependentAttestationTiming,
       final boolean generateEarlyAttestations,
       final List<URI> additionalPublishingUrls) {
-    final BeaconNodeApi primaryInterface =
+    final BeaconNodeApi beaconNodeApi =
         beaconNodeApiEndpoint
             .map(
                 endpoint ->
@@ -102,22 +64,16 @@ public class MultiPublishingBeaconNodeApi implements BeaconNodeApi, ValidatorApi
                         generateEarlyAttestations,
                         spec));
 
-    final List<AdditionalPublisherApi> additionalPublishingApis = new ArrayList<>();
-    for (int i = 0; i < additionalPublishingUrls.size(); i++) {
-      final URI uri = additionalPublishingUrls.get(i);
-      additionalPublishingApis.add(
-          new AdditionalPublisherApi(
-              uri,
-              RemoteBeaconNodeApi.create(
-                  serviceConfig,
-                  asyncRunner,
-                  uri,
-                  spec,
-                  useIndependentAttestationTiming,
-                  generateEarlyAttestations)));
-    }
-
-    return new MultiPublishingBeaconNodeApi(primaryInterface, additionalPublishingApis);
+    final ValidatorApiChannel validatorApiChannel =
+        MultiPublishingValidatorApiChannel.create(
+            serviceConfig,
+            asyncRunner,
+            spec,
+            useIndependentAttestationTiming,
+            generateEarlyAttestations,
+            beaconNodeApi.getValidatorApi(),
+            additionalPublishingUrls);
+    return new MultiPublishingBeaconNodeApi(beaconNodeApi, validatorApiChannel);
   }
 
   @Override
@@ -132,157 +88,6 @@ public class MultiPublishingBeaconNodeApi implements BeaconNodeApi, ValidatorApi
 
   @Override
   public ValidatorApiChannel getValidatorApi() {
-    return this;
-  }
-
-  @Override
-  public SafeFuture<Optional<GenesisData>> getGenesisData() {
-    return delegate.getValidatorApi().getGenesisData();
-  }
-
-  @Override
-  public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
-      final Collection<BLSPublicKey> publicKeys) {
-    return delegate.getValidatorApi().getValidatorIndices(publicKeys);
-  }
-
-  @Override
-  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
-      final Collection<BLSPublicKey> validatorIdentifiers) {
-    return delegate.getValidatorApi().getValidatorStatuses(validatorIdentifiers);
-  }
-
-  @Override
-  public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
-    return delegate.getValidatorApi().getAttestationDuties(epoch, validatorIndices);
-  }
-
-  @Override
-  public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
-    return delegate.getValidatorApi().getSyncCommitteeDuties(epoch, validatorIndices);
-  }
-
-  @Override
-  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
-    return delegate.getValidatorApi().getProposerDuties(epoch);
-  }
-
-  @Override
-  public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
-      final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
-    return delegate.getValidatorApi().createUnsignedBlock(slot, randaoReveal, graffiti);
-  }
-
-  @Override
-  public SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
-    return delegate.getValidatorApi().createAttestationData(slot, committeeIndex);
-  }
-
-  @Override
-  public SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
-    return delegate.getValidatorApi().createAggregate(slot, attestationHashTreeRoot);
-  }
-
-  @Override
-  public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
-      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
-    return delegate
-        .getValidatorApi()
-        .createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot);
-  }
-
-  @Override
-  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
-    delegate.getValidatorApi().subscribeToBeaconCommittee(requests);
-  }
-
-  @Override
-  public void subscribeToSyncCommitteeSubnets(
-      final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
-    delegate.getValidatorApi().subscribeToSyncCommitteeSubnets(subscriptions);
-  }
-
-  @Override
-  public void subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions) {
-    delegate.getValidatorApi().subscribeToPersistentSubnets(subnetSubscriptions);
-  }
-
-  @Override
-  public SafeFuture<List<SubmitDataError>> sendSignedAttestations(
-      final List<Attestation> attestations) {
-    final SafeFuture<List<SubmitDataError>> future =
-        delegate.getValidatorApi().sendSignedAttestations(attestations);
-
-    for (AdditionalPublisherApi api : additionalPublisherApis) {
-      api.sendSignedAttestations(attestations)
-          .finish(error -> logPublishError("attestations", api.getSanitizedUrl(), error));
-    }
-
-    return future;
-  }
-
-  @Override
-  public SafeFuture<List<SubmitDataError>> sendAggregateAndProofs(
-      final List<SignedAggregateAndProof> aggregateAndProofs) {
-    final SafeFuture<List<SubmitDataError>> future =
-        delegate.getValidatorApi().sendAggregateAndProofs(aggregateAndProofs);
-    for (AdditionalPublisherApi api : additionalPublisherApis) {
-      api.sendAggregateAndProofs(aggregateAndProofs)
-          .finish(error -> logPublishError("aggregateAndProofs", api.getSanitizedUrl(), error));
-    }
-    return future;
-  }
-
-  @Override
-  public SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block) {
-    final SafeFuture<SendSignedBlockResult> future =
-        delegate.getValidatorApi().sendSignedBlock(block);
-    for (AdditionalPublisherApi api : additionalPublisherApis) {
-      api.sendSignedBlock(block)
-          .finish(error -> logPublishError("block", api.getSanitizedUrl(), error));
-    }
-
-    return future;
-  }
-
-  @Override
-  public SafeFuture<List<SubmitDataError>> sendSyncCommitteeMessages(
-      final List<SyncCommitteeMessage> syncCommitteeMessages) {
-    final SafeFuture<List<SubmitDataError>> future =
-        delegate.getValidatorApi().sendSyncCommitteeMessages(syncCommitteeMessages);
-    for (AdditionalPublisherApi api : additionalPublisherApis) {
-      api.sendSyncCommitteeMessages(syncCommitteeMessages)
-          .finish(error -> logPublishError("syncCommitteeMessages", api.getSanitizedUrl(), error));
-    }
-
-    return future;
-  }
-
-  @Override
-  public SafeFuture<Void> sendSignedContributionAndProofs(
-      final Collection<SignedContributionAndProof> signedContributionAndProofs) {
-    final SafeFuture<Void> future =
-        delegate.getValidatorApi().sendSignedContributionAndProofs(signedContributionAndProofs);
-    for (AdditionalPublisherApi api : additionalPublisherApis) {
-      api.sendSignedContributionAndProofs(signedContributionAndProofs)
-          .finish(
-              error ->
-                  logPublishError("signedContributionAndProofs", api.getSanitizedUrl(), error));
-    }
-
-    return future;
-  }
-
-  private void logPublishError(
-      final String actionDescription, final String sanitizedUrl, final Throwable error) {
-    logger.warn(
-        "Failed to send {} to remote publishing host ({}): {}",
-        actionDescription,
-        sanitizedUrl,
-        error.getMessage());
+    return validatorApiChannel;
   }
 }

--- a/validator/relaypublisher/src/main/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingValidatorApiChannel.java
+++ b/validator/relaypublisher/src/main/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingValidatorApiChannel.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.relaypublisher;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.service.serviceutils.ServiceConfig;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
+import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
+import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi;
+
+public class MultiPublishingValidatorApiChannel implements ValidatorApiChannel {
+
+  private final ValidatorApiChannel delegate;
+  final List<AdditionalPublisherApi> additionalPublisherApis;
+
+  @SuppressWarnings("PrivateStaticFinalLoggers")
+  private final Logger logger;
+
+  MultiPublishingValidatorApiChannel(
+      final ValidatorApiChannel validatorApiChannel,
+      final List<AdditionalPublisherApi> additionalPublisherApis) {
+    this(validatorApiChannel, additionalPublisherApis, LogManager.getLogger());
+  }
+
+  MultiPublishingValidatorApiChannel(
+      final ValidatorApiChannel validatorApiChannel,
+      final List<AdditionalPublisherApi> additionalPublisherApis,
+      final Logger logger) {
+    this.delegate = validatorApiChannel;
+    this.additionalPublisherApis = additionalPublisherApis;
+    this.logger = logger;
+  }
+
+  public static MultiPublishingValidatorApiChannel create(
+      final ServiceConfig serviceConfig,
+      final AsyncRunner asyncRunner,
+      final Spec spec,
+      final boolean useIndependentAttestationTiming,
+      final boolean generateEarlyAttestations,
+      final ValidatorApiChannel validatorApiChannel,
+      final List<URI> additionalPublishingUrls) {
+    final List<AdditionalPublisherApi> additionalPublishingApis = new ArrayList<>();
+    for (final URI uri : additionalPublishingUrls) {
+      additionalPublishingApis.add(
+          new AdditionalPublisherApi(
+              uri,
+              RemoteBeaconNodeApi.create(
+                  serviceConfig,
+                  asyncRunner,
+                  uri,
+                  spec,
+                  useIndependentAttestationTiming,
+                  generateEarlyAttestations)));
+    }
+    return new MultiPublishingValidatorApiChannel(
+        validatorApiChannel, additionalPublishingApis, LogManager.getLogger());
+  }
+
+  @Override
+  public SafeFuture<Optional<GenesisData>> getGenesisData() {
+    return delegate.getGenesisData();
+  }
+
+  @Override
+  public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
+      final Collection<BLSPublicKey> publicKeys) {
+    return delegate.getValidatorIndices(publicKeys);
+  }
+
+  @Override
+  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+      final Collection<BLSPublicKey> validatorIdentifiers) {
+    return delegate.getValidatorStatuses(validatorIdentifiers);
+  }
+
+  @Override
+  public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
+      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+    return delegate.getAttestationDuties(epoch, validatorIndices);
+  }
+
+  @Override
+  public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
+      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+    return delegate.getSyncCommitteeDuties(epoch, validatorIndices);
+  }
+
+  @Override
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
+    return delegate.getProposerDuties(epoch);
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
+      final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
+    return delegate.createUnsignedBlock(slot, randaoReveal, graffiti);
+  }
+
+  @Override
+  public SafeFuture<Optional<AttestationData>> createAttestationData(
+      final UInt64 slot, final int committeeIndex) {
+    return delegate.createAttestationData(slot, committeeIndex);
+  }
+
+  @Override
+  public SafeFuture<Optional<Attestation>> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+    return delegate.createAggregate(slot, attestationHashTreeRoot);
+  }
+
+  @Override
+  public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
+      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
+    return delegate.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot);
+  }
+
+  @Override
+  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
+    delegate.subscribeToBeaconCommittee(requests);
+  }
+
+  @Override
+  public void subscribeToSyncCommitteeSubnets(
+      final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
+    delegate.subscribeToSyncCommitteeSubnets(subscriptions);
+  }
+
+  @Override
+  public void subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions) {
+    delegate.subscribeToPersistentSubnets(subnetSubscriptions);
+  }
+
+  @Override
+  public SafeFuture<List<SubmitDataError>> sendSignedAttestations(
+      final List<Attestation> attestations) {
+    final SafeFuture<List<SubmitDataError>> future = delegate.sendSignedAttestations(attestations);
+
+    for (AdditionalPublisherApi api : additionalPublisherApis) {
+      api.sendSignedAttestations(attestations)
+          .finish(error -> logPublishError("attestations", api.getSanitizedUrl(), error));
+    }
+
+    return future;
+  }
+
+  @Override
+  public SafeFuture<List<SubmitDataError>> sendAggregateAndProofs(
+      final List<SignedAggregateAndProof> aggregateAndProofs) {
+    final SafeFuture<List<SubmitDataError>> future =
+        delegate.sendAggregateAndProofs(aggregateAndProofs);
+    for (AdditionalPublisherApi api : additionalPublisherApis) {
+      api.sendAggregateAndProofs(aggregateAndProofs)
+          .finish(error -> logPublishError("aggregateAndProofs", api.getSanitizedUrl(), error));
+    }
+    return future;
+  }
+
+  @Override
+  public SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block) {
+    final SafeFuture<SendSignedBlockResult> future = delegate.sendSignedBlock(block);
+    for (AdditionalPublisherApi api : additionalPublisherApis) {
+      api.sendSignedBlock(block)
+          .finish(error -> logPublishError("block", api.getSanitizedUrl(), error));
+    }
+
+    return future;
+  }
+
+  @Override
+  public SafeFuture<List<SubmitDataError>> sendSyncCommitteeMessages(
+      final List<SyncCommitteeMessage> syncCommitteeMessages) {
+    final SafeFuture<List<SubmitDataError>> future =
+        delegate.sendSyncCommitteeMessages(syncCommitteeMessages);
+    for (AdditionalPublisherApi api : additionalPublisherApis) {
+      api.sendSyncCommitteeMessages(syncCommitteeMessages)
+          .finish(error -> logPublishError("syncCommitteeMessages", api.getSanitizedUrl(), error));
+    }
+
+    return future;
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedContributionAndProofs(
+      final Collection<SignedContributionAndProof> signedContributionAndProofs) {
+    final SafeFuture<Void> future =
+        delegate.sendSignedContributionAndProofs(signedContributionAndProofs);
+    for (AdditionalPublisherApi api : additionalPublisherApis) {
+      api.sendSignedContributionAndProofs(signedContributionAndProofs)
+          .finish(
+              error ->
+                  logPublishError("signedContributionAndProofs", api.getSanitizedUrl(), error));
+    }
+
+    return future;
+  }
+
+  private void logPublishError(
+      final String actionDescription, final String sanitizedUrl, final Throwable error) {
+    logger.warn(
+        "Failed to send {} to remote publishing host ({}): {}",
+        actionDescription,
+        sanitizedUrl,
+        error.getMessage());
+  }
+}

--- a/validator/relaypublisher/src/test/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingBeaconNodeApiTest.java
+++ b/validator/relaypublisher/src/test/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingBeaconNodeApiTest.java
@@ -14,50 +14,30 @@
 package tech.pegasys.teku.validator.relaypublisher;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
 
 class MultiPublishingBeaconNodeApiTest {
-  private final Spec spec = TestSpecFactory.createMinimalAltair();
-  private final DataStructureUtil data = new DataStructureUtil(spec);
-
-  @SuppressWarnings("PrivateStaticFinalLoggers")
-  private final Logger logger = mock(Logger.class);
-
   private final BeaconNodeApi delegate = mock(BeaconNodeApi.class);
   private final ValidatorApiChannel validator = mock(ValidatorApiChannel.class);
-  private final List<AdditionalPublisherApi> publishers =
-      List.of(mock(AdditionalPublisherApi.class), mock(AdditionalPublisherApi.class));
 
   @BeforeEach
   void setup() {
@@ -66,368 +46,48 @@ class MultiPublishingBeaconNodeApiTest {
 
   @Test
   void shouldOnlyCallDelegate_subscribeToEvents() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
+    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, validator);
 
     ignoreFuture(api.subscribeToEvents());
     verify(delegate, times(1)).subscribeToEvents();
     verifyNoMoreInteractions(delegate);
-    publishers.forEach(Mockito::verifyNoInteractions);
   }
 
   @Test
   void shouldOnlyCallDelegate_unsubscribeFromEvents() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
+    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, validator);
 
     ignoreFuture(api.unsubscribeFromEvents());
     verify(delegate, times(1)).unsubscribeFromEvents();
     verifyNoMoreInteractions(delegate);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
   }
 
   @Test
   void shouldGetMultiPublishObject_getValidatorApi() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
+    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, validator);
 
-    assertThat(api.getValidatorApi()).isEqualTo(api);
+    assertThat(api.getValidatorApi()).isEqualTo(validator);
+    verifyNoInteractions(delegate);
   }
 
   @Test
-  void shouldOnlyCallDelegate_getValidatorIndices() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.getValidatorIndices(Collections.emptyList()));
-    verify(validator, times(1)).getValidatorIndices(Collections.emptyList());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_getGenesisData() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.getGenesisData());
-    verify(validator, times(1)).getGenesisData();
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_getValidatorStatuses() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.getValidatorStatuses(Collections.emptyList()));
-    verify(validator, times(1)).getValidatorStatuses(Collections.emptyList());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_getAttestationDuties() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.getAttestationDuties(UInt64.ONE, Collections.emptyList()));
-    verify(validator, times(1)).getAttestationDuties(UInt64.ONE, Collections.emptyList());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_getSyncCommitteeDuties() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.getSyncCommitteeDuties(UInt64.ONE, Collections.emptyList()));
-    verify(validator, times(1)).getSyncCommitteeDuties(UInt64.ONE, Collections.emptyList());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_getProposerDuties() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.getProposerDuties(UInt64.ONE));
-    verify(validator, times(1)).getProposerDuties(UInt64.ONE);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_createUnsignedBlock() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.createUnsignedBlock(UInt64.ONE, BLSSignature.empty(), Optional.empty()));
-    verify(validator, times(1))
-        .createUnsignedBlock(UInt64.ONE, BLSSignature.empty(), Optional.empty());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_createAttestationData() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.createAttestationData(UInt64.ONE, 1));
-    verify(validator, times(1)).createAttestationData(UInt64.ONE, 1);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_createAggregate() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.createAggregate(UInt64.ONE, Bytes32.ZERO));
-    verify(validator, times(1)).createAggregate(UInt64.ONE, Bytes32.ZERO);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_createSyncCommitteeContribution() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    ignoreFuture(api.createSyncCommitteeContribution(UInt64.ONE, 1, Bytes32.ZERO));
-    verify(validator, times(1)).createSyncCommitteeContribution(UInt64.ONE, 1, Bytes32.ZERO);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_subscribeToBeaconCommittee() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    api.subscribeToBeaconCommittee(Collections.emptyList());
-    verify(validator, times(1)).subscribeToBeaconCommittee(Collections.emptyList());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_subscribeToSyncCommitteeSubnets() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    api.subscribeToSyncCommitteeSubnets(Collections.emptyList());
-    verify(validator, times(1)).subscribeToSyncCommitteeSubnets(Collections.emptyList());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldOnlyCallDelegate_subscribeToPersistentSubnets() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-
-    api.subscribeToPersistentSubnets(Collections.emptySet());
-    verify(validator, times(1)).subscribeToPersistentSubnets(Collections.emptySet());
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(Mockito::verifyNoInteractions);
-  }
-
-  @Test
-  void shouldCallDelegateAndPublishers_sendSignedAttestations() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-    final List<Attestation> attestationsList = Collections.emptyList();
-    publishers.forEach(
-        val ->
-            when(val.sendSignedAttestations(anyList()))
-                .thenReturn(SafeFuture.completedFuture(Collections.emptyList())));
-
-    ignoreFuture(api.sendSignedAttestations(attestationsList));
-    verify(validator, times(1)).sendSignedAttestations(attestationsList);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(val -> verify(val, times(1)).sendSignedAttestations(attestationsList));
-  }
-
-  @Test
-  void shouldLogPublisherWarnings_sendSignedAttestations() {
-
-    MultiPublishingBeaconNodeApi api =
-        new MultiPublishingBeaconNodeApi(delegate, publishers, logger);
-    final List<Attestation> attestationsList = Collections.emptyList();
-    publishers.forEach(
-        val -> {
-          when(val.sendSignedAttestations(anyList()))
-              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
-          when(val.getSanitizedUrl()).thenReturn("http://host");
-        });
-
-    ignoreFuture(api.sendSignedAttestations(attestationsList));
-    verify(validator, times(1)).sendSignedAttestations(attestationsList);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(val -> verify(val, times(1)).sendSignedAttestations(attestationsList));
-    verify(logger, times(2))
-        .warn(anyString(), eq("attestations"), eq("http://host"), eq("computer says no"));
-  }
-
-  @Test
-  void shouldCallDelegateAndPublishers_sendAggregateAndProofs() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-    final List<SignedAggregateAndProof> signedAggregateAndProofs = Collections.emptyList();
-    publishers.forEach(
-        val ->
-            when(val.sendAggregateAndProofs(anyList()))
-                .thenReturn(SafeFuture.completedFuture(Collections.emptyList())));
-
-    ignoreFuture(api.sendAggregateAndProofs(signedAggregateAndProofs));
-    verify(validator, times(1)).sendAggregateAndProofs(signedAggregateAndProofs);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(
-        val -> verify(val, times(1)).sendAggregateAndProofs(signedAggregateAndProofs));
-  }
-
-  @Test
-  void shouldLogPublisherWarnings_sendAggregateAndProofs() {
-    MultiPublishingBeaconNodeApi api =
-        new MultiPublishingBeaconNodeApi(delegate, publishers, logger);
-    final List<SignedAggregateAndProof> signedAggregateAndProofs = Collections.emptyList();
-    publishers.forEach(
-        val -> {
-          when(val.sendAggregateAndProofs(anyList()))
-              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
-          when(val.getSanitizedUrl()).thenReturn("http://host");
-        });
-
-    ignoreFuture(api.sendAggregateAndProofs(signedAggregateAndProofs));
-    verify(validator, times(1)).sendAggregateAndProofs(signedAggregateAndProofs);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(
-        val -> verify(val, times(1)).sendAggregateAndProofs(signedAggregateAndProofs));
-    verify(logger, times(2))
-        .warn(anyString(), eq("aggregateAndProofs"), eq("http://host"), eq("computer says no"));
-  }
-
-  @Test
-  void shouldCallDelegateAndPublishers_sendSignedBlock() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-    final SignedBeaconBlock block = data.randomSignedBeaconBlock(1);
-    publishers.forEach(
-        val ->
-            when(val.sendSignedBlock(block))
-                .thenReturn(SafeFuture.completedFuture(mock(SendSignedBlockResult.class))));
-
-    ignoreFuture(api.sendSignedBlock(block));
-    verify(validator, times(1)).sendSignedBlock(block);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(val -> verify(val, times(1)).sendSignedBlock(block));
-  }
-
-  @Test
-  void shouldLogPublisherWarnings_sendSignedBlock() {
-    MultiPublishingBeaconNodeApi api =
-        new MultiPublishingBeaconNodeApi(delegate, publishers, logger);
-    final SignedBeaconBlock block = data.randomSignedBeaconBlock(1);
-    publishers.forEach(
-        val -> {
-          when(val.sendSignedBlock(block))
-              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
-          when(val.getSanitizedUrl()).thenReturn("http://host");
-        });
-
-    ignoreFuture(api.sendSignedBlock(block));
-    verify(validator, times(1)).sendSignedBlock(block);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(val -> verify(val, times(1)).sendSignedBlock(block));
-    verify(logger, times(2))
-        .warn(anyString(), eq("block"), eq("http://host"), eq("computer says no"));
-  }
-
-  @Test
-  void shouldCallDelegateAndPublishers_sendSyncCommitteeMessages() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-    final List<SyncCommitteeMessage> syncCommitteeMessages = Collections.emptyList();
-    publishers.forEach(
-        val ->
-            when(val.sendSyncCommitteeMessages(anyList()))
-                .thenReturn(SafeFuture.completedFuture(Collections.emptyList())));
-
-    ignoreFuture(api.sendSyncCommitteeMessages(syncCommitteeMessages));
-    verify(validator, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(
-        val -> verify(val, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages));
-  }
-
-  @Test
-  void shouldLogPublisherWarnings_sendSyncCommitteeMessages() {
-    MultiPublishingBeaconNodeApi api =
-        new MultiPublishingBeaconNodeApi(delegate, publishers, logger);
-    final List<SyncCommitteeMessage> syncCommitteeMessages = Collections.emptyList();
-    publishers.forEach(
-        val -> {
-          when(val.sendSyncCommitteeMessages(anyList()))
-              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
-          when(val.getSanitizedUrl()).thenReturn("http://host");
-        });
-
-    ignoreFuture(api.sendSyncCommitteeMessages(syncCommitteeMessages));
-    verify(validator, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(
-        val -> verify(val, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages));
-    verify(logger, times(2))
-        .warn(anyString(), eq("syncCommitteeMessages"), eq("http://host"), eq("computer says no"));
-  }
-
-  @Test
-  void shouldCallDelegateAndPublishers_sendSignedContributionAndProofs() {
-    MultiPublishingBeaconNodeApi api = new MultiPublishingBeaconNodeApi(delegate, publishers);
-    final List<SignedContributionAndProof> signedContributionAndProofs = Collections.emptyList();
-    publishers.forEach(
-        val ->
-            when(val.sendSignedContributionAndProofs(anyList())).thenReturn(SafeFuture.COMPLETE));
-
-    ignoreFuture(api.sendSignedContributionAndProofs(signedContributionAndProofs));
-    verify(validator, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(
-        val -> verify(val, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs));
-  }
-
-  @Test
-  void shouldLogPublisherWarnings_sendSignedContributionAndProofs() {
-    MultiPublishingBeaconNodeApi api =
-        new MultiPublishingBeaconNodeApi(delegate, publishers, logger);
-    final List<SignedContributionAndProof> signedContributionAndProofs = Collections.emptyList();
-    publishers.forEach(
-        val -> {
-          when(val.sendSignedContributionAndProofs(anyList()))
-              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
-          when(val.getSanitizedUrl()).thenReturn("http://host");
-        });
-
-    ignoreFuture(api.sendSignedContributionAndProofs(signedContributionAndProofs));
-    verify(validator, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs);
-    verifyNoMoreInteractions(validator);
-
-    publishers.forEach(
-        val -> verify(val, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs));
-    verify(logger, times(2))
-        .warn(
-            anyString(),
-            eq("signedContributionAndProofs"),
-            eq("http://host"),
-            eq("computer says no"));
+  void shouldCreateWithMultiPublishingValidatorClient() {
+    final ServiceConfig services = mock(ServiceConfig.class);
+    final EventChannels eventChannels = mock(EventChannels.class);
+    final MetricsSystem metricsSystem = mock(MetricsSystem.class);
+    when(services.getEventChannels()).thenReturn(eventChannels);
+    when(services.getMetricsSystem()).thenReturn(metricsSystem);
+    when(eventChannels.getPublisher(any(), any())).thenReturn(validator);
+    BeaconNodeApi api =
+        MultiPublishingBeaconNodeApi.create(
+            services,
+            new StubAsyncRunner(),
+            Optional.empty(),
+            TestSpecFactory.createMinimalAltair(),
+            false,
+            false,
+            Collections.emptyList());
+
+    assertThat(api.getValidatorApi()).isInstanceOf(MultiPublishingValidatorApiChannel.class);
   }
 }

--- a/validator/relaypublisher/src/test/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingValidatorApiChannelTest.java
+++ b/validator/relaypublisher/src/test/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingValidatorApiChannelTest.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.relaypublisher;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class MultiPublishingValidatorApiChannelTest {
+  @SuppressWarnings("PrivateStaticFinalLoggers")
+  private final Logger logger = mock(Logger.class);
+
+  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final DataStructureUtil data = new DataStructureUtil(spec);
+  private final ValidatorApiChannel delegate = mock(ValidatorApiChannel.class);
+  private final List<AdditionalPublisherApi> publishers =
+      List.of(mock(AdditionalPublisherApi.class), mock(AdditionalPublisherApi.class));
+
+  @Test
+  void shouldOnlyCallDelegate_getValidatorIndices() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.getValidatorIndices(Collections.emptyList()));
+    verify(delegate, times(1)).getValidatorIndices(Collections.emptyList());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_getGenesisData() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.getGenesisData());
+    verify(delegate, times(1)).getGenesisData();
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_getValidatorStatuses() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.getValidatorStatuses(Collections.emptyList()));
+    verify(delegate, times(1)).getValidatorStatuses(Collections.emptyList());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_getAttestationDuties() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.getAttestationDuties(UInt64.ONE, Collections.emptyList()));
+    verify(delegate, times(1)).getAttestationDuties(UInt64.ONE, Collections.emptyList());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_getSyncCommitteeDuties() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.getSyncCommitteeDuties(UInt64.ONE, Collections.emptyList()));
+    verify(delegate, times(1)).getSyncCommitteeDuties(UInt64.ONE, Collections.emptyList());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_getProposerDuties() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.getProposerDuties(UInt64.ONE));
+    verify(delegate, times(1)).getProposerDuties(UInt64.ONE);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_createUnsignedBlock() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.createUnsignedBlock(UInt64.ONE, BLSSignature.empty(), Optional.empty()));
+    verify(delegate, times(1))
+        .createUnsignedBlock(UInt64.ONE, BLSSignature.empty(), Optional.empty());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_createAttestationData() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.createAttestationData(UInt64.ONE, 1));
+    verify(delegate, times(1)).createAttestationData(UInt64.ONE, 1);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_createAggregate() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.createAggregate(UInt64.ONE, Bytes32.ZERO));
+    verify(delegate, times(1)).createAggregate(UInt64.ONE, Bytes32.ZERO);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_createSyncCommitteeContribution() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    ignoreFuture(api.createSyncCommitteeContribution(UInt64.ONE, 1, Bytes32.ZERO));
+    verify(delegate, times(1)).createSyncCommitteeContribution(UInt64.ONE, 1, Bytes32.ZERO);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_subscribeToBeaconCommittee() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    api.subscribeToBeaconCommittee(Collections.emptyList());
+    verify(delegate, times(1)).subscribeToBeaconCommittee(Collections.emptyList());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_subscribeToSyncCommitteeSubnets() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    api.subscribeToSyncCommitteeSubnets(Collections.emptyList());
+    verify(delegate, times(1)).subscribeToSyncCommitteeSubnets(Collections.emptyList());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldOnlyCallDelegate_subscribeToPersistentSubnets() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+
+    api.subscribeToPersistentSubnets(Collections.emptySet());
+    verify(delegate, times(1)).subscribeToPersistentSubnets(Collections.emptySet());
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(Mockito::verifyNoInteractions);
+  }
+
+  @Test
+  void shouldCallDelegateAndPublishers_sendSignedAttestations() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+    final List<Attestation> attestationsList = Collections.emptyList();
+    publishers.forEach(
+        val ->
+            when(val.sendSignedAttestations(anyList()))
+                .thenReturn(SafeFuture.completedFuture(Collections.emptyList())));
+
+    ignoreFuture(api.sendSignedAttestations(attestationsList));
+    verify(delegate, times(1)).sendSignedAttestations(attestationsList);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(val -> verify(val, times(1)).sendSignedAttestations(attestationsList));
+  }
+
+  @Test
+  void shouldLogPublisherWarnings_sendSignedAttestations() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers, logger);
+
+    final List<Attestation> attestationsList = Collections.emptyList();
+    publishers.forEach(
+        val -> {
+          when(val.sendSignedAttestations(anyList()))
+              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
+          when(val.getSanitizedUrl()).thenReturn("http://host");
+        });
+
+    ignoreFuture(api.sendSignedAttestations(attestationsList));
+    verify(delegate, times(1)).sendSignedAttestations(attestationsList);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(val -> verify(val, times(1)).sendSignedAttestations(attestationsList));
+    verify(logger, times(2))
+        .warn(anyString(), eq("attestations"), eq("http://host"), eq("computer says no"));
+  }
+
+  @Test
+  void shouldCallDelegateAndPublishers_sendAggregateAndProofs() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+    final List<SignedAggregateAndProof> signedAggregateAndProofs = Collections.emptyList();
+    publishers.forEach(
+        val ->
+            when(val.sendAggregateAndProofs(anyList()))
+                .thenReturn(SafeFuture.completedFuture(Collections.emptyList())));
+
+    ignoreFuture(api.sendAggregateAndProofs(signedAggregateAndProofs));
+    verify(delegate, times(1)).sendAggregateAndProofs(signedAggregateAndProofs);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(
+        val -> verify(val, times(1)).sendAggregateAndProofs(signedAggregateAndProofs));
+  }
+
+  @Test
+  void shouldLogPublisherWarnings_sendAggregateAndProofs() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers, logger);
+    final List<SignedAggregateAndProof> signedAggregateAndProofs = Collections.emptyList();
+    publishers.forEach(
+        val -> {
+          when(val.sendAggregateAndProofs(anyList()))
+              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
+          when(val.getSanitizedUrl()).thenReturn("http://host");
+        });
+
+    ignoreFuture(api.sendAggregateAndProofs(signedAggregateAndProofs));
+    verify(delegate, times(1)).sendAggregateAndProofs(signedAggregateAndProofs);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(
+        val -> verify(val, times(1)).sendAggregateAndProofs(signedAggregateAndProofs));
+    verify(logger, times(2))
+        .warn(anyString(), eq("aggregateAndProofs"), eq("http://host"), eq("computer says no"));
+  }
+
+  @Test
+  void shouldCallDelegateAndPublishers_sendSignedBlock() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+    final SignedBeaconBlock block = data.randomSignedBeaconBlock(1);
+    publishers.forEach(
+        val ->
+            when(val.sendSignedBlock(block))
+                .thenReturn(SafeFuture.completedFuture(mock(SendSignedBlockResult.class))));
+
+    ignoreFuture(api.sendSignedBlock(block));
+    verify(delegate, times(1)).sendSignedBlock(block);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(val -> verify(val, times(1)).sendSignedBlock(block));
+  }
+
+  @Test
+  void shouldLogPublisherWarnings_sendSignedBlock() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers, logger);
+    final SignedBeaconBlock block = data.randomSignedBeaconBlock(1);
+    publishers.forEach(
+        val -> {
+          when(val.sendSignedBlock(block))
+              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
+          when(val.getSanitizedUrl()).thenReturn("http://host");
+        });
+
+    ignoreFuture(api.sendSignedBlock(block));
+    verify(delegate, times(1)).sendSignedBlock(block);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(val -> verify(val, times(1)).sendSignedBlock(block));
+    verify(logger, times(2))
+        .warn(anyString(), eq("block"), eq("http://host"), eq("computer says no"));
+  }
+
+  @Test
+  void shouldCallDelegateAndPublishers_sendSyncCommitteeMessages() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+    final List<SyncCommitteeMessage> syncCommitteeMessages = Collections.emptyList();
+    publishers.forEach(
+        val ->
+            when(val.sendSyncCommitteeMessages(anyList()))
+                .thenReturn(SafeFuture.completedFuture(Collections.emptyList())));
+
+    ignoreFuture(api.sendSyncCommitteeMessages(syncCommitteeMessages));
+    verify(delegate, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(
+        val -> verify(val, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages));
+  }
+
+  @Test
+  void shouldLogPublisherWarnings_sendSyncCommitteeMessages() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers, logger);
+    final List<SyncCommitteeMessage> syncCommitteeMessages = Collections.emptyList();
+    publishers.forEach(
+        val -> {
+          when(val.sendSyncCommitteeMessages(anyList()))
+              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
+          when(val.getSanitizedUrl()).thenReturn("http://host");
+        });
+
+    ignoreFuture(api.sendSyncCommitteeMessages(syncCommitteeMessages));
+    verify(delegate, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(
+        val -> verify(val, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages));
+    verify(logger, times(2))
+        .warn(anyString(), eq("syncCommitteeMessages"), eq("http://host"), eq("computer says no"));
+  }
+
+  @Test
+  void shouldCallDelegateAndPublishers_sendSignedContributionAndProofs() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers);
+    final List<SignedContributionAndProof> signedContributionAndProofs = Collections.emptyList();
+    publishers.forEach(
+        val ->
+            when(val.sendSignedContributionAndProofs(anyList())).thenReturn(SafeFuture.COMPLETE));
+
+    ignoreFuture(api.sendSignedContributionAndProofs(signedContributionAndProofs));
+    verify(delegate, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(
+        val -> verify(val, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs));
+  }
+
+  @Test
+  void shouldLogPublisherWarnings_sendSignedContributionAndProofs() {
+    final MultiPublishingValidatorApiChannel api =
+        new MultiPublishingValidatorApiChannel(delegate, publishers, logger);
+    final List<SignedContributionAndProof> signedContributionAndProofs = Collections.emptyList();
+    publishers.forEach(
+        val -> {
+          when(val.sendSignedContributionAndProofs(anyList()))
+              .thenReturn(SafeFuture.failedFuture(new IllegalStateException("computer says no")));
+          when(val.getSanitizedUrl()).thenReturn("http://host");
+        });
+
+    ignoreFuture(api.sendSignedContributionAndProofs(signedContributionAndProofs));
+    verify(delegate, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs);
+    verifyNoMoreInteractions(delegate);
+
+    publishers.forEach(
+        val -> verify(val, times(1)).sendSignedContributionAndProofs(signedContributionAndProofs));
+    verify(logger, times(2))
+        .warn(
+            anyString(),
+            eq("signedContributionAndProofs"),
+            eq("http://host"),
+            eq("computer says no"));
+  }
+}

--- a/validator/relaypublisher/src/test/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingValidatorApiChannelTest.java
+++ b/validator/relaypublisher/src/test/java/tech/pegasys/teku/validator/relaypublisher/MultiPublishingValidatorApiChannelTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.relaypublisher;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,6 +43,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class MultiPublishingValidatorApiChannelTest {
@@ -333,6 +335,8 @@ public class MultiPublishingValidatorApiChannelTest {
     final MultiPublishingValidatorApiChannel api =
         new MultiPublishingValidatorApiChannel(delegate, publishers);
     final List<SyncCommitteeMessage> syncCommitteeMessages = Collections.emptyList();
+    final SafeFuture<List<SubmitDataError>> future = new SafeFuture<>();
+    when(delegate.sendSyncCommitteeMessages(any())).thenReturn(future);
     publishers.forEach(
         val ->
             when(val.sendSyncCommitteeMessages(anyList()))
@@ -341,6 +345,7 @@ public class MultiPublishingValidatorApiChannelTest {
     ignoreFuture(api.sendSyncCommitteeMessages(syncCommitteeMessages));
     verify(delegate, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages);
     verifyNoMoreInteractions(delegate);
+    future.complete(Collections.emptyList());
 
     publishers.forEach(
         val -> verify(val, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages));
@@ -351,6 +356,8 @@ public class MultiPublishingValidatorApiChannelTest {
     final MultiPublishingValidatorApiChannel api =
         new MultiPublishingValidatorApiChannel(delegate, publishers, logger);
     final List<SyncCommitteeMessage> syncCommitteeMessages = Collections.emptyList();
+    final SafeFuture<List<SubmitDataError>> future = new SafeFuture<>();
+    when(delegate.sendSyncCommitteeMessages(any())).thenReturn(future);
     publishers.forEach(
         val -> {
           when(val.sendSyncCommitteeMessages(anyList()))
@@ -361,7 +368,7 @@ public class MultiPublishingValidatorApiChannelTest {
     ignoreFuture(api.sendSyncCommitteeMessages(syncCommitteeMessages));
     verify(delegate, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages);
     verifyNoMoreInteractions(delegate);
-
+    future.complete(Collections.emptyList());
     publishers.forEach(
         val -> verify(val, times(1)).sendSyncCommitteeMessages(syncCommitteeMessages));
     verify(logger, times(2))


### PR DESCRIPTION
split out the ValidatorApiChannel interface.

partially addresses #4223

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
