### PR TITLE
Set locale to C.UTF-8 in Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Log a warning instead of a verbose error if node is syncing while performing sync committee duties
 
 ### Bug Fixes
- - Fix rendering emoticons in graffiti when running in a Docker container
+ - Fix not rendering emoticons correctly in graffiti when running in a Docker container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
- - Log a warning if node is syncing while performing sync committee duties instead of a verbose error
+ - Log a warning instead of a verbose error if node is syncing while performing sync committee duties
 
 ### Bug Fixes
+ - Fix rendering emoticons in graffiti when running in a Docker container

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -25,7 +25,8 @@ WORKDIR /opt/teku
 # copy application (with libraries inside)
 COPY --chown=teku:teku teku /opt/teku/
 
-ENV LANG="C.UTF-8"
+# Default to UTF-8 locale
+ENV LANG C.UTF-8
 
 ENV TEKU_REST_API_INTERFACE="0.0.0.0"
 ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -25,6 +25,8 @@ WORKDIR /opt/teku
 # copy application (with libraries inside)
 COPY --chown=teku:teku teku /opt/teku/
 
+ENV LANG="C.UTF-8"
+
 ENV TEKU_REST_API_INTERFACE="0.0.0.0"
 ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"
 ENV TEKU_METRICS_INTERFACE="0.0.0.0"

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -25,7 +25,8 @@ WORKDIR /opt/teku
 # copy application (with libraries inside)
 COPY --chown=teku:teku teku /opt/teku/
 
-ENV LANG="C.UTF-8"
+# Default to UTF-8 locale
+ENV LANG C.UTF-8
 
 ENV TEKU_REST_API_INTERFACE="0.0.0.0"
 ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -25,6 +25,8 @@ WORKDIR /opt/teku
 # copy application (with libraries inside)
 COPY --chown=teku:teku teku /opt/teku/
 
+ENV LANG="C.UTF-8"
+
 ENV TEKU_REST_API_INTERFACE="0.0.0.0"
 ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"
 ENV TEKU_METRICS_INTERFACE="0.0.0.0"


### PR DESCRIPTION
## PR Description
Add `ENV LANG C.UTF-8` to the two Dockerfiles

**Before**
![image](https://user-images.githubusercontent.com/14827647/176211597-67abcb1a-ae80-4258-b885-b2e7ecc898d5.png)

**After**
![image](https://user-images.githubusercontent.com/14827647/176211184-2bc8076f-4e14-4978-836d-ee7dc27ac808.png)

## Fixed Issue(s)
fixes #5731

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
