### PR TITLE
Support different ports for tcp and udp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Added `validator_local_validator_counts` metric to report number of local validators by current status.
 - Added JDK 17 docker images. The JDK 16 based images remain the default, append `-jdk17` to the docker image version to use the JDK 17 variant. 
 - Upgraded dependencies `io.netty`, `okhttp` and `io.vertex`.
+- Added new `--p2p-udp-port` and `--p2p-advertised-udp-port` options to support using different ports for TCP and UDP.
 
 
 ### Bug Fixes

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/PortAvailability.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/PortAvailability.java
@@ -19,6 +19,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 
 public class PortAvailability {
   private static final Logger LOG = LogManager.getLogger();
@@ -55,7 +56,18 @@ public class PortAvailability {
     return (port >= 0 && port <= 65535);
   }
 
-  public static boolean isPortAvailable(final int port) {
-    return isPortAvailableForTcp(port) && isPortAvailableForUdp(port);
+  public static void checkPortsAvailable(final int tcpPort, final int udpPort) {
+    if (!isPortAvailableForTcp(tcpPort)) {
+      throw new InvalidConfigurationException(
+          String.format(
+              "P2P Port %d (TCP) is already in use. Check for other processes using this port.",
+              tcpPort));
+    }
+    if (!isPortAvailableForTcp(udpPort)) {
+      throw new InvalidConfigurationException(
+          String.format(
+              "P2P Port %d (UDP) is already in use. Check for other processes using this port.",
+              udpPort));
+    }
   }
 }

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/PortAvailability.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/PortAvailability.java
@@ -63,7 +63,7 @@ public class PortAvailability {
               "P2P Port %d (TCP) is already in use. Check for other processes using this port.",
               tcpPort));
     }
-    if (!isPortAvailableForTcp(udpPort)) {
+    if (!isPortAvailableForUdp(udpPort)) {
       throw new InvalidConfigurationException(
           String.format(
               "P2P Port %d (UDP) is already in use. Check for other processes using this port.",

--- a/infrastructure/io/src/test/java/tech/pegasys/teku/infrastructure/io/PortAvailabilityTest.java
+++ b/infrastructure/io/src/test/java/tech/pegasys/teku/infrastructure/io/PortAvailabilityTest.java
@@ -45,7 +45,6 @@ public class PortAvailabilityTest {
     try (final ServerSocket serverSocket = new ServerSocket(0)) {
       final int port = serverSocket.getLocalPort();
       Assertions.assertThat(PortAvailability.isPortAvailableForTcp(port)).isFalse();
-      Assertions.assertThat(PortAvailability.isPortAvailable(port)).isFalse();
     }
   }
 
@@ -53,14 +52,12 @@ public class PortAvailabilityTest {
   void shouldDetectPortAvailableForTcp() {
     final int port = 0;
     Assertions.assertThat(PortAvailability.isPortAvailableForTcp(port)).isTrue();
-    Assertions.assertThat(PortAvailability.isPortAvailable(port)).isTrue();
   }
 
   @Test
   void shouldDetectPortAvailableForUdp() {
     final int port = 0;
     Assertions.assertThat(PortAvailability.isPortAvailableForUdp(port)).isTrue();
-    Assertions.assertThat(PortAvailability.isPortAvailable(port)).isTrue();
   }
 
   @Test
@@ -68,7 +65,6 @@ public class PortAvailabilityTest {
     try (final DatagramSocket datagramSocket = new DatagramSocket(0)) {
       final int port = datagramSocket.getPort();
       Assertions.assertThat(PortAvailability.isPortAvailableForUdp(port)).isFalse();
-      Assertions.assertThat(PortAvailability.isPortAvailable(port)).isFalse();
     }
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
@@ -14,12 +14,16 @@
 package tech.pegasys.teku.networking.p2p.discovery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static tech.pegasys.teku.networking.p2p.network.config.NetworkConfig.Builder.DEFAULT_P2P_PORT;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.OptionalInt;
 
 public class DiscoveryConfig {
   private final boolean isDiscoveryEnabled;
+  private final int listenUdpPort;
+  private final OptionalInt advertisedUdpPort;
   private final List<String> staticPeers;
   private final List<String> bootnodes;
   private final int minPeers;
@@ -28,12 +32,16 @@ public class DiscoveryConfig {
 
   private DiscoveryConfig(
       final boolean isDiscoveryEnabled,
+      final int listenUdpPort,
+      final OptionalInt advertisedUdpPort,
       final List<String> staticPeers,
       final List<String> bootnodes,
       final int minPeers,
       final int maxPeers,
       final int minRandomlySelectedPeers) {
     this.isDiscoveryEnabled = isDiscoveryEnabled;
+    this.listenUdpPort = listenUdpPort;
+    this.advertisedUdpPort = advertisedUdpPort;
     this.staticPeers = staticPeers;
     this.bootnodes = bootnodes;
     this.minPeers = minPeers;
@@ -47,6 +55,14 @@ public class DiscoveryConfig {
 
   public boolean isDiscoveryEnabled() {
     return isDiscoveryEnabled;
+  }
+
+  public int getListenUdpPort() {
+    return listenUdpPort;
+  }
+
+  public int getAdvertisedUdpPort() {
+    return advertisedUdpPort.orElse(listenUdpPort);
   }
 
   public List<String> getStaticPeers() {
@@ -76,8 +92,22 @@ public class DiscoveryConfig {
     private int minPeers = 64;
     private int maxPeers = 74;
     private int minRandomlySelectedPeers = 2;
+    private int listenUdpPort = DEFAULT_P2P_PORT;
+    private OptionalInt advertisedUdpPort = OptionalInt.empty();
 
     private Builder() {}
+
+    public DiscoveryConfig build() {
+      return new DiscoveryConfig(
+          isDiscoveryEnabled,
+          listenUdpPort,
+          advertisedUdpPort,
+          staticPeers,
+          bootnodes,
+          minPeers,
+          maxPeers,
+          minRandomlySelectedPeers);
+    }
 
     public Builder isDiscoveryEnabled(final Boolean discoveryEnabled) {
       checkNotNull(discoveryEnabled);
@@ -85,9 +115,15 @@ public class DiscoveryConfig {
       return this;
     }
 
-    public DiscoveryConfig build() {
-      return new DiscoveryConfig(
-          isDiscoveryEnabled, staticPeers, bootnodes, minPeers, maxPeers, minRandomlySelectedPeers);
+    public Builder listenUdpPort(final int listenUdpPort) {
+      this.listenUdpPort = listenUdpPort;
+      return this;
+    }
+
+    public Builder advertisedUdpPort(final OptionalInt advertisedUdpPort) {
+      checkNotNull(advertisedUdpPort);
+      this.advertisedUdpPort = advertisedUdpPort;
+      return this;
     }
 
     public Builder staticPeers(final List<String> staticPeers) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -147,7 +147,9 @@ public class DiscV5Service extends Service implements DiscoveryService {
   protected SafeFuture<?> doStop() {
     final Cancellable refreshTask = this.bootnodeRefreshTask;
     this.bootnodeRefreshTask = null;
-    refreshTask.cancel();
+    if (refreshTask != null) {
+      refreshTask.cancel();
+    }
     discoverySystem.stop();
     return SafeFuture.completedFuture(null);
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -73,13 +73,14 @@ public class DiscV5Service extends Service implements DiscoveryService {
     this.localNodePrivateKey = privateKey;
     this.currentSchemaDefinitionsSupplier = currentSchemaDefinitionsSupplier;
     final String listenAddress = p2pConfig.getNetworkInterface();
-    final int listenPort = p2pConfig.getListenPort();
+    final int listenUdpPort = discoConfig.getListenUdpPort();
     final String advertisedAddress = p2pConfig.getAdvertisedIp();
-    final int advertisedPort = p2pConfig.getAdvertisedPort();
+    final int advertisedTcpPort = p2pConfig.getAdvertisedPort();
+    final int advertisedUdpPort = discoConfig.getAdvertisedUdpPort();
     final UInt64 seqNo =
         kvStore.get(SEQ_NO_STORE_KEY).map(UInt64::fromBytes).orElse(UInt64.ZERO).add(1);
     final NewAddressHandler maybeUpdateNodeRecordHandler =
-        maybeUpdateNodeRecord(p2pConfig.hasUserExplicitlySetAdvertisedIp(), advertisedPort);
+        maybeUpdateNodeRecord(p2pConfig.hasUserExplicitlySetAdvertisedIp(), advertisedTcpPort);
     this.bootnodes =
         discoConfig.getBootnodes().stream()
             .map(NodeRecordFactory.DEFAULT::fromEnr)
@@ -87,12 +88,12 @@ public class DiscV5Service extends Service implements DiscoveryService {
     final NodeRecordBuilder nodeRecordBuilder =
         new NodeRecordBuilder().privateKey(privateKey).seq(seqNo);
     if (p2pConfig.hasUserExplicitlySetAdvertisedIp()) {
-      nodeRecordBuilder.address(advertisedAddress, advertisedPort);
+      nodeRecordBuilder.address(advertisedAddress, advertisedUdpPort, advertisedTcpPort);
     }
     final NodeRecord localNodeRecord = nodeRecordBuilder.build();
     this.discoverySystem =
         new DiscoverySystemBuilder()
-            .listen(listenAddress, listenPort)
+            .listen(listenAddress, listenUdpPort)
             .privateKey(privateKey)
             .bootnodes(bootnodes)
             .localNodeRecord(localNodeRecord)

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -24,7 +24,6 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
-import tech.pegasys.teku.infrastructure.io.PortAvailability;
 import tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig;
 
 public class NetworkConfig {
@@ -69,16 +68,6 @@ public class NetworkConfig {
 
   public static Builder builder() {
     return new Builder();
-  }
-
-  public void validateListenPortAvailable() {
-    if (listenPort != 0 && !PortAvailability.isPortAvailable(listenPort)) {
-      throw new InvalidConfigurationException(
-          String.format(
-              "P2P Port %d (TCP/UDP) is already in use. "
-                  + "Check for other processes using this port.",
-              listenPort));
-    }
   }
 
   public boolean isEnabled() {
@@ -142,7 +131,7 @@ public class NetworkConfig {
     private Optional<String> privateKeyFile = Optional.empty();
     private String networkInterface = "0.0.0.0";
     private Optional<String> advertisedIp = Optional.empty();
-    private Integer listenPort = DEFAULT_P2P_PORT;
+    private int listenPort = DEFAULT_P2P_PORT;
     private OptionalInt advertisedPort = OptionalInt.empty();
 
     private Builder() {}
@@ -193,8 +182,7 @@ public class NetworkConfig {
       return this;
     }
 
-    public Builder listenPort(final Integer listenPort) {
-      checkNotNull(listenPort);
+    public Builder listenPort(final int listenPort) {
       this.listenPort = listenPort;
       return this;
     }

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -86,7 +86,11 @@ public class DiscoveryNetworkFactory {
         final Random random = new Random();
         final int port = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
         final DiscoveryConfig discoveryConfig =
-            DiscoveryConfig.builder().staticPeers(staticPeers).bootnodes(bootnodes).build();
+            DiscoveryConfig.builder()
+                .listenUdpPort(port)
+                .staticPeers(staticPeers)
+                .bootnodes(bootnodes)
+                .build();
         final NetworkConfig config =
             NetworkConfig.builder()
                 .listenPort(port)

--- a/services/beaconchain/build.gradle
+++ b/services/beaconchain/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:exceptions')
   implementation project(':infrastructure:http')
+  implementation project(':infrastructure:io')
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:version')
   implementation project(':networking:p2p')

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.AsyncRunnerEventThread;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.io.PortAvailability;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
@@ -596,7 +597,9 @@ public class BeaconChainController extends Service implements TimeTickChannel {
       return;
     }
 
-    beaconConfig.p2pConfig().getNetworkConfig().validateListenPortAvailable();
+    PortAvailability.checkPortsAvailable(
+        beaconConfig.p2pConfig().getNetworkConfig().getListenPort(),
+        beaconConfig.p2pConfig().getDiscoveryConfig().getListenUdpPort());
 
     final GossipPublisher<AttesterSlashing> attesterSlashingGossipPublisher =
         new GossipPublisher<>();

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -431,7 +431,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .powchain(
             b -> {
               b.depositContract(networkConfig.getEth1DepositContractAddress());
-              b.eth1Endpoints(new ArrayList<String>())
+              b.eth1Endpoints(new ArrayList<>())
                   .depositContractDeployBlock(networkConfig.getEth1DepositContractDeployBlock());
             })
         .storageConfiguration(
@@ -446,7 +446,11 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
             b -> b.metricsCategories(DEFAULT_METRICS_CATEGORIES).metricsPublicationInterval(60))
         .restApi(b -> b.eth1DepositContractAddress(networkConfig.getEth1DepositContractAddress()))
         .p2p(p -> p.peerRateLimit(500).peerRequestLimit(50))
-        .discovery(d -> d.isDiscoveryEnabled(true).bootnodes(networkConfig.getDiscoveryBootnodes()))
+        .discovery(
+            d ->
+                d.isDiscoveryEnabled(true)
+                    .listenUdpPort(9000)
+                    .bootnodes(networkConfig.getDiscoveryBootnodes()))
         .network(
             n ->
                 n.advertisedPort(OptionalInt.empty())
@@ -495,7 +499,13 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .peerRequestLimit(50)
                     .batchVerifyAttestationSignatures(true))
         .discovery(
-            d -> d.isDiscoveryEnabled(false).minPeers(64).maxPeers(74).minRandomlySelectedPeers(12))
+            d ->
+                d.isDiscoveryEnabled(false)
+                    .listenUdpPort(1234)
+                    .advertisedUdpPort(OptionalInt.of(9000))
+                    .minPeers(64)
+                    .maxPeers(74)
+                    .minRandomlySelectedPeers(12))
         .network(
             n ->
                 n.isEnabled(false)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -69,6 +69,29 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void p2pUdpPort_shouldDefaultToP2pPortWhenNeitherSet() {
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments();
+    assertThat(tekuConfig.discovery().getListenUdpPort())
+        .isEqualTo(tekuConfig.network().getListenPort());
+  }
+
+  @Test
+  void p2pUdpPort_shouldDefaultToP2pPortWhenP2pPortIsSet() {
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments("--p2p-port=9999");
+    assertThat(tekuConfig.discovery().getListenUdpPort())
+        .isEqualTo(tekuConfig.network().getListenPort());
+    assertThat(tekuConfig.discovery().getListenUdpPort()).isEqualTo(9999);
+  }
+
+  @Test
+  void p2pUdpPort_shouldOverrideP2pPortWhenBothSet() {
+    final TekuConfiguration tekuConfig =
+        getTekuConfigurationFromArguments("--p2p-udp-port=9888", "--p2p-port=9999");
+    assertThat(tekuConfig.discovery().getListenUdpPort()).isEqualTo(9888);
+    assertThat(tekuConfig.network().getListenPort()).isEqualTo(9999);
+  }
+
+  @Test
   public void advertisedIp_shouldDefaultToEmpty() {
     final NetworkConfig config = getTekuConfigurationFromArguments().network();
     assertThat(config.hasUserExplicitlySetAdvertisedIp()).isFalse();
@@ -96,6 +119,40 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
                 .network()
                 .getAdvertisedPort())
         .isEqualTo(8056);
+  }
+
+  @Test
+  void advertisedUdpPort_shouldDefaultToTcpListenPortWhenNeitherSet() {
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments();
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPort())
+        .isEqualTo(tekuConfig.network().getAdvertisedPort());
+  }
+
+  @Test
+  void advertisedUdpPort_shouldDefaultToTcpListenPortWhenListenPortSet() {
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments("--p2p-port=8000");
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPort()).isEqualTo(8000);
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPort())
+        .isEqualTo(tekuConfig.network().getAdvertisedPort());
+  }
+
+  @Test
+  void advertisedUdpPort_shouldDefaultToAdvertisedTcpPortWhenAdvertisedPortSet() {
+    final TekuConfiguration tekuConfig =
+        getTekuConfigurationFromArguments("--p2p-port=8000", "--p2p-advertised-port=7000");
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPort()).isEqualTo(7000);
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPort())
+        .isEqualTo(tekuConfig.network().getAdvertisedPort());
+  }
+
+  @Test
+  void advertisedUdpPort_shouldOverrideAdvertisedUdpPort() {
+    final TekuConfiguration tekuConfig =
+        getTekuConfigurationFromArguments(
+            "--p2p-advertised-udp-port=6000", "--p2p-port=8000", "--p2p-advertised-port=7000");
+    assertThat(tekuConfig.discovery().getAdvertisedUdpPort()).isEqualTo(6000);
+    assertThat(tekuConfig.network().getAdvertisedPort()).isEqualTo(7000);
+    assertThat(tekuConfig.network().getListenPort()).isEqualTo(8000);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Adds `--p2p-udp-port` and `--p2p-advertised-udp-port` options to support using a different port for tcp and udp.

`--p2p-udp-port` defaults to the value set in `--p2p-port`.
`--p2p-advertised-udp-port` defaults to `--p2p-advertised-port` if set, otherwise `--p2p-udp-port`.

## Fixed Issue(s)
fixes #4389 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
