### PR TITLE
[Merge] fixes optimistic sync consensusValidated not called

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/OptimisticSyncExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/OptimisticSyncExecutionEngineChannel.java
@@ -55,7 +55,7 @@ public class OptimisticSyncExecutionEngineChannel implements ExecutionEngineChan
 
   @Override
   public SafeFuture<Void> consensusValidated(Bytes32 blockHash, ConsensusValidationResult result) {
-    return SafeFuture.completedFuture(null);
+    return delegate.consensusValidated(blockHash, result);
   }
 
   @Override


### PR DESCRIPTION
## PR Description

fixes `consensusValidated` not called even when `engine_executePayload` returning `VALID`

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
