### PR TITLE
add unprefixed hex jwt secret load test and ignore (CR)LF

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoader.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoader.java
@@ -35,7 +35,6 @@ public class JwtSecretKeyLoader {
   private static final Logger LOG = LogManager.getLogger();
 
   public static final String JWT_SECRET_FILE_NAME = "ee-jwt-secret.hex";
-  public static final String UNPREFIXED_JWT_SECRET_FILE_NAME = "unprefixed-ee-jwt-secret.hex";
   private final Optional<String> jwtSecretFile;
   private final Path beaconDataDirectory;
 
@@ -72,7 +71,7 @@ public class JwtSecretKeyLoader {
   private SecretKeySpec loadSecretFromFile(final String jwtSecretFile) {
     final Path filePath = Paths.get(jwtSecretFile);
     try {
-      final Bytes bytesFromHex = Bytes.fromHexString(Files.readAllLines(filePath).get(0));
+      final Bytes bytesFromHex = Bytes.fromHexString(Files.readString(filePath).trim());
       return new SecretKeySpec(bytesFromHex.toArray(), SignatureAlgorithm.HS256.getJcaName());
     } catch (final FileNotFoundException | NoSuchFileException e) {
       throw new InvalidConfigurationException(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoader.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoader.java
@@ -35,6 +35,7 @@ public class JwtSecretKeyLoader {
   private static final Logger LOG = LogManager.getLogger();
 
   public static final String JWT_SECRET_FILE_NAME = "ee-jwt-secret.hex";
+  public static final String UNPREFIXED_JWT_SECRET_FILE_NAME = "unprefixed-ee-jwt-secret.hex";
   private final Optional<String> jwtSecretFile;
   private final Path beaconDataDirectory;
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoader.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoader.java
@@ -72,7 +72,7 @@ public class JwtSecretKeyLoader {
   private SecretKeySpec loadSecretFromFile(final String jwtSecretFile) {
     final Path filePath = Paths.get(jwtSecretFile);
     try {
-      final Bytes bytesFromHex = Bytes.fromHexString(Files.readString(filePath));
+      final Bytes bytesFromHex = Bytes.fromHexString(Files.readAllLines(filePath).get(0));
       return new SecretKeySpec(bytesFromHex.toArray(), SignatureAlgorithm.HS256.getJcaName());
     } catch (final FileNotFoundException | NoSuchFileException e) {
       throw new InvalidConfigurationException(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoaderTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoaderTest.java
@@ -32,17 +32,19 @@ class JwtSecretKeyLoaderTest {
   void testGetSecretKey_ReadSecretFromProvidedFilePath(@TempDir final Path tempDir)
       throws IOException {
     final Path jwtSecretFile = tempDir.resolve(JwtSecretKeyLoader.JWT_SECRET_FILE_NAME);
-    final Path unprefixedJwtSecretFile = tempDir.resolve(JwtSecretKeyLoader.UNPREFIXED_JWT_SECRET_FILE_NAME);
+    final Path unprefixedJwtSecretFile =
+        tempDir.resolve(JwtSecretKeyLoader.UNPREFIXED_JWT_SECRET_FILE_NAME);
 
     final SecretKeySpec jwtSecret = JwtTestHelper.generateJwtSecret();
 
     Files.writeString(jwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toHexString());
-    Files.writeString(unprefixedJwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toUnprefixedHexString());
+    Files.writeString(
+        unprefixedJwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toUnprefixedHexString());
 
     final JwtSecretKeyLoader keyLoader =
         new JwtSecretKeyLoader(Optional.of(jwtSecretFile.toString()), tempDir);
     final JwtSecretKeyLoader unprefixedFileKeyLoader =
-            new JwtSecretKeyLoader(Optional.of(unprefixedJwtSecretFile.toString()), tempDir);
+        new JwtSecretKeyLoader(Optional.of(unprefixedJwtSecretFile.toString()), tempDir);
 
     final Key loadedSecret = keyLoader.getSecretKey();
     final Key unprefixedLoadedSecret = unprefixedFileKeyLoader.getSecretKey();

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoaderTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoaderTest.java
@@ -38,8 +38,10 @@ class JwtSecretKeyLoaderTest {
     final SecretKeySpec jwtSecret = JwtTestHelper.generateJwtSecret();
 
     Files.writeString(jwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toHexString());
+
+    // should strip (CR)LF too
     Files.writeString(
-        unprefixedJwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toUnprefixedHexString());
+        unprefixedJwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toUnprefixedHexString() + "\n");
 
     final JwtSecretKeyLoader keyLoader =
         new JwtSecretKeyLoader(Optional.of(jwtSecretFile.toString()), tempDir);

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoaderTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtSecretKeyLoaderTest.java
@@ -32,12 +32,22 @@ class JwtSecretKeyLoaderTest {
   void testGetSecretKey_ReadSecretFromProvidedFilePath(@TempDir final Path tempDir)
       throws IOException {
     final Path jwtSecretFile = tempDir.resolve(JwtSecretKeyLoader.JWT_SECRET_FILE_NAME);
+    final Path unprefixedJwtSecretFile = tempDir.resolve(JwtSecretKeyLoader.UNPREFIXED_JWT_SECRET_FILE_NAME);
+
     final SecretKeySpec jwtSecret = JwtTestHelper.generateJwtSecret();
+
     Files.writeString(jwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toHexString());
+    Files.writeString(unprefixedJwtSecretFile, Bytes.wrap(jwtSecret.getEncoded()).toUnprefixedHexString());
+
     final JwtSecretKeyLoader keyLoader =
         new JwtSecretKeyLoader(Optional.of(jwtSecretFile.toString()), tempDir);
+    final JwtSecretKeyLoader unprefixedFileKeyLoader =
+            new JwtSecretKeyLoader(Optional.of(unprefixedJwtSecretFile.toString()), tempDir);
+
     final Key loadedSecret = keyLoader.getSecretKey();
+    final Key unprefixedLoadedSecret = unprefixedFileKeyLoader.getSecretKey();
     assertSecretEquals(jwtSecret, loadedSecret);
+    assertSecretEquals(jwtSecret, unprefixedLoadedSecret);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Since the specs are not clear if the jwt secret needs to be stored in file using "0x" prefix or not, I add a test to be sure we are able to load unprefixed key too.

it also ignores '\n' from the file, which may cause users heachache

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
