### PR TITLE
Some Improvements in Exception handling

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -315,6 +315,12 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         "calling builderRegisterValidator(slot={},signedValidatorRegistrations={})",
         slot,
         signedValidatorRegistrations);
+
+    if (!isBuilderAvailable()) {
+      return SafeFuture.failedFuture(
+          new RuntimeException("unable to register validators: builder not available"));
+    }
+
     return executionBuilderClient
         .orElseThrow()
         .registerValidators(slot, signedValidatorRegistrations)
@@ -453,7 +459,10 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     LOG.trace("calling builderGetPayload(signedBlindedBeaconBlock={})", signedBlindedBeaconBlock);
 
     return executionBuilderClient
-        .orElseThrow()
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    "unable to get payload from builder: builder endpoint not available"))
         .getPayload(signedBlindedBeaconBlock)
         .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
         .thenPeek(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
@@ -239,7 +239,12 @@ public class TerminalPowBlockMonitor {
               final UInt256 totalDifficulty = powBlock.getTotalDifficulty();
               if (totalDifficulty.compareTo(specConfigBellatrix.getTerminalTotalDifficulty()) < 0) {
                 LOG.trace("checkTerminalBlockByTTD: Total Terminal Difficulty not reached.");
-                checkTtdEta(powBlock);
+                try {
+                  checkTtdEta(powBlock);
+                } catch (Exception ex) {
+                  LOG.debug("TTD ETA calculation exception", ex);
+                }
+
                 return SafeFuture.COMPLETE;
               }
               if (powBlock.getBlockTimestamp().isGreaterThan(timeProvider.getTimeInSeconds())) {


### PR DESCRIPTION
- Add builder endpoint availability check in validator registration call to prevent the following exception when a validator tries to call register against a BN without a configured\unavailable builder endpoint

```
{"timestamp":"2022-07-04T10:23:24,069","level":"ERROR","thread":"validator-async-4","class":"teku-validator-log","message":"Validator   *** Failed to send validator registrations to Beacon Node","throwable":" java.util.concurrent.CompletionException: java.util.NoSuchElementException: No value present\n\tat java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)\n\tat java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)\n\tat java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1141)\n\tat java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)\n\tat java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)\n\tat tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateResult$3(SafeFuture.java:145)\n\tat java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)\n\tat java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)\n\tat java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)\n\tat java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)\n\tat tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateToAsync$15(SafeFuture.java:273)\n\tat tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:81)\n\tat tech.pegasys.teku.infrastructure.async.AsyncRunner.lambda$runAsync$2(AsyncRunner.java:38)\n\tat tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:73)\n\tat tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner.lambda$createRunnableForAction$1(ScheduledExecutorAsyncRunner.java:119)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:833)\nCaused by: java.util.NoSuchElementException: No value present\n\tat java.base/java.util.Optional.orElseThrow(Optional.java:377)\n\tat tech.pegasys.teku.ethereum.executionlayer.ExecutionLayerManagerImpl.builderRegisterValidators(ExecutionLayerManagerImpl.java:319)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:568)\n\tat tech.pegasys.teku.infrastructure.events.DirectEventDeliverer.executeMethod(DirectEventDeliverer.java:74)\n\tat tech.pegasys.teku.infrastructure.events.DirectEventDeliverer.deliverToWithResponse(DirectEventDeliverer.java:67)\n\tat tech.pegasys.teku.infrastructure.events.AsyncEventDeliverer.lambda$deliverToWithResponse$1(AsyncEventDeliverer.java:75)\n\tat tech.pegasys.teku.infrastructure.events.AsyncEventDeliverer$QueueReader.deliverNextEvent(AsyncEventDeliverer.java:117)\n\tat tech.pegasys.teku.infrastructure.events.AsyncEventDeliverer$QueueReader.run(AsyncEventDeliverer.java:109)\n\t... 3 more\n"}
```


- Add a clearer exception in builder getPayload when the endpoint is not available
I haven't put here a call to `isBuilderAvailable()` because at this point we don't have any other option other than call the builder. So let's call it if it is configured, even if it might be returned a "not available" in the most recent `status` call.

- Surrounds TTD ETA with try\catch to catch a potential DateTimeException when TTD is so big that the Instant calculation overflows to a too distant future.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
