### PR TITLE
Adds `debug-tools db dump-blobs-sidecar` command

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.storage.server.DepositStorage;
 import tech.pegasys.teku.storage.server.RetryingStorageUpdateChannel;
 import tech.pegasys.teku.storage.server.StorageConfiguration;
 import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
-import tech.pegasys.teku.storage.server.pruner.BlobsPruner;
+import tech.pegasys.teku.storage.server.pruner.BlobsSidecarPruner;
 import tech.pegasys.teku.storage.server.pruner.BlockPruner;
 
 public class StorageService extends Service implements StorageServiceFacade {
@@ -47,7 +47,7 @@ public class StorageService extends Service implements StorageServiceFacade {
   private volatile Database database;
   private volatile BatchingVoteUpdateChannel batchingVoteUpdateChannel;
   private volatile Optional<BlockPruner> blockPruner = Optional.empty();
-  private volatile Optional<BlobsPruner> blobsPruner = Optional.empty();
+  private volatile Optional<BlobsSidecarPruner> blobsPruner = Optional.empty();
   private final boolean depositSnapshotStorageEnabled;
 
   public StorageService(
@@ -90,7 +90,7 @@ public class StorageService extends Service implements StorageServiceFacade {
               if (config.getSpec().isMilestoneSupported(SpecMilestone.EIP4844)) {
                 blobsPruner =
                     Optional.of(
-                        new BlobsPruner(
+                        new BlobsSidecarPruner(
                             config.getSpec(),
                             database,
                             storagePrunerAsyncRunner,
@@ -136,7 +136,7 @@ public class StorageService extends Service implements StorageServiceFacade {
         .thenCompose(
             __ ->
                 blobsPruner
-                    .map(BlobsPruner::start)
+                    .map(BlobsSidecarPruner::start)
                     .orElseGet(() -> SafeFuture.completedFuture(null)));
   }
 

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -250,7 +250,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar1, blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune unconfirmed with limit to 1
-    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(UInt64.MAX_VALUE, 1)).isTrue();
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecars(UInt64.MAX_VALUE, 1)).isTrue();
     assertUnconfirmedBlobsStream(
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
@@ -259,7 +259,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune unconfirmed up to slot 1 (nothing will be pruned)
-    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(ONE, 10)).isFalse();
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecars(ONE, 10)).isFalse();
     assertUnconfirmedBlobsStream(
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
@@ -268,7 +268,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune all unconfirmed
-    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(UInt64.valueOf(3), 10)).isFalse();
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecars(UInt64.valueOf(3), 10)).isFalse();
     assertUnconfirmedBlobsStream();
     // we have blobsSidecar4
     assertBlobsStream(blobsSidecar4);
@@ -2335,7 +2335,7 @@ public class DatabaseTest {
   private void assertUnconfirmedBlobsStream(
       UInt64 startSlot, UInt64 endSlot, SlotAndBlockRoot... slotAndBlockRoots) {
     try (Stream<SlotAndBlockRoot> blobsSidecarStream =
-        database.streamUnconfirmedBlobsSidecar(startSlot, endSlot)) {
+        database.streamUnconfirmedBlobsSidecars(startSlot, endSlot)) {
       final List<SlotAndBlockRoot> allSlotAndBlockRoots = blobsSidecarStream.collect(toList());
       assertThat(allSlotAndBlockRoots).containsExactly(slotAndBlockRoots);
     }
@@ -2347,7 +2347,7 @@ public class DatabaseTest {
 
   private void assertBlobsStream(UInt64 startSlot, UInt64 endSlot, BlobsSidecar... blobsSidecars) {
     try (Stream<BlobsSidecar> blobsSidecarStream =
-        database.streamBlobsSidecar(startSlot, endSlot)) {
+        database.streamBlobsSidecars(startSlot, endSlot)) {
       final List<BlobsSidecar> allBlobs = blobsSidecarStream.collect(toList());
       assertThat(allBlobs).containsExactly(blobsSidecars);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -84,16 +84,20 @@ public interface Database extends AutoCloseable {
    * @param pruneLimit
    * @return true if number of pruned blobs reached the pruneLimit, false otherwise
    */
-  boolean pruneOldestUnconfirmedBlobsSidecar(UInt64 lastSlotToPrune, int pruneLimit);
+  boolean pruneOldestUnconfirmedBlobsSidecars(UInt64 lastSlotToPrune, int pruneLimit);
 
   @MustBeClosed
-  Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+  Stream<BlobsSidecar> streamBlobsSidecars(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
+  Stream<Map.Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecarsAsSsz(
+      UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
   Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
-  Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+  Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(UInt64 startSlot, UInt64 endSlot);
 
   Optional<UInt64> getEarliestBlobsSidecarSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -733,10 +733,10 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public boolean pruneOldestUnconfirmedBlobsSidecar(
+  public boolean pruneOldestUnconfirmedBlobsSidecars(
       final UInt64 lastSlotToPrune, final int pruneLimit) {
     try (final Stream<SlotAndBlockRoot> prunableUnconfirmed =
-            streamUnconfirmedBlobsSidecar(UInt64.ZERO, lastSlotToPrune);
+            streamUnconfirmedBlobsSidecars(UInt64.ZERO, lastSlotToPrune);
         final FinalizedUpdater updater = finalizedUpdater()) {
       final long pruned =
           prunableUnconfirmed
@@ -755,13 +755,20 @@ public class KvStoreDatabase implements Database {
 
   @MustBeClosed
   @Override
-  public Stream<BlobsSidecar> streamBlobsSidecar(final UInt64 startSlot, final UInt64 endSlot) {
+  public Stream<BlobsSidecar> streamBlobsSidecars(final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamBlobsSidecar(startSlot, endSlot)
         .map(
             slotAndBlockRootBytesEntry ->
                 spec.deserializeBlobsSidecar(
                     slotAndBlockRootBytesEntry.getValue(),
                     slotAndBlockRootBytesEntry.getKey().getSlot()));
+  }
+
+  @MustBeClosed
+  @Override
+  public Stream<Map.Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecarsAsSsz(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return dao.streamBlobsSidecar(startSlot, endSlot);
   }
 
   @MustBeClosed
@@ -773,7 +780,7 @@ public class KvStoreDatabase implements Database {
 
   @MustBeClosed
   @Override
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(
       final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -274,7 +275,13 @@ public class NoOpDatabase implements Database {
   public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {}
 
   @Override
-  public Stream<BlobsSidecar> streamBlobsSidecar(final UInt64 startSlot, final UInt64 endSlot) {
+  public Stream<BlobsSidecar> streamBlobsSidecars(final UInt64 startSlot, final UInt64 endSlot) {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecarsAsSsz(
+      final UInt64 startSlot, final UInt64 endSlot) {
     return Stream.empty();
   }
 
@@ -294,13 +301,13 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(
       final UInt64 startSlot, final UInt64 endSlot) {
     return Stream.empty();
   }
 
   @Override
-  public boolean pruneOldestUnconfirmedBlobsSidecar(
+  public boolean pruneOldestUnconfirmedBlobsSidecars(
       final UInt64 lastSlotToPrune, final int pruneLimit) {
     return false;
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 
-public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
+public class BlobsSidecarPruner extends Service implements FinalizedCheckpointChannel {
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
@@ -49,7 +49,7 @@ public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
   private AtomicReference<Optional<UInt64>> latestFinalizedSlot =
       new AtomicReference<>(Optional.empty());
 
-  public BlobsPruner(
+  public BlobsSidecarPruner(
       final Spec spec,
       final Database database,
       final AsyncRunner asyncRunner,
@@ -102,7 +102,7 @@ public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
     try {
       final long start = System.currentTimeMillis();
       final boolean limitReached =
-          database.pruneOldestUnconfirmedBlobsSidecar(maybeLatestFinalizedSlot.get(), pruneLimit);
+          database.pruneOldestUnconfirmedBlobsSidecars(maybeLatestFinalizedSlot.get(), pruneLimit);
       LOG.debug(
           "Unconfirmed blobs pruning finished in {} ms. Limit reached: {}",
           () -> System.currentTimeMillis() - start,

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.server.Database;
 
-public class BlobsPrunerTest {
+public class BlobsSidecarPrunerTest {
   public static final Duration PRUNE_INTERVAL = Duration.ofSeconds(5);
   public static final int PRUNE_LIMIT = 10;
 
@@ -51,8 +51,9 @@ public class BlobsPrunerTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
   private final Database database = mock(Database.class);
 
-  private final BlobsPruner blobsPruner =
-      new BlobsPruner(spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
+  private final BlobsSidecarPruner blobsPruner =
+      new BlobsSidecarPruner(
+          spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
 
   @BeforeEach
   void setUp() {
@@ -110,7 +111,7 @@ public class BlobsPrunerTest {
   void shouldNotPruneUnconfirmedBlobsWithoutFinalizedCheckpoint() {
     asyncRunner.executeDueActions();
 
-    verify(database, never()).pruneOldestUnconfirmedBlobsSidecar(any(), anyInt());
+    verify(database, never()).pruneOldestUnconfirmedBlobsSidecars(any(), anyInt());
   }
 
   @Test
@@ -121,12 +122,12 @@ public class BlobsPrunerTest {
     final UInt64 expectedLastSlotToPrune =
         UInt64.valueOf(spec.getGenesisSpecConfig().getSlotsPerEpoch());
 
-    verify(database).pruneOldestUnconfirmedBlobsSidecar(expectedLastSlotToPrune, PRUNE_LIMIT);
+    verify(database).pruneOldestUnconfirmedBlobsSidecars(expectedLastSlotToPrune, PRUNE_LIMIT);
 
     timeProvider.advanceTimeBy(PRUNE_INTERVAL);
     asyncRunner.executeDueActions();
 
     verify(database, times(1))
-        .pruneOldestUnconfirmedBlobsSidecar(expectedLastSlotToPrune, PRUNE_LIMIT);
+        .pruneOldestUnconfirmedBlobsSidecars(expectedLastSlotToPrune, PRUNE_LIMIT);
   }
 }


### PR DESCRIPTION
Adds a `dump-blobs-sidecar` to dump all blobs sidecar in DB

Additionally renames:
- `BlobsPruner` to `BlobsSidecarPruner`
- `pruneOldestUnconfirmedBlobsSidecar` to `pruneOldestUnconfirmedBlobsSidecars`
- `streamUnconfirmedBlobsSidecar` to `streamUnconfirmedBlobsSidecars`

## Fixed Issue(s)
will apply few of the commits in https://github.com/ConsenSys/teku/pull/6728 to master

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
