### PR TITLE
Percentage sign escape in `--builder-bid-compare-factor` description

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -105,7 +105,7 @@ public class ExecutionLayerOptions {
       description =
           "Set the compare factor applied to the builder bid value when comparing it with locally produced payload."
               + " Factor is expressed in percentage (e.g. '100' means locally produced payload will be chosen when its value is equal or greater than the entire builder bid value, "
-              + "'80' means local payload will be chosen when its value is at least 80% of builder bid value).\n"
+              + "'80' means local payload will be chosen when its value is at least 80%% of builder bid value).\n"
               + "Set it to '"
               + BUILDER_ALWAYS_KEYWORD
               + "' to always use builder bid. In this configuration locally produced payload will be used only when the bid is invalid.",


### PR DESCRIPTION
fixes:
```
[picocli WARN] Could not format 'Set the compare factor applied to the builder bid value when comparing it with locally produced payload. Factor is expressed in percentage (e.g. '100' means locally produced payload will be chosen when its value is equal or greater than the entire builder bid value, '80' means local payload will be chosen when its value is at least 80% of builder bid value).
Set it to 'BUILDER_ALWAYS' to always use builder bid. In this configuration locally produced payload will be used only when the bid is invalid.' (Underlying error: Format specifier '% o'). Using raw String: '%n' format strings have not been replaced with newlines. Please ensure to escape '%' characters with another '%'.
```

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
