### PR TITLE
Remove + from branch docker version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -741,7 +741,7 @@ task cloudsmithUpload {
 
 task dockerUpload {
   dependsOn([distDocker])
-  def dockerBuildVersion = "${rootProject.version}"
+  def dockerBuildVersion = "${rootProject.version}".replace('+', '-')
   def imageName = "consensys/teku"
   def image = "${imageName}:${dockerBuildVersion}"
 


### PR DESCRIPTION
## PR Description
Docker hub does not allow `+` in docker tags. When building on a release branch the publish version is `<branch>+develop` which doesn't work.  Fix this by replacing the `+` with a `-` in the docker published version.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
