### PR TITLE
Improve `ReexecutingExecutionPayloadBlockManager`

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -44,7 +44,7 @@ public class BlockManager extends Service
     implements SlotEventsChannel, BlockImportChannel, BlockImportNotifications {
   private static final Logger LOG = LogManager.getLogger();
 
-  private final RecentChainData recentChainData;
+  protected final RecentChainData recentChainData;
   private final BlockImporter blockImporter;
   private final PendingPool<SignedBeaconBlock> pendingBlocks;
   private final BlockValidator validator;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
@@ -91,8 +91,7 @@ public class ReexecutingExecutionPayloadBlockManager extends BlockManager {
   @Override
   public void onSlot(UInt64 slot) {
     super.onSlot(slot);
-    pendingBlocksForEPReexecution.removeIf(
-        block -> isReexecutionExpiredForBlock(block, slot));
+    pendingBlocksForEPReexecution.removeIf(block -> isReexecutionExpiredForBlock(block, slot));
   }
 
   @Override
@@ -104,16 +103,17 @@ public class ReexecutingExecutionPayloadBlockManager extends BlockManager {
                 return;
               }
               final Optional<UInt64> currentSlot = recentChainData.getCurrentSlot();
-              if(currentSlot.isEmpty()) {
+              if (currentSlot.isEmpty()) {
                 return;
               }
-              if(!isReexecutionExpiredForBlock(block, currentSlot.get())) {
-                  pendingBlocksForEPReexecution.add(block);
+              if (!isReexecutionExpiredForBlock(block, currentSlot.get())) {
+                pendingBlocksForEPReexecution.add(block);
               }
             });
   }
 
-  private boolean isReexecutionExpiredForBlock(final SignedBeaconBlock block, final UInt64 currentSlot) {
+  private boolean isReexecutionExpiredForBlock(
+      final SignedBeaconBlock block, final UInt64 currentSlot) {
     return block.getSlot().plus(EXPIRES_IN_SLOT).isLessThan(currentSlot);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -107,7 +106,8 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
   public void setup() {
     forwardBlockImportedNotificationsTo(blockManager);
     remoteStorageSystem.chainUpdater().initializeGenesisWithPayload(false);
-    when(recentChainData.getCurrentSlot()).thenReturn(remoteStorageSystem.recentChainData().getCurrentSlot());
+    when(recentChainData.getCurrentSlot())
+        .thenReturn(remoteStorageSystem.recentChainData().getCurrentSlot());
     assertThat(blockManager.start()).isCompleted();
   }
 
@@ -204,13 +204,13 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
   @Test
   public void onInvalidBlockImport_shouldNotRetryExpiredBlock() {
     final SignedBeaconBlock nextBlock =
-            remoteStorageSystem.chainUpdater().chainBuilder.generateNextBlock().getBlock();
+        remoteStorageSystem.chainUpdater().chainBuilder.generateNextBlock().getBlock();
 
     // communication error
     when(blockImporter.importBlock(nextBlock, Optional.empty()))
-            .thenReturn(
-                    SafeFuture.completedFuture(
-                            BlockImportResult.failedExecutionPayloadExecution(new RuntimeException("error"))));
+        .thenReturn(
+            SafeFuture.completedFuture(
+                BlockImportResult.failedExecutionPayloadExecution(new RuntimeException("error"))));
 
     when(recentChainData.getCurrentSlot()).thenReturn(Optional.of(UInt64.MAX_VALUE));
     assertThat(blockManager.importBlock(nextBlock)).isCompleted();


### PR DESCRIPTION
- Reduces reexecution window to only one slot.

- Adds a check where the reexecution applies only to blocks close to currenSlot (ie not already expired). This will avoid reexecution while importing blocks during sync. (not super sure about this, but in case of massive problems on EL while syncing this will avoid unnecessary over-reexecutions)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
