### PR TITLE
Set default `--Xvalidators-batch-attestations-enabled` to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Support v.2.1.0 of the standard rest api. it should be noted that the 'version' has been changed to lower case to comply with the api specification.
+- Changed default value for `--Xvalidators-batch-attestations-enabled` to `true` to reduce load on the beacon node and avoid queuing requests.
 
 ### Bug Fixes
 - Fixed issue where discovery did not correctly abort handshake attempts when a request timed out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Support v.2.1.0 of the standard rest api. it should be noted that the 'version' has been changed to lower case to comply with the api specification.
-- Changed default value for `--Xvalidators-batch-attestations-enabled` to `true` to reduce load on the beacon node and avoid queuing requests.
+- Attestations are now sent to the beacon node in batches by default when using the validator-client.
 
 ### Bug Fixes
 - Fixed issue where discovery did not correctly abort handshake attempts when a request timed out.

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -110,11 +110,11 @@ public class ValidatorOptions {
       names = {"--Xvalidators-batch-attestations-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Send all attestations for a slot to the beacon node in a single batch. Default: false",
+          "Send all attestations for a slot to the beacon node in a single batch. Default: true",
       fallbackValue = "true",
       hidden = true,
       arity = "0..1")
-  private boolean sendAttestationsAsBatch = false;
+  private boolean sendAttestationsAsBatch = true;
 
   @Option(
       names = {"--Xvalidators-publish-to-additional-nodes"},

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -94,10 +94,10 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  void shouldDisableSendAttestationsAsBatchByDefault() {
+  void shouldEnableSendAttestationsAsBatchByDefault() {
     final ValidatorConfig config =
         getTekuConfigurationFromArguments().validatorClient().getValidatorConfig();
-    assertThat(config.sendAttestationsAsBatch()).isFalse();
+    assertThat(config.sendAttestationsAsBatch()).isTrue();
   }
 
   @Test

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -183,7 +183,7 @@ public class ValidatorConfig {
     private boolean validatorExternalSignerSlashingProtectionEnabled = true;
     private boolean useDependentRoots = false;
     private boolean generateEarlyAttestations = true;
-    private boolean sendAttestationsAsBatch = false;
+    private boolean sendAttestationsAsBatch = true;
 
     private Builder() {}
 


### PR DESCRIPTION
## PR Description
Changing the default value for `--Xvalidators-batch-attestations-enabled` to `true` to reduce the load on the beacon node.
fixed #4487 

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
