### PR TITLE
Update besu metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
  - Fixed a possible crash on shutdown when using levelDb.
+ - Set an idle timeout for metrics connections, to clean up ports when no longer used

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -149,8 +149,8 @@ dependencyManagement {
 
     dependency 'io.prometheus:simpleclient:0.9.0'
 
-    dependency 'org.hyperledger.besu.internal:metrics-core:21.1.1'
-    dependency 'org.hyperledger.besu:plugin-api:21.1.1'
+    dependency 'org.hyperledger.besu.internal:metrics-core:21.7.4'
+    dependency 'org.hyperledger.besu:plugin-api:21.7.4'
 
     dependency "org.testcontainers:testcontainers:1.15.3"
     dependency "org.testcontainers:junit-jupiter:1.15.3"

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -27,6 +27,7 @@ public class MetricsConfig {
   private final List<String> metricsHostAllowlist;
   private final String metricsEndpoint;
   private final int publicationInterval;
+  private final int idleTimeoutSeconds;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -35,7 +36,8 @@ public class MetricsConfig {
       final Set<MetricCategory> metricsCategories,
       final List<String> metricsHostAllowlist,
       final String metricsEndpoint,
-      final int publicationInterval) {
+      final int publicationInterval,
+      final int idleTimeoutSeconds) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -43,6 +45,7 @@ public class MetricsConfig {
     this.metricsHostAllowlist = metricsHostAllowlist;
     this.metricsEndpoint = metricsEndpoint;
     this.publicationInterval = publicationInterval;
+    this.idleTimeoutSeconds = idleTimeoutSeconds;
   }
 
   public static MetricsConfigBuilder builder() {
@@ -77,6 +80,10 @@ public class MetricsConfig {
     return publicationInterval;
   }
 
+  public int getIdleTimeoutSeconds() {
+    return idleTimeoutSeconds;
+  }
+
   public static final class MetricsConfigBuilder {
 
     private boolean metricsEnabled;
@@ -86,6 +93,7 @@ public class MetricsConfig {
     private List<String> metricsHostAllowlist;
     private String metricsEndpoint;
     private int metricsPublicationInterval;
+    private int idleTimeoutSeconds;
 
     private MetricsConfigBuilder() {}
 
@@ -124,6 +132,11 @@ public class MetricsConfig {
       return this;
     }
 
+    public MetricsConfigBuilder idleTimeoutSeconds(final int idleTimeoutSeconds) {
+      this.idleTimeoutSeconds = idleTimeoutSeconds;
+      return this;
+    }
+
     public MetricsConfig build() {
       return new MetricsConfig(
           metricsEnabled,
@@ -132,7 +145,8 @@ public class MetricsConfig {
           metricsCategories,
           metricsHostAllowlist,
           metricsEndpoint,
-          metricsPublicationInterval);
+          metricsPublicationInterval,
+          idleTimeoutSeconds);
     }
   }
 }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsEndpoint.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsEndpoint.java
@@ -60,6 +60,7 @@ public class MetricsEndpoint {
         .host(config.getMetricsInterface())
         .metricCategories(config.getMetricsCategories())
         .hostsAllowlist(config.getMetricsHostAllowlist())
+        .idleTimeout(config.getIdleTimeoutSeconds())
         .build();
   }
 }

--- a/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubMetricsSystem.java
+++ b/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubMetricsSystem.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.DoubleSupplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
@@ -40,16 +41,25 @@ public class StubMetricsSystem implements MetricsSystem {
   }
 
   @Override
+  public LabelledGauge createLabelledGauge(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labelNames) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
   public void createGauge(
       final MetricCategory category,
       final String name,
       final String help,
       final DoubleSupplier valueSupplier) {
-    final StubGauge guage = new StubGauge(category, name, help, valueSupplier);
+    final StubGauge gauge = new StubGauge(category, name, help, valueSupplier);
     final Map<String, StubGauge> gaugesInCategory =
         gauges.computeIfAbsent(category, key -> new ConcurrentHashMap<>());
 
-    if (gaugesInCategory.putIfAbsent(name, guage) != null) {
+    if (gaugesInCategory.putIfAbsent(name, gauge) != null) {
       throw new IllegalArgumentException("Attempting to create two gauges with the same name");
     }
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -107,6 +107,6 @@ public class MetricsOptions {
                 .metricsHostAllowlist(metricsHostAllowlist)
                 .metricsEndpoint(metricsEndpoint)
                 .metricsPublicationInterval(metricsPublicationInterval)
-                .idleTimeoutSeconds(metricsPublicationInterval));
+                .idleTimeoutSeconds(idleTimeoutSeconds));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -73,6 +73,14 @@ public class MetricsOptions {
   private final List<String> metricsHostAllowlist = Arrays.asList("127.0.0.1", "localhost");
 
   @Option(
+      names = {"--Xmetrics-idle-timeout"},
+      paramLabel = "<INTEGER>",
+      description = "Idle timeout for metrics connections in seconds",
+      arity = "1",
+      hidden = true)
+  private int idleTimeoutSeconds = 60;
+
+  @Option(
       names = {"--Xmetrics-endpoint"},
       hidden = true,
       paramLabel = "<ENDPOINT>",
@@ -98,6 +106,7 @@ public class MetricsOptions {
                 .metricsCategories(metricsCategories)
                 .metricsHostAllowlist(metricsHostAllowlist)
                 .metricsEndpoint(metricsEndpoint)
-                .metricsPublicationInterval(metricsPublicationInterval));
+                .metricsPublicationInterval(metricsPublicationInterval)
+                .idleTimeoutSeconds(metricsPublicationInterval));
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -542,7 +542,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .metricsCategories(Set.of(BEACON, LIBP2P, NETWORK, EVENTBUS, JVM, PROCESS))
                     .metricsHostAllowlist(List.of("127.0.0.1", "localhost"))
                     .metricsEndpoint(null)
-                    .metricsPublicationInterval(60))
+                    .metricsPublicationInterval(60)
+                    .idleTimeoutSeconds(60))
         .interop(
             b ->
                 b.interopGenesisTime(1)


### PR DESCRIPTION
## PR Description
Updates to the latest besu release which includes improvements to metrics.  Idle timeout for metrics connections can now be set (added --X option in teku to configure idle timeout for metrics connections) and labelled gauges are now supported.

## Fixed Issue(s)
fixes #4327

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
