### PR TITLE
Adds info log when pruning completes

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
@@ -83,6 +83,7 @@ public class BlockPruner extends Service {
     LOG.info("Pruning finalized blocks before slot {}", earliestSlotToKeep);
     try {
       database.pruneFinalizedBlocks(earliestSlotToKeep.decrement());
+      LOG.info("Finalized blocks before slot {} have been pruned.", earliestSlotToKeep);
     } catch (ShuttingDownException | RejectedExecutionException ex) {
       LOG.debug("Shutting down", ex);
     }


### PR DESCRIPTION
With this we can see when the block pruning ends.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
