### PR TITLE
[Merge] let Altair spec datastructures ready to be extended for the merge

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockBodyAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockBodyAltair.java
@@ -72,8 +72,8 @@ public class BeaconBlockBodyAltair extends BeaconBlockBody {
   @Override
   public tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody
       asInternalBeaconBlockBody(final SpecVersion spec) {
-    BeaconBlockBodySchemaAltair schema =
-        (BeaconBlockBodySchemaAltair) spec.getSchemaDefinitions().getBeaconBlockBodySchema();
+    BeaconBlockBodySchemaAltair<?> schema =
+        (BeaconBlockBodySchemaAltair<?>) spec.getSchemaDefinitions().getBeaconBlockBodySchema();
     SyncAggregateSchema syncAggregateSchema = schema.getSyncAggregateSchema();
     return super.asInternalBeaconBlockBody(
         spec,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ConsenSys AG.
+ * Copyright 2021 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,69 +14,12 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.Deposit;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.datastructures.type.SszSignature;
-import tech.pegasys.teku.ssz.SszList;
-import tech.pegasys.teku.ssz.containers.Container9;
-import tech.pegasys.teku.ssz.primitive.SszBytes32;
-import tech.pegasys.teku.ssz.tree.TreeNode;
 
 /** A Beacon block body */
-public class BeaconBlockBodyAltair
-    extends Container9<
-        BeaconBlockBodyAltair,
-        SszSignature,
-        Eth1Data,
-        SszBytes32,
-        SszList<ProposerSlashing>,
-        SszList<AttesterSlashing>,
-        SszList<Attestation>,
-        SszList<Deposit>,
-        SszList<SignedVoluntaryExit>,
-        SyncAggregate>
-    implements BeaconBlockBody {
+public interface BeaconBlockBodyAltair extends BeaconBlockBody {
 
-  BeaconBlockBodyAltair(BeaconBlockBodySchemaAltair type) {
-    super(type);
-  }
-
-  BeaconBlockBodyAltair(BeaconBlockBodySchemaAltair type, TreeNode backingNode) {
-    super(type, backingNode);
-  }
-
-  BeaconBlockBodyAltair(
-      BeaconBlockBodySchemaAltair type,
-      SszSignature randaoReveal,
-      Eth1Data eth1Data,
-      SszBytes32 graffiti,
-      SszList<ProposerSlashing> proposerSlashings,
-      SszList<AttesterSlashing> attesterSlashings,
-      SszList<Attestation> attestations,
-      SszList<Deposit> deposits,
-      SszList<SignedVoluntaryExit> voluntaryExits,
-      SyncAggregate syncAggregate) {
-    super(
-        type,
-        randaoReveal,
-        eth1Data,
-        graffiti,
-        proposerSlashings,
-        attesterSlashings,
-        attestations,
-        deposits,
-        voluntaryExits,
-        syncAggregate);
-  }
-
-  public static BeaconBlockBodyAltair required(final BeaconBlockBody body) {
+  static BeaconBlockBodyAltair required(final BeaconBlockBody body) {
     return body.toVersionAltair()
         .orElseThrow(
             () ->
@@ -84,57 +27,13 @@ public class BeaconBlockBodyAltair
                     "Expected altair block body but got " + body.getClass().getSimpleName()));
   }
 
-  @Override
-  public BLSSignature getRandao_reveal() {
-    return getField0().getSignature();
-  }
+  SyncAggregate getSyncAggregate();
 
   @Override
-  public Eth1Data getEth1_data() {
-    return getField1();
-  }
+  BeaconBlockBodySchemaAltair<?> getSchema();
 
   @Override
-  public Bytes32 getGraffiti() {
-    return getField2().get();
-  }
-
-  @Override
-  public SszList<ProposerSlashing> getProposer_slashings() {
-    return getField3();
-  }
-
-  @Override
-  public SszList<AttesterSlashing> getAttester_slashings() {
-    return getField4();
-  }
-
-  @Override
-  public SszList<Attestation> getAttestations() {
-    return getField5();
-  }
-
-  @Override
-  public SszList<Deposit> getDeposits() {
-    return getField6();
-  }
-
-  @Override
-  public SszList<SignedVoluntaryExit> getVoluntary_exits() {
-    return getField7();
-  }
-
-  public SyncAggregate getSyncAggregate() {
-    return getField8();
-  }
-
-  @Override
-  public BeaconBlockBodySchemaAltair getSchema() {
-    return (BeaconBlockBodySchemaAltair) super.getSchema();
-  }
-
-  @Override
-  public Optional<BeaconBlockBodyAltair> toVersionAltair() {
+  default Optional<BeaconBlockBodyAltair> toVersionAltair() {
     return Optional.of(this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.ssz.SszList;
+import tech.pegasys.teku.ssz.containers.Container9;
+import tech.pegasys.teku.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.ssz.tree.TreeNode;
+
+/** A Beacon block body */
+public class BeaconBlockBodyAltairImpl
+    extends Container9<
+        BeaconBlockBodyAltairImpl,
+        SszSignature,
+        Eth1Data,
+        SszBytes32,
+        SszList<ProposerSlashing>,
+        SszList<AttesterSlashing>,
+        SszList<Attestation>,
+        SszList<Deposit>,
+        SszList<SignedVoluntaryExit>,
+        SyncAggregate>
+    implements BeaconBlockBodyAltair {
+
+  BeaconBlockBodyAltairImpl(BeaconBlockBodySchemaAltairImpl type) {
+    super(type);
+  }
+
+  BeaconBlockBodyAltairImpl(BeaconBlockBodySchemaAltairImpl type, TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  BeaconBlockBodyAltairImpl(
+      BeaconBlockBodySchemaAltairImpl type,
+      SszSignature randaoReveal,
+      Eth1Data eth1Data,
+      SszBytes32 graffiti,
+      SszList<ProposerSlashing> proposerSlashings,
+      SszList<AttesterSlashing> attesterSlashings,
+      SszList<Attestation> attestations,
+      SszList<Deposit> deposits,
+      SszList<SignedVoluntaryExit> voluntaryExits,
+      SyncAggregate syncAggregate) {
+    super(
+        type,
+        randaoReveal,
+        eth1Data,
+        graffiti,
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+        syncAggregate);
+  }
+
+  public static BeaconBlockBodyAltair required(final BeaconBlockBody body) {
+    return body.toVersionAltair()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Expected altair block body but got " + body.getClass().getSimpleName()));
+  }
+
+  @Override
+  public BLSSignature getRandao_reveal() {
+    return getField0().getSignature();
+  }
+
+  @Override
+  public Eth1Data getEth1_data() {
+    return getField1();
+  }
+
+  @Override
+  public Bytes32 getGraffiti() {
+    return getField2().get();
+  }
+
+  @Override
+  public SszList<ProposerSlashing> getProposer_slashings() {
+    return getField3();
+  }
+
+  @Override
+  public SszList<AttesterSlashing> getAttester_slashings() {
+    return getField4();
+  }
+
+  @Override
+  public SszList<Attestation> getAttestations() {
+    return getField5();
+  }
+
+  @Override
+  public SszList<Deposit> getDeposits() {
+    return getField6();
+  }
+
+  @Override
+  public SszList<SignedVoluntaryExit> getVoluntary_exits() {
+    return getField7();
+  }
+
+  @Override
+  public SyncAggregate getSyncAggregate() {
+    return getField8();
+  }
+
+  @Override
+  public BeaconBlockBodySchemaAltairImpl getSchema() {
+    return (BeaconBlockBodySchemaAltairImpl) super.getSchema();
+  }
+
+  @Override
+  public Optional<BeaconBlockBodyAltair> toVersionAltair() {
+    return Optional.of(this);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
@@ -23,10 +23,10 @@ import tech.pegasys.teku.ssz.primitive.SszBytes32;
 
 public class BeaconBlockBodyBuilderAltair extends AbstractBeaconBlockBodyBuilder {
 
-  private BeaconBlockBodySchemaAltair schema;
+  private BeaconBlockBodySchemaAltairImpl schema;
   private SyncAggregate syncAggregate;
 
-  public BeaconBlockBodyBuilderAltair schema(final BeaconBlockBodySchemaAltair schema) {
+  public BeaconBlockBodyBuilderAltair schema(final BeaconBlockBodySchemaAltairImpl schema) {
     this.schema = schema;
     return this;
   }
@@ -44,10 +44,10 @@ public class BeaconBlockBodyBuilderAltair extends AbstractBeaconBlockBodyBuilder
     checkNotNull(syncAggregate, "syncAggregate must be specified");
   }
 
-  public BeaconBlockBodyAltair build() {
+  public BeaconBlockBodyAltairImpl build() {
     validate();
 
-    return new BeaconBlockBodyAltair(
+    return new BeaconBlockBodyAltairImpl(
         schema,
         new SszSignature(randaoReveal),
         eth1Data,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltair.java
@@ -15,65 +15,16 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.function.Consumer;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.BlockBodyFields;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.Deposit;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.datastructures.type.SszSignature;
-import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
-import tech.pegasys.teku.ssz.SszList;
-import tech.pegasys.teku.ssz.containers.ContainerSchema9;
-import tech.pegasys.teku.ssz.primitive.SszBytes32;
-import tech.pegasys.teku.ssz.schema.SszListSchema;
-import tech.pegasys.teku.ssz.schema.SszPrimitiveSchemas;
-import tech.pegasys.teku.ssz.tree.TreeNode;
 
-public class BeaconBlockBodySchemaAltair
-    extends ContainerSchema9<
-        BeaconBlockBodyAltair,
-        SszSignature,
-        Eth1Data,
-        SszBytes32,
-        SszList<ProposerSlashing>,
-        SszList<AttesterSlashing>,
-        SszList<Attestation>,
-        SszList<Deposit>,
-        SszList<SignedVoluntaryExit>,
-        SyncAggregate>
-    implements BeaconBlockBodySchema<BeaconBlockBodyAltair> {
+public interface BeaconBlockBodySchemaAltair<T extends BeaconBlockBodyAltair>
+    extends BeaconBlockBodySchema<T> {
 
-  private BeaconBlockBodySchemaAltair(
-      NamedSchema<SszSignature> randaoRevealSchema,
-      NamedSchema<Eth1Data> eth1DataSchema,
-      NamedSchema<SszBytes32> graffitiSchema,
-      NamedSchema<SszList<ProposerSlashing>> proposerSlashingsSchema,
-      NamedSchema<SszList<AttesterSlashing>> attesterSlashingsSchema,
-      NamedSchema<SszList<Attestation>> attestationsSchema,
-      NamedSchema<SszList<Deposit>> depositsSchema,
-      NamedSchema<SszList<SignedVoluntaryExit>> voluntaryExitsSchema,
-      NamedSchema<SyncAggregate> syncAggregateSchema) {
-    super(
-        "BeaconBlockBody",
-        randaoRevealSchema,
-        eth1DataSchema,
-        graffitiSchema,
-        proposerSlashingsSchema,
-        attesterSlashingsSchema,
-        attestationsSchema,
-        depositsSchema,
-        voluntaryExitsSchema,
-        syncAggregateSchema);
-  }
+  static BeaconBlockBodySchemaAltair<? extends BeaconBlockBodyAltair> create(
+      final SpecConfig specConfig) {
 
-  public static BeaconBlockBodySchemaAltair create(final SpecConfig specConfig) {
-    return create(
+    return BeaconBlockBodySchemaAltairImpl.create(
         specConfig.getMaxProposerSlashings(),
         specConfig.getMaxAttesterSlashings(),
         specConfig.getMaxAttestations(),
@@ -82,94 +33,13 @@ public class BeaconBlockBodySchemaAltair
         specConfig.toVersionAltair().orElseThrow().getSyncCommitteeSize());
   }
 
-  private static BeaconBlockBodySchemaAltair create(
-      final long maxProposerSlashings,
-      final long maxAttesterSlashings,
-      final long maxAttestations,
-      final long maxDeposits,
-      final long maxVoluntaryExits,
-      final int syncCommitteeSize) {
-    return new BeaconBlockBodySchemaAltair(
-        namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
-        namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
-        namedSchema(BlockBodyFields.GRAFFITI.name(), SszPrimitiveSchemas.BYTES32_SCHEMA),
-        namedSchema(
-            BlockBodyFields.PROPOSER_SLASHINGS.name(),
-            SszListSchema.create(ProposerSlashing.SSZ_SCHEMA, maxProposerSlashings)),
-        namedSchema(
-            BlockBodyFields.ATTESTER_SLASHINGS.name(),
-            SszListSchema.create(AttesterSlashing.SSZ_SCHEMA, maxAttesterSlashings)),
-        namedSchema(
-            BlockBodyFields.ATTESTATIONS.name(),
-            SszListSchema.create(Attestation.SSZ_SCHEMA, maxAttestations)),
-        namedSchema(
-            BlockBodyFields.DEPOSITS.name(), SszListSchema.create(Deposit.SSZ_SCHEMA, maxDeposits)),
-        namedSchema(
-            BlockBodyFields.VOLUNTARY_EXITS.name(),
-            SszListSchema.create(SignedVoluntaryExit.SSZ_SCHEMA, maxVoluntaryExits)),
-        namedSchema(
-            BlockBodyFields.SYNC_AGGREGATE.name(), SyncAggregateSchema.create(syncCommitteeSize)));
-  }
-
-  public static BeaconBlockBodySchemaAltair required(final BeaconBlockBodySchema<?> schema) {
+  static BeaconBlockBodySchemaAltair<?> required(final BeaconBlockBodySchema<?> schema) {
     checkArgument(
         schema instanceof BeaconBlockBodySchemaAltair,
         "Expected a BeaconBlockBodySchemaAltair but was %s",
         schema.getClass());
-    return (BeaconBlockBodySchemaAltair) schema;
+    return (BeaconBlockBodySchemaAltair<?>) schema;
   }
 
-  @Override
-  public BeaconBlockBodyAltair createBlockBody(final Consumer<BeaconBlockBodyBuilder> bodyBuilder) {
-    final BeaconBlockBodyBuilderAltair bodyContent =
-        new BeaconBlockBodyBuilderAltair().schema(this);
-    // Provide a default empty sync aggregate
-    bodyContent.syncAggregate(getSyncAggregateSchema()::createEmpty);
-    bodyBuilder.accept(bodyContent);
-    return bodyContent.build();
-  }
-
-  @Override
-  public BeaconBlockBodyAltair createEmpty() {
-    return new BeaconBlockBodyAltair(this);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public SszListSchema<ProposerSlashing, ?> getProposerSlashingsSchema() {
-    return (SszListSchema<ProposerSlashing, ?>) getFieldSchema3();
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public SszListSchema<AttesterSlashing, ?> getAttesterSlashingsSchema() {
-    return (SszListSchema<AttesterSlashing, ?>) getFieldSchema4();
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public SszListSchema<Attestation, ?> getAttestationsSchema() {
-    return (SszListSchema<Attestation, ?>) getFieldSchema5();
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public SszListSchema<Deposit, ?> getDepositsSchema() {
-    return (SszListSchema<Deposit, ?>) getFieldSchema6();
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public SszListSchema<SignedVoluntaryExit, ?> getVoluntaryExitsSchema() {
-    return (SszListSchema<SignedVoluntaryExit, ?>) getFieldSchema7();
-  }
-
-  public SyncAggregateSchema getSyncAggregateSchema() {
-    return (SyncAggregateSchema) getFieldSchema8();
-  }
-
-  @Override
-  public BeaconBlockBodyAltair createFromBackingNode(TreeNode node) {
-    return new BeaconBlockBodyAltair(this, node);
-  }
+  SyncAggregateSchema getSyncAggregateSchema();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
+
+import java.util.function.Consumer;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.BlockBodyFields;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+import tech.pegasys.teku.ssz.SszList;
+import tech.pegasys.teku.ssz.containers.ContainerSchema9;
+import tech.pegasys.teku.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.ssz.schema.SszListSchema;
+import tech.pegasys.teku.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.ssz.tree.TreeNode;
+
+public class BeaconBlockBodySchemaAltairImpl
+    extends ContainerSchema9<
+        BeaconBlockBodyAltairImpl,
+        SszSignature,
+        Eth1Data,
+        SszBytes32,
+        SszList<ProposerSlashing>,
+        SszList<AttesterSlashing>,
+        SszList<Attestation>,
+        SszList<Deposit>,
+        SszList<SignedVoluntaryExit>,
+        SyncAggregate>
+    implements BeaconBlockBodySchemaAltair<BeaconBlockBodyAltairImpl> {
+
+  private BeaconBlockBodySchemaAltairImpl(
+      NamedSchema<SszSignature> randaoRevealSchema,
+      NamedSchema<Eth1Data> eth1DataSchema,
+      NamedSchema<SszBytes32> graffitiSchema,
+      NamedSchema<SszList<ProposerSlashing>> proposerSlashingsSchema,
+      NamedSchema<SszList<AttesterSlashing>> attesterSlashingsSchema,
+      NamedSchema<SszList<Attestation>> attestationsSchema,
+      NamedSchema<SszList<Deposit>> depositsSchema,
+      NamedSchema<SszList<SignedVoluntaryExit>> voluntaryExitsSchema,
+      NamedSchema<SyncAggregate> syncAggregateSchema) {
+    super(
+        "BeaconBlockBody",
+        randaoRevealSchema,
+        eth1DataSchema,
+        graffitiSchema,
+        proposerSlashingsSchema,
+        attesterSlashingsSchema,
+        attestationsSchema,
+        depositsSchema,
+        voluntaryExitsSchema,
+        syncAggregateSchema);
+  }
+
+  public static BeaconBlockBodySchemaAltair<? extends BeaconBlockBodyAltair> create(
+      final SpecConfig specConfig) {
+    return create(
+        specConfig.getMaxProposerSlashings(),
+        specConfig.getMaxAttesterSlashings(),
+        specConfig.getMaxAttestations(),
+        specConfig.getMaxDeposits(),
+        specConfig.getMaxVoluntaryExits(),
+        specConfig.toVersionAltair().orElseThrow().getSyncCommitteeSize());
+  }
+
+  static BeaconBlockBodySchemaAltair<? extends BeaconBlockBodyAltair> create(
+      final long maxProposerSlashings,
+      final long maxAttesterSlashings,
+      final long maxAttestations,
+      final long maxDeposits,
+      final long maxVoluntaryExits,
+      final int syncCommitteeSize) {
+    return new BeaconBlockBodySchemaAltairImpl(
+        namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
+        namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
+        namedSchema(BlockBodyFields.GRAFFITI.name(), SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(
+            BlockBodyFields.PROPOSER_SLASHINGS.name(),
+            SszListSchema.create(ProposerSlashing.SSZ_SCHEMA, maxProposerSlashings)),
+        namedSchema(
+            BlockBodyFields.ATTESTER_SLASHINGS.name(),
+            SszListSchema.create(AttesterSlashing.SSZ_SCHEMA, maxAttesterSlashings)),
+        namedSchema(
+            BlockBodyFields.ATTESTATIONS.name(),
+            SszListSchema.create(Attestation.SSZ_SCHEMA, maxAttestations)),
+        namedSchema(
+            BlockBodyFields.DEPOSITS.name(), SszListSchema.create(Deposit.SSZ_SCHEMA, maxDeposits)),
+        namedSchema(
+            BlockBodyFields.VOLUNTARY_EXITS.name(),
+            SszListSchema.create(SignedVoluntaryExit.SSZ_SCHEMA, maxVoluntaryExits)),
+        namedSchema(
+            BlockBodyFields.SYNC_AGGREGATE.name(), SyncAggregateSchema.create(syncCommitteeSize)));
+  }
+
+  @Override
+  public BeaconBlockBodyAltairImpl createBlockBody(
+      final Consumer<BeaconBlockBodyBuilder> bodyBuilder) {
+    final BeaconBlockBodyBuilderAltair bodyContent =
+        new BeaconBlockBodyBuilderAltair().schema(this);
+    // Provide a default empty sync aggregate
+    bodyContent.syncAggregate(getSyncAggregateSchema()::createEmpty);
+    bodyBuilder.accept(bodyContent);
+    return bodyContent.build();
+  }
+
+  @Override
+  public BeaconBlockBodyAltairImpl createEmpty() {
+    return new BeaconBlockBodyAltairImpl(this);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<ProposerSlashing, ?> getProposerSlashingsSchema() {
+    return (SszListSchema<ProposerSlashing, ?>) getFieldSchema3();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<AttesterSlashing, ?> getAttesterSlashingsSchema() {
+    return (SszListSchema<AttesterSlashing, ?>) getFieldSchema4();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<Attestation, ?> getAttestationsSchema() {
+    return (SszListSchema<Attestation, ?>) getFieldSchema5();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<Deposit, ?> getDepositsSchema() {
+    return (SszListSchema<Deposit, ?>) getFieldSchema6();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszListSchema<SignedVoluntaryExit, ?> getVoluntaryExitsSchema() {
+    return (SszListSchema<SignedVoluntaryExit, ?>) getFieldSchema7();
+  }
+
+  @Override
+  public SyncAggregateSchema getSyncAggregateSchema() {
+    return (SyncAggregateSchema) getFieldSchema8();
+  }
+
+  @Override
+  public BeaconBlockBodyAltairImpl createFromBackingNode(TreeNode node) {
+    return new BeaconBlockBodyAltairImpl(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.B
 
 public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   private final BeaconStateSchemaAltair beaconStateSchema;
-  private final BeaconBlockBodySchemaAltair beaconBlockBodySchema;
+  private final BeaconBlockBodySchemaAltair<?> beaconBlockBodySchema;
   private final BeaconBlockSchema beaconBlockSchema;
   private final SignedBeaconBlockSchema signedBeaconBlockSchema;
   private final SyncCommitteeContributionSchema syncCommitteeContributionSchema;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
 
   protected abstract T createBlockBody(final Consumer<BeaconBlockBodyBuilder> contentProvider);
 
-  protected abstract BeaconBlockBodySchema<T> getBlockBodySchema();
+  protected abstract BeaconBlockBodySchema<? extends T> getBlockBodySchema();
 
   protected T createDefaultBlockBody() {
     return createBlockBody();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
@@ -43,7 +43,7 @@ class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockB
   }
 
   @Override
-  protected BeaconBlockBodySchema<BeaconBlockBodyAltair> getBlockBodySchema() {
+  protected BeaconBlockBodySchema<? extends BeaconBlockBodyAltair> getBlockBodySchema() {
     return BeaconBlockBodySchemaAltair.create(spec.getGenesisSpecConfig());
   }
 }


### PR DESCRIPTION
## PR Description

Updates Altair classes in `tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair` to be ready for being the base for Merge datastructures.

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
