### PR TITLE
Fix publishDockerArm64 job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,24 @@ jobs:
             ./gradlew --no-daemon --parallel checkMavenCoordinateCollisions spotlessCheck checkModuleDependencies
       - notify
 
+  javaCheck:
+    executor: machine_executor_arm64
+    steps:
+      - run:
+          name: test
+          command: |
+            echo $JAVA_HOME
+            java --version
+
+  javaCheckAgain:
+    executor: machine_executor_amd64
+    steps:
+      - run:
+          name: test
+          command: |
+            echo $JAVA_HOME
+            java --version  
+
   dockerScan:
     executor: trivy_executor
     steps:
@@ -534,6 +552,14 @@ workflows:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
       - spotless:
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - javaCheck:
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - javaCheckAgain:
           filters:
             tags:
               <<: *filters-release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-  win: circleci/windows@5.0
+  win: circleci/windows@5.0.0
 executors:
   small_executor:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.7
         auth: &docker-auth
           # Don't panic, throw away account to avoid Docker rate limits when downloading.
           # Second reason we're doing this is so that forked PRs from external contributors works ie env vars aren't visible to forked PRs from within contexts
@@ -27,7 +27,7 @@ executors:
 
   medium_executor:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.7
         auth:
           <<: *docker-auth
     resource_class: medium
@@ -39,7 +39,7 @@ executors:
 
   medium_plus_executor:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.7
         auth:
           <<: *docker-auth
     resource_class: "medium+"
@@ -50,7 +50,7 @@ executors:
 
   large_executor:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.7
         auth:
           <<: *docker-auth
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ executors:
 
   machine_executor_amd64:
     machine:
-      image: ubuntu-2204:2022.10.2 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2023.04.2 # https://circleci.com/developer/machine/image/ubuntu-2204
       docker_layer_caching: true
     working_directory: ~/project
     environment:
@@ -70,7 +70,7 @@ executors:
 
   machine_executor_arm64:
     machine:
-      image: ubuntu-2204:2022.10.2 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2023.04.2 # https://circleci.com/developer/machine/image/ubuntu-2204
     resource_class: arm.medium
     environment:
       architecture: "arm64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,24 +225,6 @@ jobs:
             ./gradlew --no-daemon --parallel checkMavenCoordinateCollisions spotlessCheck checkModuleDependencies
       - notify
 
-  javaCheck:
-    executor: machine_executor_arm64
-    steps:
-      - run:
-          name: test
-          command: |
-            echo $JAVA_HOME
-            java --version
-
-  javaCheckAgain:
-    executor: machine_executor_amd64
-    steps:
-      - run:
-          name: test
-          command: |
-            echo $JAVA_HOME
-            java --version  
-
   dockerScan:
     executor: trivy_executor
     steps:
@@ -552,14 +534,6 @@ workflows:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
       - spotless:
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - javaCheck:
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - javaCheckAgain:
           filters:
             tags:
               <<: *filters-release-tags

--- a/build.gradle
+++ b/build.gradle
@@ -494,7 +494,7 @@ tasks.register("dockerDistUntar") {
 }
 
 def dockerImage = "consensys/teku"
-def dockerJdkVariants = [ "jdk17", ]
+def dockerJdkVariants = [ "jdk17" ]
 def dockerBuildDir = "build/docker-teku/"
 
 task distDocker  {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix failing job on master https://app.circleci.com/pipelines/github/Consensys/teku/26584/workflows/7b0f58fd-80f7-4187-818d-a2d1e9168919/jobs/194859

For some reason `ubuntu-2204:2022.10.2` on `arm64` `JAVA_HOME` was returning Java 11. Looks fixed in `2023.04.2`

Use specific java version for images to have more reproducible builds.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
