### PR TITLE
[Mev Boost\Builder] we should be using builder post-merge only

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -154,18 +154,17 @@ public class BlockOperationSelectorFactory {
                         .getHeaderOfDefaultPayload(),
                 (executionPayloadContext) -> {
                   final boolean forceLocalFallback =
-                          executionPayloadContext
-                                  .getForkChoiceState()
-                                  .getFinalizedExecutionBlockHash()
-                                  .isZero();
+                      executionPayloadContext
+                          .getForkChoiceState()
+                          .getFinalizedExecutionBlockHash()
+                          .isZero();
 
                   if (forceLocalFallback) {
                     LOG.info(
-                            "Merge transition not finalized: forcing block production using local execution engine");
+                        "Merge transition not finalized: forcing block production using local execution engine");
                   }
-                  return executionLayerChannel
-                          .builderGetHeader(
-                                  executionPayloadContext, blockSlotState.getSlot(), forceLocalFallback);
+                  return executionLayerChannel.builderGetHeader(
+                      executionPayloadContext, blockSlotState.getSlot(), forceLocalFallback);
                 }));
         return;
       }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -45,6 +47,8 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 
 public class BlockOperationSelectorFactory {
+  private static final Logger LOG = LogManager.getLogger();
+
   private final Spec spec;
   private final AggregatingAttestationPool attestationPool;
   private final OperationPool<AttesterSlashing> attesterSlashingPool;
@@ -141,6 +145,11 @@ public class BlockOperationSelectorFactory {
 
         final boolean forceLocalFallback =
             !specVersion.miscHelpers().isMergeTransitionComplete(blockSlotState);
+
+        if (forceLocalFallback) {
+          LOG.info(
+              "Merge transition not completed: forcing block production using local execution engine");
+        }
 
         bodyBuilder.executionPayloadHeader(
             payloadProvider(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -305,7 +306,7 @@ class BlockFactoryTest {
                 Optional.of(dataStructureUtil.randomPayloadExecutionContext(false))));
     when(executionLayer.engineGetPayload(any(), any()))
         .thenReturn(SafeFuture.completedFuture(executionPayload));
-    when(executionLayer.builderGetHeader(any(), any()))
+    when(executionLayer.builderGetHeader(any(), any(), anyBoolean()))
         .thenReturn(SafeFuture.completedFuture(executionPayloadHeader));
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -373,7 +373,7 @@ class BlockOperationSelectorFactoryTest {
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconStatePreMerge(slot);
 
     final ExecutionPayloadContext executionPayloadContext =
-        dataStructureUtil.randomPayloadExecutionContext(false);
+        dataStructureUtil.randomPayloadExecutionContext(Bytes32.ZERO, false);
     final ExecutionPayloadHeader randomExecutionPayloadHeader =
         dataStructureUtil.randomExecutionPayloadHeader();
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -130,9 +130,9 @@ class BlockOperationSelectorFactoryTest {
           .getDefault();
 
   private final ExecutionPayloadHeader executionPayloadHeaderOfDefaultPayload =
-          SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
-                  .getExecutionPayloadHeaderSchema()
-                  .getHeaderOfDefaultPayload();
+      SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
+          .getExecutionPayloadHeaderSchema()
+          .getHeaderOfDefaultPayload();
 
   private final CapturingBeaconBlockBodyBuilder bodyBuilder =
       new CapturingBeaconBlockBodyBuilder(false);
@@ -293,10 +293,11 @@ class BlockOperationSelectorFactoryTest {
     final UInt64 slot = UInt64.ONE;
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconStatePreMerge(slot);
     factory
-            .createSelector(
-                    parentRoot, blockSlotState, dataStructureUtil.randomSignature(), Optional.empty())
-            .accept(blindedBodyBuilder);
-    assertThat(blindedBodyBuilder.executionPayloadHeader).isEqualTo(executionPayloadHeaderOfDefaultPayload);
+        .createSelector(
+            parentRoot, blockSlotState, dataStructureUtil.randomSignature(), Optional.empty())
+        .accept(blindedBodyBuilder);
+    assertThat(blindedBodyBuilder.executionPayloadHeader)
+        .isEqualTo(executionPayloadHeaderOfDefaultPayload);
   }
 
   @Test

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -287,7 +287,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final UInt64 slot,
-      boolean forceLocalFallback) {
+      final boolean forceLocalFallback) {
 
     final SafeFuture<ExecutionPayload> localExecutionPayload =
         engineGetPayload(executionPayloadContext, slot, true);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -74,7 +74,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   private final AtomicBoolean latestBuilderAvailability;
 
   /**
-   * slotToLocalElFallbackData usage:
+   * slotToLocalElFallbackPayload usage:
    *
    * <p>if we serve builderGetHeader using local execution engine, we store slot->executionPayload
    * to be able to serve builderGetPayload later
@@ -285,7 +285,9 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
   @Override
   public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
-      final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
+      final ExecutionPayloadContext executionPayloadContext,
+      final UInt64 slot,
+      boolean forceLocalFallback) {
 
     final SafeFuture<ExecutionPayload> localExecutionPayload =
         engineGetPayload(executionPayloadContext, slot, true);
@@ -293,7 +295,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     final Optional<BLSPublicKey> registeredValidatorPublicKey =
         executionPayloadContext.getPayloadBuildingAttributes().getValidatorRegistrationPublicKey();
 
-    if (!isBuilderAvailable() || registeredValidatorPublicKey.isEmpty()) {
+    if (forceLocalFallback || !isBuilderAvailable() || registeredValidatorPublicKey.isEmpty()) {
       // fallback to local execution engine
       return doFallbackToLocal(localExecutionPayload, slot);
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -74,7 +74,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
             final ExecutionPayloadContext executionPayloadContext,
             final UInt64 slot,
-            boolean forceLocalFallback) {
+            final boolean forceLocalFallback) {
           return SafeFuture.completedFuture(null);
         }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -72,7 +72,9 @@ public interface ExecutionLayerChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
-            final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
+            final ExecutionPayloadContext executionPayloadContext,
+            final UInt64 slot,
+            boolean forceLocalFallback) {
           return SafeFuture.completedFuture(null);
         }
 
@@ -106,7 +108,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       SignedValidatorRegistration signedValidatorRegistration, UInt64 slot);
 
   SafeFuture<ExecutionPayloadHeader> builderGetHeader(
-      ExecutionPayloadContext executionPayloadContext, UInt64 slot);
+      ExecutionPayloadContext executionPayloadContext, UInt64 slot, boolean forceLocalFallback);
 
   SafeFuture<ExecutionPayload> builderGetPayload(SignedBeaconBlock signedBlindedBeaconBlock);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -268,7 +268,9 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
-      final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
+      final ExecutionPayloadContext executionPayloadContext,
+      final UInt64 slot,
+      boolean forceLocalFallback) {
     LOG.info(
         "getPayloadHeader: payloadId: {} slot: {} ... delegating to getPayload ...",
         executionPayloadContext,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -270,7 +270,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final UInt64 slot,
-      boolean forceLocalFallback) {
+      final boolean forceLocalFallback) {
     LOG.info(
         "getPayloadHeader: payloadId: {} slot: {} ... delegating to getPayload ...",
         executionPayloadContext,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1260,6 +1260,20 @@ public final class DataStructureUtil {
     return randomBeaconState().updated(state -> state.setSlot(slot));
   }
 
+  public BeaconState randomBeaconStatePreMerge(UInt64 slot) {
+    return randomBeaconState()
+        .updated(state -> state.setSlot(slot))
+        .updated(
+            state ->
+                state
+                    .toMutableVersionBellatrix()
+                    .orElseThrow()
+                    .setLatestExecutionPayloadHeader(
+                        getBellatrixSchemaDefinitions(slot)
+                            .getExecutionPayloadHeaderSchema()
+                            .getDefault()));
+  }
+
   public AnchorPoint randomAnchorPoint(final long epoch) {
     return randomAnchorPoint(UInt64.valueOf(epoch));
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1147,6 +1147,14 @@ public final class DataStructureUtil {
   }
 
   public ExecutionPayloadContext randomPayloadExecutionContext(
+      final Bytes32 finalizedBlockHash, final boolean optimisticHead) {
+    return new ExecutionPayloadContext(
+        randomBytes8(),
+        randomForkChoiceState(randomUInt64(), finalizedBlockHash, optimisticHead),
+        randomPayloadBuildingAttributes(false));
+  }
+
+  public ExecutionPayloadContext randomPayloadExecutionContext(
       final boolean optimisticHead, final boolean withValidatorRegistration) {
     return new ExecutionPayloadContext(
         randomBytes8(),
@@ -1158,7 +1166,7 @@ public final class DataStructureUtil {
       final UInt64 slot, final boolean optimisticHead) {
     return new ExecutionPayloadContext(
         randomBytes8(),
-        randomForkChoiceState(slot, optimisticHead),
+        randomForkChoiceState(slot, randomBytes32(), optimisticHead),
         randomPayloadBuildingAttributes(false));
   }
 
@@ -1201,17 +1209,17 @@ public final class DataStructureUtil {
   }
 
   public ForkChoiceState randomForkChoiceState(final boolean optimisticHead) {
-    return randomForkChoiceState(randomUInt64(), optimisticHead);
+    return randomForkChoiceState(randomUInt64(), randomBytes32(), optimisticHead);
   }
 
   public ForkChoiceState randomForkChoiceState(
-      final UInt64 headBlockSlot, final boolean optimisticHead) {
+      final UInt64 headBlockSlot, final Bytes32 finalizedBlockHash, final boolean optimisticHead) {
     return new ForkChoiceState(
         randomBytes32(),
         headBlockSlot,
         randomBytes32(),
         randomBytes32(),
-        randomBytes32(),
+        finalizedBlockHash,
         optimisticHead);
   }
 


### PR DESCRIPTION
To reduce complexity during the transition, has been decided to start using builder infrastructure post merge only.

I'm introducing a `forceLocalFallback` in `builderGetHeader` to be used by `BlockOperationSelectorFactory` to control the fallback based on current transition state.

to summarize the flows:

blinded flow:
- pre bellatrix: `BlockFactory` transparently passthrough blocks
- post bellatrix:
  - pre transition: `BlockOperationSelectorFactory` will produce `executionHeaderOfDefaultPayload`. The flow completes in `createUnblinderSelector` which generates the corresponding `defaultPayload`
  - transition occurred, not finalized: `BlockOperationSelectorFactory` will force `forceLocalFallback` in `builderGetHeader`. The flow completes in `createUnblinderSelector` which calls `builderGetPayload` that rebuilds the payload from the fallback cache.
  - transition occurred and finalized: `BlockOperationSelectorFactory` will call `builderGetHeader` which eventually fallback. The flow completes in `createUnblinderSelector` which calls `builderGetPayload` that rebuilds the payload by calling  the builder or from the fallback cache.

unblinded flow (standard):
- pre bellatrix:  standard flow
- post bellatrix:
  - pre transition: `BlockOperationSelectorFactory` will produce `defaultPayload`
  - transition occurred, not finalized: `BlockOperationSelectorFactory` will call local `engineGetPayload`
  - transition occurred and finalized: same as above.

related to #5396 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
