### PR TITLE
[MEV Boost\Builder] Retrieve gasLimit and use an enabled flag for validator registration

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -55,6 +55,16 @@ public class ProposerConfig {
     return Optional.ofNullable(proposerConfig.get(pubKey));
   }
 
+  public Optional<Boolean> isValidatorRegistrationEnabledForPubKey(final BLSPublicKey pubKey) {
+    Config config = getConfigForPubKey(pubKey).orElse(defaultConfig);
+    return config.getValidatorRegistration().map(ValidatorRegistration::isEnabled);
+  }
+
+  public Optional<UInt64> getValidatorRegistrationGasLimitForPubKey(final BLSPublicKey pubKey) {
+    Config config = getConfigForPubKey(pubKey).orElse(defaultConfig);
+    return config.getValidatorRegistration().flatMap(ValidatorRegistration::getGasLimit);
+  }
+
   public Config getDefaultConfig() {
     return defaultConfig;
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -55,14 +55,20 @@ public class ProposerConfig {
     return Optional.ofNullable(proposerConfig.get(pubKey));
   }
 
+  public Config getConfigForPubKeyOrDefault(final BLSPublicKey pubKey) {
+    return getConfigForPubKey(pubKey).orElse(defaultConfig);
+  }
+
   public Optional<Boolean> isValidatorRegistrationEnabledForPubKey(final BLSPublicKey pubKey) {
-    Config config = getConfigForPubKey(pubKey).orElse(defaultConfig);
-    return config.getValidatorRegistration().map(ValidatorRegistration::isEnabled);
+    return getConfigForPubKeyOrDefault(pubKey)
+        .getValidatorRegistration()
+        .map(ValidatorRegistration::isEnabled);
   }
 
   public Optional<UInt64> getValidatorRegistrationGasLimitForPubKey(final BLSPublicKey pubKey) {
-    Config config = getConfigForPubKey(pubKey).orElse(defaultConfig);
-    return config.getValidatorRegistration().flatMap(ValidatorRegistration::getGasLimit);
+    return getConfigForPubKeyOrDefault(pubKey)
+        .getValidatorRegistration()
+        .flatMap(ValidatorRegistration::getGasLimit);
   }
 
   public Config getDefaultConfig() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -159,6 +159,17 @@ public class ValidatorClientService extends Service {
                   Optional.of(
                       ValidatorClientService.getKeyManagerPath(services.getDataDirLayout())
                           .resolve("api-proposer-config.json"))));
+
+      validatorRegistrator =
+          Optional.of(
+              new ValidatorRegistrator(
+                  config.getSpec(),
+                  services.getTimeProvider(),
+                  validatorLoader.getOwnedValidators(),
+                  proposerConfigProvider.get(),
+                  config.getValidatorConfig(),
+                  beaconProposerPreparer.get(),
+                  validatorApiChannel));
     }
     if (validatorApiConfig.isRestApiEnabled()) {
       validatorRestApi =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationIdentity.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationIdentity.java
@@ -15,23 +15,23 @@ package tech.pegasys.teku.validator.client;
 
 import java.util.Objects;
 import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 public class ValidatorRegistrationIdentity {
 
-  private final Bytes20 feeRecipient;
+  private final Eth1Address feeRecipient;
   private final UInt64 gasLimit;
   private final BLSPublicKey publicKey;
 
   public ValidatorRegistrationIdentity(
-      final Bytes20 feeRecipient, final UInt64 gasLimit, final BLSPublicKey publicKey) {
+      final Eth1Address feeRecipient, final UInt64 gasLimit, final BLSPublicKey publicKey) {
     this.feeRecipient = feeRecipient;
     this.gasLimit = gasLimit;
     this.publicKey = publicKey;
   }
 
-  public Bytes20 getFeeRecipient() {
+  public Eth1Address getFeeRecipient() {
     return feeRecipient;
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -39,8 +39,10 @@ import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrati
 import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.schemas.ApiSchemas;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+import tech.pegasys.teku.validator.client.proposerconfig.ProposerConfigProvider;
 
 public class ValidatorRegistrator implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
@@ -54,6 +56,8 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   private final Spec spec;
   private final TimeProvider timeProvider;
   private final OwnedValidators ownedValidators;
+  private final ProposerConfigProvider proposerConfigProvider;
+  private final ValidatorConfig validatorConfig;
   private final FeeRecipientProvider feeRecipientProvider;
   private final ValidatorApiChannel validatorApiChannel;
 
@@ -61,13 +65,17 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       final Spec spec,
       final TimeProvider timeProvider,
       final OwnedValidators ownedValidators,
+      final ProposerConfigProvider proposerConfigProvider,
+      final ValidatorConfig validatorConfig,
       final FeeRecipientProvider feeRecipientProvider,
       final ValidatorApiChannel validatorApiChannel) {
     this.spec = spec;
     this.timeProvider = timeProvider;
     this.ownedValidators = ownedValidators;
+    this.proposerConfigProvider = proposerConfigProvider;
     this.feeRecipientProvider = feeRecipientProvider;
     this.validatorApiChannel = validatorApiChannel;
+    this.validatorConfig = validatorConfig;
   }
 
   @Override
@@ -130,54 +138,85 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       return SafeFuture.completedFuture(null);
     }
 
-    final Stream<SafeFuture<SignedValidatorRegistration>> validatorRegistrationsFutures =
-        validators.stream()
-            .flatMap(
-                validator -> {
-                  final BLSPublicKey publicKey = validator.getPublicKey();
-                  final Optional<Eth1Address> maybeFeeRecipient =
-                      feeRecipientProvider.getFeeRecipient(publicKey);
+    return proposerConfigProvider
+        .getProposerConfig()
+        .thenCompose(
+            maybeProposerConfig -> {
+              final Stream<SafeFuture<SignedValidatorRegistration>> validatorRegistrationsFutures =
+                  validators.stream()
+                      .flatMap(
+                          validator -> {
+                            final BLSPublicKey publicKey = validator.getPublicKey();
 
-                  if (maybeFeeRecipient.isEmpty()) {
-                    LOG.warn(
-                        "There is no fee recipient configured for {}. Can't register.", validator);
-                    return Stream.empty();
-                  }
+                            if (!registrationIsEnabled(maybeProposerConfig, publicKey)) {
+                              return Stream.empty();
+                            }
 
-                  final ValidatorRegistrationIdentity validatorRegistrationIdentity =
-                      createValidatorRegistrationIdentity(validator, maybeFeeRecipient.get());
+                            final Optional<Eth1Address> maybeFeeRecipient =
+                                feeRecipientProvider.getFeeRecipient(publicKey);
 
-                  if (cachedValidatorRegistrations.containsKey(validatorRegistrationIdentity)) {
-                    final SignedValidatorRegistration cachedRegistration =
-                        cachedValidatorRegistrations.get(validatorRegistrationIdentity);
-                    return Stream.of(SafeFuture.completedFuture(cachedRegistration));
-                  }
+                            if (maybeFeeRecipient.isEmpty()) {
+                              LOG.warn(
+                                  "There is no fee recipient configured for {}. Can't register.",
+                                  validator);
+                              return Stream.empty();
+                            }
 
-                  final ValidatorRegistration validatorRegistration =
-                      createValidatorRegistration(validatorRegistrationIdentity);
-                  final Signer signer = validator.getSigner();
-                  final SafeFuture<SignedValidatorRegistration> registrationFuture =
-                      signValidatorRegistration(validatorRegistration, signer, epoch)
-                          .thenPeek(
-                              signedValidatorRegistration ->
-                                  cachedValidatorRegistrations.put(
-                                      validatorRegistrationIdentity, signedValidatorRegistration));
-                  return Stream.of(registrationFuture);
-                });
+                            final UInt64 gasLimit = getGasLimit(maybeProposerConfig, publicKey);
 
-    return SafeFuture.collectAll(validatorRegistrationsFutures)
-        .thenApply(
-            validatorRegistrations ->
-                SszUtils.toSszList(
-                    ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA, validatorRegistrations))
-        .thenCompose(validatorApiChannel::registerValidators);
+                            final ValidatorRegistrationIdentity validatorRegistrationIdentity =
+                                createValidatorRegistrationIdentity(
+                                    validator, maybeFeeRecipient.get(), gasLimit);
+
+                            if (cachedValidatorRegistrations.containsKey(
+                                validatorRegistrationIdentity)) {
+                              final SignedValidatorRegistration cachedRegistration =
+                                  cachedValidatorRegistrations.get(validatorRegistrationIdentity);
+                              return Stream.of(SafeFuture.completedFuture(cachedRegistration));
+                            }
+
+                            final ValidatorRegistration validatorRegistration =
+                                createValidatorRegistration(validatorRegistrationIdentity);
+                            final Signer signer = validator.getSigner();
+                            final SafeFuture<SignedValidatorRegistration> registrationFuture =
+                                signValidatorRegistration(validatorRegistration, signer, epoch)
+                                    .thenPeek(
+                                        signedValidatorRegistration ->
+                                            cachedValidatorRegistrations.put(
+                                                validatorRegistrationIdentity,
+                                                signedValidatorRegistration));
+                            return Stream.of(registrationFuture);
+                          });
+
+              return SafeFuture.collectAll(validatorRegistrationsFutures)
+                  .thenApply(
+                      validatorRegistrations ->
+                          SszUtils.toSszList(
+                              ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA,
+                              validatorRegistrations))
+                  .thenCompose(validatorApiChannel::registerValidators);
+            });
+  }
+
+  private boolean registrationIsEnabled(
+      final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
+    return maybeProposerConfig
+        .flatMap(
+            proposerConfig -> proposerConfig.isValidatorRegistrationEnabledForPubKey(publicKey))
+        .orElse(validatorConfig.isValidatorsRegistrationDefaultEnabled());
+  }
+
+  private UInt64 getGasLimit(
+      final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
+    return maybeProposerConfig
+        .flatMap(
+            proposerConfig -> proposerConfig.getValidatorRegistrationGasLimitForPubKey(publicKey))
+        .orElse(validatorConfig.getValidatorsRegistrationDefaultGasLimit());
   }
 
   private ValidatorRegistrationIdentity createValidatorRegistrationIdentity(
-      final Validator validator, final Eth1Address feeRecipient) {
-    // hardcoding gas_limit to ZERO for now. The real value will be
-    // taken from the proposer config in a future PR.
-    return new ValidatorRegistrationIdentity(feeRecipient, UInt64.ZERO, validator.getPublicKey());
+      final Validator validator, final Eth1Address feeRecipient, final UInt64 gasLimit) {
+    return new ValidatorRegistrationIdentity(feeRecipient, gasLimit, validator.getPublicKey());
   }
 
   private ValidatorRegistration createValidatorRegistration(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.tuweni.bytes.Bytes48;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+import tech.pegasys.teku.validator.client.ProposerConfig.Config;
+import tech.pegasys.teku.validator.client.ProposerConfig.ValidatorRegistration;
+
+class ProposerConfigTest {
+
+  private static final Eth1Address ETH1_ADDRESS =
+      Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3");
+  private static final Bytes48 PUB_KEY =
+      Bytes48.fromHexString(
+          "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
+  private static final Bytes48 ANOTHER_PUB_KEY =
+      Bytes48.fromHexString(
+          "0x89ece308f9d1f0131765212deca99697b112d61f9be9a5f1f3780a51335b3ff981747a0b2ca2179b96d2c0c9024e5224");
+
+  private static final Config NO_VALIDATOR_REGISTRATION_CONFIG = new Config(ETH1_ADDRESS, null);
+
+  private static final UInt64 DEFAULT_GAS_LIMIT = UInt64.valueOf(30_000_000);
+  private static final UInt64 CUSTOM_GAS_LIMIT = UInt64.valueOf(28_000_000);
+
+  private static final Config DEFAULT_CONFIG =
+      new Config(ETH1_ADDRESS, new ValidatorRegistration(false, DEFAULT_GAS_LIMIT));
+
+  @Test
+  void gets_isValidatorRegistrationEnabled_forPubKey() {
+    Map<Bytes48, Config> configByPubKey = new HashMap<>();
+    configByPubKey.put(
+        PUB_KEY, new Config(ETH1_ADDRESS, new ValidatorRegistration(true, CUSTOM_GAS_LIMIT)));
+    ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
+
+    assertThat(
+            proposerConfig.isValidatorRegistrationEnabledForPubKey(
+                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .hasValue(true);
+
+    // defaults to default config
+    assertThat(
+            proposerConfig.isValidatorRegistrationEnabledForPubKey(
+                BLSPublicKey.fromBytesCompressed(ANOTHER_PUB_KEY)))
+        .hasValue(false);
+  }
+
+  @Test
+  void registrationIsNotEnabledDoesNotExist_whenRegistrationIsNull() {
+    ProposerConfig proposerConfig =
+        new ProposerConfig(new HashMap<>(), NO_VALIDATOR_REGISTRATION_CONFIG);
+
+    assertThat(
+            proposerConfig.isValidatorRegistrationEnabledForPubKey(
+                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .isEmpty();
+  }
+
+  @Test
+  void gets_validatorRegistrationGasLimit_forPubKey() {
+    Map<Bytes48, Config> configByPubKey = new HashMap<>();
+    configByPubKey.put(
+        PUB_KEY, new Config(ETH1_ADDRESS, new ValidatorRegistration(true, CUSTOM_GAS_LIMIT)));
+    ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
+
+    assertThat(
+            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
+                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .hasValue(CUSTOM_GAS_LIMIT);
+
+    // defaults to default config
+    assertThat(
+            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
+                BLSPublicKey.fromBytesCompressed(ANOTHER_PUB_KEY)))
+        .hasValue(DEFAULT_GAS_LIMIT);
+  }
+
+  @Test
+  void registrationGasLimitDoesNotExist_whenRegistrationIsNull() {
+    ProposerConfig proposerConfig =
+        new ProposerConfig(new HashMap<>(), NO_VALIDATOR_REGISTRATION_CONFIG);
+
+    assertThat(
+            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
+                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .isEmpty();
+  }
+
+  @Test
+  void registrationGasLimitDoesNotExist_whenGasLimitIsNull() {
+    Map<Bytes48, Config> configByPubKey = new HashMap<>();
+    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new ValidatorRegistration(true, null)));
+    ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
+
+    assertThat(
+            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
+                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .isEmpty();
+  }
+}


### PR DESCRIPTION
## PR Description
Introduced helper methods in `ProposerConfig` to retrieve validator registration specific fields
Initialized `ValidatorRegistrator` in `ValidatorClientService`
Changed `ValidatorRegistrator` to get the gas limit and the enabled flag from the config

## Fixed Issue(s)
Fixes #5637 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
