### PR TITLE
Remove unneeded\misleading exception handling in `ForkChoicePayloadExecuror`

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
@@ -71,15 +71,7 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
           Optional.of(
               bellatrixTransitionHelpers.validateMergeBlock(executionEngine, executionPayload));
     } else {
-      result =
-          Optional.of(
-              executionEngine
-                  .executePayload(executionPayload)
-                  .exceptionally(
-                      error -> {
-                        LOG.error("Error while executing payload", error);
-                        return ExecutePayloadResult.SYNCING;
-                      }));
+      result = Optional.of(executionEngine.executePayload(executionPayload));
     }
     return true;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
@@ -14,8 +14,6 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -27,8 +25,6 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecution
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 
 class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
-  private static final Logger LOG = LogManager.getLogger();
-
   private final Spec spec;
   private final SignedBeaconBlock block;
   private final ExecutionEngineChannel executionEngine;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,19 +68,6 @@ class ForkChoicePayloadExecutorTest {
     final boolean result = payloadExecutor.optimisticallyExecute(payloadHeader, payload);
     verify(executionEngine).executePayload(payload);
     assertThat(result).isTrue();
-  }
-
-  @Test
-  void optimisticallyExecute_shouldTreatErrorFromExecutionEngineAsSyncing() {
-    when(executionEngine.executePayload(any()))
-        .thenReturn(SafeFuture.failedFuture(new IOException("Boom")));
-    final ForkChoicePayloadExecutor payloadExecutor = createPayloadExecutor();
-    final boolean result = payloadExecutor.optimisticallyExecute(payloadHeader, payload);
-    verify(executionEngine).executePayload(payload);
-    assertThat(result).isTrue();
-
-    final SafeFuture<ExecutePayloadResult> combinedResult = payloadExecutor.getExecutionResult();
-    assertThat(combinedResult).isCompletedWithValue(ExecutePayloadResult.SYNCING);
   }
 
   @Test


### PR DESCRIPTION
## PR Description

`ExcetutionEngineChannelImpl:executePayload` is already handling exceptions when calling the engine API (implemented in #4809) mapping them to failed result. So there is no case to intercept them in `ForkChoicePayloadExecuror::optimisticallyExecute` anymore.