### PR TITLE
[Merge] Enable MergeStateUpgrade and fix BlockOperationSelectorFactory

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
 import tech.pegasys.teku.ssz.SszList;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -117,7 +118,13 @@ public class BlockOperationSelectorFactory {
           .syncAggregate(
               () ->
                   contributionPool.createSyncAggregateForBlock(
-                      blockSlotState.getSlot(), parentRoot));
+                      blockSlotState.getSlot(), parentRoot))
+          .executionPayload(
+              () ->
+                  SchemaDefinitionsMerge.required(
+                          spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions())
+                      .getExecutionPayloadSchema()
+                      .getDefault());
     };
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/SpecLogicMerge.java
@@ -21,7 +21,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigMerge;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
@@ -33,12 +32,10 @@ import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
-import tech.pegasys.teku.spec.logic.versions.altair.forktransition.AltairStateUpgrade;
-import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.attestation.AttestationWorthinessCheckerAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
 import tech.pegasys.teku.spec.logic.versions.merge.block.BlockProcessorMerge;
+import tech.pegasys.teku.spec.logic.versions.merge.forktransition.MergeStateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateAccessorsMerge;
 import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateMutatorsMerge;
 import tech.pegasys.teku.spec.logic.versions.merge.helpers.MergeTransitionHelpers;
@@ -57,21 +54,21 @@ public class SpecLogicMerge extends AbstractSpecLogic {
   private SpecLogicMerge(
       final SpecConfigMerge specConfig,
       final Predicates predicates,
-      final MiscHelpersAltair miscHelpers,
+      final MiscHelpersMerge miscHelpers,
       final BeaconStateAccessorsMerge beaconStateAccessors,
-      final BeaconStateMutators beaconStateMutators,
+      final BeaconStateMutatorsMerge beaconStateMutators,
       final OperationSignatureVerifier operationSignatureVerifier,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final OperationValidator operationValidator,
       final ValidatorStatusFactoryAltair validatorStatusFactory,
-      final EpochProcessorAltair epochProcessor,
+      final EpochProcessorMerge epochProcessor,
       final BlockProcessorMerge blockProcessor,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil,
       final SyncCommitteeUtil syncCommitteeUtil,
-      final AltairStateUpgrade stateUpgrade,
+      final MergeStateUpgrade stateUpgrade,
       final ExecutionPayloadUtil executionPayloadUtil,
       final MergeTransitionHelpers mergeTransitionHelpers) {
     super(
@@ -160,9 +157,8 @@ public class SpecLogicMerge extends AbstractSpecLogic {
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
 
     // State upgrade
-    final AltairStateUpgrade stateUpgrade =
-        new AltairStateUpgrade(
-            config, schemaDefinitions, beaconStateAccessors, attestationUtil, miscHelpers);
+    final MergeStateUpgrade stateUpgrade =
+        new MergeStateUpgrade(config, schemaDefinitions, beaconStateAccessors);
 
     final MergeTransitionHelpers mergeTransitionHelpers =
         new MergeTransitionHelpers(miscHelpers, config);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/forktransition/MergeStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/merge/forktransition/MergeStateUpgrade.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.merge.forktransition;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigMerge;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.merge.BeaconStateMerge;
+import tech.pegasys.teku.spec.logic.common.forktransition.StateUpgrade;
+import tech.pegasys.teku.spec.logic.versions.merge.helpers.BeaconStateAccessorsMerge;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsMerge;
+
+public class MergeStateUpgrade implements StateUpgrade<BeaconStateMerge> {
+  final SpecConfigMerge specConfig;
+  final SchemaDefinitionsMerge schemaDefinitions;
+  final BeaconStateAccessorsMerge beaconStateAccessors;
+
+  public MergeStateUpgrade(
+      final SpecConfigMerge specConfig,
+      final SchemaDefinitionsMerge schemaDefinitions,
+      final BeaconStateAccessorsMerge beaconStateAccessors) {
+    this.specConfig = specConfig;
+    this.schemaDefinitions = schemaDefinitions;
+    this.beaconStateAccessors = beaconStateAccessors;
+  }
+
+  @Override
+  public BeaconStateMerge upgrade(final BeaconState preState) {
+    final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(preState);
+    BeaconStateAltair preStateAltair = BeaconStateAltair.required(preState);
+
+    return schemaDefinitions
+        .getBeaconStateSchema()
+        .createEmpty()
+        .updatedMerge(
+            state -> {
+              BeaconStateFields.copyCommonFieldsFromSource(state, preState);
+
+              state.setCurrentEpochParticipation(preStateAltair.getCurrentEpochParticipation());
+              state.setPreviousEpochParticipation(preStateAltair.getPreviousEpochParticipation());
+              state.setCurrentSyncCommittee(preStateAltair.getCurrentSyncCommittee());
+              state.setNextSyncCommittee(preStateAltair.getNextSyncCommittee());
+              state.setInactivityScores(preStateAltair.getInactivityScores());
+
+              state.setFork(
+                  new Fork(
+                      preState.getFork().getCurrent_version(),
+                      specConfig.getMergeForkVersion(),
+                      epoch));
+
+              state.setLatestExecutionPayloadHeader(
+                  schemaDefinitions.getExecutionPayloadHeaderSchema().getDefault());
+            });
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
@@ -32,4 +32,6 @@ public @interface TestSpecContext {
   boolean allMilestones() default false;
 
   boolean allNetworks() default false;
+
+  boolean doNotGenerateSpec() default false;
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -73,6 +73,18 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.ALTAIR);
   }
 
+  /**
+   * Create a spec that forks to merge at the provided slot (altair genesis)
+   *
+   * @param mergeForkEpoch The merge fork epoch
+   * @return A spec with altair and merge enabled, forking to merge at the given epoch
+   */
+  public static Spec createMinimalWithMergeForkEpoch(final UInt64 mergeForkEpoch) {
+    final SpecConfigMerge config =
+        getMergeSpecConfig(Eth2Network.MINIMAL, UInt64.ZERO, mergeForkEpoch);
+    return create(config, SpecMilestone.MERGE);
+  }
+
   public static Spec createMinimalPhase0() {
     final SpecConfig specConfig = SpecConfigLoader.loadConfig(Eth2Network.MINIMAL.configName());
     return create(specConfig, SpecMilestone.PHASE0);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
@@ -63,7 +63,10 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
         specMilestone -> {
           networks.forEach(
               eth2Network -> {
-                invocations.add(generateContext(new SpecContext(specMilestone, eth2Network)));
+                invocations.add(
+                    generateContext(
+                        new SpecContext(
+                            specMilestone, eth2Network, testSpecContext.doNotGenerateSpec())));
               });
         });
 
@@ -92,9 +95,14 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
     private final SpecMilestone specMilestone;
     private final Eth2Network network;
 
-    SpecContext(SpecMilestone specMilestone, Eth2Network network) {
-      this.spec = TestSpecFactory.create(specMilestone, network);
-      this.dataStructureUtil = new DataStructureUtil(spec);
+    SpecContext(SpecMilestone specMilestone, Eth2Network network, boolean doNotGenerateSpec) {
+      if (doNotGenerateSpec) {
+        spec = null;
+        dataStructureUtil = null;
+      } else {
+        this.spec = TestSpecFactory.create(specMilestone, network);
+        this.dataStructureUtil = new DataStructureUtil(spec);
+      }
       this.displayName = specMilestone.name() + ' ' + network.name();
 
       this.specMilestone = specMilestone;


### PR DESCRIPTION
## PR Description

related to #4504

implement BeaconState transition from `Altair` to `Merge`
Fix block generation in Merge by providing a default `ExecutionPayload`

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
