### PR TITLE
Add ability to set a preferred peer when fetching blocks/blobs

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/DefaultFetchTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/DefaultFetchTaskFactory.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beacon.sync.fetch;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
@@ -27,12 +28,14 @@ public class DefaultFetchTaskFactory implements FetchTaskFactory {
   }
 
   @Override
-  public FetchBlockTask createFetchBlockTask(final Bytes32 blockRoot) {
-    return new FetchBlockTask(eth2Network, blockRoot);
+  public FetchBlockTask createFetchBlockTask(
+      final Bytes32 blockRoot, final Optional<Eth2Peer> preferredPeer) {
+    return new FetchBlockTask(eth2Network, preferredPeer, blockRoot);
   }
 
   @Override
-  public FetchBlobSidecarTask createFetchBlobSidecarTask(final BlobIdentifier blobIdentifier) {
-    return new FetchBlobSidecarTask(eth2Network, blobIdentifier);
+  public FetchBlobSidecarTask createFetchBlobSidecarTask(
+      final BlobIdentifier blobIdentifier, final Optional<Eth2Peer> preferredPeer) {
+    return new FetchBlobSidecarTask(eth2Network, preferredPeer, blobIdentifier);
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTask.java
@@ -58,7 +58,11 @@ public class FetchBlobSidecarTask extends AbstractFetchTask<BlobIdentifier, Blob
                     .orElseGet(() -> FetchResult.createFailed(peer, Status.FETCH_FAILED)))
         .exceptionally(
             err -> {
-              LOG.debug("Failed to fetch blob sidecar by identifier " + blobIdentifier, err);
+              LOG.debug(
+                  String.format(
+                      "Failed to fetch blob sidecar by identifier %s from peer %s",
+                      blobIdentifier, peer.getId()),
+                  err);
               return FetchResult.createFailed(peer, Status.FETCH_FAILED);
             });
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
@@ -57,7 +57,10 @@ public class FetchBlockTask extends AbstractFetchTask<Bytes32, SignedBeaconBlock
                     .orElseGet(() -> FetchResult.createFailed(peer, Status.FETCH_FAILED)))
         .exceptionally(
             err -> {
-              LOG.debug("Failed to fetch block by root " + blockRoot, err);
+              LOG.debug(
+                  String.format(
+                      "Failed to fetch block by root %s from peer %s", blockRoot, peer.getId()),
+                  err);
               return FetchResult.createFailed(peer, Status.FETCH_FAILED);
             });
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchResult.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchResult.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beacon.sync.fetch;
 
 import java.util.Optional;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 
 public final class FetchResult<T> {
 
@@ -24,31 +25,47 @@ public final class FetchResult<T> {
     FETCH_FAILED
   }
 
+  private final Optional<Eth2Peer> peer;
   private final Status status;
   private final Optional<T> result;
 
-  private FetchResult(final Status status, final Optional<T> result) {
+  private FetchResult(
+      final Optional<Eth2Peer> peer, final Status status, final Optional<T> result) {
+    this.peer = peer;
     this.status = status;
     this.result = result;
   }
 
   public static <T> FetchResult<T> createSuccessful(final T result) {
-    return new FetchResult<>(Status.SUCCESSFUL, Optional.of(result));
+    return new FetchResult<>(Optional.empty(), Status.SUCCESSFUL, Optional.of(result));
+  }
+
+  public static <T> FetchResult<T> createSuccessful(final Eth2Peer peer, T result) {
+    return new FetchResult<>(Optional.of(peer), Status.SUCCESSFUL, Optional.of(result));
   }
 
   public static <T> FetchResult<T> createFailed(final Status failureStatus) {
-    return new FetchResult<>(failureStatus, Optional.empty());
+    return new FetchResult<>(Optional.empty(), failureStatus, Optional.empty());
+  }
+
+  public static <T> FetchResult<T> createFailed(final Eth2Peer peer, final Status failureStatus) {
+    return new FetchResult<>(Optional.of(peer), failureStatus, Optional.empty());
+  }
+
+  public Optional<Eth2Peer> getPeer() {
+    return peer;
   }
 
   public boolean isSuccessful() {
     return status == Status.SUCCESSFUL;
   }
 
-  public Optional<T> getResult() {
-    return result;
-  }
-
   public Status getStatus() {
     return status;
+  }
+
+  /** Present if {@link #isSuccessful} returns true * */
+  public Optional<T> getResult() {
+    return result;
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchTaskFactory.java
@@ -13,12 +13,23 @@
 
 package tech.pegasys.teku.beacon.sync.fetch;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
 public interface FetchTaskFactory {
 
-  FetchBlockTask createFetchBlockTask(Bytes32 blockRoot);
+  default FetchBlockTask createFetchBlockTask(Bytes32 blockRoot) {
+    return createFetchBlockTask(blockRoot, Optional.empty());
+  }
 
-  FetchBlobSidecarTask createFetchBlobSidecarTask(BlobIdentifier blobIdentifier);
+  FetchBlockTask createFetchBlockTask(Bytes32 blockRoot, Optional<Eth2Peer> preferredPeer);
+
+  default FetchBlobSidecarTask createFetchBlobSidecarTask(BlobIdentifier blobIdentifier) {
+    return createFetchBlobSidecarTask(blobIdentifier, Optional.empty());
+  }
+
+  FetchBlobSidecarTask createFetchBlobSidecarTask(
+      BlobIdentifier blobIdentifier, Optional<Eth2Peer> preferredPeer);
 }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchTaskTest.java
@@ -38,11 +38,15 @@ public class AbstractFetchTaskTest {
   }
 
   protected Eth2Peer registerNewPeer(final int id) {
+    final Eth2Peer peer = createNewPeer(id);
+    peers.add(peer);
+    return peer;
+  }
+
+  protected Eth2Peer createNewPeer(final int id) {
     final Eth2Peer peer = mock(Eth2Peer.class);
     when(peer.getOutstandingRequests()).thenReturn(0);
     when(peer.getId()).thenReturn(new MockNodeId(id));
-
-    peers.add(peer);
     return peer;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This functionality is not used currently, but could be utilised in the future for better fetching of blocks and blobs (e.g. retrieve blobs from same peer we got a block from)

- Add ability to specify a preferred peer `Optional<Eth2Peer>` when creating fetch tasks for blocks and blobs in the `FetchTaskFactory`
- Peer will be preferred over a random selected ones for fetching. Any retries will use other random peers.
- Exposing the peer used for fetching in `FetchResult`

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
