### PR TITLE
late block import warning

### DIFF
--- a/beacon/sync/build.gradle
+++ b/beacon/sync/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testFixturesImplementation testFixtures(project('::networking:eth2'))
     testFixturesImplementation testFixtures(project('::networking:p2p'))
     testFixturesImplementation testFixtures(project('::infrastructure:events'))
+    testFixturesImplementation testFixtures(project(':infrastructure:logging'))
 
     testFixturesImplementation 'org.mockito:mockito-core'
     testFixturesImplementation 'org.hyperledger.besu:plugin-api'

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beacon.sync;
 
 import static tech.pegasys.teku.infrastructure.events.TestExceptionHandler.TEST_EXCEPTION_HANDLER;
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkFactory;
@@ -118,7 +120,13 @@ public class SyncingNodeManager {
         FutureItems.create(SignedBeaconBlock::getSlot);
     BlockManager blockManager =
         new BlockManager(
-            recentChainData, blockImporter, pendingBlocks, futureBlocks, blockValidator);
+            recentChainData,
+            blockImporter,
+            pendingBlocks,
+            futureBlocks,
+            blockValidator,
+            new SystemTimeProvider(),
+            EVENT_LOG);
 
     eventChannels
         .subscribe(SlotEventsChannel.class, blockManager)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.block;
+
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class BlockImportPerformance {
+  private final TimeProvider timeProvider;
+  private UInt64 timeAtSlotStartMs;
+  private UInt64 blockArrivalTimeStamp;
+  private UInt64 importCompletedTimeStamp;
+  private UInt64 arrivalDelay;
+  private UInt64 timeWarningLimitMs;
+  private UInt64 processingTime;
+
+  public BlockImportPerformance(final TimeProvider timeProvider) {
+    this.timeProvider = timeProvider;
+  }
+
+  public void arrival(final RecentChainData recentChainData, final UInt64 slot) {
+    blockArrivalTimeStamp = timeProvider.getTimeInMillis();
+    timeAtSlotStartMs = recentChainData.computeTimeAtSlot(slot).times(1000);
+
+    arrivalDelay = blockArrivalTimeStamp.minusMinZero(timeAtSlotStartMs);
+
+    timeWarningLimitMs =
+        timeAtSlotStartMs.plus((recentChainData.getSpec().getSecondsPerSlot(slot) * 1000L) / 3);
+  }
+
+  public void processed() {
+    importCompletedTimeStamp = timeProvider.getTimeInMillis();
+    processingTime = timeProvider.getTimeInMillis().minus(blockArrivalTimeStamp);
+  }
+
+  public UInt64 getTimeAtSlotStartMs() {
+    return timeAtSlotStartMs;
+  }
+
+  public UInt64 getBlockArrivalTimeStamp() {
+    return blockArrivalTimeStamp;
+  }
+
+  public UInt64 getArrivalDelay() {
+    return arrivalDelay;
+  }
+
+  public boolean isSlotTimeWarningPassed() {
+    return importCompletedTimeStamp.isGreaterThan(timeWarningLimitMs);
+  }
+
+  public UInt64 getProcessingTime() {
+    return processingTime;
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
@@ -19,11 +19,11 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class BlockImportPerformance {
   private final TimeProvider timeProvider;
-  private UInt64 timeAtSlotStartMs;
+  private UInt64 timeAtSlotStartTimeStamp;
   private UInt64 blockArrivalTimeStamp;
   private UInt64 importCompletedTimeStamp;
   private UInt64 arrivalDelay;
-  private UInt64 timeWarningLimitMs;
+  private UInt64 timeWarningLimitTimeStamp;
   private UInt64 processingTime;
 
   public BlockImportPerformance(final TimeProvider timeProvider) {
@@ -32,12 +32,13 @@ public class BlockImportPerformance {
 
   public void arrival(final RecentChainData recentChainData, final UInt64 slot) {
     blockArrivalTimeStamp = timeProvider.getTimeInMillis();
-    timeAtSlotStartMs = recentChainData.computeTimeAtSlot(slot).times(1000);
+    timeAtSlotStartTimeStamp = recentChainData.computeTimeAtSlot(slot).times(1000);
 
-    arrivalDelay = blockArrivalTimeStamp.minusMinZero(timeAtSlotStartMs);
+    arrivalDelay = blockArrivalTimeStamp.minusMinZero(timeAtSlotStartTimeStamp);
 
-    timeWarningLimitMs =
-        timeAtSlotStartMs.plus((recentChainData.getSpec().getSecondsPerSlot(slot) * 1000L) / 3);
+    timeWarningLimitTimeStamp =
+        timeAtSlotStartTimeStamp.plus(
+            (recentChainData.getSpec().getSecondsPerSlot(slot) * 1000L) / 3);
   }
 
   public void processed() {
@@ -45,8 +46,8 @@ public class BlockImportPerformance {
     processingTime = timeProvider.getTimeInMillis().minus(blockArrivalTimeStamp);
   }
 
-  public UInt64 getTimeAtSlotStartMs() {
-    return timeAtSlotStartMs;
+  public UInt64 getTimeAtSlotStartTimeStamp() {
+    return timeAtSlotStartTimeStamp;
   }
 
   public UInt64 getBlockArrivalTimeStamp() {
@@ -58,7 +59,7 @@ public class BlockImportPerformance {
   }
 
   public boolean isSlotTimeWarningPassed() {
-    return importCompletedTimeStamp.isGreaterThan(timeWarningLimitMs);
+    return importCompletedTimeStamp.isGreaterThan(timeWarningLimitTimeStamp);
   }
 
   public UInt64 getProcessingTime() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
@@ -13,13 +13,14 @@
 
 package tech.pegasys.teku.statetransition.block;
 
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
+
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class BlockImportPerformance {
   private final TimeProvider timeProvider;
-  private UInt64 timeAtSlotStartTimeStamp;
   private UInt64 blockArrivalTimeStamp;
   private UInt64 importCompletedTimeStamp;
   private UInt64 arrivalDelay;
@@ -32,22 +33,19 @@ public class BlockImportPerformance {
 
   public void arrival(final RecentChainData recentChainData, final UInt64 slot) {
     blockArrivalTimeStamp = timeProvider.getTimeInMillis();
-    timeAtSlotStartTimeStamp = recentChainData.computeTimeAtSlot(slot).times(1000);
+    final UInt64 timeAtSlotStartTimeStamp =
+        secondsToMillis(recentChainData.computeTimeAtSlot(slot));
 
     arrivalDelay = blockArrivalTimeStamp.minusMinZero(timeAtSlotStartTimeStamp);
 
     timeWarningLimitTimeStamp =
         timeAtSlotStartTimeStamp.plus(
-            (recentChainData.getSpec().getSecondsPerSlot(slot) * 1000L) / 3);
+            secondsToMillis(recentChainData.getSpec().getSecondsPerSlot(slot)).dividedBy(3));
   }
 
   public void processed() {
     importCompletedTimeStamp = timeProvider.getTimeInMillis();
     processingTime = timeProvider.getTimeInMillis().minus(blockArrivalTimeStamp);
-  }
-
-  public UInt64 getTimeAtSlotStartTimeStamp() {
-    return timeAtSlotStartTimeStamp;
   }
 
   public UInt64 getBlockArrivalTimeStamp() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -274,13 +274,11 @@ public class BlockManager extends Service
 
           if (currentTime.isGreaterThan(timeWarningLimitMs)) {
 
-            final UInt64 processingTime = currentTime.minus(blockArrivalTimeMs);
-
             eventLogger.lateBlockImport(
                 block.getRoot(),
                 block.getSlot(),
                 blockArrivalTimeMs.minus(timeAtSlotStartMs),
-                processingTime);
+                currentTime.minus(blockArrivalTimeMs));
           }
         });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
@@ -23,6 +23,8 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.Cancellable;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
@@ -43,13 +45,22 @@ public class ReexecutingExecutionPayloadBlockManager extends BlockManager {
   private Optional<Cancellable> cancellable = Optional.empty();
 
   public ReexecutingExecutionPayloadBlockManager(
-      RecentChainData recentChainData,
-      BlockImporter blockImporter,
-      PendingPool<SignedBeaconBlock> pendingBlocks,
-      FutureItems<SignedBeaconBlock> futureBlocks,
-      BlockValidator validator,
+      final RecentChainData recentChainData,
+      final BlockImporter blockImporter,
+      final PendingPool<SignedBeaconBlock> pendingBlocks,
+      final FutureItems<SignedBeaconBlock> futureBlocks,
+      final BlockValidator validator,
+      final TimeProvider timeProvider,
+      final EventLogger eventLogger,
       final AsyncRunner asyncRunner) {
-    super(recentChainData, blockImporter, pendingBlocks, futureBlocks, validator);
+    super(
+        recentChainData,
+        blockImporter,
+        pendingBlocks,
+        futureBlocks,
+        validator,
+        timeProvider,
+        eventLogger);
     this.asyncRunner = asyncRunner;
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -65,6 +67,8 @@ import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityFactory;
 
 @SuppressWarnings("FutureReturnValueIgnored")
 public class BlockManagerTest {
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+  private final EventLogger eventLogger = mock(EventLogger.class);
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final BlockImportNotifications blockImportNotifications =
@@ -105,7 +109,13 @@ public class BlockManagerTest {
           executionEngine);
   private final BlockManager blockManager =
       new BlockManager(
-          localRecentChainData, blockImporter, pendingBlocks, futureBlocks, blockValidator);
+          localRecentChainData,
+          blockImporter,
+          pendingBlocks,
+          futureBlocks,
+          blockValidator,
+          timeProvider,
+          eventLogger);
 
   private UInt64 currentSlot = GENESIS_SLOT;
 
@@ -243,7 +253,9 @@ public class BlockManagerTest {
             blockImporter,
             pendingBlocks,
             futureBlocks,
-            mock(BlockValidator.class));
+            mock(BlockValidator.class),
+            timeProvider,
+            eventLogger);
     forwardBlockImportedNotificationsTo(blockManager);
     assertThat(blockManager.start()).isCompleted();
 
@@ -528,6 +540,54 @@ public class BlockManagerTest {
                     invalidBlockDescendant, BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK));
 
     assertThat(pendingBlocks.size()).isEqualTo(0);
+  }
+
+  @Test
+  void onValidateAndImportBlock_shouldLogSlowImport() {
+    final SignedBeaconBlock block =
+        localChain.chainBuilder().generateBlockAtSlot(incrementSlot()).getBlock();
+    // slot 1 - secondPerSlot 6
+
+    // arrival time
+    timeProvider.advanceTimeByMillis(7_000); // 1 second late
+
+    when(blockValidator.validate(any()))
+        .thenAnswer(
+            invocation -> {
+              // advance to simulate processing time of 3000ms
+              // we are now 4s into the slot (threshold for warning is 2)
+              timeProvider.advanceTimeByMillis(3_000);
+              return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
+            });
+
+    assertThat(blockManager.validateAndImportBlock(block))
+        .isCompletedWithValueMatching(InternalValidationResult::isAccept);
+    verify(eventLogger)
+        .lateBlockImport(
+            block.getRoot(), block.getSlot(), UInt64.valueOf(7_000), UInt64.valueOf(3_000));
+  }
+
+  @Test
+  void onValidateAndImportBlock_shouldNotLogSlowImport() {
+    final SignedBeaconBlock block =
+        localChain.chainBuilder().generateBlockAtSlot(incrementSlot()).getBlock();
+    // slot 1 - secondPerSlot 6
+
+    // arrival time
+    timeProvider.advanceTimeByMillis(7_000); // 1 second late
+
+    when(blockValidator.validate(any()))
+        .thenAnswer(
+            invocation -> {
+              // advance to simulate processing time of 500ms
+              // we are now 1.5s into the slot (threshold for warning is 2)
+              timeProvider.advanceTimeByMillis(500);
+              return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
+            });
+
+    assertThat(blockManager.validateAndImportBlock(block))
+        .isCompletedWithValueMatching(InternalValidationResult::isAccept);
+    verifyNoInteractions(eventLogger);
   }
 
   private void assertImportBlockWithResult(SignedBeaconBlock block, FailureReason failureReason) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -564,7 +564,7 @@ public class BlockManagerTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
     verify(eventLogger)
         .lateBlockImport(
-            block.getRoot(), block.getSlot(), UInt64.valueOf(7_000), UInt64.valueOf(3_000));
+            block.getRoot(), block.getSlot(), UInt64.valueOf(1_000), UInt64.valueOf(3_000));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -45,6 +47,8 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public class ReexecutingExecutionPayloadBlockManagerTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+  private final EventLogger eventLogger = mock(EventLogger.class);
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final BlockImportNotifications blockImportNotifications =
       mock(BlockImportNotifications.class);
@@ -80,6 +84,8 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
           pendingBlocks,
           futureBlocks,
           mock(BlockValidator.class),
+          timeProvider,
+          eventLogger,
           asyncRunner);
 
   @BeforeAll

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -200,12 +200,12 @@ public class EventLogger {
   public void lateBlockImport(
       final Bytes32 root,
       final UInt64 slot,
-      final UInt64 arrivalTime,
+      final UInt64 arrivalDelayMs,
       final UInt64 processingTimeMs) {
     String reorgEventLog =
         String.format(
-            "Late Block Import *** Arrival Time: %s, Processing Time: %s: Block: %s",
-            processingTimeMs, arrivalTime, LogFormatter.formatBlock(slot, root));
+            "Late Block Import *** Arrival Delay: %s, Processing Time: %s: Block: %s",
+            processingTimeMs, arrivalDelayMs, LogFormatter.formatBlock(slot, root));
     warn(reorgEventLog, Color.YELLOW);
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -197,6 +197,18 @@ public class EventLogger {
     error(configurationErrorEventLog, Color.RED);
   }
 
+  public void lateBlockImport(
+      final Bytes32 root,
+      final UInt64 slot,
+      final UInt64 arrivalTime,
+      final UInt64 processingTimeMs) {
+    String reorgEventLog =
+        String.format(
+            "Late Block Import *** Arrival Time: %s, Processing Time: %s: Block: %s",
+            processingTimeMs, arrivalTime, LogFormatter.formatBlock(slot, root));
+    warn(reorgEventLog, Color.YELLOW);
+  }
+
   private void info(final String message, final Color color) {
     log.info(print(message, color));
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -205,7 +205,7 @@ public class EventLogger {
     String reorgEventLog =
         String.format(
             "Late Block Import *** Arrival Delay: %s, Processing Time: %s: Block: %s",
-            processingTimeMs, arrivalDelayMs, LogFormatter.formatBlock(slot, root));
+            arrivalDelayMs, processingTimeMs, LogFormatter.formatBlock(slot, root));
     warn(reorgEventLog, Color.YELLOW);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -819,11 +819,19 @@ public class BeaconChainController extends Service implements BeaconChainControl
               pendingBlocks,
               futureBlocks,
               blockValidator,
+              timeProvider,
+              EVENT_LOG,
               beaconAsyncRunner);
     } else {
       blockManager =
           new BlockManager(
-              recentChainData, blockImporter, pendingBlocks, futureBlocks, blockValidator);
+              recentChainData,
+              blockImporter,
+              pendingBlocks,
+              futureBlocks,
+              blockValidator,
+              timeProvider,
+              EVENT_LOG);
     }
     eventChannels
         .subscribe(SlotEventsChannel.class, blockManager)

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -163,6 +163,14 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return genesisTime;
   }
 
+  public UInt64 computeTimeAtSlot(UInt64 slot) {
+    return genesisTime.plus(slot.times(spec.getSecondsPerSlot(slot)));
+  }
+
+  public UInt64 computeMillisSinceSlotStart(UInt64 currentTimeMs, UInt64 slot) {
+    return currentTimeMs.minus(computeTimeAtSlot(slot).times(1000));
+  }
+
   public Optional<GenesisData> getGenesisData() {
     return genesisData;
   }


### PR DESCRIPTION
## PR Description

Adds a late block import event log which writes a yellow warning if block import finishes after 4s into the slot.
It tracks block arrival time and processing time

## Fixed Issue(s)
related to #5188 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
