### PR TITLE
Add independent data expiration in `ProposersDataManager`

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExpiringInfo.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExpiringInfo.java
@@ -23,7 +23,7 @@ public abstract class ExpiringInfo {
   }
 
   public boolean hasExpired(final UInt64 currentSlot) {
-    return currentSlot.isGreaterThanOrEqualTo(expirySlot);
+    return currentSlot.isGreaterThan(expirySlot);
   }
 
   public UInt64 getExpirySlot() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -973,6 +973,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     proposersDataManager =
         new ProposersDataManager(
             eventThread, spec, executionLayer, recentChainData, getProposerDefaultFeeRecipient());
+    eventChannels.subscribe(SlotEventsChannel.class, proposersDataManager);
     forkChoiceNotifier =
         new ForkChoiceNotifierImpl(
             eventThread, spec, executionLayer, recentChainData, proposersDataManager);


### PR DESCRIPTION
Makes sure that we are cleaning up prepared proposers and validator registrations when corresponding API calls are no more called. The cleanup happens on every second slot of each epoch.

Note: We also forgotten to expire validator registration, now it is covered by this PR.

## Fixed Issue(s)
fixes #5737

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
