### PR TITLE
Fix blinded block signing for `ExternalSignerBlockRequestProvider`

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProvider.java
@@ -46,7 +46,9 @@ public class ExternalSignerBlockRequestProvider {
     final Map<String, Object> metadata = new HashMap<>(additionalEntries);
 
     final tech.pegasys.teku.api.schema.BeaconBlock beaconBlock =
-        schemaObjectProvider.getBeaconBlock(block);
+        block.getBody().isBlinded()
+            ? schemaObjectProvider.getBlindedBlock(block)
+            : schemaObjectProvider.getBeaconBlock(block);
     final tech.pegasys.teku.api.schema.BeaconBlockHeader beaconBlockHeader =
         new tech.pegasys.teku.api.schema.BeaconBlockHeader(blockHeader);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBlockRequestProviderTest.java
@@ -81,4 +81,25 @@ class ExternalSignerBlockRequestProviderTest {
     assertThat(blockRequestBody.getBeaconBlock()).isNull();
     assertThat(blockRequestBody.getBeaconBlockHeader()).isNotNull();
   }
+
+  @Test
+  void bellatrixBlindedBlockGeneratesCorrectSignTypeAndMetadata() {
+    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final BeaconBlock block = new DataStructureUtil(spec).randomBlindedBeaconBlock(10);
+
+    final ExternalSignerBlockRequestProvider externalSignerBlockRequestProvider =
+        new ExternalSignerBlockRequestProvider(spec, block);
+    final SignType signType = externalSignerBlockRequestProvider.getSignType();
+    final Map<String, Object> blockMetadata =
+        externalSignerBlockRequestProvider.getBlockMetadata(Map.of());
+
+    assertThat(signType).isEqualTo(SignType.BLOCK_V2);
+    assertThat(blockMetadata).containsKey("beacon_block");
+    assertThat(blockMetadata.get("beacon_block")).isExactlyInstanceOf(BlockRequestBody.class);
+
+    final BlockRequestBody blockRequestBody = (BlockRequestBody) blockMetadata.get("beacon_block");
+    assertThat(blockRequestBody.getVersion()).isEqualTo(SpecMilestone.BELLATRIX);
+    assertThat(blockRequestBody.getBeaconBlock()).isNull();
+    assertThat(blockRequestBody.getBeaconBlockHeader()).isNotNull();
+  }
 }


### PR DESCRIPTION
When external signer is configured and blinded block flow is enabled, we were failing preparing the signature request to the external signer.

```
16:14:24.486 ERROR - Validator   *** Failed to produce block  Slot: ... Validator: ... java.lang.IllegalArgumentException: Expected bellatrix block body but got BlindedBeaconBlockBodyBellatrixImpl (See log file for full stack trace)
```

This is a quick fix.
`SchemaObjectProvider` might be improved to seamlessly handle blinded blocks to avoid spaghettification.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
