### PR TITLE
Fix building from source downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,5 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
  - Fixed a possible crash on shutdown when using levelDb.
  - Set an idle timeout for metrics connections, to clean up ports when no longer used
+ - Fixed error when building from a source download rather than a git checkout.
+   Now logs a warning when building without git information to warn users that version information will not be available.

--- a/build.gradle
+++ b/build.gradle
@@ -702,7 +702,7 @@ def calculatePublishVersion() {
 // Otherwise use git describe --tags and replace the - after the tag with a +
 def calculateVersion() {
   if (!grgit) {
-    logger.warn("Not building from a git checkout. Version information will not be available. Checkout out source from git is strongly recommended.")
+    logger.warn("Not building from a git checkout. Version information will not be available. Building from a git checkout is strongly recommended.")
     return 'UNKNOWN+develop'
   }
   String version = grgit.describe(tags: true)

--- a/build.gradle
+++ b/build.gradle
@@ -687,7 +687,7 @@ def buildTime() {
 // Otherwise, use develop
 def calculatePublishVersion() {
   if (!grgit) {
-    return 'UNKNOWN'
+    return 'develop'
   }
   def specificVersion = calculateVersion()
   def isReleaseBranch = grgit.branch.current().name.startsWith('release-')
@@ -702,7 +702,8 @@ def calculatePublishVersion() {
 // Otherwise use git describe --tags and replace the - after the tag with a +
 def calculateVersion() {
   if (!grgit) {
-    return 'UNKNOWN'
+    logger.warn("Not building from a git checkout. Version information will not be available. Checkout out source from git is strongly recommended.")
+    return 'UNKNOWN+develop'
   }
   String version = grgit.describe(tags: true)
   if (version == null) {


### PR DESCRIPTION
## PR Description
Fixes error where the "UNKNOWN" version used when building from a source download (rather than a git checkout) was treated as a release version but couldn't then be parsed correctly when creating docker tags.

Now also logs a warning when building from a source download instead of a git checkout to warn users that version information will not be available.

## Fixed Issue(s)
fixes #4411 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
