### PR TITLE
[Altair] Remove empty `syncAggregate` creation in Altair block creation

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.api.response.v1.SyncStateChangeEvent;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -95,7 +96,7 @@ public class EventSubscriptionManagerTest {
 
   private final SyncState sampleSyncState = SyncState.IN_SYNC;
   private final SignedBeaconBlock sampleBlock =
-      new SignedBeaconBlock(data.randomSignedBeaconBlock(0));
+      new SignedBeaconBlockAltair(data.randomSignedBeaconBlock(0));
   private final Attestation sampleAttestation = new Attestation(data.randomAttestation(0));
   private final SignedVoluntaryExit sampleVoluntaryExit =
       new SignedVoluntaryExit(data.randomSignedVoluntaryExit());

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SignedBeaconBlock.java
@@ -49,7 +49,7 @@ public class SignedBeaconBlock implements SignedBlock {
   public tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock asInternalSignedBeaconBlock(
       final Spec spec) {
     final tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock beaconBlock =
-        message.asInternalBeaconBlock(spec);
+        getMessage().asInternalBeaconBlock(spec);
     return tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock.create(
         spec, beaconBlock, signature.asInternalBLSSignature());
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockAltair.java
@@ -19,9 +19,31 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.interfaces.UnsignedBlock;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
 public class BeaconBlockAltair extends BeaconBlock implements UnsignedBlock {
   private final BeaconBlockBodyAltair body;
+
+  public BeaconBlockAltair(tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock message) {
+    super(message);
+    this.body = new BeaconBlockBodyAltair(message.getBody().toVersionAltair().orElseThrow());
+  }
+
+  @Override
+  public tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock asInternalBeaconBlock(
+      final Spec spec) {
+    final SpecVersion specVersion = spec.atSlot(slot);
+    return SchemaDefinitionsAltair.required(specVersion.getSchemaDefinitions())
+        .getBeaconBlockSchema()
+        .create(
+            slot,
+            proposer_index,
+            parent_root,
+            state_root,
+            body.asInternalBeaconBlockBody(specVersion));
+  }
 
   @JsonProperty("body")
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
-import tech.pegasys.teku.spec.Spec;
 
 public class SignedBeaconBlockAltair extends SignedBeaconBlock implements SignedBlock {
   private final BeaconBlockAltair message;
@@ -27,15 +26,6 @@ public class SignedBeaconBlockAltair extends SignedBeaconBlock implements Signed
       tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
     super(internalBlock);
     this.message = new BeaconBlockAltair(internalBlock.getMessage());
-  }
-
-  @Override
-  public tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock asInternalSignedBeaconBlock(
-      final Spec spec) {
-    final tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock beaconBlock =
-        message.asInternalBeaconBlock(spec);
-    return tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock.create(
-        spec, beaconBlock, signature.asInternalBLSSignature());
   }
 
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/SignedBeaconBlockAltair.java
@@ -18,9 +18,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
+import tech.pegasys.teku.spec.Spec;
 
 public class SignedBeaconBlockAltair extends SignedBeaconBlock implements SignedBlock {
   private final BeaconBlockAltair message;
+
+  public SignedBeaconBlockAltair(
+      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
+    super(internalBlock);
+    this.message = new BeaconBlockAltair(internalBlock.getMessage());
+  }
+
+  @Override
+  public tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock asInternalSignedBeaconBlock(
+      final Spec spec) {
+    final tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock beaconBlock =
+        message.asInternalBeaconBlock(spec);
+    return tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock.create(
+        spec, beaconBlock, signature.asInternalBLSSignature());
+  }
 
   @Override
   public BeaconBlockAltair getMessage() {

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -36,14 +36,17 @@ import tech.pegasys.teku.spec.datastructures.util.BeaconBlockBodyLists;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.SszList;
 
 public class BlockProposalTestUtil {
   private final Spec spec;
+  private final DataStructureUtil dataStructureUtil;
   private final BeaconBlockBodyLists blockBodyLists;
 
   public BlockProposalTestUtil(final Spec spec) {
     this.spec = spec;
+    this.dataStructureUtil = new DataStructureUtil(spec);
     blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
   }
 
@@ -79,7 +82,11 @@ public class BlockProposalTestUtil {
                     .proposerSlashings(slashings)
                     .attesterSlashings(blockBodyLists.createAttesterSlashings())
                     .deposits(deposits)
-                    .voluntaryExits(exits));
+                    .voluntaryExits(exits)
+                    .syncAggregate(
+                        () ->
+                            dataStructureUtil.randomSyncAggregateIfRequiredByState(
+                                blockSlotState)));
 
     // Sign block and set block signature
     final BeaconBlock block = newBlockAndState.getBlock();

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/BlockProposalTestUtil.java
@@ -85,8 +85,7 @@ public class BlockProposalTestUtil {
                     .voluntaryExits(exits)
                     .syncAggregate(
                         () ->
-                            dataStructureUtil.randomSyncAggregateIfRequiredByState(
-                                blockSlotState)));
+                            dataStructureUtil.emptySyncAggregateIfRequiredByState(blockSlotState)));
 
     // Sign block and set block signature
     final BeaconBlock block = newBlockAndState.getBlock();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
@@ -113,8 +113,6 @@ public class BeaconBlockBodySchemaAltairImpl
   @Override
   public BeaconBlockBody createBlockBody(final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
     final BeaconBlockBodyBuilderAltair builder = new BeaconBlockBodyBuilderAltair().schema(this);
-    // Provide a default empty sync aggregate
-    builder.syncAggregate(getSyncAggregateSchema()::createEmpty);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodySchemaMergeImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodySchemaMergeImpl.java
@@ -110,8 +110,6 @@ class BeaconBlockBodySchemaMergeImpl
   @Override
   public BeaconBlockBody createBlockBody(final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
     final BeaconBlockBodyBuilderMerge builder = new BeaconBlockBodyBuilderMerge().schema(this);
-    // Provide a default empty sync aggregate
-    builder.syncAggregate(getSyncAggregateSchema()::createEmpty);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -70,30 +70,31 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
 
   @BeforeEach
   void setUpBaseClass() {
-    if(!isSetUp) {
+    if (!isSetUp) {
       isSetUp = true;
 
       BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
       executionPayload = dataStructureUtil.randomExecutionPayload();
       voluntaryExits =
-              blockBodyLists.createVoluntaryExits(
-                      dataStructureUtil.randomSignedVoluntaryExit(),
-                      dataStructureUtil.randomSignedVoluntaryExit(),
-                      dataStructureUtil.randomSignedVoluntaryExit());
+          blockBodyLists.createVoluntaryExits(
+              dataStructureUtil.randomSignedVoluntaryExit(),
+              dataStructureUtil.randomSignedVoluntaryExit(),
+              dataStructureUtil.randomSignedVoluntaryExit());
       deposits =
-              blockBodyLists.createDeposits(dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
+          blockBodyLists.createDeposits(
+              dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
       attestations =
-              blockBodyLists.createAttestations(
-                      dataStructureUtil.randomAttestation(),
-                      dataStructureUtil.randomAttestation(),
-                      dataStructureUtil.randomAttestation());
+          blockBodyLists.createAttestations(
+              dataStructureUtil.randomAttestation(),
+              dataStructureUtil.randomAttestation(),
+              dataStructureUtil.randomAttestation());
       attesterSlashings =
-              blockBodyLists.createAttesterSlashings(dataStructureUtil.randomAttesterSlashing());
+          blockBodyLists.createAttesterSlashings(dataStructureUtil.randomAttesterSlashing());
       proposerSlashings =
-              blockBodyLists.createProposerSlashings(
-                      dataStructureUtil.randomProposerSlashing(),
-                      dataStructureUtil.randomProposerSlashing(),
-                      dataStructureUtil.randomProposerSlashing());
+          blockBodyLists.createProposerSlashings(
+              dataStructureUtil.randomProposerSlashing(),
+              dataStructureUtil.randomProposerSlashing(),
+              dataStructureUtil.randomProposerSlashing());
       graffiti = dataStructureUtil.randomBytes32();
       eth1Data = dataStructureUtil.randomEth1Data();
       randaoReveal = dataStructureUtil.randomSignature();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -42,34 +43,39 @@ import tech.pegasys.teku.ssz.SszData;
 import tech.pegasys.teku.ssz.SszList;
 
 public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
-  protected final Spec spec = TestSpecFactory.createMinimalPhase0();
-  private final BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
+  protected final Spec specPhase0 = TestSpecFactory.createMinimalPhase0();
+  protected final Spec specAltair = TestSpecFactory.createMinimalAltair();
+  protected final Spec specMerge = TestSpecFactory.createMinimalMerge();
+  private final BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(specPhase0);
 
-  protected final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  protected final DataStructureUtil dataStructureUtilPhase0 = new DataStructureUtil(specPhase0);
+  protected final DataStructureUtil dataStructureUtilAltair = new DataStructureUtil(specAltair);
 
-  protected BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-  protected Eth1Data eth1Data = dataStructureUtil.randomEth1Data();
-  protected Bytes32 graffiti = dataStructureUtil.randomBytes32();
+  protected BLSSignature randaoReveal = dataStructureUtilPhase0.randomSignature();
+  protected Eth1Data eth1Data = dataStructureUtilPhase0.randomEth1Data();
+  protected Bytes32 graffiti = dataStructureUtilPhase0.randomBytes32();
   protected SszList<ProposerSlashing> proposerSlashings =
       blockBodyLists.createProposerSlashings(
-          dataStructureUtil.randomProposerSlashing(),
-          dataStructureUtil.randomProposerSlashing(),
-          dataStructureUtil.randomProposerSlashing());
+          dataStructureUtilPhase0.randomProposerSlashing(),
+          dataStructureUtilPhase0.randomProposerSlashing(),
+          dataStructureUtilPhase0.randomProposerSlashing());
   protected SszList<AttesterSlashing> attesterSlashings =
-      blockBodyLists.createAttesterSlashings(dataStructureUtil.randomAttesterSlashing());
+      blockBodyLists.createAttesterSlashings(dataStructureUtilPhase0.randomAttesterSlashing());
   protected SszList<Attestation> attestations =
       blockBodyLists.createAttestations(
-          dataStructureUtil.randomAttestation(),
-          dataStructureUtil.randomAttestation(),
-          dataStructureUtil.randomAttestation());
+          dataStructureUtilPhase0.randomAttestation(),
+          dataStructureUtilPhase0.randomAttestation(),
+          dataStructureUtilPhase0.randomAttestation());
   protected SszList<Deposit> deposits =
-      blockBodyLists.createDeposits(dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
+      blockBodyLists.createDeposits(
+          dataStructureUtilPhase0.randomDeposits(2).toArray(new Deposit[0]));
   protected SszList<SignedVoluntaryExit> voluntaryExits =
       blockBodyLists.createVoluntaryExits(
-          dataStructureUtil.randomSignedVoluntaryExit(),
-          dataStructureUtil.randomSignedVoluntaryExit(),
-          dataStructureUtil.randomSignedVoluntaryExit());
-  protected ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
+          dataStructureUtilPhase0.randomSignedVoluntaryExit(),
+          dataStructureUtilPhase0.randomSignedVoluntaryExit(),
+          dataStructureUtilPhase0.randomSignedVoluntaryExit());
+  protected SyncAggregate syncAggregate = dataStructureUtilAltair.randomSyncAggregate();
+  protected ExecutionPayload executionPayload = dataStructureUtilPhase0.randomExecutionPayload();
 
   private final T defaultBlockBody = createDefaultBlockBody();
   BeaconBlockBodySchema<?> blockBodySchema = defaultBlockBody.getSchema();
@@ -119,7 +125,8 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
     // Create copy of attesterSlashings and change the element to ensure it is different.
     attesterSlashings =
         Stream.concat(
-                Stream.of(dataStructureUtil.randomAttesterSlashing()), attesterSlashings.stream())
+                Stream.of(dataStructureUtilPhase0.randomAttesterSlashing()),
+                attesterSlashings.stream())
             .collect(blockBodySchema.getAttesterSlashingsSchema().collector());
 
     T testBeaconBlockBody = createBlockBody();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -60,39 +60,46 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
   private T defaultBlockBody;
   BeaconBlockBodySchema<?> blockBodySchema;
 
+  private boolean isSetUp;
+
   protected AbstractBeaconBlockBodyTest(final SpecMilestone milestone) {
     spec = TestSpecFactory.createMinimal(milestone);
     dataStructureUtil = new DataStructureUtil(spec);
+    isSetUp = false;
   }
 
   @BeforeEach
   void setUpBaseClass() {
-    BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
-    executionPayload = dataStructureUtil.randomExecutionPayload();
-    voluntaryExits =
-        blockBodyLists.createVoluntaryExits(
-            dataStructureUtil.randomSignedVoluntaryExit(),
-            dataStructureUtil.randomSignedVoluntaryExit(),
-            dataStructureUtil.randomSignedVoluntaryExit());
-    deposits =
-        blockBodyLists.createDeposits(dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
-    attestations =
-        blockBodyLists.createAttestations(
-            dataStructureUtil.randomAttestation(),
-            dataStructureUtil.randomAttestation(),
-            dataStructureUtil.randomAttestation());
-    attesterSlashings =
-        blockBodyLists.createAttesterSlashings(dataStructureUtil.randomAttesterSlashing());
-    proposerSlashings =
-        blockBodyLists.createProposerSlashings(
-            dataStructureUtil.randomProposerSlashing(),
-            dataStructureUtil.randomProposerSlashing(),
-            dataStructureUtil.randomProposerSlashing());
-    graffiti = dataStructureUtil.randomBytes32();
-    eth1Data = dataStructureUtil.randomEth1Data();
-    randaoReveal = dataStructureUtil.randomSignature();
-    defaultBlockBody = createDefaultBlockBody();
-    blockBodySchema = defaultBlockBody.getSchema();
+    if(!isSetUp) {
+      isSetUp = true;
+
+      BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
+      executionPayload = dataStructureUtil.randomExecutionPayload();
+      voluntaryExits =
+              blockBodyLists.createVoluntaryExits(
+                      dataStructureUtil.randomSignedVoluntaryExit(),
+                      dataStructureUtil.randomSignedVoluntaryExit(),
+                      dataStructureUtil.randomSignedVoluntaryExit());
+      deposits =
+              blockBodyLists.createDeposits(dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
+      attestations =
+              blockBodyLists.createAttestations(
+                      dataStructureUtil.randomAttestation(),
+                      dataStructureUtil.randomAttestation(),
+                      dataStructureUtil.randomAttestation());
+      attesterSlashings =
+              blockBodyLists.createAttesterSlashings(dataStructureUtil.randomAttesterSlashing());
+      proposerSlashings =
+              blockBodyLists.createProposerSlashings(
+                      dataStructureUtil.randomProposerSlashing(),
+                      dataStructureUtil.randomProposerSlashing(),
+                      dataStructureUtil.randomProposerSlashing());
+      graffiti = dataStructureUtil.randomBytes32();
+      eth1Data = dataStructureUtil.randomEth1Data();
+      randaoReveal = dataStructureUtil.randomSignature();
+      defaultBlockBody = createDefaultBlockBody();
+      blockBodySchema = defaultBlockBody.getSchema();
+    }
   }
 
   private T createBlockBody() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
@@ -14,11 +14,20 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import java.util.function.Consumer;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 
 class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyAltair> {
+
+  private final SyncAggregate syncAggregate;
+
+  public BeaconBlockBodyAltairTest() {
+    super(SpecMilestone.ALTAIR);
+    syncAggregate = dataStructureUtil.randomSyncAggregate();
+  }
+
   @Override
   protected BeaconBlockBodyAltair createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
@@ -27,7 +36,7 @@ class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockB
 
   @Override
   protected BeaconBlockBodySchema<? extends BeaconBlockBodyAltair> getBlockBodySchema() {
-    return BeaconBlockBodySchemaAltair.create(specAltair.getGenesisSpecConfig());
+    return BeaconBlockBodySchemaAltair.create(spec.getGenesisSpecConfig());
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
@@ -13,29 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.function.Consumer;
-import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 
 class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyAltair> {
-
-  @Test
-  void shouldCreateWithEmptySyncAggregate() {
-    // This won't always be true but until we can calculate the actual SyncAggregate, use the empty
-    // one to make the block valid
-
-    final BeaconBlockBodyAltair blockBody = createDefaultBlockBody();
-    final SyncAggregate emptySyncAggregate =
-        SyncAggregateSchema.create(
-                spec.getGenesisSpecConfig().toVersionAltair().orElseThrow().getSyncCommitteeSize())
-            .createEmpty();
-    assertThat(blockBody.getSyncAggregate()).isEqualTo(emptySyncAggregate);
-  }
-
   @Override
   protected BeaconBlockBodyAltair createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
@@ -44,6 +27,12 @@ class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockB
 
   @Override
   protected BeaconBlockBodySchema<? extends BeaconBlockBodyAltair> getBlockBodySchema() {
-    return BeaconBlockBodySchemaAltair.create(spec.getGenesisSpecConfig());
+    return BeaconBlockBodySchemaAltair.create(specAltair.getGenesisSpecConfig());
+  }
+
+  @Override
+  protected Consumer<BeaconBlockBodyBuilder> createContentProvider() {
+    return super.createContentProvider()
+        .andThen(builder -> builder.syncAggregate(() -> syncAggregate));
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
@@ -21,11 +22,12 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBea
 
 class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyAltair> {
 
-  private final SyncAggregate syncAggregate;
+  protected SyncAggregate syncAggregate;
 
-  public BeaconBlockBodyAltairTest() {
-    super(SpecMilestone.ALTAIR);
-    syncAggregate = dataStructureUtil.randomSyncAggregate();
+  @BeforeEach
+  void setup() {
+    super.setUpBaseClass(
+        SpecMilestone.ALTAIR, () -> syncAggregate = dataStructureUtil.randomSyncAggregate());
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodyMergeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodyMergeTest.java
@@ -14,11 +14,21 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.merge;
 
 import java.util.function.Consumer;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 
 class BeaconBlockBodyMergeTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyMerge> {
+
+  private final SyncAggregate syncAggregate;
+
+  public BeaconBlockBodyMergeTest() {
+    super(SpecMilestone.MERGE);
+    syncAggregate = dataStructureUtil.randomSyncAggregate();
+  }
+
   @Override
   protected BeaconBlockBodyMerge createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
@@ -27,7 +37,7 @@ class BeaconBlockBodyMergeTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
 
   @Override
   protected BeaconBlockBodySchema<? extends BeaconBlockBodyMerge> getBlockBodySchema() {
-    return BeaconBlockBodySchemaMerge.create(specMerge.getGenesisSpecConfig());
+    return BeaconBlockBodySchemaMerge.create(spec.getGenesisSpecConfig());
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodyMergeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodyMergeTest.java
@@ -13,31 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.merge;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.function.Consumer;
-import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
 
 class BeaconBlockBodyMergeTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyMerge> {
-
-  @Test
-  void shouldCreateWithEmptySyncAggregate() {
-    // This won't always be true but until we can calculate the actual SyncAggregate, use the empty
-    // one to make the block valid
-
-    final BeaconBlockBodyMerge blockBody = createDefaultBlockBody();
-    final SyncAggregate emptySyncAggregate =
-        SyncAggregateSchema.create(
-                spec.getGenesisSpecConfig().toVersionMerge().orElseThrow().getSyncCommitteeSize())
-            .createEmpty();
-    assertThat(blockBody.getSyncAggregate()).isEqualTo(emptySyncAggregate);
-  }
-
   @Override
   protected BeaconBlockBodyMerge createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
@@ -46,12 +27,16 @@ class BeaconBlockBodyMergeTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
 
   @Override
   protected BeaconBlockBodySchema<? extends BeaconBlockBodyMerge> getBlockBodySchema() {
-    return BeaconBlockBodySchemaMerge.create(spec.getGenesisSpecConfig());
+    return BeaconBlockBodySchemaMerge.create(specMerge.getGenesisSpecConfig());
   }
 
   @Override
   protected Consumer<BeaconBlockBodyBuilder> createContentProvider() {
     return super.createContentProvider()
-        .andThen(builder -> builder.executionPayload(() -> executionPayload));
+        .andThen(
+            builder ->
+                builder
+                    .syncAggregate(() -> syncAggregate)
+                    .executionPayload(() -> executionPayload));
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodyMergeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/merge/BeaconBlockBodyMergeTest.java
@@ -14,19 +14,27 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.merge;
 
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 
 class BeaconBlockBodyMergeTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyMerge> {
 
-  private final SyncAggregate syncAggregate;
+  protected SyncAggregate syncAggregate;
+  protected ExecutionPayload executionPayload;
 
-  public BeaconBlockBodyMergeTest() {
-    super(SpecMilestone.MERGE);
-    syncAggregate = dataStructureUtil.randomSyncAggregate();
+  @BeforeEach
+  void setup() {
+    super.setUpBaseClass(
+        SpecMilestone.MERGE,
+        () -> {
+          syncAggregate = dataStructureUtil.randomSyncAggregate();
+          executionPayload = dataStructureUtil.randomExecutionPayload();
+        });
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0;
 
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
@@ -21,8 +22,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBea
 
 public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<BeaconBlockBodyPhase0> {
 
-  public BeaconBlockBodyPhase0Test() {
-    super(SpecMilestone.PHASE0);
+  @BeforeEach
+  void setup() {
+    super.setUpBaseClass(SpecMilestone.PHASE0, () -> {});
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
@@ -28,6 +28,6 @@ public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<Beaco
 
   @Override
   protected BeaconBlockBodySchema<BeaconBlockBodyPhase0> getBlockBodySchema() {
-    return BeaconBlockBodySchemaPhase0.create(spec.getGenesisSpecConfig());
+    return BeaconBlockBodySchemaPhase0.create(specPhase0.getGenesisSpecConfig());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
@@ -14,11 +14,16 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0;
 
 import java.util.function.Consumer;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 
 public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<BeaconBlockBodyPhase0> {
+
+  public BeaconBlockBodyPhase0Test() {
+    super(SpecMilestone.PHASE0);
+  }
 
   @Override
   protected BeaconBlockBodyPhase0 createBlockBody(
@@ -28,6 +33,6 @@ public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<Beaco
 
   @Override
   protected BeaconBlockBodySchema<BeaconBlockBodyPhase0> getBlockBodySchema() {
-    return BeaconBlockBodySchemaPhase0.create(specPhase0.getGenesisSpecConfig());
+    return BeaconBlockBodySchemaPhase0.create(spec.getGenesisSpecConfig());
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -17,6 +17,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
 import tech.pegasys.teku.spec.config.TestConfigLoader;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
@@ -26,11 +27,6 @@ public class TestSpecFactory {
     return createMinimalPhase0();
   }
 
-  public static Spec createMinimalAltair() {
-    final SpecConfigAltair specConfig = getAltairSpecConfig(Eth2Network.MINIMAL);
-    return create(specConfig, SpecMilestone.ALTAIR);
-  }
-
   public static Spec createMinimal(final SpecMilestone specMilestone) {
     switch (specMilestone) {
       case PHASE0:
@@ -38,6 +34,7 @@ public class TestSpecFactory {
       case ALTAIR:
         return createMinimalAltair();
       case MERGE:
+        return createMinimalMerge();
       default:
         throw new IllegalStateException("unsupported milestone");
     }
@@ -50,9 +47,20 @@ public class TestSpecFactory {
       case ALTAIR:
         return createMainnetAltair();
       case MERGE:
+        return createMainnetMerge();
       default:
         throw new IllegalStateException("unsupported milestone");
     }
+  }
+
+  public static Spec createMinimalMerge() {
+    final SpecConfigMerge specConfig = getMergeSpecConfig(Eth2Network.MINIMAL);
+    return create(specConfig, SpecMilestone.MERGE);
+  }
+
+  public static Spec createMinimalAltair() {
+    final SpecConfigAltair specConfig = getAltairSpecConfig(Eth2Network.MINIMAL);
+    return create(specConfig, SpecMilestone.ALTAIR);
   }
 
   /**
@@ -69,6 +77,11 @@ public class TestSpecFactory {
   public static Spec createMinimalPhase0() {
     final SpecConfig specConfig = SpecConfigLoader.loadConfig(Eth2Network.MINIMAL.configName());
     return create(specConfig, SpecMilestone.PHASE0);
+  }
+
+  public static Spec createMainnetMerge() {
+    final SpecConfigMerge specConfig = getMergeSpecConfig(Eth2Network.MAINNET);
+    return create(specConfig, SpecMilestone.MERGE);
   }
 
   public static Spec createMainnetAltair() {
@@ -94,6 +107,10 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.ALTAIR);
   }
 
+  public static Spec createMerge(final SpecConfig config) {
+    return create(config, SpecMilestone.MERGE);
+  }
+
   private static Spec create(
       final SpecConfig config, final SpecMilestone highestSupportedMilestone) {
     return Spec.create(config, highestSupportedMilestone);
@@ -108,5 +125,19 @@ public class TestSpecFactory {
     return SpecConfigAltair.required(
         TestConfigLoader.loadConfig(
             network.configName(), c -> c.altairBuilder(a -> a.altairForkEpoch(altairForkEpoch))));
+  }
+
+  private static SpecConfigMerge getMergeSpecConfig(final Eth2Network network) {
+    return getMergeSpecConfig(network, UInt64.ZERO, UInt64.ZERO);
+  }
+
+  private static SpecConfigMerge getMergeSpecConfig(
+      final Eth2Network network, final UInt64 altairForkEpoch, UInt64 mergeForkEpoch) {
+    return SpecConfigMerge.required(
+        TestConfigLoader.loadConfig(
+            network.configName(),
+            c ->
+                c.altairBuilder(a -> a.altairForkEpoch(altairForkEpoch))
+                    .mergeBuilder(m -> m.mergeForkEpoch(mergeForkEpoch))));
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -338,8 +338,26 @@ public final class DataStructureUtil {
     return state.toVersionAltair().map(__ -> randomSyncAggregate()).orElse(null);
   }
 
+  public SyncAggregate emptySyncAggregateIfRequiredByState(BeaconState state) {
+    return state.toVersionAltair().map(__ -> emptySyncAggregate()).orElse(null);
+  }
+
   public SyncAggregate randomSyncAggregate() {
     return randomSyncAggregate(randomInt(4), randomInt(4));
+  }
+
+  public SyncAggregate emptySyncAggregate() {
+    SpecVersion specVersionAltair =
+        Optional.ofNullable(spec.forMilestone(SpecMilestone.ALTAIR)).orElseThrow();
+
+    final SyncAggregateSchema schema =
+        SchemaDefinitionsAltair.required(specVersionAltair.getSchemaDefinitions())
+            .getBeaconBlockBodySchema()
+            .toVersionAltair()
+            .orElseThrow()
+            .getSyncAggregateSchema();
+
+    return schema.createEmpty();
   }
 
   public SyncAggregate randomSyncAggregate(final Integer... participantIndices) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -357,15 +357,16 @@ public final class DataStructureUtil {
     SpecVersion specVersionAltair =
         Optional.ofNullable(spec.forMilestone(SpecMilestone.ALTAIR)).orElseThrow();
 
-    return getSyncAggregateSchema(specVersionAltair).create(List.of(participantIndices), randomSignature());
+    return getSyncAggregateSchema(specVersionAltair)
+        .create(List.of(participantIndices), randomSignature());
   }
 
   private SyncAggregateSchema getSyncAggregateSchema(SpecVersion specVersionAltair) {
     return SchemaDefinitionsAltair.required(specVersionAltair.getSchemaDefinitions())
-            .getBeaconBlockBodySchema()
-            .toVersionAltair()
-            .orElseThrow()
-            .getSyncAggregateSchema();
+        .getBeaconBlockBodySchema()
+        .toVersionAltair()
+        .orElseThrow()
+        .getSyncAggregateSchema();
   }
 
   public SyncCommittee randomSyncCommittee() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_S
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -55,7 +56,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
@@ -330,14 +330,27 @@ public final class DataStructureUtil {
     return new Checkpoint(randomEpoch(), randomBytes32());
   }
 
+  public SyncAggregate randomSyncAggregateIfRequiredBySchema(BeaconBlockBodySchema<?> schema) {
+    return schema.toVersionAltair().map(__ -> randomSyncAggregate()).orElse(null);
+  }
+
+  public SyncAggregate randomSyncAggregateIfRequiredByState(BeaconState state) {
+    return state.toVersionAltair().map(__ -> randomSyncAggregate()).orElse(null);
+  }
+
   public SyncAggregate randomSyncAggregate() {
     return randomSyncAggregate(randomInt(4), randomInt(4));
   }
 
   public SyncAggregate randomSyncAggregate(final Integer... participantIndices) {
+    SpecVersion specVersionAltair =
+        Optional.ofNullable(spec.forMilestone(SpecMilestone.ALTAIR)).orElseThrow();
+
     final SyncAggregateSchema schema =
-        BeaconBlockBodySchemaAltair.required(
-                spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema())
+        SchemaDefinitionsAltair.required(specVersionAltair.getSchemaDefinitions())
+            .getBeaconBlockBodySchema()
+            .toVersionAltair()
+            .orElseThrow()
             .getSyncAggregateSchema();
     return schema.create(List.of(participantIndices), randomSignature());
   }
@@ -385,6 +398,11 @@ public final class DataStructureUtil {
         randomUInt256(),
         randomBytes32(),
         randomBytes32());
+  }
+
+  public ExecutionPayload randomExecutionPayloadIfRequiredBySchema(
+      BeaconBlockBodySchema<?> schema) {
+    return schema.toVersionMerge().map(__ -> randomExecutionPayload()).orElse(null);
   }
 
   public ExecutionPayload randomExecutionPayload() {
@@ -706,7 +724,9 @@ public final class DataStructureUtil {
                     randomSszList(schema.getDepositsSchema(), this::randomDepositWithoutIndex, 1))
                 .voluntaryExits(
                     randomSszList(
-                        schema.getVoluntaryExitsSchema(), this::randomSignedVoluntaryExit, 1)));
+                        schema.getVoluntaryExitsSchema(), this::randomSignedVoluntaryExit, 1))
+                .syncAggregate(() -> this.randomSyncAggregateIfRequiredBySchema(schema))
+                .executionPayload(() -> this.randomExecutionPayloadIfRequiredBySchema(schema)));
   }
 
   public BeaconBlockBody randomFullBeaconBlockBody() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -350,27 +350,22 @@ public final class DataStructureUtil {
     SpecVersion specVersionAltair =
         Optional.ofNullable(spec.forMilestone(SpecMilestone.ALTAIR)).orElseThrow();
 
-    final SyncAggregateSchema schema =
-        SchemaDefinitionsAltair.required(specVersionAltair.getSchemaDefinitions())
-            .getBeaconBlockBodySchema()
-            .toVersionAltair()
-            .orElseThrow()
-            .getSyncAggregateSchema();
-
-    return schema.createEmpty();
+    return getSyncAggregateSchema(specVersionAltair).createEmpty();
   }
 
   public SyncAggregate randomSyncAggregate(final Integer... participantIndices) {
     SpecVersion specVersionAltair =
         Optional.ofNullable(spec.forMilestone(SpecMilestone.ALTAIR)).orElseThrow();
 
-    final SyncAggregateSchema schema =
-        SchemaDefinitionsAltair.required(specVersionAltair.getSchemaDefinitions())
+    return getSyncAggregateSchema(specVersionAltair).create(List.of(participantIndices), randomSignature());
+  }
+
+  private SyncAggregateSchema getSyncAggregateSchema(SpecVersion specVersionAltair) {
+    return SchemaDefinitionsAltair.required(specVersionAltair.getSchemaDefinitions())
             .getBeaconBlockBodySchema()
             .toVersionAltair()
             .orElseThrow()
             .getSyncAggregateSchema();
-    return schema.create(List.of(participantIndices), randomSignature());
   }
 
   public SyncCommittee randomSyncCommittee() {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -35,11 +35,11 @@ import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.store.StoreConfig;
 
 public class StorageSystem implements AutoCloseable {
-  private final TrackingChainHeadChannel reorgEventChannel;
   private final ChainBuilder chainBuilder;
   private final ChainUpdater chainUpdater;
   private final TrackingEth1EventsChannel eth1EventsChannel = new TrackingEth1EventsChannel();
 
+  private final TrackingChainHeadChannel reorgEventChannel;
   private final StubMetricsSystem metricsSystem;
   private final RecentChainData recentChainData;
   private final StateStorageMode storageMode;

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -35,11 +35,11 @@ import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.store.StoreConfig;
 
 public class StorageSystem implements AutoCloseable {
+  private final TrackingChainHeadChannel reorgEventChannel;
   private final ChainBuilder chainBuilder;
   private final ChainUpdater chainUpdater;
   private final TrackingEth1EventsChannel eth1EventsChannel = new TrackingEth1EventsChannel();
 
-  private final TrackingChainHeadChannel reorgEventChannel;
   private final StubMetricsSystem metricsSystem;
   private final RecentChainData recentChainData;
   private final StateStorageMode storageMode;
@@ -57,7 +57,8 @@ public class StorageSystem implements AutoCloseable {
       final RecentChainData recentChainData,
       final CombinedChainDataClient combinedChainDataClient,
       final RestartedStorageSupplier restartedSupplier,
-      final ChainBuilder chainBuilder) {
+      final ChainBuilder chainBuilder,
+      final Spec spec) {
     this.metricsSystem = metricsSystem;
     this.chainStorage = chainStorage;
     this.recentChainData = recentChainData;
@@ -68,7 +69,7 @@ public class StorageSystem implements AutoCloseable {
     this.restartedSupplier = restartedSupplier;
 
     this.chainBuilder = chainBuilder;
-    chainUpdater = new ChainUpdater(this.recentChainData, this.chainBuilder);
+    chainUpdater = new ChainUpdater(this.recentChainData, this.chainBuilder, spec);
   }
 
   static StorageSystem create(
@@ -114,7 +115,8 @@ public class StorageSystem implements AutoCloseable {
         recentChainData,
         combinedChainDataClient,
         restartedSupplier,
-        chainBuilder);
+        chainBuilder,
+        spec);
   }
 
   public StubMetricsSystem getMetricsSystem() {


### PR DESCRIPTION
## PR Description

avoid systematic creation of empty `SyncAggregate` on each `Altair` block creation.
reference: https://github.com/ConsenSys/teku/pull/4503#discussion_r735744787

atop #4527 

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
