### PR TITLE
Adds Blobs metrics [TODO: activates under a `--X` flag]

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -93,6 +93,7 @@ public class StorageService extends Service implements StorageServiceFacade {
                         new BlobsSidecarPruner(
                             config.getSpec(),
                             database,
+                            serviceConfig.getMetricsSystem(),
                             storagePrunerAsyncRunner,
                             serviceConfig.getTimeProvider(),
                             config.getBlobsPruningInterval(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -205,6 +205,8 @@ public interface Database extends AutoCloseable {
 
   Map<String, Long> getColumnCounts();
 
+  Map<String, Long> getBlobsSidecarColumnCounts();
+
   void migrate();
 
   Optional<Checkpoint> getAnchor();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
@@ -79,6 +79,9 @@ public interface KvStoreAccessor extends AutoCloseable {
   @MustBeClosed
   Stream<ColumnEntry<Bytes, Bytes>> streamRaw(KvStoreColumn<?, ?> column);
 
+  @MustBeClosed
+  Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column);
+
   /**
    * WARNING: should only be used to migrate data between tables
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -324,6 +324,11 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return dao.getBlobsSidecarColumnCounts();
+  }
+
+  @Override
   public void migrate() {}
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -379,6 +379,18 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+
+    schema.getColumnMap().entrySet().stream()
+        .filter(
+            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+        .forEach((k, v) -> columnCounts.put(k, db.size(v)));
+    return columnCounts;
+  }
+
+  @Override
   @MustBeClosed
   public Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot) {
     return stateStorageLogic.streamFinalizedStateSlots(db, schema, startSlot, endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -139,6 +139,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Map<String, Long> getColumnCounts();
 
+  Map<String, Long> getBlobsSidecarColumnCounts();
+
   @MustBeClosed
   Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -217,6 +217,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return new LinkedHashMap<>(finalizedDao.getBlobsSidecarColumnCounts());
+  }
+
+  @Override
   @MustBeClosed
   public Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamFinalizedStateSlots(startSlot, endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -20,8 +20,10 @@ import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -202,6 +204,17 @@ public class V4FinalizedKvStoreDao {
   public Map<String, Long> getColumnCounts() {
     final Map<String, Long> columnCounts = new HashMap<>();
     schema.getColumnMap().forEach((k, v) -> columnCounts.put(k, db.size(v)));
+    return columnCounts;
+  }
+
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+
+    schema.getColumnMap().entrySet().stream()
+        .filter(
+            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+        .forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -113,7 +113,7 @@ public class LevelDbInstance implements KvStoreAccessor {
   @Override
   public long size(final KvStoreColumn<?, ?> column) {
     assertOpen();
-    try (final Stream<?> rawStream = streamRaw(column)) {
+    try (final Stream<?> rawStream = streamKeysRaw(column)) {
       return rawStream.count();
     }
   }
@@ -241,6 +241,13 @@ public class LevelDbInstance implements KvStoreAccessor {
   public Stream<ColumnEntry<Bytes, Bytes>> streamRaw(final KvStoreColumn<?, ?> column) {
     return streamRaw(column, column.getId().toArrayUnsafe(), getKeyAfterColumn(column))
         .map(entry -> ColumnEntry.create(Bytes.wrap(entry.getKey()), Bytes.wrap(entry.getValue())));
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column) {
+    return streamKeysRaw(column, column.getId().toArrayUnsafe(), getKeyAfterColumn(column))
+        .map(Bytes::wrap);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -247,6 +247,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return new HashMap<>();
+  }
+
+  @Override
   public void migrate() {}
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -157,6 +157,12 @@ public class RocksDbInstance implements KvStoreAccessor {
   }
 
   @Override
+  @MustBeClosed
+  public Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column) {
+    return createStreamKeyRaw(column, RocksIterator::seekToFirst, key -> true).map(Bytes::wrap);
+  }
+
+  @Override
   public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
     assertOpen();
     final ColumnFamilyHandle handle = columnHandles.get(column);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -47,10 +48,17 @@ public class BlobsSidecarPrunerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
   private final Database database = mock(Database.class);
+  private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
 
   private final BlobsSidecarPruner blobsPruner =
       new BlobsSidecarPruner(
-          spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
+          spec,
+          database,
+          stubMetricsSystem,
+          asyncRunner,
+          timeProvider,
+          PRUNE_INTERVAL,
+          PRUNE_LIMIT);
 
   @BeforeEach
   void setUp() {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
@@ -149,7 +149,7 @@ public class MockKvStoreInstance implements KvStoreAccessor {
 
   @Override
   public <K, V> Stream<K> streamKeys(KvStoreColumn<K, V> column) {
-    return streamKeyRaw(column)
+    return streamKeysRaw(column)
         .map(entry -> column.getKeySerializer().deserialize(entry.toArrayUnsafe()));
   }
 
@@ -162,7 +162,8 @@ public class MockKvStoreInstance implements KvStoreAccessor {
         .map(entry -> columnEntry(entry));
   }
 
-  public Stream<Bytes> streamKeyRaw(final KvStoreColumn<?, ?> column) {
+  @Override
+  public Stream<Bytes> streamKeysRaw(KvStoreColumn<?, ?> column) {
     assertOpen();
     assertValidColumn(column);
     return columnData.get(column).keySet().stream();


### PR DESCRIPTION
Implement a more efficient way of counting db columns by streaming keys only
Adds a metric to `BlobsSidecarPruner` to track `BlobsSidecar` counts stored on DB.
- total: counts all blobs sidecar stored including the unconfirmed ones
- unconfirmed: counts only unconfirmed blobs sidecar

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
