### PR TITLE
Blobs pruner fix

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsPruner.java
@@ -122,17 +122,16 @@ public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
     final UInt64 currentSlot =
         spec.getCurrentSlot(timeProvider.getTimeInSeconds(), genesisTime.get());
 
-    final UInt64 earliestPrunableSlot = getEarliestPrunableSlot(currentSlot);
+    final UInt64 latestPrunableSlot = getLatestPrunableSlot(currentSlot);
 
-    if (earliestPrunableSlot.isZero()) {
+    if (latestPrunableSlot.isZero()) {
       LOG.debug("Not pruning as slots to keep includes genesis.");
       return;
     }
-    LOG.debug("Pruning blobs up to slot {}, limit {}", earliestPrunableSlot, pruneLimit);
+    LOG.debug("Pruning blobs up to slot {}, limit {}", latestPrunableSlot, pruneLimit);
     try {
       final long start = System.currentTimeMillis();
-      final boolean limitReached =
-          database.pruneOldestBlobsSidecar(earliestPrunableSlot, pruneLimit);
+      final boolean limitReached = database.pruneOldestBlobsSidecar(latestPrunableSlot, pruneLimit);
       LOG.debug(
           "Blobs pruning finished in {} ms. Limit reached: {}",
           () -> System.currentTimeMillis() - start,
@@ -156,9 +155,30 @@ public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
     return genesisTime;
   }
 
-  private UInt64 getEarliestPrunableSlot(final UInt64 currentSlot) {
-    final int slotsPerEpoch = spec.getSlotsPerEpoch(currentSlot);
+  private UInt64 getLatestPrunableSlot(final UInt64 currentSlot) {
+    // we have to guarantee that current epoch data is fully available,
+    // moreover we want to gradually delete blobs at each iteration
 
-    return currentSlot.minusMinZero((long) MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS * slotsPerEpoch);
+    // MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS = 1
+    //    (5)
+    //  latest                        (70)
+    //  prunable   DA boundary          current_slot
+    //     |       |                    |
+    // 0 ----- 31 // 32 ---- 63 // 64 ---- 95 // 96
+
+    // edge case 1 (only 1 slot of tolerance to support slight client timing differences):
+    //   current_slot = 95
+    //   DA_boundary: 32
+    //   latest_prunable_slot = 30
+
+    // edge case 2 (1 entire epoch of extra data):
+    //   current_slot = 96
+    //   DA_boundary: 64
+    //   latest_prunable_slot = 31
+
+    return currentSlot.minusMinZero(
+        ((long) (MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS + 1)
+                * spec.atSlot(currentSlot).getSlotsPerEpoch())
+            + 1);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsPruner.java
@@ -125,7 +125,7 @@ public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
     final UInt64 latestPrunableSlot = getLatestPrunableSlot(currentSlot);
 
     if (latestPrunableSlot.isZero()) {
-      LOG.debug("Not pruning as slots to keep includes genesis.");
+      LOG.debug("Not pruning as slots to keep include genesis.");
       return;
     }
     LOG.debug("Pruning blobs up to slot {}, limit {}", latestPrunableSlot, pruneLimit);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsPrunerTest.java
@@ -41,7 +41,10 @@ public class BlobsPrunerTest {
 
   private final Spec spec = TestSpecFactory.createMinimalEip4844();
 
-  private UInt64 genesisTime = UInt64.valueOf(100);
+  private final int slotsPerEpoch = spec.getGenesisSpecConfig().getSlotsPerEpoch();
+  private final int secondsPerSlot = spec.getGenesisSpecConfig().getSecondsPerSlot();
+
+  private UInt64 genesisTime = UInt64.valueOf(0);
 
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
@@ -76,19 +79,31 @@ public class BlobsPrunerTest {
   }
 
   @Test
-  void shouldPrune() {
-    // set current time to MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS window + 2 slots
+  void shouldNotPruneWhenLatestPrunableIncludeGenesis() {
+    // set current slot inside the availability window
     final UInt64 currentSlot =
-        UInt64.valueOf(MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS)
-            .times(spec.getGenesisSpecConfig().getSlotsPerEpoch())
-            .plus(2);
-    final UInt64 currentTime =
-        currentSlot.times(spec.getGenesisSpecConfig().getSecondsPerSlot()).plus(genesisTime);
+        UInt64.valueOf(MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS).times(slotsPerEpoch);
+    final UInt64 currentTime = currentSlot.times(secondsPerSlot);
 
     timeProvider.advanceTimeBy(Duration.ofSeconds(currentTime.longValue()));
 
     asyncRunner.executeDueActions();
-    verify(database).pruneOldestBlobsSidecar(UInt64.valueOf(2), PRUNE_LIMIT);
+    verify(database, never()).pruneOldestBlobsSidecar(any(), anyInt());
+  }
+
+  @Test
+  void shouldPruneWhenLatestPrunableSlotIsGreaterThanOldestDAEpoch() {
+    // set current slot to MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS + 1 epoch + half epoch
+    final UInt64 currentSlot =
+        UInt64.valueOf(MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS + 1)
+            .times(slotsPerEpoch)
+            .plus(slotsPerEpoch / 2);
+    final UInt64 currentTime = currentSlot.times(secondsPerSlot);
+
+    timeProvider.advanceTimeBy(Duration.ofSeconds(currentTime.longValue()));
+
+    asyncRunner.executeDueActions();
+    verify(database).pruneOldestBlobsSidecar(UInt64.valueOf((slotsPerEpoch / 2) - 1), PRUNE_LIMIT);
   }
 
   @Test


### PR DESCRIPTION
Fixes a bug that was causing the blobs pruner to prune sidecars at the beginning of the first epoch of the DA window.
The error was calculating the DA in slots instead of epochs.

Additionally, this implementation ensure we can frequently prune blobs by adding an epoch of "buffer" during which we can continuously prune blobs in little chunks avoiding to prune blobs of an entire epoch all at once.

## Fixed Issue(s)
will resolve one of the tasks under https://github.com/ConsenSys/teku/pull/6728

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
