### PR TITLE
Rollback to jblst 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fixed issue where discovery did not correctly abort handshake attempts when a request timed out.
+- Downgrade to jbslt 0.3.5 to resolve incompatibility with Windows 10.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -42,7 +42,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
     dependency 'io.libp2p:jvm-libp2p-minimal:0.8.3-RELEASE'
-    dependency 'tech.pegasys:jblst:0.3.6'
+    dependency 'tech.pegasys:jblst:0.3.5'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'
 


### PR DESCRIPTION
## PR Description
Rollback to jblst 0.3.5.  0.3.6 is failing to load on Windows 10.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
