### PR TITLE
Pass proposing slot to FCNotifier during block proposal preparation

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -682,7 +682,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       return SafeFuture.COMPLETE;
     }
 
-    return SafeFuture.allOf(tickProcessor.onTick(currentTime), applyDeferredAttestations(slot))
+    return SafeFuture.allOf(
+            tickProcessor.onTick(slotStartTimeMillis), applyDeferredAttestations(slot))
         .thenCompose(__ -> processHead(slot, true))
         .toVoid();
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -163,19 +163,19 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   }
 
   public SafeFuture<Boolean> processHead() {
-    return processHead(Optional.empty(), true);
+    return processHead(Optional.empty(), false);
   }
 
   public SafeFuture<Boolean> processHead(final UInt64 nodeSlot) {
-    return processHead(Optional.of(nodeSlot), true);
+    return processHead(Optional.of(nodeSlot), false);
   }
 
-  public SafeFuture<Boolean> processHead(final UInt64 nodeSlot, final boolean sendNotifications) {
-    return processHead(Optional.of(nodeSlot), sendNotifications);
+  public SafeFuture<Boolean> processHead(final UInt64 nodeSlot, final boolean isPreProposal) {
+    return processHead(Optional.of(nodeSlot), isPreProposal);
   }
 
   private SafeFuture<Boolean> processHead(
-      final Optional<UInt64> nodeSlot, final boolean sendNotifications) {
+      final Optional<UInt64> nodeSlot, final boolean isPreProposal) {
     final Checkpoint retrievedJustifiedCheckpoint =
         recentChainData.getStore().getJustifiedCheckpoint();
     return recentChainData
@@ -225,9 +225,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                                                   + headBlockRoot))));
 
                       transaction.commit();
-                      if (sendNotifications) {
-                        notifyForkChoiceUpdatedAndOptimisticSyncingChanged();
-                      }
+                      notifyForkChoiceUpdatedAndOptimisticSyncingChanged(
+                          isPreProposal ? nodeSlot : Optional.empty());
+
                       return true;
                     }));
   }
@@ -409,7 +409,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     if (forkChoiceUpdateHeadOnBlockImportEnabled) {
       updateForkChoiceForImportedBlock(block, result, forkChoiceStrategy);
     }
-    notifyForkChoiceUpdatedAndOptimisticSyncingChanged();
+    notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
     return result;
   }
 
@@ -515,7 +515,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         result.getFailureCause());
   }
 
-  private void notifyForkChoiceUpdatedAndOptimisticSyncingChanged() {
+  private void notifyForkChoiceUpdatedAndOptimisticSyncingChanged(
+      final Optional<UInt64> proposingSlot) {
     final ForkChoiceState forkChoiceState =
         getForkChoiceStrategy()
             .getForkChoiceState(
@@ -523,7 +524,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                 recentChainData.getJustifiedCheckpoint().orElseThrow(),
                 recentChainData.getFinalizedCheckpoint().orElseThrow());
 
-    forkChoiceNotifier.onForkChoiceUpdated(forkChoiceState);
+    forkChoiceNotifier.onForkChoiceUpdated(forkChoiceState, proposingSlot);
 
     if (optimisticSyncing
         .map(oldValue -> !oldValue.equals(forkChoiceState.isHeadOptimistic()))
@@ -682,7 +683,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     }
 
     return SafeFuture.allOf(tickProcessor.onTick(currentTime), applyDeferredAttestations(slot))
-        .thenCompose(__ -> processHead(slot, false))
+        .thenCompose(__ -> processHead(slot, true))
         .toVoid();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 
 public interface ForkChoiceNotifier {
-  void onForkChoiceUpdated(ForkChoiceState forkChoiceState);
+  void onForkChoiceUpdated(ForkChoiceState forkChoiceState, Optional<UInt64> proposingSlot);
 
   void onAttestationsDue(UInt64 slot);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -156,6 +156,8 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
     } else {
       // Request a new payload.
 
+      LOG.warn("No suitable payloadId, requesting a new one");
+
       // to make sure that we deal with the same data when calculatePayloadAttributes asynchronously
       // returns, we save locally the current class reference.
       ForkChoiceUpdateData localForkChoiceUpdateData = forkChoiceUpdateData;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -156,7 +156,9 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
     } else {
       // Request a new payload.
 
-      LOG.warn("No suitable payloadId, requesting a new one");
+      LOG.warn(
+          "No suitable payloadId for block production at slot {}, requesting a new one to the EL",
+          blockSlot);
 
       // to make sure that we deal with the same data when calculatePayloadAttributes asynchronously
       // returns, we save locally the current class reference.

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -209,6 +209,22 @@ class ForkChoiceNotifierTest {
 
   @Test
   void
+      onForkChoiceUpdated_shouldSendNotificationWithPayloadBuildingAttributesForProposerAtProposingSlot() {
+    final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
+    final BeaconState headState = getHeadState();
+    final UInt64 blockSlot = headState.getSlot().plus(1);
+    final PayloadBuildingAttributes payloadBuildingAttributes =
+        withProposerForSlot(headState, blockSlot);
+
+    storageSystem.chainUpdater().setCurrentSlot(blockSlot);
+
+    notifyForkChoiceUpdated(forkChoiceState, Optional.of(blockSlot));
+    verify(executionLayerChannel)
+        .engineForkChoiceUpdated(forkChoiceState, Optional.of(payloadBuildingAttributes));
+  }
+
+  @Test
+  void
       onForkChoiceUpdated_shouldSendNotificationWithoutPayloadBuildingAttributesWhenNotProposingNext() {
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final BeaconState headState = getHeadState();
@@ -797,8 +813,13 @@ class ForkChoiceNotifierTest {
   }
 
   private void notifyForkChoiceUpdated(final ForkChoiceState forkChoiceState) {
+    notifyForkChoiceUpdated(forkChoiceState, Optional.empty());
+  }
+
+  private void notifyForkChoiceUpdated(
+      final ForkChoiceState forkChoiceState, final Optional<UInt64> proposingSlot) {
     forkChoiceUpdatedResultNotification = null;
-    notifier.onForkChoiceUpdated(forkChoiceState);
+    notifier.onForkChoiceUpdated(forkChoiceState, proposingSlot);
     assertThat(forkChoiceUpdatedResultNotification).isNotNull();
     assertThat(forkChoiceUpdatedResultNotification.getForkChoiceUpdatedResult()).isCompleted();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
+import static tech.pegasys.teku.statetransition.forkchoice.ForkChoice.BLOCK_CREATION_TOLERANCE_MS;
 
 import java.util.List;
 import java.util.Optional;
@@ -809,12 +810,31 @@ class ForkChoiceTest {
   }
 
   @Test
-  void prepareForBlockProduction_shouldSendForkChoiceUpdatedNotificationWithProposalSlot() {
-    storageSystem.chainUpdater().setCurrentSlot(ONE);
+  void prepareForBlockProduction_NotYetInProposalSlotShouldRunOnTickWhenWithinTolerance() {
+    final UInt64 newTime =
+        spec.getSlotStartTimeMillis(ONE, recentChainData.getGenesisTimeMillis())
+            .minusMinZero(BLOCK_CREATION_TOLERANCE_MS - 100);
+    storageSystem.chainUpdater().setTimeMillis(newTime);
 
+    assertThat(recentChainData.getCurrentSlot()).isEqualTo(Optional.of(ZERO));
     assertThat(forkChoice.prepareForBlockProduction(ONE)).isCompleted();
+    assertThat(recentChainData.getCurrentSlot()).isEqualTo(Optional.of(ONE));
 
     verify(forkChoiceNotifier, times(1)).onForkChoiceUpdated(any(), eq(Optional.of(ONE)));
+  }
+
+  @Test
+  void prepareForBlockProduction_NotYetInProposalSlotShouldNotRunOnTickWhenOutOfTolerance() {
+    final UInt64 newTime =
+        spec.getSlotStartTimeMillis(ONE, recentChainData.getGenesisTimeMillis())
+            .minusMinZero(BLOCK_CREATION_TOLERANCE_MS + 100);
+    storageSystem.chainUpdater().setTimeMillis(newTime);
+
+    assertThat(recentChainData.getCurrentSlot()).isEqualTo(Optional.of(ZERO));
+    assertThat(forkChoice.prepareForBlockProduction(ONE)).isCompleted();
+    assertThat(recentChainData.getCurrentSlot()).isEqualTo(Optional.of(ZERO));
+
+    verifyNoInteractions(forkChoiceNotifier);
   }
 
   private static Stream<ForkChoiceUpdatedResult> getForkChoiceUpdatedResults() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -805,6 +805,15 @@ class ForkChoiceTest {
     }
   }
 
+  @Test
+  void prepareForBlockProduction_shouldNotSendForkChoiceUpdatedNotification() {
+    storageSystem.chainUpdater().setCurrentSlot(ONE);
+
+    assertThat(forkChoice.prepareForBlockProduction(ONE)).isCompleted();
+
+    verifyNoInteractions(forkChoiceNotifier);
+  }
+
   private static Stream<ForkChoiceUpdatedResult> getForkChoiceUpdatedResults() {
     Set<PayloadStatus> statuses =
         Set.of(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -699,7 +699,7 @@ class ForkChoiceTest {
         ArgumentCaptor.forClass(ForkChoiceState.class);
 
     verify(forkChoiceNotifier, times(2))
-        .onForkChoiceUpdated(forkChoiceStateCaptor.capture(), Optional.empty());
+        .onForkChoiceUpdated(forkChoiceStateCaptor.capture(), eq(Optional.empty()));
 
     // EL should have been notified of the invalid head first and after that the valid
     // head
@@ -778,7 +778,7 @@ class ForkChoiceTest {
     ArgumentCaptor<ForkChoiceState> forkChoiceStateCaptor =
         ArgumentCaptor.forClass(ForkChoiceState.class);
     verify(forkChoiceNotifier, atLeastOnce())
-        .onForkChoiceUpdated(forkChoiceStateCaptor.capture(), Optional.empty());
+        .onForkChoiceUpdated(forkChoiceStateCaptor.capture(), eq(Optional.empty()));
 
     // last notification to EL should be a valid block
     ForkChoiceState lastNotifiedState = forkChoiceStateCaptor.getValue();

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
@@ -36,17 +36,19 @@ public class StubForkChoiceNotifier implements ForkChoiceNotifier {
   }
 
   @Override
-  public long subscribeToForkChoiceUpdatedResult(ForkChoiceUpdatedResultSubscriber subscriber) {
+  public long subscribeToForkChoiceUpdatedResult(
+      final ForkChoiceUpdatedResultSubscriber subscriber) {
     return subscribers.subscribe(subscriber);
   }
 
   @Override
-  public boolean unsubscribeFromForkChoiceUpdatedResult(long subscriberId) {
+  public boolean unsubscribeFromForkChoiceUpdatedResult(final long subscriberId) {
     return subscribers.unsubscribe(subscriberId);
   }
 
   @Override
-  public void onForkChoiceUpdated(ForkChoiceState forkChoiceState) {
+  public void onForkChoiceUpdated(
+      final ForkChoiceState forkChoiceState, final Optional<UInt64> proposingSlot) {
     subscribers.deliver(
         ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
         new ForkChoiceUpdatedResultNotification(
@@ -54,17 +56,17 @@ public class StubForkChoiceNotifier implements ForkChoiceNotifier {
   }
 
   @Override
-  public void onAttestationsDue(UInt64 slot) {}
+  public void onAttestationsDue(final UInt64 slot) {}
 
   @Override
-  public void onSyncingStatusChanged(boolean inSync) {}
+  public void onSyncingStatusChanged(final boolean inSync) {}
 
   @Override
   public SafeFuture<Optional<ExecutionPayloadContext>> getPayloadId(
-      Bytes32 parentBeaconBlockRoot, UInt64 blockSlot) {
+      final Bytes32 parentBeaconBlockRoot, UInt64 blockSlot) {
     return null;
   }
 
   @Override
-  public void onTerminalBlockReached(Bytes32 executionBlockHash) {}
+  public void onTerminalBlockReached(final Bytes32 executionBlockHash) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -77,6 +77,13 @@ public class ChainUpdater {
     tx.commit().join();
   }
 
+  public void setTimeMillis(final UInt64 time) {
+    checkState(!recentChainData.isPreGenesis(), "Cannot set time before genesis");
+    final StoreTransaction tx = recentChainData.startStoreTransaction();
+    tx.setTimeMillis(time);
+    tx.commit().join();
+  }
+
   public SignedBlockAndState addNewBestBlock() {
     final SignedBlockAndState nextBlock = chainBuilder.generateNextBlock();
     updateBestBlock(nextBlock);


### PR DESCRIPTION
Fixes a bug that wasn't running `onTick` with the intended time variable. Now the transition to proposing slot is actually taking place when BN time is close enough to it but not yet into the slot.

During block proposal preparation we could have transitioned to the slot in which we may have to propose.
So in this case don't have to calculate payload attributes based on get current slot + 1, but just use the given `proposingSlot`

fixes #6266

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
