### PR TITLE
Implements max allowed consecutive faults in builder circuit breaker

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
@@ -40,9 +40,6 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
     checkArgument(
         faultInspectionWindow > allowedFaults,
         "FaultInspectionWindow must be greater than AllowedFaults");
-    checkArgument(
-        faultInspectionWindow > consecutiveAllowedFaults,
-        "ConsecutiveAllowedFaults must be greater than AllowedFaults");
     this.spec = spec;
     this.faultInspectionWindow = faultInspectionWindow;
     this.minimumUniqueBlockRootsInWindow = faultInspectionWindow - allowedFaults;
@@ -107,10 +104,7 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
     int lastConsecutiveEmptySlots =
         lastSlotOfInspectionWindow.minus(state.getLatestBlockHeader().getSlot()).intValue();
 
-    // if getLatestBlockHeader is outside the fault window,
-    // we have definitely missed all blocks so count will be 0
-    // consecutive missed slots at least the entire window size
-    if (state.getLatestBlockHeader().getSlot().isLessThan(firstSlotOfInspectionWindow)) {
+    if (lastConsecutiveEmptySlots >= faultInspectionWindow) {
       return new InspectionWindowCounters(0, lastConsecutiveEmptySlots);
     }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
@@ -30,28 +30,46 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
   private final Spec spec;
   private final int faultInspectionWindow;
   private final int minimumUniqueBlockRootsInWindow;
+  private final int consecutiveAllowedFaults;
 
   public BuilderCircuitBreakerImpl(
-      final Spec spec, final int faultInspectionWindow, final int allowedFaults) {
+      final Spec spec,
+      final int faultInspectionWindow,
+      final int allowedFaults,
+      final int consecutiveAllowedFaults) {
     checkArgument(
         faultInspectionWindow > allowedFaults,
         "FaultInspectionWindow must be greater than AllowedFaults");
+    checkArgument(
+        faultInspectionWindow > consecutiveAllowedFaults,
+        "ConsecutiveAllowedFaults must be greater than AllowedFaults");
     this.spec = spec;
     this.faultInspectionWindow = faultInspectionWindow;
     this.minimumUniqueBlockRootsInWindow = faultInspectionWindow - allowedFaults;
+    this.consecutiveAllowedFaults = consecutiveAllowedFaults;
   }
 
   @Override
   public boolean isEngaged(final BeaconState state) {
 
-    final int uniqueBlockRootsCount = getLatestUniqueBlockRootsCount(state);
-    if (uniqueBlockRootsCount < minimumUniqueBlockRootsInWindow) {
+    final InspectionWindowCounters inspectionWindowCounters = getLatestUniqueBlockRootsCount(state);
+    if (inspectionWindowCounters.uniqueBlockRootsCount < minimumUniqueBlockRootsInWindow) {
       LOG.debug(
           "Builder circuit breaker engaged: slot: {}, uniqueBlockRootsCount: {}, window: {},  minimumUniqueBlockRootsInWindow: {}",
           state.getSlot(),
-          uniqueBlockRootsCount,
+          inspectionWindowCounters.uniqueBlockRootsCount,
           faultInspectionWindow,
           minimumUniqueBlockRootsInWindow);
+      return true;
+    }
+
+    if (inspectionWindowCounters.lastConsecutiveEmptySlots > consecutiveAllowedFaults) {
+      LOG.debug(
+          "Builder circuit breaker engaged: slot: {}, lastConsecutiveEmptySlots: {}, window: {},  consecutiveAllowedFaults: {}",
+          state.getSlot(),
+          inspectionWindowCounters.lastConsecutiveEmptySlots,
+          faultInspectionWindow,
+          consecutiveAllowedFaults);
       return true;
     }
 
@@ -61,7 +79,8 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
   }
 
   @VisibleForTesting
-  int getLatestUniqueBlockRootsCount(final BeaconState state) throws IllegalArgumentException {
+  InspectionWindowCounters getLatestUniqueBlockRootsCount(final BeaconState state)
+      throws IllegalArgumentException {
     final int slotsPerHistoricalRoot =
         spec.atSlot(state.getSlot()).getConfig().getSlotsPerHistoricalRoot();
     checkArgument(
@@ -85,11 +104,19 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
     final UInt64 firstSlotOfInspectionWindow = state.getSlot().minusMinZero(faultInspectionWindow);
     final UInt64 lastSlotOfInspectionWindow = state.getSlot().minusMinZero(1);
 
+    int lastConsecutiveEmptySlots =
+        lastSlotOfInspectionWindow.minus(state.getLatestBlockHeader().getSlot()).intValue();
+
     // if getLatestBlockHeader is outside the fault window,
     // we have definitely missed all blocks so count will be 0
+    // consecutive missed slots at least the entire window size
     if (state.getLatestBlockHeader().getSlot().isLessThan(firstSlotOfInspectionWindow)) {
-      return 0;
+      return new InspectionWindowCounters(0, lastConsecutiveEmptySlots);
     }
+
+    // we can consider getLatestBlockHeader root because at this stage has been already updated with
+    // state root
+    uniqueBlockRoots.add(state.getLatestBlockHeader().getRoot());
 
     UInt64 currentSlot = firstSlotOfInspectionWindow;
     while (currentSlot.isLessThan(lastSlotOfInspectionWindow)) {
@@ -98,13 +125,17 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
       currentSlot = currentSlot.increment();
     }
 
-    int uniqueBlockRootsCount = uniqueBlockRoots.size();
+    return new InspectionWindowCounters(uniqueBlockRoots.size(), lastConsecutiveEmptySlots);
+  }
 
-    // let's count the latest block header only if it is from the last slot
-    if (state.getLatestBlockHeader().getSlot().equals(lastSlotOfInspectionWindow)) {
-      uniqueBlockRootsCount++;
+  protected static class InspectionWindowCounters {
+    final int uniqueBlockRootsCount;
+    final int lastConsecutiveEmptySlots;
+
+    private InspectionWindowCounters(
+        final int uniqueBlockRootsCount, final int lastConsecutiveEmptySlots) {
+      this.uniqueBlockRootsCount = uniqueBlockRootsCount;
+      this.lastConsecutiveEmptySlots = lastConsecutiveEmptySlots;
     }
-
-    return uniqueBlockRootsCount;
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
@@ -49,7 +49,7 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
   @Override
   public boolean isEngaged(final BeaconState state) {
 
-    final InspectionWindowCounters inspectionWindowCounters = getLatestUniqueBlockRootsCount(state);
+    final InspectionWindowCounters inspectionWindowCounters = getInspectionWindowCounters(state);
     if (inspectionWindowCounters.uniqueBlockRootsCount < minimumUniqueBlockRootsInWindow) {
       LOG.debug(
           "Builder circuit breaker engaged: slot: {}, uniqueBlockRootsCount: {}, window: {},  minimumUniqueBlockRootsInWindow: {}",
@@ -76,7 +76,7 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
   }
 
   @VisibleForTesting
-  InspectionWindowCounters getLatestUniqueBlockRootsCount(final BeaconState state)
+  InspectionWindowCounters getInspectionWindowCounters(final BeaconState state)
       throws IllegalArgumentException {
     final int slotsPerHistoricalRoot =
         spec.atSlot(state.getSlot()).getConfig().getSlotsPerHistoricalRoot();

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
@@ -200,7 +200,7 @@ public class BuilderCircuitBreakerImplTest {
       final BeaconState state,
       final int uniqueBlockRootsCount,
       final int lastConsecutiveIdenticalBlockRoots) {
-    assertThat(builderCircuitBreaker.getLatestUniqueBlockRootsCount(state))
+    assertThat(builderCircuitBreaker.getInspectionWindowCounters(state))
         .matches(
             counters -> counters.uniqueBlockRootsCount == uniqueBlockRootsCount,
             "uniqueBlockRootsCount must match")

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
@@ -178,15 +178,13 @@ public class BuilderCircuitBreakerImplTest {
       throws SlotProcessingException, EpochProcessingException {
     final UInt64 blockBuildingSlot = UInt64.valueOf(69);
 
-    // window from 59 to 68 (10 slots)
-
     // build up to 58
     final BeaconState preState = advance(58, false);
 
     final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
 
     assertThat(builderCircuitBreaker.isEngaged(state)).isTrue();
-    assertCounters(state, 0, INSPECTION_WINDOW);
+    assertCounters(state, 0, 10);
   }
 
   private BeaconState advance(final long toSlot, final boolean missing) {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
@@ -29,13 +29,15 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProce
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 
 public class BuilderCircuitBreakerImplTest {
+  private static final int INSPECTION_WINDOW = 10;
+  private static final int ALLOWED_FAULTS = 5;
+  private static final int ALLOWED_CONSECUTIVE_FAULTS = 2;
+
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
 
   private final BuilderCircuitBreakerImpl builderCircuitBreaker =
-      new BuilderCircuitBreakerImpl(spec, INSPECTION_WINDOW, ALLOWED_FAULTS);
-
-  private static final int INSPECTION_WINDOW = 10;
-  private static final int ALLOWED_FAULTS = 5;
+      new BuilderCircuitBreakerImpl(
+          spec, INSPECTION_WINDOW, ALLOWED_FAULTS, ALLOWED_CONSECUTIVE_FAULTS);
 
   private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
 
@@ -58,15 +60,15 @@ public class BuilderCircuitBreakerImplTest {
   }
 
   @Test
-  void shouldNotEngage_noMissedSlots() {
+  void shouldNotEngage_noMissedSlots() throws SlotProcessingException, EpochProcessingException {
     final UInt64 blockBuildingSlot = UInt64.valueOf(32);
 
     final BeaconState preState = advance(31, false);
 
-    final BeaconState state = preState.updated(s -> s.setSlot(blockBuildingSlot));
+    final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
 
     assertThat(builderCircuitBreaker.isEngaged(state)).isFalse();
-    assertThat(builderCircuitBreaker.getLatestUniqueBlockRootsCount(state)).isEqualTo(10);
+    assertCounters(state, 10, 0);
   }
 
   @Test
@@ -89,7 +91,24 @@ public class BuilderCircuitBreakerImplTest {
     final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
 
     assertThat(builderCircuitBreaker.isEngaged(state)).isFalse();
-    assertThat(builderCircuitBreaker.getLatestUniqueBlockRootsCount(state)).isEqualTo(5);
+    assertCounters(state, 5, 0);
+  }
+
+  @Test
+  void shouldNotEngage_minimalConsecutiveAllowedFaults()
+      throws SlotProcessingException, EpochProcessingException {
+    final UInt64 blockBuildingSlot = UInt64.valueOf(69);
+
+    // window from 59 to 68 (10 slots)
+
+    // no missing slot up to 66 (unique count: 8)
+    final BeaconState preState = advance(66, false);
+
+    // generate state for the building slot
+    final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
+
+    assertThat(builderCircuitBreaker.isEngaged(state)).isFalse();
+    assertCounters(state, 8, 2);
   }
 
   @Test
@@ -109,7 +128,7 @@ public class BuilderCircuitBreakerImplTest {
     final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
 
     assertThat(builderCircuitBreaker.isEngaged(state)).isTrue();
-    assertThat(builderCircuitBreaker.getLatestUniqueBlockRootsCount(state)).isEqualTo(4);
+    assertCounters(state, 4, 0);
   }
 
   @Test
@@ -130,7 +149,28 @@ public class BuilderCircuitBreakerImplTest {
     final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
 
     assertThat(builderCircuitBreaker.isEngaged(state)).isTrue();
-    assertThat(builderCircuitBreaker.getLatestUniqueBlockRootsCount(state)).isEqualTo(4);
+    assertCounters(state, 4, 1);
+  }
+
+  @Test
+  void shouldEngage_belowAllowedFaultsWithTooManyLastSlotsEmpty()
+      throws SlotProcessingException, EpochProcessingException {
+    final UInt64 blockBuildingSlot = UInt64.valueOf(69);
+
+    // window from 59 to 68 (10 slots)
+
+    // no missing slot up to 63 (unique count: 5)
+    advance(63, false);
+
+    // 64, 65 with block (unique count: 5 + 1)
+    final BeaconState preState = advance(65, true);
+
+    // generate state for the building slot
+    // last block header will be from slot 65
+    final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
+
+    assertThat(builderCircuitBreaker.isEngaged(state)).isTrue();
+    assertCounters(state, 6, 3);
   }
 
   @Test
@@ -146,7 +186,7 @@ public class BuilderCircuitBreakerImplTest {
     final BeaconState state = spec.processSlots(preState, blockBuildingSlot);
 
     assertThat(builderCircuitBreaker.isEngaged(state)).isTrue();
-    assertThat(builderCircuitBreaker.getLatestUniqueBlockRootsCount(state)).isEqualTo(0);
+    assertCounters(state, 0, INSPECTION_WINDOW);
   }
 
   private BeaconState advance(final long toSlot, final boolean missing) {
@@ -156,5 +196,18 @@ public class BuilderCircuitBreakerImplTest {
       chainBuilder.generateBlocksUpToSlot(toSlot);
     }
     return chainBuilder.getLatestBlockAndState().getState();
+  }
+
+  private void assertCounters(
+      final BeaconState state,
+      final int uniqueBlockRootsCount,
+      final int lastConsecutiveIdenticalBlockRoots) {
+    assertThat(builderCircuitBreaker.getLatestUniqueBlockRootsCount(state))
+        .matches(
+            counters -> counters.uniqueBlockRootsCount == uniqueBlockRootsCount,
+            "uniqueBlockRootsCount must match")
+        .matches(
+            counters -> counters.lastConsecutiveEmptySlots == lastConsecutiveIdenticalBlockRoots,
+            "lastConsecutiveIdenticalBlockRoots must match");
   }
 }

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -27,6 +27,7 @@ public class ExecutionLayerConfiguration {
   public static final boolean DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED = true;
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW = 32;
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS = 8;
+  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS = 3;
 
   public static final int BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP = 64;
 
@@ -38,6 +39,7 @@ public class ExecutionLayerConfiguration {
   boolean isBuilderCircuitBreakerEnabled;
   int builderCircuitBreakerWindow;
   int builderCircuitBreakerAllowedFaults;
+  int builderCircuitBreakerAllowedConsecutiveFaults;
 
   private ExecutionLayerConfiguration(
       final Spec spec,
@@ -47,7 +49,8 @@ public class ExecutionLayerConfiguration {
       final Optional<String> builderEndpoint,
       final boolean isBuilderCircuitBreakerEnabled,
       final int builderCircuitBreakerWindow,
-      final int builderCircuitBreakerAllowedFaults) {
+      final int builderCircuitBreakerAllowedFaults,
+      final int builderCircuitBreakerAllowedConsecutiveFaults) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
     this.engineVersion = engineVersion;
@@ -56,6 +59,8 @@ public class ExecutionLayerConfiguration {
     this.isBuilderCircuitBreakerEnabled = isBuilderCircuitBreakerEnabled;
     this.builderCircuitBreakerWindow = builderCircuitBreakerWindow;
     this.builderCircuitBreakerAllowedFaults = builderCircuitBreakerAllowedFaults;
+    this.builderCircuitBreakerAllowedConsecutiveFaults =
+        builderCircuitBreakerAllowedConsecutiveFaults;
   }
 
   public static Builder builder() {
@@ -101,6 +106,10 @@ public class ExecutionLayerConfiguration {
     return builderCircuitBreakerAllowedFaults;
   }
 
+  public int getBuilderCircuitBreakerAllowedConsecutiveFaults() {
+    return builderCircuitBreakerAllowedConsecutiveFaults;
+  }
+
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
@@ -110,6 +119,8 @@ public class ExecutionLayerConfiguration {
     private boolean isBuilderCircuitBreakerEnabled = DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
     private int builderCircuitBreakerWindow = DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
     private int builderCircuitBreakerAllowedFaults = DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS;
+    private int builderCircuitBreakerAllowedConsecutiveFaults =
+        DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS;
 
     private Builder() {}
 
@@ -124,7 +135,8 @@ public class ExecutionLayerConfiguration {
           builderEndpoint,
           isBuilderCircuitBreakerEnabled,
           builderCircuitBreakerWindow,
-          builderCircuitBreakerAllowedFaults);
+          builderCircuitBreakerAllowedFaults,
+          builderCircuitBreakerAllowedConsecutiveFaults);
     }
 
     public Builder engineEndpoint(final String engineEndpoint) {
@@ -160,6 +172,13 @@ public class ExecutionLayerConfiguration {
     public Builder builderCircuitBreakerAllowedFaults(
         final int builderCircuitBreakerAllowedFaults) {
       this.builderCircuitBreakerAllowedFaults = builderCircuitBreakerAllowedFaults;
+      return this;
+    }
+
+    public Builder builderCircuitBreakerAllowedConsecutiveFaults(
+        final int builderCircuitBreakerAllowedConsecutiveFaults) {
+      this.builderCircuitBreakerAllowedConsecutiveFaults =
+          builderCircuitBreakerAllowedConsecutiveFaults;
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -101,7 +101,8 @@ public class ExecutionLayerService extends Service {
           new BuilderCircuitBreakerImpl(
               config.getSpec(),
               config.getBuilderCircuitBreakerWindow(),
-              config.getBuilderCircuitBreakerAllowedFaults());
+              config.getBuilderCircuitBreakerAllowedFaults(),
+              config.getBuilderCircuitBreakerAllowedConsecutiveFaults());
     } else {
       builderCircuitBreaker = BuilderCircuitBreaker.NOOP;
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.config.TekuConfiguration.Builder;
+import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
@@ -87,6 +88,15 @@ public class ExecutionLayerOptions {
       hidden = true)
   private int builderCircuitBreakerAllowedFaults = DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS;
 
+  @Option(
+      names = {"--Xbuilder-circuit-breaker-allowed-consecutive-faults"},
+      paramLabel = "<INTEGER>",
+      description = "Circuit Breaker maximum allowed consecutive faults (missing block).",
+      arity = "1",
+      hidden = true)
+  private int builderCircuitBreakerAllowedConsecutiveFaults =
+      DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS;
+
   public void configure(final Builder builder) {
     builder.executionLayer(
         b ->
@@ -96,7 +106,9 @@ public class ExecutionLayerOptions {
                 .builderEndpoint(builderEndpoint)
                 .isBuilderCircuitBreakerEnabled(builderCircuitBreakerEnabled)
                 .builderCircuitBreakerWindow(builderCircuitBreakerWindow)
-                .builderCircuitBreakerAllowedFaults(builderCircuitBreakerAllowedFaults));
+                .builderCircuitBreakerAllowedFaults(builderCircuitBreakerAllowedFaults)
+                .builderCircuitBreakerAllowedConsecutiveFaults(
+                    builderCircuitBreakerAllowedConsecutiveFaults));
     depositOptions.configure(builder);
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.cli.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP;
+import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
 
@@ -98,6 +99,8 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW);
     assertThat(config.executionLayer().getBuilderCircuitBreakerAllowedFaults())
         .isEqualTo(DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS);
+    assertThat(config.executionLayer().getBuilderCircuitBreakerAllowedConsecutiveFaults())
+        .isEqualTo(DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS);
   }
 
   @Test
@@ -108,13 +111,17 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
       "--Xbuilder-circuit-breaker-window",
       "40",
       "--Xbuilder-circuit-breaker-allowed-faults",
-      "2"
+      "2",
+      "--Xbuilder-circuit-breaker-allowed-consecutive-faults",
+      "20"
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
 
     assertThat(config.executionLayer().isBuilderCircuitBreakerEnabled()).isFalse();
     assertThat(config.executionLayer().getBuilderCircuitBreakerWindow()).isEqualTo(40);
     assertThat(config.executionLayer().getBuilderCircuitBreakerAllowedFaults()).isEqualTo(2);
+    assertThat(config.executionLayer().getBuilderCircuitBreakerAllowedConsecutiveFaults())
+        .isEqualTo(20);
   }
 
   @Test


### PR DESCRIPTION
Implements an additional check on the circuit breaker logic which forces local fallback in execution payload building in case `n` blocks in a row has been missed.

Default value is 3. Overridable via `--Xbuilder-circuit-breaker-allowed-consecutive-faults`

fixes #6304 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
