### PR TITLE
[MEV Boost\Builder] remove "already in progress" warning, implements a last config validity period

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -75,6 +75,10 @@ public class ProposerConfig {
     return defaultConfig;
   }
 
+  public int getNumberOfProposerConfigs() {
+    return proposerConfig.size();
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -146,6 +146,7 @@ public class ValidatorClientService extends Service {
                   asyncRunner,
                   config.getValidatorConfig().getRefreshProposerConfigFromSource(),
                   new ProposerConfigLoader(new JsonProvider().getObjectMapper()),
+                  services.getTimeProvider(),
                   config.getValidatorConfig().getProposerConfigSource()));
 
       beaconProposerPreparer =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/AbstractProposerConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/AbstractProposerConfigProvider.java
@@ -19,25 +19,33 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.client.ProposerConfig;
 import tech.pegasys.teku.validator.client.proposerconfig.loader.ProposerConfigLoader;
 
 public abstract class AbstractProposerConfigProvider implements ProposerConfigProvider {
   private static final Logger LOG = LogManager.getLogger();
 
+  public static final int LAST_PROPOSER_CONFIG_VALIDITY_PERIOD = 300;
+
   private final boolean refresh;
   private final AsyncRunner asyncRunner;
   protected final ProposerConfigLoader proposerConfigLoader;
+  private final TimeProvider timeProvider;
   private Optional<ProposerConfig> lastProposerConfig = Optional.empty();
+  private UInt64 lastProposerConfigTimeStamp = UInt64.ZERO;
   private Optional<SafeFuture<Optional<ProposerConfig>>> futureProposerConfig = Optional.empty();
 
   AbstractProposerConfigProvider(
       final AsyncRunner asyncRunner,
       final boolean refresh,
-      final ProposerConfigLoader proposerConfigLoader) {
+      final ProposerConfigLoader proposerConfigLoader,
+      final TimeProvider timeProvider) {
     this.asyncRunner = asyncRunner;
     this.refresh = refresh;
     this.proposerConfigLoader = proposerConfigLoader;
+    this.timeProvider = timeProvider;
   }
 
   @Override
@@ -47,16 +55,24 @@ public abstract class AbstractProposerConfigProvider implements ProposerConfigPr
     }
 
     if (futureProposerConfig.isPresent()) {
-      LOG.warn(
-          "A proposer config load is already progress, waiting it instead of generating a new request");
+      // a proposer config reload is in progress, use that as result
       return futureProposerConfig.get();
     }
+
+    if (lastProposerConfig.isPresent()
+        && lastProposerConfigTimeStamp.isGreaterThan(
+            timeProvider.getTimeInSeconds().minus(LAST_PROPOSER_CONFIG_VALIDITY_PERIOD))) {
+      // last proposer config is still valid
+      return SafeFuture.completedFuture(lastProposerConfig);
+    }
+
     futureProposerConfig =
         Optional.of(
             asyncRunner
                 .runAsync(
                     () -> {
                       lastProposerConfig = Optional.of(internalGetProposerConfig());
+                      lastProposerConfigTimeStamp = timeProvider.getTimeInSeconds();
                       return lastProposerConfig;
                     })
                 .orTimeout(30, TimeUnit.SECONDS)
@@ -72,7 +88,11 @@ public abstract class AbstractProposerConfigProvider implements ProposerConfigPr
                           "An error occurred while obtaining config and there is no previously loaded config",
                           throwable);
                     })
-                .thenPeek(__ -> LOG.info("proposer config successfully loaded"))
+                .thenPeek(
+                    proposerConfig ->
+                        LOG.info(
+                            "proposer config successfully loaded. It contains the default configuration and {} specific configuration(s).",
+                            proposerConfig.orElseThrow().getNumberOfProposerConfigs()))
                 .alwaysRun(
                     () -> {
                       synchronized (this) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/AbstractProposerConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/AbstractProposerConfigProvider.java
@@ -91,7 +91,7 @@ public abstract class AbstractProposerConfigProvider implements ProposerConfigPr
                 .thenPeek(
                     proposerConfig ->
                         LOG.info(
-                            "proposer config successfully loaded. It contains the default configuration and {} specific configuration(s).",
+                            "Proposer config successfully loaded. It contains the default configuration and {} specific configuration(s).",
                             proposerConfig.orElseThrow().getNumberOfProposerConfigs()))
                 .alwaysRun(
                     () -> {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProvider.java
@@ -19,6 +19,7 @@ import java.net.URL;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.validator.client.ProposerConfig;
 import tech.pegasys.teku.validator.client.proposerconfig.loader.ProposerConfigLoader;
 
@@ -29,13 +30,15 @@ public interface ProposerConfigProvider {
       final AsyncRunner asyncRunner,
       final boolean refresh,
       final ProposerConfigLoader proposerConfigLoader,
+      final TimeProvider timeProvider,
       final Optional<String> source) {
 
     if (source.isPresent()) {
       URL sourceUrl;
       try {
         sourceUrl = new URL(source.get());
-        return new UrlProposerConfigProvider(asyncRunner, refresh, proposerConfigLoader, sourceUrl);
+        return new UrlProposerConfigProvider(
+            asyncRunner, refresh, proposerConfigLoader, timeProvider, sourceUrl);
       } catch (MalformedURLException e1) {
         try {
           sourceUrl = new File(source.get()).toURI().toURL();
@@ -43,7 +46,8 @@ public interface ProposerConfigProvider {
           throw new RuntimeException("Unable to translate file to URL", e2);
         }
       }
-      return new UrlProposerConfigProvider(asyncRunner, refresh, proposerConfigLoader, sourceUrl);
+      return new UrlProposerConfigProvider(
+          asyncRunner, refresh, proposerConfigLoader, timeProvider, sourceUrl);
     }
     return NOOP;
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/UrlProposerConfigProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/proposerconfig/UrlProposerConfigProvider.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.proposerconfig;
 
 import java.net.URL;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.validator.client.ProposerConfig;
 import tech.pegasys.teku.validator.client.proposerconfig.loader.ProposerConfigLoader;
 
@@ -25,8 +26,9 @@ public class UrlProposerConfigProvider extends AbstractProposerConfigProvider {
       final AsyncRunner asyncRunner,
       final boolean refresh,
       final ProposerConfigLoader proposerConfigLoader,
+      final TimeProvider timeProvider,
       final URL source) {
-    super(asyncRunner, refresh, proposerConfigLoader);
+    super(asyncRunner, refresh, proposerConfigLoader, timeProvider);
     this.source = source;
   }
 


### PR DESCRIPTION
now that we have `ValidatorRegistrator` that uses proposerConfigProvider to retrieve info, it is perfectly fine that we have multiple concurrent requests to provide the config.

So I removed the warning and improved the refresh logic which will provide last refreshed config for 5 minutes. Only after this period the config is considered expired and actually reloaded.

## PR Description

## Fixed Issue(s)
fixes #5648

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
