### PR TITLE
Rebuild forkchoice state in `getPayloadId` during on-the-fly flow

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -58,6 +58,7 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.PandaPrinter;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
@@ -110,12 +111,14 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
     final MergeTransitionBlockValidator transitionBlockValidator =
         new MergeTransitionBlockValidator(spec, recentChainData, ExecutionLayerChannel.NOOP);
+    final InlineEventThread eventThread = new InlineEventThread();
     final ForkChoice forkChoice =
         new ForkChoice(
             spec,
-            new InlineEventThread(),
+            eventThread,
             recentChainData,
             new StubForkChoiceNotifier(),
+            new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             PandaPrinter.NOOP,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -519,7 +519,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   }
 
   private void notifyForkChoiceUpdatedAndOptimisticSyncingChanged(
-          final Optional<UInt64> proposingSlot) {
+      final Optional<UInt64> proposingSlot) {
     forkChoiceStateProvider
         .getForkChoiceState()
         .thenAccept(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -134,6 +134,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
    *     <p>2. builds on top of the terminal block
    *     <p>in all other cases it must Throw to avoid block production
    */
+  @SuppressWarnings("FutureReturnValueIgnored")
   private SafeFuture<Optional<ExecutionPayloadContext>> internalGetPayloadId(
       final Bytes32 parentBeaconBlockRoot, final UInt64 blockSlot) {
     eventThread.checkOnEventThread();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -36,6 +36,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
   private static final Logger LOG = LogManager.getLogger();
 
   private final EventThread eventThread;
+  private final ForkChoiceStateProvider forkChoiceStateProvider;
   private final ExecutionLayerChannel executionLayerChannel;
   private final RecentChainData recentChainData;
   private final ProposersDataManager proposersDataManager;
@@ -50,12 +51,14 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
   private boolean inSync = false; // Assume we are not in sync at startup.
 
   public ForkChoiceNotifierImpl(
+      final ForkChoiceStateProvider forkChoiceStateProvider,
       final EventThread eventThread,
       final TimeProvider timeProvider,
       final Spec spec,
       final ExecutionLayerChannel executionLayerChannel,
       final RecentChainData recentChainData,
       final ProposersDataManager proposersDataManager) {
+    this.forkChoiceStateProvider = forkChoiceStateProvider;
     this.eventThread = eventThread;
     this.spec = spec;
     this.executionLayerChannel = executionLayerChannel;
@@ -155,7 +158,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
       // Pre-merge so ok to use default payload
       return SafeFuture.completedFuture(Optional.empty());
     } else {
-      // Request a new payload.
+      // Request a new payload with refreshed forkChoiceState and payloadBuildingAttributes
 
       LOG.warn(
           "No suitable payloadId for block production at slot {}, requesting a new one to the EL",
@@ -163,28 +166,37 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
 
       // to make sure that we deal with the same data when calculatePayloadAttributes asynchronously
       // returns, we save locally the current class reference.
-      ForkChoiceUpdateData localForkChoiceUpdateData = forkChoiceUpdateData;
-      return proposersDataManager
-          .calculatePayloadBuildingAttributes(blockSlot, inSync, localForkChoiceUpdateData, true)
-          .thenCompose(
-              newPayloadAttributes -> {
+      final ForkChoiceUpdateData localForkChoiceUpdateData = forkChoiceUpdateData;
 
-                // we make the updated local data global, reverting any potential data not yet sent
-                // to EL
+      return forkChoiceStateProvider
+          .getForkChoiceState()
+          .thenCombine(
+              proposersDataManager.calculatePayloadBuildingAttributes(
+                  blockSlot, inSync, localForkChoiceUpdateData, true),
+              (forkChoiceState, payloadBuildingAttributes) -> {
                 forkChoiceUpdateData =
-                    localForkChoiceUpdateData.withPayloadBuildingAttributes(newPayloadAttributes);
+                    localForkChoiceUpdateData
+                        .withForkChoiceState(forkChoiceState)
+                        .withPayloadBuildingAttributes(payloadBuildingAttributes);
+
+                if (!forkChoiceUpdateData.isPayloadIdSuitable(parentExecutionHash, timestamp)) {
+                  throw new IllegalStateException(
+                      "recalculated forkChoiceUpdateData still not suitable");
+                }
+
                 sendForkChoiceUpdated();
-                return forkChoiceUpdateData
-                    .getExecutionPayloadContext()
-                    .thenApply(
-                        executionPayloadContext -> {
-                          if (executionPayloadContext.isEmpty()) {
-                            throw new IllegalStateException(
-                                "Unable to obtain an executionPayloadContext");
-                          }
-                          return executionPayloadContext;
-                        });
-              });
+                return forkChoiceUpdateData.getExecutionPayloadContext();
+              })
+          .thenCompose(
+              executionPayloadContextFuture ->
+                  executionPayloadContextFuture.thenApply(
+                      maybeExecutionPayloadContext -> {
+                        if (maybeExecutionPayloadContext.isEmpty()) {
+                          throw new IllegalStateException(
+                              "Unable to obtain an executionPayloadContext");
+                        }
+                        return maybeExecutionPayloadContext;
+                      }));
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -179,12 +179,13 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
                         .withForkChoiceState(forkChoiceState)
                         .withPayloadBuildingAttributes(payloadBuildingAttributes);
 
+                sendForkChoiceUpdated();
+
                 if (!forkChoiceUpdateData.isPayloadIdSuitable(parentExecutionHash, timestamp)) {
                   throw new IllegalStateException(
                       "recalculated forkChoiceUpdateData still not suitable");
                 }
 
-                sendForkChoiceUpdated();
                 return forkChoiceUpdateData.getExecutionPayloadContext();
               })
           .thenCompose(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -184,7 +184,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
 
                 if (!forkChoiceUpdateData.isPayloadIdSuitable(parentExecutionHash, timestamp)) {
                   throw new IllegalStateException(
-                      "recalculated forkChoiceUpdateData still not suitable");
+                      "payloadId still not suitable after requesting a new one via FcU with recalculated data");
                 }
 
                 return forkChoiceUpdateData.getExecutionPayloadContext();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class ForkChoiceStateProvider {
+  private final EventThread forkChoiceExecutor;
+  private final RecentChainData recentChainData;
+
+  public ForkChoiceStateProvider(EventThread forkChoiceExecutor, RecentChainData recentChainData) {
+    this.forkChoiceExecutor = forkChoiceExecutor;
+    this.recentChainData = recentChainData;
+  }
+
+  SafeFuture<ForkChoiceState> getForkChoiceState() {
+    return forkChoiceExecutor
+        .execute(() -> recentChainData.getUpdatableForkChoiceStrategy().orElseThrow())
+        .thenApply(
+            forkChoiceStrategy ->
+                forkChoiceStrategy.getForkChoiceState(
+                    recentChainData.getCurrentEpoch().orElseThrow(),
+                    recentChainData.getJustifiedCheckpoint().orElseThrow(),
+                    recentChainData.getFinalizedCheckpoint().orElseThrow()));
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
@@ -27,14 +27,22 @@ public class ForkChoiceStateProvider {
     this.recentChainData = recentChainData;
   }
 
-  SafeFuture<ForkChoiceState> getForkChoiceState() {
-    return forkChoiceExecutor
-        .execute(() -> recentChainData.getUpdatableForkChoiceStrategy().orElseThrow())
-        .thenApply(
-            forkChoiceStrategy ->
-                forkChoiceStrategy.getForkChoiceState(
-                    recentChainData.getCurrentEpoch().orElseThrow(),
-                    recentChainData.getJustifiedCheckpoint().orElseThrow(),
-                    recentChainData.getFinalizedCheckpoint().orElseThrow()));
+  public SafeFuture<ForkChoiceState> getForkChoiceStateAsync() {
+    return forkChoiceExecutor.execute(this::internalGetForkChoiceState);
+  }
+
+  public ForkChoiceState getForkChoiceStateSync() {
+    forkChoiceExecutor.checkOnEventThread();
+    return internalGetForkChoiceState();
+  }
+
+  private ForkChoiceState internalGetForkChoiceState() {
+    return recentChainData
+        .getUpdatableForkChoiceStrategy()
+        .orElseThrow()
+        .getForkChoiceState(
+            recentChainData.getCurrentEpoch().orElseThrow(),
+            recentChainData.getJustifiedCheckpoint().orElseThrow(),
+            recentChainData.getFinalizedCheckpoint().orElseThrow());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -121,15 +121,15 @@ public class ForkChoiceUpdateData {
 
   public boolean isPayloadIdSuitable(final Bytes32 parentExecutionHash, final UInt64 timestamp) {
     if (payloadBuildingAttributes.isEmpty()) {
-      LOG.debug("isPayloadIdSuitable - payloadAttributes.isEmpty returning false");
-      // not producing a block
+      LOG.debug("isPayloadIdSuitable - payloadAttributes.isEmpty, returning false");
+      // EL building a block with wrong timestamp
       return false;
     }
 
     final PayloadBuildingAttributes attributes = this.payloadBuildingAttributes.get();
     if (!attributes.getTimestamp().equals(timestamp)) {
-      LOG.debug("isPayloadIdSuitable - wrong timestamp");
-      // wrong timestamp
+      LOG.debug("isPayloadIdSuitable - wrong timestamp, returning false");
+      // EL building a block with wrong timestamp
       return false;
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -122,7 +122,7 @@ public class ForkChoiceUpdateData {
   public boolean isPayloadIdSuitable(final Bytes32 parentExecutionHash, final UInt64 timestamp) {
     if (payloadBuildingAttributes.isEmpty()) {
       LOG.debug("isPayloadIdSuitable - payloadAttributes.isEmpty, returning false");
-      // EL building a block with wrong timestamp
+      // EL is not building a block
       return false;
     }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -85,6 +85,8 @@ class ForkChoiceNotifierTest {
       Optional.of(Eth1Address.fromHexString("0x2Df386eFF130f991321bfC4F8372Ba838b9AB14B"));
 
   private final ExecutionLayerChannel executionLayerChannel = mock(ExecutionLayerChannel.class);
+  private final ForkChoiceStateProvider forkChoiceStateProvider =
+      mock(ForkChoiceStateProvider.class);
 
   private ForkChoiceNotifierImpl notifier;
   private ForkChoiceUpdatedResultNotification forkChoiceUpdatedResultNotification;
@@ -120,6 +122,7 @@ class ForkChoiceNotifierTest {
                 doNotInitializeWithDefaultFeeRecipient ? Optional.empty() : defaultFeeRecipient));
     notifier =
         new ForkChoiceNotifierImpl(
+            forkChoiceStateProvider,
             eventThread,
             timeProvider,
             spec,
@@ -159,6 +162,7 @@ class ForkChoiceNotifierTest {
                 defaultFeeRecipient));
     notifier =
         new ForkChoiceNotifierImpl(
+            forkChoiceStateProvider,
             eventThread,
             timeProvider,
             spec,
@@ -834,6 +838,9 @@ class ForkChoiceNotifierTest {
     final SafeFuture<ForkChoiceUpdatedResult> responseFuture = new SafeFuture<>();
 
     storageSystem.chainUpdater().setCurrentSlot(blockSlot);
+
+    when(forkChoiceStateProvider.getForkChoiceState())
+        .thenReturn(SafeFuture.completedFuture(forkChoiceState));
 
     when(executionLayerChannel.engineForkChoiceUpdated(
             forkChoiceState, Optional.of(payloadBuildingAttributes)))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -839,7 +839,7 @@ class ForkChoiceNotifierTest {
 
     storageSystem.chainUpdater().setCurrentSlot(blockSlot);
 
-    when(forkChoiceStateProvider.getForkChoiceState())
+    when(forkChoiceStateProvider.getForkChoiceStateAsync())
         .thenReturn(SafeFuture.completedFuture(forkChoiceState));
 
     when(executionLayerChannel.engineForkChoiceUpdated(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -114,12 +114,16 @@ class ForkChoiceTest {
       new ExecutionLayerChannelStub(spec, false, Optional.empty());
   private final MergeTransitionBlockValidator transitionBlockValidator =
       mock(MergeTransitionBlockValidator.class);
+
+  private final InlineEventThread eventThread = new InlineEventThread();
+
   private ForkChoice forkChoice =
       new ForkChoice(
           spec,
-          new InlineEventThread(),
+          eventThread,
           recentChainData,
           forkChoiceNotifier,
+          new ForkChoiceStateProvider(eventThread, recentChainData),
           new TickProcessor(spec, recentChainData),
           transitionBlockValidator,
           PandaPrinter.NOOP,
@@ -206,9 +210,10 @@ class ForkChoiceTest {
     forkChoice =
         new ForkChoice(
             spec,
-            new InlineEventThread(),
+            eventThread,
             recentChainData,
             forkChoiceNotifier,
+            new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             PandaPrinter.NOOP,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -103,6 +103,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ActivePandaPrinter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifierImpl;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionConfigCheck;
@@ -214,6 +215,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile ActiveValidatorTracker activeValidatorTracker;
   protected volatile AttestationTopicSubscriber attestationTopicSubscriber;
   protected volatile ForkChoiceNotifier forkChoiceNotifier;
+  protected volatile ForkChoiceStateProvider forkChoiceStateProvider;
   protected volatile ExecutionLayerChannel executionLayer;
   protected volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();
   protected volatile Optional<MergeTransitionConfigCheck> mergeTransitionConfigCheck =
@@ -379,6 +381,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   public void initAll() {
     initKeyValueStore();
     initExecutionLayer();
+    initForkChoiceStateProvider();
     initForkChoiceNotifier();
     initMergeMonitors();
     initForkChoice();
@@ -525,6 +528,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             forkChoiceExecutor,
             recentChainData,
             forkChoiceNotifier,
+            forkChoiceStateProvider,
             new TickProcessor(spec, recentChainData),
             new MergeTransitionBlockValidator(spec, recentChainData, executionLayer),
             new ActivePandaPrinter(keyValueStore, STATUS_LOG),
@@ -983,6 +987,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
     eventChannels.subscribe(ChainHeadChannel.class, operationsReOrgManager);
   }
 
+  protected void initForkChoiceStateProvider() {
+    LOG.debug("BeaconChainController.initForkChoiceStateProvider()");
+    forkChoiceStateProvider = new ForkChoiceStateProvider(forkChoiceExecutor, recentChainData);
+  }
+
   protected void initForkChoiceNotifier() {
     LOG.debug("BeaconChainController.initForkChoiceNotifier()");
     final AsyncRunnerEventThread eventThread =
@@ -999,7 +1008,13 @@ public class BeaconChainController extends Service implements BeaconChainControl
     eventChannels.subscribe(SlotEventsChannel.class, proposersDataManager);
     forkChoiceNotifier =
         new ForkChoiceNotifierImpl(
-            eventThread, timeProvider, spec, executionLayer, recentChainData, proposersDataManager);
+            forkChoiceStateProvider,
+            eventThread,
+            timeProvider,
+            spec,
+            executionLayer,
+            recentChainData,
+            proposersDataManager);
   }
 
   private Optional<Eth1Address> getProposerDefaultFeeRecipient() {


### PR DESCRIPTION
When in `getPayloadId` the `isPayloadIdSuitable` check fails, it may fail because the parent block doesn't match. So this PR makes sure that we regenerate forkChoiceUpdateData (state and attributes) and recheck them before proceeding.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
