### PR TITLE
Improve readability in `Web3JClient::doRequest` error handling

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionlayer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessageOrSimpleName;
 import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_EB_REQUESTS;
 import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_EE_REQUESTS;
 
@@ -495,7 +496,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
                 }
               }
             },
-            throwable -> markBuilderAsNotAvailable(throwable.getMessage()));
+            throwable -> markBuilderAsNotAvailable(getMessageOrSimpleName(throwable)));
   }
 
   private void markBuilderAsNotAvailable(String errorMessage) {

--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/ExceptionUtil.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/ExceptionUtil.java
@@ -31,4 +31,8 @@ public class ExceptionUtil {
       final Throwable err, Class<? extends T> targetType) {
     return getCause(err, targetType).isPresent();
   }
+
+  public static String getMessageOrSimpleName(final Throwable throwable) {
+    return Optional.ofNullable(throwable.getMessage()).orElse(throwable.getClass().getSimpleName());
+  }
 }


### PR DESCRIPTION
It also avoid possibility of `null` message in `updateBuilderAvailability` logging.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
