### PR TITLE
Add labelled gauge reporting validators by current status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ For information on changes in released versions of Teku, see the [releases page]
 ## Unreleased Changes
 
 ### Additions and Improvements
-- Upgraded `io.netty` lib to 4.1.69.Final, `okhttp` lib to 4.9.3, `io.vertex` lib to 3.9.9.
+- Added `validator_local_validator_counts` metric to report number of local validators by current status.
+- Upgraded dependencies `io.netty`, `okhttp` and `io.vertex`.
 
 
 ### Bug Fixes

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/SettableLabelledGauge.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/SettableLabelledGauge.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.metrics;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
+
+public class SettableLabelledGauge {
+
+  private final Map<List<String>, AtomicDouble> valueHolders = new ConcurrentHashMap<>();
+  private final LabelledGauge labelledGauge;
+
+  private SettableLabelledGauge(final LabelledGauge labelledGauge) {
+    this.labelledGauge = labelledGauge;
+  }
+
+  public static SettableLabelledGauge create(
+      final MetricsSystem metricsSystem,
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labels) {
+    final LabelledGauge labelledGauge =
+        metricsSystem.createLabelledGauge(category, name, help, labels);
+    return new SettableLabelledGauge(labelledGauge);
+  }
+
+  public void set(double value, String... labels) {
+    final AtomicDouble valueHolder =
+        valueHolders.computeIfAbsent(
+            List.of(labels),
+            __ -> {
+              final AtomicDouble holder = new AtomicDouble();
+              labelledGauge.labels(holder::get, labels);
+              return holder;
+            });
+
+    valueHolder.set(value);
+  }
+}

--- a/infrastructure/metrics/src/test/java/tech/pegasys/teku/infrastructure/metrics/SettableLabelledGaugeTest.java
+++ b/infrastructure/metrics/src/test/java/tech/pegasys/teku/infrastructure/metrics/SettableLabelledGaugeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.OptionalDouble;
+import org.junit.jupiter.api.Test;
+
+class SettableLabelledGaugeTest {
+
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+  @Test
+  void shouldSetValuesForGaugeWithOneLabel() {
+    final SettableLabelledGauge labelledGauge =
+        SettableLabelledGauge.create(
+            metricsSystem, TekuMetricCategory.BEACON, "test", "Help text", "type");
+    labelledGauge.set(1d, "type1");
+    labelledGauge.set(2d, "type2");
+    labelledGauge.set(3d, "type3");
+
+    final StubLabelledGauge gauge =
+        metricsSystem.getLabelledGauge(TekuMetricCategory.BEACON, "test");
+    assertThat(gauge.getValue("type1")).isEqualTo(OptionalDouble.of(1d));
+    assertThat(gauge.getValue("type2")).isEqualTo(OptionalDouble.of(2d));
+    assertThat(gauge.getValue("type3")).isEqualTo(OptionalDouble.of(3d));
+    assertThat(gauge.getValue("type4")).isEqualTo(OptionalDouble.empty());
+
+    labelledGauge.set(0d, "type1");
+    assertThat(gauge.getValue("type1")).isEqualTo(OptionalDouble.of(0d));
+    assertThat(gauge.getValue("type2")).isEqualTo(OptionalDouble.of(2d));
+    assertThat(gauge.getValue("type3")).isEqualTo(OptionalDouble.of(3d));
+  }
+
+  @Test
+  void shouldSetValuesForGaugeWithMultipleLabels() {
+    final SettableLabelledGauge labelledGauge =
+        SettableLabelledGauge.create(
+            metricsSystem, TekuMetricCategory.BEACON, "test", "Help text", "a", "b");
+    labelledGauge.set(11d, "a1", "b1");
+    labelledGauge.set(12d, "a1", "b2");
+    labelledGauge.set(21d, "a2", "b1");
+    labelledGauge.set(22d, "a2", "b2");
+
+    final StubLabelledGauge gauge =
+        metricsSystem.getLabelledGauge(TekuMetricCategory.BEACON, "test");
+    assertThat(gauge.getValue("a1", "b1")).isEqualTo(OptionalDouble.of(11d));
+    assertThat(gauge.getValue("a1", "b2")).isEqualTo(OptionalDouble.of(12d));
+    assertThat(gauge.getValue("a2", "b1")).isEqualTo(OptionalDouble.of(21d));
+    assertThat(gauge.getValue("a2", "b2")).isEqualTo(OptionalDouble.of(22d));
+
+    labelledGauge.set(33d, "a2", "b2");
+    assertThat(gauge.getValue("a1", "b1")).isEqualTo(OptionalDouble.of(11d));
+    assertThat(gauge.getValue("a1", "b2")).isEqualTo(OptionalDouble.of(12d));
+    assertThat(gauge.getValue("a2", "b1")).isEqualTo(OptionalDouble.of(21d));
+    assertThat(gauge.getValue("a2", "b2")).isEqualTo(OptionalDouble.of(33d));
+  }
+}

--- a/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubCounter.java
+++ b/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubCounter.java
@@ -24,7 +24,7 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 
 public class StubCounter implements LabelledMetric<Counter> {
-  private Map<List<String>, UnlabelledCounter> values = new ConcurrentHashMap<>();
+  private final Map<List<String>, UnlabelledCounter> values = new ConcurrentHashMap<>();
 
   @Override
   public Counter labels(final String... labels) {

--- a/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubLabelledGauge.java
+++ b/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubLabelledGauge.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.metrics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.DoubleSupplier;
+import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
+
+public class StubLabelledGauge extends StubMetric implements LabelledGauge {
+
+  private final Map<List<String>, DoubleSupplier> suppliers = new ConcurrentHashMap<>();
+
+  protected StubLabelledGauge(final MetricCategory category, final String name, final String help) {
+    super(category, name, help);
+  }
+
+  @Override
+  public void labels(final DoubleSupplier valueSupplier, final String... labelValues) {
+    final DoubleSupplier oldValue = suppliers.putIfAbsent(List.of(labelValues), valueSupplier);
+    if (oldValue != null) {
+      throw new IllegalArgumentException(
+          "Attempting to create two gauges with the same name and labels");
+    }
+  }
+
+  public OptionalDouble getValue(final String... labels) {
+    final DoubleSupplier doubleSupplier = suppliers.get(List.of(labels));
+    return doubleSupplier != null
+        ? OptionalDouble.of(doubleSupplier.getAsDouble())
+        : OptionalDouble.empty();
+  }
+}

--- a/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubMetricsSystem.java
+++ b/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubMetricsSystem.java
@@ -28,6 +28,8 @@ public class StubMetricsSystem implements MetricsSystem {
 
   private final Map<MetricCategory, Map<String, StubCounter>> counters = new ConcurrentHashMap<>();
   private final Map<MetricCategory, Map<String, StubGauge>> gauges = new ConcurrentHashMap<>();
+  private final Map<MetricCategory, Map<String, StubLabelledGauge>> labelledGauges =
+      new ConcurrentHashMap<>();
 
   @Override
   public LabelledMetric<Counter> createLabelledCounter(
@@ -46,7 +48,9 @@ public class StubMetricsSystem implements MetricsSystem {
       final String name,
       final String help,
       final String... labelNames) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return labelledGauges
+        .computeIfAbsent(category, __ -> new ConcurrentHashMap<>())
+        .computeIfAbsent(name, __ -> new StubLabelledGauge(category, name, help));
   }
 
   @Override
@@ -76,7 +80,14 @@ public class StubMetricsSystem implements MetricsSystem {
   public StubGauge getGauge(final MetricCategory category, final String name) {
     return Optional.ofNullable(gauges.get(category))
         .map(categoryGauges -> categoryGauges.get(name))
-        .orElseThrow(() -> new IllegalArgumentException("Unknown guage: " + category + " " + name));
+        .orElseThrow(() -> new IllegalArgumentException("Unknown gauge: " + category + " " + name));
+  }
+
+  public StubLabelledGauge getLabelledGauge(final MetricCategory category, final String name) {
+    return Optional.ofNullable(labelledGauges.get(category))
+        .map(categoryGauges -> categoryGauges.get(name))
+        .orElseThrow(
+            () -> new IllegalArgumentException("Unknown labelled gauge: " + category + " " + name));
   }
 
   public StubCounter getCounter(final MetricCategory category, final String name) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -198,7 +198,8 @@ public class ValidatorClientService extends Service {
     }
     addValidatorCountMetric(metricsSystem, validators);
     this.validatorStatusLogger =
-        new DefaultValidatorStatusLogger(validators, validatorApiChannel, asyncRunner);
+        new DefaultValidatorStatusLogger(
+            metricsSystem, validators, validatorApiChannel, asyncRunner);
   }
 
   public static Path getSlashingProtectionPath(final DataDirLayout dataDirLayout) {


### PR DESCRIPTION
## PR Description
Add `validator_local_validator_counts` metric to report number of local validators by current status.

## Fixed Issue(s)
fixes #3892 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
