### PR TITLE
Use POST validator statuses in VC

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/beacon/PostStateValidatorsRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/beacon/PostStateValidatorsRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.request.v1.beacon;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatus;
+
+public class PostStateValidatorsRequest {
+
+  @JsonProperty("ids")
+  @ArraySchema(schema = @Schema(type = "string"))
+  public final List<String> ids;
+
+  @JsonProperty("statuses")
+  @ArraySchema(schema = @Schema(type = "string"))
+  public final List<ValidatorStatus> statuses;
+
+  @JsonCreator
+  public PostStateValidatorsRequest(
+      @JsonProperty("ids") final List<String> ids,
+      @JsonProperty("statuses") final List<ValidatorStatus> statuses) {
+    this.ids = ids;
+    this.statuses = statuses;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/beacon/PostStateValidatorsRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/beacon/PostStateValidatorsRequest.java
@@ -15,19 +15,15 @@ package tech.pegasys.teku.api.request.v1.beacon;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatus;
 
 public class PostStateValidatorsRequest {
 
   @JsonProperty("ids")
-  @ArraySchema(schema = @Schema(type = "string"))
   public final List<String> ids;
 
   @JsonProperty("statuses")
-  @ArraySchema(schema = @Schema(type = "string"))
   public final List<ValidatorStatus> statuses;
 
   @JsonCreator

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/beacon/PostStateValidatorsRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/beacon/PostStateValidatorsRequest.java
@@ -16,21 +16,14 @@ package tech.pegasys.teku.api.request.v1.beacon;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatus;
 
 public class PostStateValidatorsRequest {
 
   @JsonProperty("ids")
   public final List<String> ids;
 
-  @JsonProperty("statuses")
-  public final List<ValidatorStatus> statuses;
-
   @JsonCreator
-  public PostStateValidatorsRequest(
-      @JsonProperty("ids") final List<String> ids,
-      @JsonProperty("statuses") final List<ValidatorStatus> statuses) {
+  public PostStateValidatorsRequest(@JsonProperty("ids") final List<String> ids) {
     this.ids = ids;
-    this.statuses = statuses;
   }
 }

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpStatusCodes.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpStatusCodes.java
@@ -23,6 +23,7 @@ public class HttpStatusCodes {
   public static final int SC_UNAUTHORIZED = 401;
   public static final int SC_FORBIDDEN = 403;
   public static final int SC_NOT_FOUND = 404;
+  public static final int SC_METHOD_NOT_ALLOWED = 405;
   public static final int SC_NOT_ACCEPTABLE = 406;
   public static final int SC_GONE = 410;
   public static final int SC_PRECONDITION_FAILED = 412;

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -177,9 +177,11 @@ class OkHttpValidatorRestApiClientTest {
     assertThat(result.get()).usingRecursiveComparison().isEqualTo(expected);
   }
 
-  @Test
-  void getValidators_MakesExpectedGetRequest_WhenPostNotAllowed() throws Exception {
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_METHOD_NOT_ALLOWED));
+  @ParameterizedTest
+  @ValueSource(ints = {SC_NOT_FOUND, SC_METHOD_NOT_ALLOWED})
+  void getValidators_MakesExpectedGetRequest_WhenPostNotAllowed(final int responseCode)
+      throws Exception {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(responseCode));
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
 
     apiClient.getValidators(List.of("1", "0x1234"));
@@ -193,13 +195,15 @@ class OkHttpValidatorRestApiClientTest {
     assertThat(request.getPath()).contains("?id=1,0x1234");
   }
 
-  @Test
-  public void getValidators_WhenPostNotAllowedAndGetSuccess_ReturnsResponse() {
+  @ParameterizedTest
+  @ValueSource(ints = {SC_NOT_FOUND, SC_METHOD_NOT_ALLOWED})
+  public void getValidators_WhenPostNotAllowedAndGetSuccess_ReturnsResponse(
+      final int responseCode) {
     final List<ValidatorResponse> expected =
         List.of(schemaObjects.validatorResponse(), schemaObjects.validatorResponse());
     final GetStateValidatorsResponse response = new GetStateValidatorsResponse(false, expected);
 
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_METHOD_NOT_ALLOWED));
+    mockWebServer.enqueue(new MockResponse().setResponseCode(responseCode));
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(asJson(response)));
 
     Optional<List<ValidatorResponse>> result = apiClient.getValidators(List.of("1", "2"));

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -160,8 +160,7 @@ class OkHttpValidatorRestApiClientTest {
     final RecordedRequest request = mockWebServer.takeRequest();
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath()).contains(ValidatorApiMethod.GET_VALIDATORS.getPath(emptyMap()));
-    assertThat(request.getBody().readUtf8())
-        .isEqualTo("{\"ids\":[\"1\",\"0x1234\"],\"statuses\":[]}");
+    assertThat(request.getBody().readUtf8()).isEqualTo("{\"ids\":[\"1\",\"0x1234\"]}");
   }
 
   @Test

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -161,7 +161,7 @@ class OkHttpValidatorRestApiClientTest {
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath()).contains(ValidatorApiMethod.GET_VALIDATORS.getPath(emptyMap()));
     assertThat(request.getBody().readUtf8())
-        .isEqualTo("{\"ids\":[\"1\",\"0x1234\"],\"statuses\":null}");
+        .isEqualTo("{\"ids\":[\"1\",\"0x1234\"],\"statuses\":[]}");
   }
 
   @Test

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/SchemaObjectsTestFixture.java
@@ -15,22 +15,17 @@ package tech.pegasys.teku.validator.remote.apiclient;
 
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
-import tech.pegasys.teku.api.SchemaObjectProvider;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorResponse;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.BLSPubKey;
-import tech.pegasys.teku.api.schema.BLSSignature;
-import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.Validator;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -61,10 +56,6 @@ public class SchemaObjectsTestFixture {
     return new SignedVoluntaryExit(dataStructureUtil.randomSignedVoluntaryExit());
   }
 
-  public BLSSignature blsSignature() {
-    return new BLSSignature(dataStructureUtil.randomSignature());
-  }
-
   public ValidatorResponse validatorResponse() {
     return validatorResponse(dataStructureUtil.randomLong(), dataStructureUtil.randomPublicKey());
   }
@@ -85,29 +76,10 @@ public class SchemaObjectsTestFixture {
             FAR_FUTURE_EPOCH));
   }
 
-  public BeaconBlock beaconBlock() {
-    return new BeaconBlockPhase0(dataStructureUtil.randomBeaconBlock(UInt64.ONE));
-  }
-
-  public BeaconBlock beaconBlockAltair() {
-    final Spec altairSpec = TestSpecFactory.createMainnetAltair();
-    final DataStructureUtil altairData = new DataStructureUtil(altairSpec);
-    final SchemaObjectProvider schemaObjectProvider = new SchemaObjectProvider(altairSpec);
-    return schemaObjectProvider.getBeaconBlock(altairData.randomBeaconBlock(UInt64.ONE));
-  }
-
   public SyncCommitteeContribution syncCommitteeContribution(final UInt64 slot) {
     final Spec altairSpec = TestSpecFactory.createMainnetAltair();
     final DataStructureUtil altairData = new DataStructureUtil(altairSpec);
     return new SyncCommitteeContribution(altairData.randomSyncCommitteeContribution(slot));
-  }
-
-  public SignedBeaconBlock signedBeaconBlock() {
-    return SignedBeaconBlock.create(dataStructureUtil.randomSignedBeaconBlock(UInt64.ONE));
-  }
-
-  public SignedBeaconBlock signedBlindedBlock() {
-    return SignedBeaconBlock.create(dataStructureUtil.randomSignedBlindedBeaconBlock(UInt64.ONE));
   }
 
   public Attestation attestation() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -142,7 +142,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
       final Function<ValidatorResponse, T> valueExtractor) {
     try {
       return apiClient
-          .postValidators(convertsPublicKeysToValidatorIds(publicKeys))
+          .postValidators(convertPublicKeysToValidatorIds(publicKeys))
           .map(responses -> convertToValidatorMap(responses, valueExtractor));
     } catch (final PostStateValidatorsNotExistingException __) {
       LOG.debug(
@@ -151,7 +151,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
     }
   }
 
-  private List<String> convertsPublicKeysToValidatorIds(final Collection<BLSPublicKey> publicKeys) {
+  private List<String> convertPublicKeysToValidatorIds(final Collection<BLSPublicKey> publicKeys) {
     return publicKeys.stream().map(BLSPublicKey::toHexString).toList();
   }
 
@@ -183,7 +183,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   private <T> Optional<Map<BLSPublicKey, T>> requestValidatorObject(
       final List<BLSPublicKey> batch, Function<ValidatorResponse, T> valueExtractor) {
     return apiClient
-        .getValidators(convertsPublicKeysToValidatorIds(batch))
+        .getValidators(convertPublicKeysToValidatorIds(batch))
         .map(responses -> convertToValidatorMap(responses, valueExtractor));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -145,7 +145,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   @Override
   public Optional<List<ValidatorResponse>> postValidators(final List<String> validatorIds) {
     final PostStateValidatorsRequest requestBody =
-        new PostStateValidatorsRequest(validatorIds, null);
+        new PostStateValidatorsRequest(validatorIds, List.of());
     return post(
             GET_VALIDATORS,
             EMPTY_MAP,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -144,8 +144,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
    */
   @Override
   public Optional<List<ValidatorResponse>> postValidators(final List<String> validatorIds) {
-    final PostStateValidatorsRequest requestBody =
-        new PostStateValidatorsRequest(validatorIds, List.of());
+    final PostStateValidatorsRequest requestBody = new PostStateValidatorsRequest(validatorIds);
     return post(
             GET_VALIDATORS,
             EMPTY_MAP,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -129,13 +129,20 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
         createHandler(GetBlockHeaderResponse.class));
   }
 
+  /**
+   * Tries <a
+   * href="https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/postStateValidators">POST
+   * Get validators from state</a> and falls back to <a
+   * href="https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateValidators">GET
+   * Get validators from state</a> if POST method is not allowed
+   */
   @Override
   public Optional<List<ValidatorResponse>> getValidators(final List<String> validatorIds) {
     try {
       return postValidators(validatorIds);
     } catch (final PostStateValidatorsNotAllowedException ex) {
       LOG.debug(
-          "POST method for getting validator from state is not allowed. Falling back to GET.");
+          "POST method for getting validators from state is not allowed. Falling back to GET.");
     }
     final Map<String, String> queryParams = new HashMap<>();
     queryParams.put("id", String.join(",", validatorIds));

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -92,6 +92,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.remote.apiclient.ResponseHandler.Handler;
 
 public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
 
@@ -100,6 +101,11 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   private static final MediaType APPLICATION_JSON =
       MediaType.parse("application/json; charset=utf-8");
   private static final Map<String, String> EMPTY_MAP = emptyMap();
+  private static final Handler<GetStateValidatorsResponse>
+      POST_VALIDATORS_NOT_ALLOWED_THROWING_EXCEPTION_HANDLER =
+          (req, res) -> {
+            throw new PostStateValidatorsNotAllowedException();
+          };
 
   private final JsonProvider jsonProvider = new JsonProvider();
   private final OkHttpClient httpClient;
@@ -163,11 +169,9 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
             EMPTY_MAP,
             request,
             createHandler(GetStateValidatorsResponse.class)
+                .withHandler(SC_NOT_FOUND, POST_VALIDATORS_NOT_ALLOWED_THROWING_EXCEPTION_HANDLER)
                 .withHandler(
-                    SC_METHOD_NOT_ALLOWED,
-                    (req, res) -> {
-                      throw new PostStateValidatorsNotAllowedException();
-                    }))
+                    SC_METHOD_NOT_ALLOWED, POST_VALIDATORS_NOT_ALLOWED_THROWING_EXCEPTION_HANDLER))
         .map(response -> response.data);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/PostStateValidatorsNotAllowedException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/PostStateValidatorsNotAllowedException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.apiclient;
+
+public class PostStateValidatorsNotAllowedException extends RuntimeException {}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/PostStateValidatorsNotExistingException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/PostStateValidatorsNotExistingException.java
@@ -13,4 +13,4 @@
 
 package tech.pegasys.teku.validator.remote.apiclient;
 
-public class PostStateValidatorsNotAllowedException extends RuntimeException {}
+public class PostStateValidatorsNotExistingException extends RuntimeException {}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ResponseHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ResponseHandler.java
@@ -64,6 +64,13 @@ public class ResponseHandler<T> {
     return this;
   }
 
+  public ResponseHandler<T> withHandler(final Handler<T> handler, final int... responseCodes) {
+    for (final int responseCode : responseCodes) {
+      handlers.put(responseCode, handler);
+    }
+    return this;
+  }
+
   public Optional<T> handleResponse(final Request request, final Response response)
       throws IOException {
     return handlers

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/ValidatorRestApiClient.java
@@ -26,10 +26,7 @@ import tech.pegasys.teku.api.response.v1.validator.PostAttesterDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostSyncDutiesResponse;
 import tech.pegasys.teku.api.response.v1.validator.PostValidatorLivenessResponse;
 import tech.pegasys.teku.api.schema.Attestation;
-import tech.pegasys.teku.api.schema.BLSSignature;
-import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.SignedAggregateAndProof;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.api.schema.SubnetSubscription;
 import tech.pegasys.teku.api.schema.altair.SignedContributionAndProof;
@@ -39,7 +36,6 @@ import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
-import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
 public interface ValidatorRestApiClient {
 
@@ -47,15 +43,12 @@ public interface ValidatorRestApiClient {
 
   Optional<List<ValidatorResponse>> getValidators(List<String> validatorIds);
 
+  Optional<List<ValidatorResponse>> postValidators(List<String> validatorIds);
+
   Optional<PostAttesterDutiesResponse> getAttestationDuties(
       final UInt64 epoch, final Collection<Integer> validatorIndices);
 
   Optional<GetProposerDutiesResponse> getProposerDuties(final UInt64 epoch);
-
-  Optional<BeaconBlock> createUnsignedBlock(
-      UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti, boolean blinded);
-
-  SendSignedBlockResult sendSignedBlock(SignedBeaconBlock beaconBlock);
 
   Optional<PostDataFailureResponse> sendSignedAttestations(List<Attestation> attestation);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -183,6 +183,39 @@ class RemoteValidatorApiHandlerTest {
   }
 
   @Test
+  void getValidatorIndices_DoesNotAttemptPostAgainIfNotExisting() {
+    final BLSPublicKey key1 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key2 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key3 = dataStructureUtil.randomPublicKey();
+    final List<String> expectedValidatorIds =
+        List.of(
+            key1.toBytesCompressed().toHexString(),
+            key2.toBytesCompressed().toHexString(),
+            key3.toBytesCompressed().toHexString());
+
+    // simulate POST not existing
+    when(apiClient.postValidators(any())).thenThrow(PostStateValidatorsNotExistingException.class);
+    when(apiClient.getValidators(expectedValidatorIds))
+        .thenReturn(Optional.of(List.of(validatorResponse(1, key1), validatorResponse(2, key2))));
+
+    // call method twice
+    final SafeFuture<Map<BLSPublicKey, Integer>> future =
+        apiHandler.getValidatorIndices(List.of(key1, key2, key3));
+    final SafeFuture<Map<BLSPublicKey, Integer>> future1 =
+        apiHandler.getValidatorIndices(List.of(key1, key2, key3));
+
+    asyncRunner.executeQueuedActions();
+    assertThat(future).isCompleted();
+    assertThat(future1).isCompleted();
+    assertThat(safeJoin(future)).containsOnly(entry(key1, 1), entry(key2, 2));
+    assertThat(safeJoin(future1)).containsOnly(entry(key1, 1), entry(key2, 2));
+    // POST only called once
+    verify(apiClient, times(1)).postValidators(expectedValidatorIds);
+    // GET called twice
+    verify(apiClient, times(2)).getValidators(expectedValidatorIds);
+  }
+
+  @Test
   void getValidatorIndices_WithSmallNumberOfPublicKeys_RequestsSingleBatch() {
     // simulate POST not existing
     when(apiClient.postValidators(any())).thenThrow(PostStateValidatorsNotExistingException.class);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -87,6 +87,7 @@ import tech.pegasys.teku.validator.api.ProposerDuty;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
+import tech.pegasys.teku.validator.remote.apiclient.PostStateValidatorsNotExistingException;
 import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
 import tech.pegasys.teku.validator.remote.typedef.OkHttpValidatorTypeDefClient;
@@ -160,7 +161,31 @@ class RemoteValidatorApiHandlerTest {
   }
 
   @Test
+  void getValidatorIndices_MakesSingleRequestUsingPost() {
+    final BLSPublicKey key1 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key2 = dataStructureUtil.randomPublicKey();
+    final BLSPublicKey key3 = dataStructureUtil.randomPublicKey();
+    final List<String> expectedValidatorIds =
+        List.of(
+            key1.toBytesCompressed().toHexString(),
+            key2.toBytesCompressed().toHexString(),
+            key3.toBytesCompressed().toHexString());
+    when(apiClient.postValidators(expectedValidatorIds))
+        .thenReturn(Optional.of(List.of(validatorResponse(1, key1), validatorResponse(2, key2))));
+
+    final SafeFuture<Map<BLSPublicKey, Integer>> future =
+        apiHandler.getValidatorIndices(List.of(key1, key2, key3));
+
+    asyncRunner.executeQueuedActions();
+    assertThat(future).isCompleted();
+    assertThat(safeJoin(future)).containsOnly(entry(key1, 1), entry(key2, 2));
+    verify(apiClient).postValidators(expectedValidatorIds);
+  }
+
+  @Test
   void getValidatorIndices_WithSmallNumberOfPublicKeys_RequestsSingleBatch() {
+    // simulate POST not existing
+    when(apiClient.postValidators(any())).thenThrow(PostStateValidatorsNotExistingException.class);
     final BLSPublicKey key1 = dataStructureUtil.randomPublicKey();
     final BLSPublicKey key2 = dataStructureUtil.randomPublicKey();
     final BLSPublicKey key3 = dataStructureUtil.randomPublicKey();
@@ -183,6 +208,8 @@ class RemoteValidatorApiHandlerTest {
 
   @Test
   void getValidatorIndices_WithLargeNumberOfPublicKeys_CombinesMultipleBatches() {
+    // simulate POST not existing
+    when(apiClient.postValidators(any())).thenThrow(PostStateValidatorsNotExistingException.class);
     // Need to ensure the URL length limit isn't exceeded, so send requests in batches
     final List<BLSPublicKey> allKeys =
         IntStream.range(0, MAX_PUBLIC_KEY_BATCH_SIZE * 3 - 2)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add postValidators to `ValidatorRestApiClient`
- Change `RemoteValidatorApiHandler` to try **POST** request before doing a batched **GET** request
- Remove unused methods from `OkHttpValidatorRestApiClient` (they have been replaced by typeDef requests)

## Fixed Issue(s)
fixes #7733 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
