### PR TITLE
Update discovery to handle timed out handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 
 ### Bug Fixes
+- Fixed issue where discovery did not correctly abort handshake attempts when a request timed out.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -149,7 +149,7 @@ dependencyManagement {
     dependency "org.testcontainers:testcontainers:1.15.3"
     dependency "org.testcontainers:junit-jupiter:1.15.3"
 
-    dependency 'tech.pegasys.discovery:discovery:0.5.0'
+    dependency 'tech.pegasys.discovery:discovery:21.10.0'
 
     dependency 'tech.pegasys.signers.internal:bls-keystore:1.0.15'
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -51,9 +51,7 @@ import tech.pegasys.teku.storage.store.KeyValueStore;
 public class DiscV5Service extends Service implements DiscoveryService {
   private static final Logger LOG = LogManager.getLogger();
   private static final String SEQ_NO_STORE_KEY = "local-enr-seqno";
-  // Currently must be longer than the 3 minute NodeSession timeout in discovery
-  // See https://github.com/ConsenSys/teku/pull/4490
-  private static final Duration BOOTNODE_REFRESH_DELAY = Duration.ofMinutes(4);
+  private static final Duration BOOTNODE_REFRESH_DELAY = Duration.ofMinutes(2);
   private final AsyncRunner asyncRunner;
   private final Bytes localNodePrivateKey;
   private final SchemaDefinitionsSupplier currentSchemaDefinitionsSupplier;


### PR DESCRIPTION
## PR Description
Updates discovery to include proper fix for timed out handshake process.

Reduce the ping time for bootnodes back down as there is no longer a need to wait for the discovery session to time out.

## Fixed Issue(s)
fixes #4482 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
