### PR TITLE
increase timeout to reduce chances of publish failure.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 
 # Enable configure on demand.
 org.gradle.configureondemand=true
 
-systemProp.org.gradle.internal.http.connectionTimeout=120000
-systemProp.org.gradle.internal.http.socketTimeout=120000
+systemProp.org.gradle.internal.http.connectionTimeout=300000
+systemProp.org.gradle.internal.http.socketTimeout=300000


### PR DESCRIPTION
It's being looked at by the cloudsmith support team, but they've recommended this until a fix is in.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
