### PR TITLE
Use Store time in flip/flop attack prevention

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "transition";
+  private static final String TEST_TYPE = "fork_choice/on_block";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "minimal";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -50,9 +50,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/get_head", new ForkChoiceTestExecutor())
           .put(
               "fork_choice/on_block",
-              new ForkChoiceTestExecutor(
-                  "new_finalized_slot_is_justified_checkpoint_ancestor",
-                  "new_justified_is_later_than_store_justified"))
+              new ForkChoiceTestExecutor("new_finalized_slot_is_justified_checkpoint_ancestor"))
           .build();
 
   private List<?> testsToSkip;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -452,11 +452,10 @@ public class ForkChoiceUtil {
 
   private boolean shouldUpdateJustifiedCheckpoint(
       ReadOnlyStore store,
-      Checkpoint new_justified_checkpoint,
+      Checkpoint newJustifiedCheckpoint,
       ReadOnlyForkChoiceStrategy forkChoiceStrategy) {
-    if (computeSlotsSinceEpochStart(getCurrentSlot(store, true))
-            .compareTo(UInt64.valueOf(specConfig.getSafeSlotsToUpdateJustified()))
-        < 0) {
+    if (computeSlotsSinceEpochStart(getCurrentSlot(store))
+        .isLessThan(specConfig.getSafeSlotsToUpdateJustified())) {
       return true;
     }
 
@@ -464,7 +463,7 @@ public class ForkChoiceUtil {
         miscHelpers.computeStartSlotAtEpoch(store.getJustifiedCheckpoint().getEpoch());
     return hasAncestorAtSlot(
         forkChoiceStrategy,
-        new_justified_checkpoint.getRoot(),
+        newJustifiedCheckpoint.getRoot(),
         justifiedSlot,
         store.getJustifiedCheckpoint().getRoot());
   }

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ProtoArray.java
@@ -149,7 +149,7 @@ public class ProtoArray {
         || !this.finalizedEpoch.equals(finalizedEpoch)) {
       this.justifiedEpoch = justifiedEpoch;
       this.finalizedEpoch = finalizedEpoch;
-      // Justified or finalized epoch changed we we have to re-evaluate all best descendants.
+      // Justified or finalized epoch changed so we have to re-evaluate all best descendants.
       applyToNodes(this::updateBestDescendantOfParent);
     }
     int justifiedIndex =


### PR DESCRIPTION
## PR Description
Use time from store instead of system time when checking if justified checkpoint should be updated.

Fixes intermittency in new_justified_is_later_than_store_justified and makes time handling more consistent.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
