### PR TITLE
[MEV Boost\Builder] ValidatorRegistration signing capability

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
@@ -48,7 +48,7 @@ public class PostRegisterValidatorTest extends AbstractDataBackedRestAPIIntegrat
   @Test
   void shouldReturnOk() throws IOException {
     final SszList<SignedValidatorRegistration> request =
-        dataStructureUtil.randomValidatorRegistrations(10);
+        dataStructureUtil.randomSignedValidatorRegistrations(10);
     when(validatorApiChannel.registerValidators(request)).thenReturn(SafeFuture.COMPLETE);
 
     try (Response response =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
@@ -41,7 +41,7 @@ public class PostRegisterValidatorTest extends AbstractMigratedBeaconHandlerTest
   public void shouldReturnOK() throws JsonProcessingException {
 
     final SszList<SignedValidatorRegistration> requestBody =
-        dataStructureUtil.randomValidatorRegistrations(2);
+        dataStructureUtil.randomSignedValidatorRegistrations(2);
     when(validatorDataProvider.registerValidators(requestBody)).thenReturn(SafeFuture.COMPLETE);
 
     request.setRequestBody(requestBody);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/GetSpecResponse.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/GetSpecResponse.java
@@ -48,6 +48,7 @@ public class GetSpecResponse {
     configAttributes.put("DOMAIN_VOLUNTARY_EXIT", getDomainVoluntaryExit().toHexString());
     configAttributes.put("DOMAIN_SELECTION_PROOF", getDomainSelectionProof().toHexString());
     configAttributes.put("DOMAIN_AGGREGATE_AND_PROOF", getDomainAggregateAndProof().toHexString());
+    configAttributes.put("DOMAIN_APPLICATION_BUILDER", getDomainApplicationBuilder().toHexString());
     getDomainSyncCommittee()
         .ifPresent(
             committee -> configAttributes.put("DOMAIN_SYNC_COMMITTEE", committee.toHexString()));
@@ -112,6 +113,10 @@ public class GetSpecResponse {
 
   private Bytes4 getDomainAggregateAndProof() {
     return Domain.AGGREGATE_AND_PROOF;
+  }
+
+  public Bytes4 getDomainApplicationBuilder() {
+    return Domain.APPLICATION_BUILDER;
   }
 
   private Optional<Bytes4> getDomainSyncCommittee() {

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/DeletableSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/DeletableSigner.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.infrastructure.async.ExceptionThrowingFutureSupplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -101,6 +102,14 @@ public class DeletableSigner implements Signer {
   public SafeFuture<BLSSignature> signContributionAndProof(
       final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
     return sign(() -> delegate.signContributionAndProof(contributionAndProof, forkInfo));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signValidatorRegistration(
+      final ValidatorRegistration validatorRegistration,
+      final UInt64 epoch,
+      final ForkInfo forkInfo) {
+    return sign(() -> delegate.signValidatorRegistration(validatorRegistration, epoch, forkInfo));
   }
 
   @Override

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -113,6 +114,16 @@ public class LocalSigner implements Signer {
             contributionAndProof.getContribution().getSlot(),
             utils -> utils.getContributionAndProofSigningRoot(contributionAndProof, forkInfo))
         .thenCompose(this::sign);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signValidatorRegistration(
+      final ValidatorRegistration validatorRegistration,
+      final UInt64 epoch,
+      final ForkInfo forkInfo) {
+    return sign(
+        signingRootUtil.signingRootForValidatorRegistration(
+            epoch, validatorRegistration, forkInfo));
   }
 
   private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
@@ -123,7 +123,7 @@ public class LocalSigner implements Signer {
       final ForkInfo forkInfo) {
     return sign(
         signingRootUtil.signingRootForValidatorRegistration(
-            epoch, validatorRegistration, forkInfo));
+            validatorRegistration, epoch, forkInfo));
   }
 
   private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -52,6 +53,9 @@ public interface Signer {
 
   SafeFuture<BLSSignature> signContributionAndProof(
       ContributionAndProof contributionAndProof, ForkInfo forkInfo);
+
+  SafeFuture<BLSSignature> signValidatorRegistration(
+      ValidatorRegistration validatorRegistration, UInt64 epoch, ForkInfo forkInfo);
 
   default boolean isLocal() {
     return getSigningServiceUrl().isEmpty();

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
@@ -111,8 +111,8 @@ public class SigningRootUtil {
   }
 
   public Bytes signingRootForValidatorRegistration(
-      final UInt64 epoch,
       final ValidatorRegistration validatorRegistration,
+      final UInt64 epoch,
       final ForkInfo forkInfo) {
     final SpecVersion specVersion = spec.atEpoch(epoch);
     final Bytes32 domain =

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -107,5 +108,19 @@ public class SigningRootUtil {
             forkInfo.getFork(),
             forkInfo.getGenesisValidatorsRoot());
     return specVersion.miscHelpers().computeSigningRoot(voluntaryExit, domain);
+  }
+
+  public Bytes signingRootForValidatorRegistration(
+      final UInt64 epoch,
+      final ValidatorRegistration validatorRegistration,
+      final ForkInfo forkInfo) {
+    final SpecVersion specVersion = spec.atEpoch(epoch);
+    final Bytes32 domain =
+        spec.getDomain(
+            Domain.APPLICATION_BUILDER,
+            epoch,
+            forkInfo.getFork(),
+            forkInfo.getGenesisValidatorsRoot());
+    return specVersion.miscHelpers().computeSigningRoot(validatorRegistration, domain);
   }
 }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -139,6 +140,12 @@ public class SlashingProtectedSigner implements Signer {
   public SafeFuture<BLSSignature> signContributionAndProof(
       final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
     return delegate.signContributionAndProof(contributionAndProof, forkInfo);
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signValidatorRegistration(
+      ValidatorRegistration validatorRegistration, UInt64 epoch, ForkInfo forkInfo) {
+    return delegate.signValidatorRegistration(validatorRegistration, epoch, forkInfo);
   }
 
   @Override

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
@@ -201,12 +201,14 @@ public class DeletableSignerTest {
   void signSyncCommitteeSelectionProof_shouldNotSignWhenDisabled() {
     final SyncAggregatorSelectionData syncAggregatorSelectionData =
         syncCommitteeUtil.createSyncAggregatorSelectionData(UInt64.ONE, UInt64.valueOf(1));
-    when(delegate.signSyncCommitteeSelectionProof(syncAggregatorSelectionData, forkInfo))
-        .thenReturn(signatureFuture);
+    signer.delete();
 
     assertThatSafeFuture(
             signer.signSyncCommitteeSelectionProof(syncAggregatorSelectionData, forkInfo))
-        .isCompletedWithValue(signature);
+        .isCompletedExceptionallyWith(SignerNotActiveException.class);
+
+    verify(delegate, never())
+        .signSyncCommitteeSelectionProof(syncAggregatorSelectionData, forkInfo);
   }
 
   @Test
@@ -219,6 +221,18 @@ public class DeletableSignerTest {
 
     assertThatSafeFuture(signer.signContributionAndProof(contributionAndProof, forkInfo))
         .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signContributionAndProof_shouldNotSignWhenDisabled() {
+    final ContributionAndProof contributionAndProof =
+        dataStructureUtil.randomSignedContributionAndProof(6L).getMessage();
+    signer.delete();
+
+    assertThatSafeFuture(signer.signContributionAndProof(contributionAndProof, forkInfo))
+        .isCompletedExceptionallyWith(SignerNotActiveException.class);
+
+    verify(delegate, never()).signContributionAndProof(contributionAndProof, forkInfo);
   }
 
   @Test
@@ -235,35 +249,23 @@ public class DeletableSignerTest {
   }
 
   @Test
-  void delete_shouldCallDeleteOnDelegate() {
-    signer.delete();
-    verify(delegate).delete();
-  }
-
-  @Test
-  void signContributionAndProof_shouldNotSignWhenDisabled() {
-    final ContributionAndProof contributionAndProof =
-        dataStructureUtil.randomSignedContributionAndProof(6L).getMessage();
-    signer.delete();
-
-    assertThatSafeFuture(signer.signContributionAndProof(contributionAndProof, forkInfo))
-        .isCompletedExceptionallyWith(SignerNotActiveException.class);
-
-    verify(delegate, never()).signContributionAndProof(contributionAndProof, forkInfo);
-  }
-
-  @Test
   void signValidatorRegistration_shouldNotSignWhenDisabled() {
     final ValidatorRegistration validatorRegistration =
         dataStructureUtil.randomValidatorRegistration();
     signer.delete();
 
     assertThatSafeFuture(
-            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+        signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
         .isCompletedExceptionallyWith(SignerNotActiveException.class);
 
     verify(delegate, never())
         .signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo);
+  }
+
+  @Test
+  void delete_shouldCallDeleteOnDelegate() {
+    signer.delete();
+    verify(delegate).delete();
   }
 
   @Test

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
@@ -255,7 +255,7 @@ public class DeletableSignerTest {
     signer.delete();
 
     assertThatSafeFuture(
-        signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
         .isCompletedExceptionallyWith(SignerNotActiveException.class);
 
     verify(delegate, never())

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -221,6 +222,19 @@ public class DeletableSignerTest {
   }
 
   @Test
+  void signValidatorRegistration_shouldSignWhenActive() {
+
+    final ValidatorRegistration validatorRegistration =
+        dataStructureUtil.randomValidatorRegistration();
+    when(delegate.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+        .thenReturn(signatureFuture);
+
+    assertThatSafeFuture(
+            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
   void delete_shouldCallDeleteOnDelegate() {
     signer.delete();
     verify(delegate).delete();
@@ -230,11 +244,26 @@ public class DeletableSignerTest {
   void signContributionAndProof_shouldNotSignWhenDisabled() {
     final ContributionAndProof contributionAndProof =
         dataStructureUtil.randomSignedContributionAndProof(6L).getMessage();
-    when(delegate.signContributionAndProof(contributionAndProof, forkInfo))
-        .thenReturn(signatureFuture);
+    signer.delete();
 
     assertThatSafeFuture(signer.signContributionAndProof(contributionAndProof, forkInfo))
-        .isCompletedWithValue(signature);
+        .isCompletedExceptionallyWith(SignerNotActiveException.class);
+
+    verify(delegate, never()).signContributionAndProof(contributionAndProof, forkInfo);
+  }
+
+  @Test
+  void signValidatorRegistration_shouldNotSignWhenDisabled() {
+    final ValidatorRegistration validatorRegistration =
+        dataStructureUtil.randomValidatorRegistration();
+    signer.delete();
+
+    assertThatSafeFuture(
+            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+        .isCompletedExceptionallyWith(SignerNotActiveException.class);
+
+    verify(delegate, never())
+        .signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo);
   }
 
   @Test

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -132,6 +133,22 @@ class LocalSignerTest {
                 "qumUYTSgi8hmsS3/a1oDLGSIfOQ4+PgByZpDprnvlQKaDTXnlzGQloQ/W0kAeMa8EhXvGvF0OiGkQxEEznpVsFNhZ01H+3S2StWqq7S0mbRcbJhT6fEcyrOMqRer36q8"));
 
     final SafeFuture<BLSSignature> result = signer.signVoluntaryExit(voluntaryExit, fork);
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result).isCompletedWithValue(expectedSignature);
+  }
+
+  @Test
+  public void shouldSignValidatorRegistration() {
+    final ValidatorRegistration validatorRegistration =
+        dataStructureUtil.randomValidatorRegistration();
+    final BLSSignature expectedSignature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromBase64String(
+                "hQLueiLQoxQIVdziM1Fu9VRFHUdHsyBVdTezeBQBlJ7eLL/7o4fVCEwn7C4DShcmFpYiUjU2Fx942SGPTHGyn42dEMsB/GX1s+jJ0ynkTGiFVFGujX8de2UELM5QExg3"));
+
+    final SafeFuture<BLSSignature> result =
+        signer.signValidatorRegistration(validatorRegistration, UInt64.valueOf(7), fork);
     asyncRunner.executeQueuedActions();
 
     assertThat(result).isCompletedWithValue(expectedSignature);

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/SlashingProtectedSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/SlashingProtectedSignerTest.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -129,6 +130,18 @@ class SlashingProtectedSignerTest {
     when(delegate.signVoluntaryExit(voluntaryExit, forkInfo)).thenReturn(signatureFuture);
 
     assertThatSafeFuture(signer.signVoluntaryExit(voluntaryExit, forkInfo))
+        .isCompletedWithValue(signature);
+  }
+
+  @Test
+  void signValidatorRegistration_shouldAlwaysSign() {
+    final ValidatorRegistration validatorRegistration =
+        dataStructureUtil.randomValidatorRegistration();
+    when(delegate.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+        .thenReturn(signatureFuture);
+
+    assertThatSafeFuture(
+            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
         .isCompletedWithValue(signature);
   }
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -82,6 +83,14 @@ public abstract class NoOpSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signContributionAndProof(
       final ContributionAndProof contributionAndProof, final ForkInfo forkInfo) {
+    return new SafeFuture<>();
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signValidatorRegistration(
+      final ValidatorRegistration validatorRegistration,
+      final UInt64 epoch,
+      final ForkInfo forkInfo) {
     return new SafeFuture<>();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -24,6 +24,7 @@ public class Domain {
   public static final Bytes4 VOLUNTARY_EXIT = Bytes4.fromHexString("0x04000000");
   public static final Bytes4 SELECTION_PROOF = Bytes4.fromHexString("0x05000000");
   public static final Bytes4 AGGREGATE_AND_PROOF = Bytes4.fromHexString("0x06000000");
+  public static final Bytes4 APPLICATION_BUILDER = Bytes4.fromHexString("0x10000001");
 
   // Altair
   public static final Bytes4 SYNC_COMMITTEE = Bytes4.fromHexString("0x07000000");

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1151,25 +1151,35 @@ public final class DataStructureUtil {
         randomUInt64(),
         randomBytes32(),
         randomEth1Address(),
-        withValidatorRegistration ? Optional.of(randomValidatorRegistration()) : Optional.empty());
+        withValidatorRegistration
+            ? Optional.of(randomSignedValidatorRegistration())
+            : Optional.empty());
   }
 
-  public SignedValidatorRegistration randomValidatorRegistration() {
-    return randomValidatorRegistration(randomPublicKey());
+  public ValidatorRegistration randomValidatorRegistration() {
+    return VALIDATOR_REGISTRATION_SCHEMA.create(
+        randomBytes20(), randomUInt64(), randomUInt64(), randomPublicKey());
   }
 
-  public SignedValidatorRegistration randomValidatorRegistration(final BLSPublicKey publicKey) {
-    final ValidatorRegistration validatorRegistration =
-        VALIDATOR_REGISTRATION_SCHEMA.create(
-            randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
-
-    return SIGNED_VALIDATOR_REGISTRATION_SCHEMA.create(validatorRegistration, randomSignature());
+  public ValidatorRegistration randomValidatorRegistration(final BLSPublicKey publicKey) {
+    return VALIDATOR_REGISTRATION_SCHEMA.create(
+        randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
   }
 
-  public SszList<SignedValidatorRegistration> randomValidatorRegistrations(final int size) {
+  public SignedValidatorRegistration randomSignedValidatorRegistration() {
+    return randomSignedValidatorRegistration(randomPublicKey());
+  }
+
+  public SignedValidatorRegistration randomSignedValidatorRegistration(
+      final BLSPublicKey publicKey) {
+    return SIGNED_VALIDATOR_REGISTRATION_SCHEMA.create(
+        randomValidatorRegistration(publicKey), randomSignature());
+  }
+
+  public SszList<SignedValidatorRegistration> randomSignedValidatorRegistrations(final int size) {
     return SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.createFromElements(
         IntStream.range(0, size)
-            .mapToObj(__ -> randomValidatorRegistration())
+            .mapToObj(__ -> randomSignedValidatorRegistration())
             .collect(Collectors.toUnmodifiableList()));
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -905,7 +905,7 @@ class ForkChoiceNotifierTest {
   private SignedValidatorRegistration createValidatorRegistration(
       final BeaconState headState, final UInt64 blockSlot) {
     final int block2Proposer = spec.getBeaconProposerIndex(headState, blockSlot);
-    return dataStructureUtil.randomValidatorRegistration(
+    return dataStructureUtil.randomSignedValidatorRegistration(
         spec.getValidatorPubKey(headState, UInt64.valueOf(block2Proposer)).orElseThrow());
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
@@ -140,7 +140,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
   }
 
   private void prepareRegistrations() {
-    registrations = dataStructureUtil.randomValidatorRegistrations(2);
+    registrations = dataStructureUtil.randomSignedValidatorRegistrations(2);
 
     when(executionLayerChannel.builderRegisterValidator(registrations.get(0), slot))
         .thenReturn(response1);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -251,6 +252,14 @@ public class ExternalSigner implements Signer {
                         FORK_INFO,
                         forkInfo(forkInfo)),
                     slashableGenericMessage("sync committee contribution and proof")));
+  }
+
+  @Override
+  public SafeFuture<BLSSignature> signValidatorRegistration(
+      final ValidatorRegistration validatorRegistration,
+      final UInt64 epoch,
+      final ForkInfo forkInfo) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not implemented"));
   }
 
   @Override

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -80,7 +80,7 @@ class OkHttpValidatorTypeDefClientTest {
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
     SszList<SignedValidatorRegistration> validatorRegistrations =
-        dataStructureUtil.randomValidatorRegistrations(5);
+        dataStructureUtil.randomSignedValidatorRegistrations(5);
 
     String expectedRequest =
         JsonUtil.serialize(
@@ -104,7 +104,7 @@ class OkHttpValidatorTypeDefClientTest {
         new MockResponse().setResponseCode(400).setBody("{\"code\":400,\"message\":\"oopsy\"}"));
 
     SszList<SignedValidatorRegistration> validatorRegistrations =
-        dataStructureUtil.randomValidatorRegistrations(5);
+        dataStructureUtil.randomSignedValidatorRegistrations(5);
 
     IllegalArgumentException badRequestException =
         Assertions.assertThrows(
@@ -133,7 +133,7 @@ class OkHttpValidatorTypeDefClientTest {
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
     SszList<SignedValidatorRegistration> validatorRegistrations =
-        dataStructureUtil.randomValidatorRegistrations(5);
+        dataStructureUtil.randomSignedValidatorRegistrations(5);
 
     sszRegisterValidatorsRequest.registerValidators(validatorRegistrations);
 
@@ -158,7 +158,7 @@ class OkHttpValidatorTypeDefClientTest {
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
     SszList<SignedValidatorRegistration> validatorRegistrations =
-        dataStructureUtil.randomValidatorRegistrations(5);
+        dataStructureUtil.randomSignedValidatorRegistrations(5);
 
     sszRegisterValidatorsRequest.registerValidators(validatorRegistrations);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -524,7 +524,7 @@ class RemoteValidatorApiHandlerTest {
   @Test
   public void registerValidators_InvokeApiWithCorrectRequest() {
     final SszList<SignedValidatorRegistration> validatorRegistrations =
-        dataStructureUtil.randomValidatorRegistrations(5);
+        dataStructureUtil.randomSignedValidatorRegistrations(5);
 
     final SafeFuture<Void> result = apiHandler.registerValidators(validatorRegistrations);
     asyncRunner.executeQueuedActions();


### PR DESCRIPTION
## PR Description

- Added `DOMAIN_APPLICATION_BUILDER` to the domains as per the builder specs: https://github.com/ethereum/builder-specs/blob/main/specs/README.md
- Added `signValidatorRegistration` method to `Signer` interface and implemented the functionality
- Return not implemented error for `ExternalSigner` until external signing of validator registration capability is released.
- Renamed `randomValidatorRegistration` to `randomSignedValidatorRegistration` in `DataStructureUtil`
- Fixed `signContributionAndProof_shouldNotSignWhenDisabled` to check the disabled scenario

## Fixed Issue(s)
related to #5396 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
