### PR TITLE
Remove unused fields from Constants

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.teku.util.config.Constants.MAX_DEPOSITS;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,8 +62,7 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
           dataStructureUtil.randomAttestation(),
           dataStructureUtil.randomAttestation());
   protected SszList<Deposit> deposits =
-      blockBodyLists.createDeposits(
-          dataStructureUtil.randomDeposits(MAX_DEPOSITS).toArray(new Deposit[0]));
+      blockBodyLists.createDeposits(dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
   protected SszList<SignedVoluntaryExit> voluntaryExits =
       blockBodyLists.createVoluntaryExits(
           dataStructureUtil.randomSignedVoluntaryExit(),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/StatusMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/StatusMessageTest.java
@@ -19,14 +19,14 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.util.config.Constants;
+import tech.pegasys.teku.ssz.type.Bytes4;
 
 class StatusMessageTest {
   @Test
   public void shouldRoundTripViaSsz() {
     final StatusMessage message =
         new StatusMessage(
-            Constants.GENESIS_FORK_VERSION,
+            Bytes4.leftPad(Bytes.EMPTY),
             Bytes32.fromHexStringLenient("0x01"),
             UInt64.valueOf(2),
             Bytes32.fromHexStringLenient("0x03"),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtilTest.java
@@ -55,6 +55,7 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.ssz.type.Bytes4;
 import tech.pegasys.teku.util.config.Constants;
 
 @ExtendWith(BouncyCastleExtension.class)
@@ -358,8 +359,8 @@ class BeaconStateUtilTest {
               beaconState.setSlot(dataStructureUtil.randomUInt64());
               beaconState.setFork(
                   new Fork(
-                      Constants.GENESIS_FORK_VERSION,
-                      Constants.GENESIS_FORK_VERSION,
+                      Bytes4.leftPad(Bytes.EMPTY),
+                      Bytes4.leftPad(Bytes.EMPTY),
                       SpecConfig.GENESIS_EPOCH));
 
               List<Validator> validatorList =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/BeaconStateUtilTest.java
@@ -55,7 +55,6 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.ssz.type.Bytes4;
 import tech.pegasys.teku.util.config.Constants;
 
 @ExtendWith(BouncyCastleExtension.class)
@@ -359,8 +358,8 @@ class BeaconStateUtilTest {
               beaconState.setSlot(dataStructureUtil.randomUInt64());
               beaconState.setFork(
                   new Fork(
-                      Bytes4.leftPad(Bytes.EMPTY),
-                      Bytes4.leftPad(Bytes.EMPTY),
+                      spec.getGenesisSpecConfig().getGenesisForkVersion(),
+                      spec.getGenesisSpecConfig().getGenesisForkVersion(),
                       SpecConfig.GENESIS_EPOCH));
 
               List<Validator> validatorList =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -40,7 +40,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.ssz.schema.SszListSchema;
-import tech.pegasys.teku.util.config.Constants;
 
 /**
  * Maintains a pool of attestations. Attestations can be retrieved either for inclusion in a block
@@ -51,7 +50,7 @@ import tech.pegasys.teku.util.config.Constants;
 public class AggregatingAttestationPool implements SlotEventsChannel {
   static final long ATTESTATION_RETENTION_EPOCHS = 2;
   private static final SszListSchema<Attestation, ?> ATTESTATIONS_SCHEMA =
-      SszListSchema.create(Attestation.SSZ_SCHEMA, Constants.MAX_ATTESTATIONS);
+      SszListSchema.create(Attestation.SSZ_SCHEMA, 128);
 
   private final Map<Bytes, MatchingDataAttestationGroup> attestationGroupByDataHash =
       new HashMap<>();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -231,7 +231,6 @@ class AggregatingAttestationPoolTest {
   @Test
   public void getAttestationsForBlock_shouldNotAddMoreAttestationsThanAllowedInBlock() {
     final BeaconState state = dataStructureUtil.randomBeaconState();
-    Constants.MAX_ATTESTATIONS = 2;
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final Attestation attestation1 = addAttestationFromValidators(attestationData, 1, 2, 3, 4);
     final Attestation attestation2 = addAttestationFromValidators(attestationData, 2, 5);

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/AbstractSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/AbstractSyncTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
@@ -35,9 +36,9 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.ssz.type.Bytes4;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.util.config.Constants;
 
 public abstract class AbstractSyncTest {
   protected final Spec spec = TestSpecFactory.createDefault();
@@ -94,7 +95,7 @@ public abstract class AbstractSyncTest {
     final PeerStatus peer_status =
         PeerStatus.fromStatusMessage(
             new StatusMessage(
-                Constants.GENESIS_FORK_VERSION,
+                Bytes4.leftPad(Bytes.EMPTY),
                 Bytes32.ZERO,
                 peerFinalizedEpoch,
                 peerHeadBlockRoot,

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/PeerSyncTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/PeerSyncTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.ssz.type.Bytes4;
 import tech.pegasys.teku.util.config.Constants;
 
 public class PeerSyncTest extends AbstractSyncTest {
@@ -59,7 +61,7 @@ public class PeerSyncTest extends AbstractSyncTest {
   private static final PeerStatus PEER_STATUS =
       PeerStatus.fromStatusMessage(
           new StatusMessage(
-              Constants.GENESIS_FORK_VERSION,
+              Bytes4.leftPad(Bytes.EMPTY),
               Bytes32.ZERO,
               PEER_FINALIZED_EPOCH,
               PEER_HEAD_BLOCK_ROOT,
@@ -552,7 +554,7 @@ public class PeerSyncTest extends AbstractSyncTest {
     final PeerStatus peer_status =
         PeerStatus.fromStatusMessage(
             new StatusMessage(
-                Constants.GENESIS_FORK_VERSION,
+                Bytes4.leftPad(Bytes.EMPTY),
                 Bytes32.ZERO,
                 finalizedEpoch,
                 PEER_HEAD_BLOCK_ROOT,

--- a/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/SyncManagerTest.java
+++ b/sync/src/test/java/tech/pegasys/teku/sync/forward/singlepeer/SyncManagerTest.java
@@ -25,6 +25,7 @@ import static tech.pegasys.teku.spec.datastructures.util.BeaconStateUtil.compute
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
+import tech.pegasys.teku.ssz.type.Bytes4;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.sync.events.SyncingStatus;
 import tech.pegasys.teku.sync.forward.ForwardSync.SyncSubscriber;
@@ -53,7 +55,7 @@ public class SyncManagerTest {
   private static final PeerStatus PEER_STATUS =
       PeerStatus.fromStatusMessage(
           new StatusMessage(
-              Constants.GENESIS_FORK_VERSION,
+              Bytes4.leftPad(Bytes.EMPTY),
               Bytes32.ZERO,
               PEER_FINALIZED_EPOCH,
               PEER_HEAD_BLOCK_ROOT,

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -56,9 +56,6 @@ public class Constants {
   @Deprecated public static UInt64 EJECTION_BALANCE;
   @Deprecated public static UInt64 EFFECTIVE_BALANCE_INCREMENT;
 
-  // Initial values
-  @Deprecated public static Bytes4 GENESIS_FORK_VERSION = Bytes4.fromHexString("0x00000000");
-
   // Time parameters
   @Deprecated public static UInt64 GENESIS_DELAY;
   @Deprecated public static int SECONDS_PER_SLOT = 12;

--- a/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/Constants.java
@@ -15,25 +15,13 @@ package tech.pegasys.teku.util.config;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.ssz.type.Bytes4;
 
 public class Constants {
 
   public static final ImmutableList<String> NETWORK_DEFINITIONS =
       ImmutableList.of("mainnet", "minimal", "swift", "pyrmont", "prater", "less-swift");
-
-  @Deprecated public static final UInt64 BASE_REWARDS_PER_EPOCH = UInt64.valueOf(4);
-  @Deprecated public static final int DEPOSIT_CONTRACT_TREE_DEPTH = 32;
-  @Deprecated public static final int JUSTIFICATION_BITS_LENGTH = 4;
-
-  // Phase0 constants which may exist in legacy config files, but are no longer configurable
-  @Deprecated public static final Bytes BLS_WITHDRAWAL_PREFIX = Bytes.fromHexString("0x00");
-  @Deprecated public static final int TARGET_AGGREGATORS_PER_COMMITTEE = 16;
-  @Deprecated public static final int RANDOM_SUBNETS_PER_VALIDATOR = 1;
-  @Deprecated public static final int EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION = 256;
 
   // Misc
   @Deprecated public static UInt64 ETH1_FOLLOW_DISTANCE = UInt64.valueOf(1024);
@@ -75,33 +63,15 @@ public class Constants {
   @Deprecated public static int HISTORICAL_ROOTS_LIMIT;
   @Deprecated public static long VALIDATOR_REGISTRY_LIMIT;
 
-  // Reward and penalty quotients
-  @Deprecated public static int BASE_REWARD_FACTOR;
   @Deprecated public static int WHISTLEBLOWER_REWARD_QUOTIENT;
   @Deprecated public static UInt64 PROPOSER_REWARD_QUOTIENT;
-  @Deprecated public static UInt64 INACTIVITY_PENALTY_QUOTIENT;
   @Deprecated public static int MIN_SLASHING_PENALTY_QUOTIENT;
-
-  // Max transactions per block
-  @Deprecated public static int MAX_PROPOSER_SLASHINGS;
-  @Deprecated public static int MAX_ATTESTER_SLASHINGS;
-  @Deprecated public static int MAX_ATTESTATIONS;
-  @Deprecated public static int MAX_DEPOSITS;
-  @Deprecated public static int MAX_VOLUNTARY_EXITS = 16;
 
   // Validator
   @Deprecated public static UInt64 SECONDS_PER_ETH1_BLOCK = UInt64.valueOf(14L);
 
-  // Fork Choice
-  @Deprecated public static int SAFE_SLOTS_TO_UPDATE_JUSTIFIED = 8;
-
   // Deposit Contract
   @Deprecated public static int DEPOSIT_CHAIN_ID;
-  @Deprecated public static int DEPOSIT_NETWORK_ID;
-
-  @Deprecated
-  public static Bytes DEPOSIT_CONTRACT_ADDRESS =
-      Bytes.fromHexString("0x1234567890123456789012345678901234567890");
 
   // Networking
   public static final int GOSSIP_MAX_SIZE = 1048576; // bytes

--- a/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
@@ -67,7 +67,24 @@ class ConstantsReader {
           "DOMAIN_SELECTION_PROOF",
           "DOMAIN_AGGREGATE_AND_PROOF",
           // Removed from Constants (only available through SpecConfig)
-          "GENESIS_FORK_VERSION");
+          "GENESIS_FORK_VERSION",
+          "BASE_REWARDS_PER_EPOCH",
+          "DEPOSIT_CONTRACT_TREE_DEPTH",
+          "JUSTIFICATION_BITS_LENGTH",
+          "BLS_WITHDRAWAL_PREFIX",
+          "TARGET_AGGREGATORS_PER_COMMITTEE",
+          "RANDOM_SUBNETS_PER_VALIDATOR",
+          "EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION",
+          "BASE_REWARD_FACTOR",
+          "INACTIVITY_PENALTY_QUOTIENT",
+          "MAX_PROPOSER_SLASHINGS",
+          "MAX_ATTESTER_SLASHINGS",
+          "MAX_ATTESTATIONS",
+          "MAX_DEPOSITS",
+          "MAX_VOLUNTARY_EXITS",
+          "SAFE_SLOTS_TO_UPDATE_JUSTIFIED",
+          "DEPOSIT_NETWORK_ID",
+          "DEPOSIT_CONTRACT_ADDRESS");
 
   private static final ImmutableMap<Class<?>, Function<Object, ?>> PARSERS =
       ImmutableMap.<Class<?>, Function<Object, ?>>builder()

--- a/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
+++ b/util/src/main/java/tech/pegasys/teku/util/config/ConstantsReader.java
@@ -32,7 +32,6 @@ import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.resource.ResourceLoader;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.ssz.type.Bytes4;
 
 class ConstantsReader {
   private static final ImmutableList<String> PRESETS = ImmutableList.of("mainnet", "minimal");
@@ -66,7 +65,9 @@ class ConstantsReader {
           "DOMAIN_DEPOSIT",
           "DOMAIN_VOLUNTARY_EXIT",
           "DOMAIN_SELECTION_PROOF",
-          "DOMAIN_AGGREGATE_AND_PROOF");
+          "DOMAIN_AGGREGATE_AND_PROOF",
+          // Removed from Constants (only available through SpecConfig)
+          "GENESIS_FORK_VERSION");
 
   private static final ImmutableMap<Class<?>, Function<Object, ?>> PARSERS =
       ImmutableMap.<Class<?>, Function<Object, ?>>builder()
@@ -75,7 +76,6 @@ class ConstantsReader {
           .put(UInt64.class, toString(UInt64::valueOf))
           .put(String.class, Function.identity())
           .put(Bytes.class, toString(Bytes::fromHexString))
-          .put(Bytes4.class, toString(Bytes4::fromHexString))
           .put(boolean.class, toString(Boolean::valueOf))
           .build();
 


### PR DESCRIPTION
## PR Description
Remove unused fields from `Constants`. Also means we can remove the ability to parse `Bytes4` from `ConstantsReader`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
