### PR TITLE
[Altair] fix sync commitee duties calculation on startup

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -150,7 +150,15 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
       final UInt64 slot,
       final Bytes32 previousDutyDependentRoot,
       final Bytes32 currentDutyDependentRoot,
-      final Bytes32 headBlockRoot) {}
+      final Bytes32 headBlockRoot) {
+
+    // recalculation of sync committee duties at the slot prior to the altair fork activation slot
+    if (spec.getSyncCommitteeUtil(slot).isEmpty()
+        && spec.getSyncCommitteeUtil(slot.plus(1)).isPresent()) {
+      currentSyncCommitteePeriod.ifPresent(SyncCommitteePeriod::recalculate);
+      nextSyncCommitteePeriod.ifPresent(SyncCommitteePeriod::recalculate);
+    }
+  }
 
   @Override
   public void onChainReorg(final UInt64 newSlot, final UInt64 commonAncestorSlot) {}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -152,9 +152,8 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
       final Bytes32 currentDutyDependentRoot,
       final Bytes32 headBlockRoot) {
 
-    // recalculation of sync committee duties at the slot prior to the altair fork activation slot
-    if (spec.getSyncCommitteeUtil(slot).isEmpty()
-        && spec.getSyncCommitteeUtil(slot.plus(1)).isPresent()) {
+    // recalculation of sync committee duties on every new block prior to the altair fork activation
+    if (spec.getSyncCommitteeUtil(slot).isEmpty()) {
       currentSyncCommitteePeriod.ifPresent(SyncCommitteePeriod::recalculate);
       nextSyncCommitteePeriod.ifPresent(SyncCommitteePeriod::recalculate);
     }


### PR DESCRIPTION
## PR Description

this fixes an issue discovered in Pithos testnet, that may happen at startup of a validator, and could last until the end of the committee period.

```
java.lang.IllegalArgumentException: Invalid contribution and proofs: ;Rejecting proof because aggregator index 31579 is not in the current sync subcommittee;Rejecting proof because aggregator index 31580 is not in the current sync subcommittee
```

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
