### PR TITLE
Block publishing performance

### DIFF
--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
 import tech.pegasys.teku.beacon.sync.events.SyncStateTracker;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceFactory;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionAndPublishingPerformanceFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricUtils;
@@ -121,7 +121,8 @@ public class ValidatorApiHandlerIntegrationTest {
           syncCommitteeMessagePool,
           syncCommitteeContributionPool,
           syncCommitteeSubscriptionManager,
-          new BlockProductionPerformanceFactory(new SystemTimeProvider(), true, 0));
+          new BlockProductionAndPublishingPerformanceFactory(
+              new SystemTimeProvider(), __ -> UInt64.ZERO, true, 0));
 
   @BeforeEach
   public void setup() {

--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -122,7 +122,7 @@ public class ValidatorApiHandlerIntegrationTest {
           syncCommitteeContributionPool,
           syncCommitteeSubscriptionManager,
           new BlockProductionAndPublishingPerformanceFactory(
-              new SystemTimeProvider(), __ -> UInt64.ZERO, true, 0));
+              new SystemTimeProvider(), __ -> UInt64.ZERO, true, 0, 0));
 
   @BeforeEach
   public void setup() {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -37,7 +38,9 @@ public interface BlockFactory {
       Optional<UInt64> requestedBuilderBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
-  SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(SignedBeaconBlock maybeBlindedBlock);
+  SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
+      SignedBeaconBlock maybeBlindedBlock, BlockPublishingPerformance blockPublishingPerformance);
 
-  List<BlobSidecar> createBlobSidecars(SignedBlockContainer blockContainer);
+  List<BlobSidecar> createBlobSidecars(
+      SignedBlockContainer blockContainer, BlockPublishingPerformance blockPublishingPerformance);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -70,8 +71,12 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
   }
 
   @Override
-  public List<BlobSidecar> createBlobSidecars(final SignedBlockContainer blockContainer) {
-    return operationSelector.createBlobSidecarsSelector().apply(blockContainer);
+  public List<BlobSidecar> createBlobSidecars(
+      final SignedBlockContainer blockContainer,
+      final BlockPublishingPerformance blockPublishingPerformance) {
+    return operationSelector
+        .createBlobSidecarsSelector(blockPublishingPerformance)
+        .apply(blockContainer);
   }
 
   private BlockContents createBlockContents(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -94,16 +95,20 @@ public class BlockFactoryPhase0 implements BlockFactory {
 
   @Override
   public SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
-      final SignedBeaconBlock maybeBlindedBlock) {
+      final SignedBeaconBlock maybeBlindedBlock,
+      final BlockPublishingPerformance blockPublishingPerformance) {
     if (maybeBlindedBlock.isBlinded()) {
       return spec.unblindSignedBeaconBlock(
-          maybeBlindedBlock.getSignedBlock(), operationSelector.createBlockUnblinderSelector());
+          maybeBlindedBlock.getSignedBlock(),
+          operationSelector.createBlockUnblinderSelector(blockPublishingPerformance));
     }
     return SafeFuture.completedFuture(maybeBlindedBlock);
   }
 
   @Override
-  public List<BlobSidecar> createBlobSidecars(final SignedBlockContainer blockContainer) {
+  public List<BlobSidecar> createBlobSidecars(
+      final SignedBlockContainer blockContainer,
+      final BlockPublishingPerformance blockPublishingPerformance) {
     return Collections.emptyList();
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -84,15 +85,22 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
 
   @Override
   public SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
-      final SignedBeaconBlock maybeBlindedBlock) {
+      final SignedBeaconBlock maybeBlindedBlock,
+      final BlockPublishingPerformance blockPublishingPerformance) {
     final SpecMilestone milestone = getMilestone(maybeBlindedBlock.getSlot());
-    return registeredFactories.get(milestone).unblindSignedBlockIfBlinded(maybeBlindedBlock);
+    return registeredFactories
+        .get(milestone)
+        .unblindSignedBlockIfBlinded(maybeBlindedBlock, blockPublishingPerformance);
   }
 
   @Override
-  public List<BlobSidecar> createBlobSidecars(final SignedBlockContainer blockContainer) {
+  public List<BlobSidecar> createBlobSidecars(
+      final SignedBlockContainer blockContainer,
+      BlockPublishingPerformance blockPublishingPerformance) {
     final SpecMilestone milestone = getMilestone(blockContainer.getSlot());
-    return registeredFactories.get(milestone).createBlobSidecars(blockContainer);
+    return registeredFactories
+        .get(milestone)
+        .createBlobSidecars(blockContainer, blockPublishingPerformance);
   }
 
   private SpecMilestone getMilestone(final UInt64 slot) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR
 import static tech.pegasys.teku.infrastructure.metrics.Validator.DutyType.ATTESTATION_PRODUCTION;
 import static tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricUtils.startTimer;
 import static tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricsSteps.CREATE;
-import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -54,8 +53,9 @@ import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
 import tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeDuty;
 import tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeSelectionProof;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionAndPublishingPerformanceFactory;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceFactory;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -116,7 +116,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
    */
   private static final int DUTY_EPOCH_TOLERANCE = 1;
 
-  private final BlockProductionPerformanceFactory blockProductionPerformanceFactory;
+  private final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory;
   private final ChainDataProvider chainDataProvider;
   private final NodeDataProvider nodeDataProvider;
   private final CombinedChainDataClient combinedChainDataClient;
@@ -160,7 +160,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final SyncCommitteeMessagePool syncCommitteeMessagePool,
       final SyncCommitteeContributionPool syncCommitteeContributionPool,
       final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager,
-      final BlockProductionPerformanceFactory blockProductionPerformanceFactory) {
+      final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory) {
     this.blockProductionPerformanceFactory = blockProductionPerformanceFactory;
     this.chainDataProvider = chainDataProvider;
     this.nodeDataProvider = nodeDataProvider;
@@ -323,21 +323,14 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       return NodeSyncingException.failedFuture();
     }
     final BlockProductionPerformance blockProductionPerformance =
-        blockProductionPerformanceFactory.create(slot);
+        blockProductionPerformanceFactory.createForProduction(slot);
     return forkChoiceTrigger
         .prepareForBlockProduction(slot, blockProductionPerformance)
         .thenCompose(
             __ ->
                 combinedChainDataClient.getStateForBlockProduction(
                     slot, forkChoiceTrigger.isForkChoiceOverrideLateBlockEnabled()))
-        .thenPeek(
-            maybeState -> {
-              maybeState.ifPresent(
-                  state ->
-                      blockProductionPerformance.slotTime(
-                          () -> secondsToMillis(spec.computeTimeAtSlot(state, slot))));
-              blockProductionPerformance.getStateAtSlot();
-            })
+        .thenPeek(__ -> blockProductionPerformance.getStateAtSlot())
         .thenCompose(
             blockSlotState ->
                 createBlock(
@@ -630,13 +623,17 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(
       final SignedBlockContainer maybeBlindedBlockContainer,
       final BroadcastValidationLevel broadcastValidationLevel) {
+    final BlockPublishingPerformance blockPublishingPerformance =
+        blockProductionPerformanceFactory.createForPublishing(maybeBlindedBlockContainer.getSlot());
     return blockPublisher
-        .sendSignedBlock(maybeBlindedBlockContainer, broadcastValidationLevel)
+        .sendSignedBlock(
+            maybeBlindedBlockContainer, broadcastValidationLevel, blockPublishingPerformance)
         .exceptionally(
             ex -> {
               final String reason = getRootCauseMessage(ex);
               return SendSignedBlockResult.rejected(reason);
-            });
+            })
+        .alwaysRun(blockPublishingPerformance::complete);
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -116,7 +116,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
    */
   private static final int DUTY_EPOCH_TOLERANCE = 1;
 
-  private final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory;
+  private final BlockProductionAndPublishingPerformanceFactory
+      blockProductionAndPublishingPerformanceFactory;
   private final ChainDataProvider chainDataProvider;
   private final NodeDataProvider nodeDataProvider;
   private final CombinedChainDataClient combinedChainDataClient;
@@ -160,8 +161,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final SyncCommitteeMessagePool syncCommitteeMessagePool,
       final SyncCommitteeContributionPool syncCommitteeContributionPool,
       final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager,
-      final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory) {
-    this.blockProductionPerformanceFactory = blockProductionPerformanceFactory;
+      final BlockProductionAndPublishingPerformanceFactory
+          blockProductionAndPublishingPerformanceFactory) {
+    this.blockProductionAndPublishingPerformanceFactory =
+        blockProductionAndPublishingPerformanceFactory;
     this.chainDataProvider = chainDataProvider;
     this.nodeDataProvider = nodeDataProvider;
     this.combinedChainDataClient = combinedChainDataClient;
@@ -323,7 +326,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       return NodeSyncingException.failedFuture();
     }
     final BlockProductionPerformance blockProductionPerformance =
-        blockProductionPerformanceFactory.createForProduction(slot);
+        blockProductionAndPublishingPerformanceFactory.createForProduction(slot);
     return forkChoiceTrigger
         .prepareForBlockProduction(slot, blockProductionPerformance)
         .thenCompose(
@@ -624,7 +627,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final SignedBlockContainer maybeBlindedBlockContainer,
       final BroadcastValidationLevel broadcastValidationLevel) {
     final BlockPublishingPerformance blockPublishingPerformance =
-        blockProductionPerformanceFactory.createForPublishing(maybeBlindedBlockContainer.getSlot());
+        blockProductionAndPublishingPerformanceFactory.createForPublishing(
+            maybeBlindedBlockContainer.getSlot());
     return blockPublisher
         .sendSignedBlock(
             maybeBlindedBlockContainer, broadcastValidationLevel, blockPublishingPerformance)

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.coordinator.publisher;
 
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
@@ -21,5 +22,7 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 /** Used to publish blocks (unblinded and blinded) and blob sidecars */
 public interface BlockPublisher {
   SafeFuture<SendSignedBlockResult> sendSignedBlock(
-      SignedBlockContainer blockContainer, BroadcastValidationLevel broadcastValidationLevel);
+      SignedBlockContainer blockContainer,
+      BroadcastValidationLevel broadcastValidationLevel,
+      BlockPublishingPerformance blockPublishingPerformance);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.coordinator.publisher;
 
 import java.util.List;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -42,13 +43,19 @@ public class BlockPublisherPhase0 extends AbstractBlockPublisher {
   SafeFuture<BlockImportAndBroadcastValidationResults> importBlockAndBlobSidecars(
       final SignedBeaconBlock block,
       final List<BlobSidecar> blobSidecars,
-      final BroadcastValidationLevel broadcastValidationLevel) {
-    return blockImportChannel.importBlock(block, broadcastValidationLevel);
+      final BroadcastValidationLevel broadcastValidationLevel,
+      final BlockPublishingPerformance blockPublishingPerformance) {
+    return blockImportChannel
+        .importBlock(block, broadcastValidationLevel)
+        .thenPeek(__ -> blockPublishingPerformance.blockImportCompleted());
   }
 
   @Override
   void publishBlockAndBlobSidecars(
-      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final SignedBeaconBlock block,
+      final List<BlobSidecar> blobSidecars,
+      final BlockPublishingPerformance blockPublishingPerformance) {
     blockGossipChannel.publishBlock(block);
+    blockPublishingPerformance.blockPublishingInitiated();
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
@@ -17,6 +17,7 @@ import com.google.common.base.Suppliers;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
@@ -79,10 +80,11 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
   @Override
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(
       final SignedBlockContainer blockContainer,
-      final BroadcastValidationLevel broadcastValidationLevel) {
+      final BroadcastValidationLevel broadcastValidationLevel,
+      BlockPublishingPerformance blockPublishingPerformance) {
     final SpecMilestone blockMilestone = spec.atSlot(blockContainer.getSlot()).getMilestone();
     return registeredPublishers
         .get(blockMilestone)
-        .sendSignedBlock(blockContainer, broadcastValidationLevel);
+        .sendSignedBlock(blockContainer, broadcastValidationLevel, blockPublishingPerformance);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.ssz.SszCollection;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.Spec;
@@ -97,7 +98,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
 
     final SignedBeaconBlock unblindedBlock = assertBlockUnblinded(blindedBlock, spec);
 
-    verify(executionLayer).getUnblindedPayload(unblindedBlock);
+    verify(executionLayer).getUnblindedPayload(unblindedBlock, BlockPublishingPerformance.NOOP);
 
     assertThat(unblindedBlock.isBlinded()).isFalse();
     assertThat(unblindedBlock).isEqualTo(expectedUnblindedBlock);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
@@ -657,10 +658,10 @@ class BlockOperationSelectorFactoryTest {
     final CapturingBeaconBlockUnblinder blockUnblinder =
         new CapturingBeaconBlockUnblinder(spec.getGenesisSchemaDefinitions(), blindedSignedBlock);
 
-    when(executionLayer.getUnblindedPayload(blindedSignedBlock))
+    when(executionLayer.getUnblindedPayload(blindedSignedBlock, BlockPublishingPerformance.NOOP))
         .thenReturn(SafeFuture.completedFuture(randomExecutionPayload));
 
-    factory.createBlockUnblinderSelector().accept(blockUnblinder);
+    factory.createBlockUnblinderSelector(BlockPublishingPerformance.NOOP).accept(blockUnblinder);
 
     assertThat(blockUnblinder.executionPayload).isCompletedWithValue(randomExecutionPayload);
   }
@@ -789,7 +790,9 @@ class BlockOperationSelectorFactoryTest {
         MiscHelpersDeneb.required(spec.atSlot(signedBlockContents.getSlot()).miscHelpers());
 
     final List<BlobSidecar> blobSidecars =
-        factory.createBlobSidecarsSelector().apply(signedBlockContents);
+        factory
+            .createBlobSidecarsSelector(BlockPublishingPerformance.NOOP)
+            .apply(signedBlockContents);
 
     final SszList<Blob> expectedBlobs = signedBlockContents.getBlobs().orElseThrow();
     final SszList<SszKZGProof> expectedProofs = signedBlockContents.getKzgProofs().orElseThrow();
@@ -833,7 +836,11 @@ class BlockOperationSelectorFactoryTest {
         dataStructureUtil.randomExecutionPayload(),
         Optional.of(blobsBundle));
 
-    assertThatThrownBy(() -> factory.createBlobSidecarsSelector().apply(signedBlindedBeaconBlock))
+    assertThatThrownBy(
+            () ->
+                factory
+                    .createBlobSidecarsSelector(BlockPublishingPerformance.NOOP)
+                    .apply(signedBlindedBeaconBlock))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "Commitments in the builder BlobsBundle don't match the commitments in the block");
@@ -854,7 +861,11 @@ class BlockOperationSelectorFactoryTest {
         dataStructureUtil.randomExecutionPayload(),
         Optional.of(blobsBundle));
 
-    assertThatThrownBy(() -> factory.createBlobSidecarsSelector().apply(signedBlindedBeaconBlock))
+    assertThatThrownBy(
+            () ->
+                factory
+                    .createBlobSidecarsSelector(BlockPublishingPerformance.NOOP)
+                    .apply(signedBlindedBeaconBlock))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "The number of blobs in BlobsBundle doesn't match the number of commitments in the block");
@@ -875,7 +886,11 @@ class BlockOperationSelectorFactoryTest {
         dataStructureUtil.randomExecutionPayload(),
         Optional.of(blobsBundle));
 
-    assertThatThrownBy(() -> factory.createBlobSidecarsSelector().apply(signedBlindedBeaconBlock))
+    assertThatThrownBy(
+            () ->
+                factory
+                    .createBlobSidecarsSelector(BlockPublishingPerformance.NOOP)
+                    .apply(signedBlindedBeaconBlock))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "The number of proofs in BlobsBundle doesn't match the number of commitments in the block");
@@ -899,7 +914,9 @@ class BlockOperationSelectorFactoryTest {
         Optional.of(blobsBundle));
 
     final List<BlobSidecar> blobSidecars =
-        factory.createBlobSidecarsSelector().apply(signedBlindedBeaconBlock);
+        factory
+            .createBlobSidecarsSelector(BlockPublishingPerformance.NOOP)
+            .apply(signedBlindedBeaconBlock);
 
     final SszList<Blob> expectedBlobs = blobsBundle.getBlobs();
     final SszList<SszKZGProof> expectedProofs = blobsBundle.getProofs();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -174,7 +174,7 @@ class ValidatorApiHandlerTest {
 
   private final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory =
       new BlockProductionAndPublishingPerformanceFactory(
-          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, 0);
+          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, 0, 0);
 
   private Spec spec;
   private UInt64 epochStartSlot;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -66,8 +66,8 @@ import tech.pegasys.teku.ethereum.json.types.validator.AttesterDuty;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuty;
 import tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeDuties;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionAndPublishingPerformanceFactory;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricUtils;
@@ -172,8 +172,9 @@ class ValidatorApiHandlerTest {
   private final ArgumentCaptor<List<BlobSidecar>> blobSidecarsCaptor2 =
       ArgumentCaptor.forClass(List.class);
 
-  private final BlockProductionPerformanceFactory blockProductionPerformanceFactory =
-      new BlockProductionPerformanceFactory(StubTimeProvider.withTimeInMillis(0), false, 0);
+  private final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory =
+      new BlockProductionAndPublishingPerformanceFactory(
+          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, 0);
 
   private Spec spec;
   private UInt64 epochStartSlot;
@@ -220,7 +221,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.isOptimisticBlock(any())).thenReturn(false);
     doAnswer(invocation -> SafeFuture.completedFuture(invocation.getArgument(0)))
         .when(blockFactory)
-        .unblindSignedBlockIfBlinded(any());
+        .unblindSignedBlockIfBlinded(any(), any());
     when(proposersDataManager.updateValidatorRegistrations(any(), any()))
         .thenReturn(SafeFuture.COMPLETE);
   }
@@ -1337,7 +1338,7 @@ class ValidatorApiHandlerTest {
                   .toList();
             })
         .when(blockFactory)
-        .createBlobSidecars(any());
+        .createBlobSidecars(any(), any());
   }
 
   private SafeFuture<BlockImportAndBroadcastValidationResults> prepareBlockImportResult(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -136,11 +137,16 @@ public class ExecutionLayerBlockProductionManagerImpl
   }
 
   @Override
-  public SafeFuture<BuilderPayload> getUnblindedPayload(final SignedBeaconBlock signedBeaconBlock) {
+  public SafeFuture<BuilderPayload> getUnblindedPayload(
+      final SignedBeaconBlock signedBeaconBlock,
+      final BlockPublishingPerformance blockPublishingPerformance) {
     return executionLayerChannel
         .builderGetPayload(signedBeaconBlock, this::getCachedPayloadResult)
         .thenPeek(
-            builderPayload -> builderResultCache.put(signedBeaconBlock.getSlot(), builderPayload));
+            builderPayload -> {
+              builderResultCache.put(signedBeaconBlock.getSlot(), builderPayload);
+              blockPublishingPerformance.builderGetPayload();
+            });
   }
 
   @Override

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.ethereum.executionclient.BuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.ethereum.executionlayer.ExecutionLayerManagerImpl.Source;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
@@ -142,13 +143,17 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final SafeFuture<BuilderPayload> unblindedPayload =
         blockProductionManager.getUnblindedPayload(
-            dataStructureUtil.randomSignedBlindedBeaconBlock(slot));
+            dataStructureUtil.randomSignedBlindedBeaconBlock(slot),
+            BlockPublishingPerformance.NOOP);
     assertThat(unblindedPayload.get()).isEqualTo(localPayload);
 
     // wrong slot, we will hit builder client by this call
     final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlock(slot.plus(1));
-    assertThatThrownBy(() -> blockProductionManager.getUnblindedPayload(signedBlindedBeaconBlock));
+    assertThatThrownBy(
+        () ->
+            blockProductionManager.getUnblindedPayload(
+                signedBlindedBeaconBlock, BlockPublishingPerformance.NOOP));
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
   }
 
@@ -195,7 +200,9 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final ExecutionPayload payload = prepareBuilderGetPayloadResponse(signedBlindedBeaconBlock);
 
     // we expect result from the builder
-    assertThat(blockProductionManager.getUnblindedPayload(signedBlindedBeaconBlock))
+    assertThat(
+            blockProductionManager.getUnblindedPayload(
+                signedBlindedBeaconBlock, BlockPublishingPerformance.NOOP))
         .isCompletedWithValue(payload);
 
     // we expect both builder and local engine have been called
@@ -241,7 +248,10 @@ class ExecutionLayerBlockProductionManagerImplTest {
     // we will hit builder client by this call
     final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
-    assertThatThrownBy(() -> blockProductionManager.getUnblindedPayload(signedBlindedBeaconBlock));
+    assertThatThrownBy(
+        () ->
+            blockProductionManager.getUnblindedPayload(
+                signedBlindedBeaconBlock, BlockPublishingPerformance.NOOP));
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
   }
 
@@ -304,7 +314,8 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final SafeFuture<BuilderPayload> unblindedPayload =
         blockProductionManager.getUnblindedPayload(
-            dataStructureUtil.randomSignedBlindedBeaconBlock(slot));
+            dataStructureUtil.randomSignedBlindedBeaconBlock(slot),
+            BlockPublishingPerformance.NOOP);
     assertThat(unblindedPayload.get()).isEqualTo(localPayload);
 
     verifyNoMoreInteractions(builderClient);
@@ -356,7 +367,9 @@ class ExecutionLayerBlockProductionManagerImplTest {
         prepareBuilderGetPayloadResponseWithBlobs(signedBlindedBeaconBlock);
 
     // we expect result from the builder
-    assertThat(blockProductionManager.getUnblindedPayload(signedBlindedBeaconBlock))
+    assertThat(
+            blockProductionManager.getUnblindedPayload(
+                signedBlindedBeaconBlock, BlockPublishingPerformance.NOOP))
         .isCompletedWithValue(payloadAndBlobsBundle);
 
     // we expect both builder and local engine have been called
@@ -407,7 +420,10 @@ class ExecutionLayerBlockProductionManagerImplTest {
     // we will hit builder client by this call
     final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
-    assertThatThrownBy(() -> blockProductionManager.getUnblindedPayload(signedBlindedBeaconBlock));
+    assertThatThrownBy(
+        () ->
+            blockProductionManager.getUnblindedPayload(
+                signedBlindedBeaconBlock, BlockPublishingPerformance.NOOP));
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
   }
 

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionAndPublishingPerformanceFactory.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionAndPublishingPerformanceFactory.java
@@ -20,24 +20,27 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public class BlockProductionAndPublishingPerformanceFactory {
   private final TimeProvider timeProvider;
   private final boolean enabled;
-  private final int lateEventThreshold;
+  private final int lateProductionEventThreshold;
+  private final int latePublishingEventThreshold;
   private final Function<UInt64, UInt64> slotTimeCalculator;
 
   public BlockProductionAndPublishingPerformanceFactory(
       final TimeProvider timeProvider,
       final Function<UInt64, UInt64> slotTimeCalculator,
       final boolean enabled,
-      final int lateEventThreshold) {
+      final int lateProductionEventThreshold,
+      final int latePublishingEventThreshold) {
     this.timeProvider = timeProvider;
     this.slotTimeCalculator = slotTimeCalculator;
     this.enabled = enabled;
-    this.lateEventThreshold = lateEventThreshold;
+    this.lateProductionEventThreshold = lateProductionEventThreshold;
+    this.latePublishingEventThreshold = latePublishingEventThreshold;
   }
 
   public BlockProductionPerformance createForProduction(final UInt64 slot) {
     if (enabled) {
       return new BlockProductionPerformanceImpl(
-          timeProvider, slot, slotTimeCalculator.apply(slot), lateEventThreshold);
+          timeProvider, slot, slotTimeCalculator.apply(slot), lateProductionEventThreshold);
     } else {
       return BlockProductionPerformance.NOOP;
     }
@@ -46,7 +49,7 @@ public class BlockProductionAndPublishingPerformanceFactory {
   public BlockPublishingPerformance createForPublishing(final UInt64 slot) {
     if (enabled) {
       return new BlockPublishingPerformanceImpl(
-          timeProvider, slot, slotTimeCalculator.apply(slot), lateEventThreshold);
+          timeProvider, slot, slotTimeCalculator.apply(slot), latePublishingEventThreshold);
     } else {
       return BlockPublishingPerformance.NOOP;
     }

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionAndPublishingPerformanceFactory.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionAndPublishingPerformanceFactory.java
@@ -13,26 +13,42 @@
 
 package tech.pegasys.teku.ethereum.performance.trackers;
 
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class BlockProductionPerformanceFactory {
+public class BlockProductionAndPublishingPerformanceFactory {
   private final TimeProvider timeProvider;
   private final boolean enabled;
   private final int lateEventThreshold;
+  private final Function<UInt64, UInt64> slotTimeCalculator;
 
-  public BlockProductionPerformanceFactory(
-      final TimeProvider timeProvider, final boolean enabled, final int lateEventThreshold) {
+  public BlockProductionAndPublishingPerformanceFactory(
+      final TimeProvider timeProvider,
+      final Function<UInt64, UInt64> slotTimeCalculator,
+      final boolean enabled,
+      final int lateEventThreshold) {
     this.timeProvider = timeProvider;
+    this.slotTimeCalculator = slotTimeCalculator;
     this.enabled = enabled;
     this.lateEventThreshold = lateEventThreshold;
   }
 
-  public BlockProductionPerformance create(final UInt64 slot) {
+  public BlockProductionPerformance createForProduction(final UInt64 slot) {
     if (enabled) {
-      return new BlockProductionPerformanceImpl(timeProvider, slot, lateEventThreshold);
+      return new BlockProductionPerformanceImpl(
+          timeProvider, slot, slotTimeCalculator.apply(slot), lateEventThreshold);
     } else {
       return BlockProductionPerformance.NOOP;
+    }
+  }
+
+  public BlockPublishingPerformance createForPublishing(final UInt64 slot) {
+    if (enabled) {
+      return new BlockPublishingPerformanceImpl(
+          timeProvider, slot, slotTimeCalculator.apply(slot), lateEventThreshold);
+    } else {
+      return BlockPublishingPerformance.NOOP;
     }
   }
 }

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
@@ -13,9 +13,6 @@
 
 package tech.pegasys.teku.ethereum.performance.trackers;
 
-import java.util.function.Supplier;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-
 /**
  * This is high level flow, some steps are executed only if builder flow take place
  *
@@ -62,8 +59,6 @@ public interface BlockProductionPerformance {
 
   BlockProductionPerformance NOOP =
       new BlockProductionPerformance() {
-        @Override
-        public void slotTime(final Supplier<UInt64> slotTimeSupplier) {}
 
         @Override
         public void complete() {}
@@ -101,8 +96,6 @@ public interface BlockProductionPerformance {
         @Override
         public void stateHashing() {}
       };
-
-  void slotTime(Supplier<UInt64> slotTimeSupplier);
 
   void complete();
 

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformance.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.performance.trackers;
+
+public interface BlockPublishingPerformance {
+  String COMPLETE_LABEL = "complete";
+
+  BlockPublishingPerformance NOOP =
+      new BlockPublishingPerformance() {
+
+        @Override
+        public void complete() {}
+
+        @Override
+        public void builderGetPayload() {}
+
+        @Override
+        public void blobSidecarsPrepared() {}
+
+        @Override
+        public void blockAndBlobSidecarsPublishingInitiated() {}
+
+        @Override
+        public void blockPublishingInitiated() {}
+
+        @Override
+        public void blockImportCompleted() {}
+      };
+
+  void blockAndBlobSidecarsPublishingInitiated();
+
+  void blockPublishingInitiated();
+
+  void builderGetPayload();
+
+  void blobSidecarsPrepared();
+
+  void blockImportCompleted();
+
+  void complete();
+}

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2023
+ * Copyright Consensys Software Inc., 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -18,13 +18,13 @@ import tech.pegasys.teku.infrastructure.time.PerformanceTracker;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class BlockProductionPerformanceImpl implements BlockProductionPerformance {
+public class BlockPublishingPerformanceImpl implements BlockPublishingPerformance {
   private final PerformanceTracker performanceTracker;
   private final UInt64 slot;
   private final UInt64 slotTime;
   private final int lateThreshold;
 
-  BlockProductionPerformanceImpl(
+  BlockPublishingPerformanceImpl(
       final TimeProvider timeProvider,
       final UInt64 slot,
       final UInt64 slotTime,
@@ -46,61 +46,31 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
         (event, stepDuration) -> {},
         totalDuration -> {},
         (totalDuration, timings) ->
-            EventLogger.EVENT_LOG.slowBlockProductionEvent(slot, totalDuration, timings));
+            EventLogger.EVENT_LOG.slowBlockPublishingEvent(slot, totalDuration, timings));
   }
 
   @Override
-  public void prepareOnTick() {
-    performanceTracker.addEvent("preparation_on_tick");
+  public void builderGetPayload() {
+    performanceTracker.addEvent("builder_get_payload");
   }
 
   @Override
-  public void prepareApplyDeferredAttestations() {
-    performanceTracker.addEvent("preparation_apply_deferred_attestations");
+  public void blobSidecarsPrepared() {
+    performanceTracker.addEvent("blob_sidecars_prepared");
   }
 
   @Override
-  public void prepareProcessHead() {
-    performanceTracker.addEvent("preparation_process_head");
+  public void blockAndBlobSidecarsPublishingInitiated() {
+    performanceTracker.addEvent("block_and_blob_sidecars_publishing_initiated");
   }
 
   @Override
-  public void beaconBlockPrepared() {
-    performanceTracker.addEvent("beacon_block_prepared");
+  public void blockPublishingInitiated() {
+    performanceTracker.addEvent("block_publishing_initiated");
   }
 
   @Override
-  public void getStateAtSlot() {
-    performanceTracker.addEvent("retrieve_state");
-  }
-
-  @Override
-  public void engineGetPayload() {
-    performanceTracker.addEvent("local_get_payload");
-  }
-
-  @Override
-  public void builderGetHeader() {
-    performanceTracker.addEvent("builder_get_header");
-  }
-
-  @Override
-  public void builderBidValidated() {
-    performanceTracker.addEvent("builder_bid_validated");
-  }
-
-  @Override
-  public void beaconBlockCreated() {
-    performanceTracker.addEvent("beacon_block_created");
-  }
-
-  @Override
-  public void stateTransition() {
-    performanceTracker.addEvent("state_transition");
-  }
-
-  @Override
-  public void stateHashing() {
-    performanceTracker.addEvent("state_hashing");
+  public void blockImportCompleted() {
+    performanceTracker.addEvent("block_import_completed");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -428,8 +428,12 @@ public class Spec {
     return atSlot(slot).miscHelpers().computeEpochAtSlot(slot);
   }
 
-  public UInt64 computeTimeAtSlot(BeaconState state, UInt64 slot) {
+  public UInt64 computeTimeAtSlot(final BeaconState state, final UInt64 slot) {
     return atSlot(slot).miscHelpers().computeTimeAtSlot(state.getGenesisTime(), slot);
+  }
+
+  public UInt64 computeTimeAtSlot(final UInt64 genesisTime, final UInt64 slot) {
+    return atSlot(slot).miscHelpers().computeTimeAtSlot(genesisTime, slot);
   }
 
   public Bytes computeSigningRoot(BeaconBlock block, Bytes32 domain) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -429,7 +429,7 @@ public class Spec {
   }
 
   public UInt64 computeTimeAtSlot(final BeaconState state, final UInt64 slot) {
-    return atSlot(slot).miscHelpers().computeTimeAtSlot(state.getGenesisTime(), slot);
+    return computeTimeAtSlot(state.getGenesisTime(), slot);
   }
 
   public UInt64 computeTimeAtSlot(final UInt64 genesisTime, final UInt64 slot) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.executionlayer;
 
 import java.util.Optional;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -59,7 +60,8 @@ public interface ExecutionLayerBlockProductionManager {
 
         @Override
         public SafeFuture<BuilderPayload> getUnblindedPayload(
-            final SignedBeaconBlock signedBeaconBlock) {
+            final SignedBeaconBlock signedBeaconBlock,
+            final BlockPublishingPerformance blockPublishingPerformance) {
           return SafeFuture.completedFuture(null);
         }
 
@@ -112,11 +114,12 @@ public interface ExecutionLayerBlockProductionManager {
    */
   Optional<ExecutionPayloadResult> getCachedPayloadResult(UInt64 slot);
 
-  SafeFuture<BuilderPayload> getUnblindedPayload(SignedBeaconBlock signedBeaconBlock);
+  SafeFuture<BuilderPayload> getUnblindedPayload(
+      SignedBeaconBlock signedBeaconBlock, BlockPublishingPerformance blockPublishingPerformance);
 
   /**
-   * Requires {@link #getUnblindedPayload(SignedBeaconBlock)} to have been called first in order for
-   * a value to be present
+   * Requires {@link #getUnblindedPayload(SignedBeaconBlock, BlockPublishingPerformance)} to have
+   * been called first in order for a value to be present
    */
   Optional<BuilderPayload> getCachedUnblindedPayload(UInt64 slot);
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -303,6 +303,15 @@ public class EventLogger {
     warn(slowBlockProductionLog, Color.YELLOW);
   }
 
+  public void slowBlockPublishingEvent(
+      final UInt64 slot, final UInt64 totalProcessingDuration, final String timings) {
+    final String slowBlockPublishingLog =
+        String.format(
+            "Slow Block Publishing *** Slot: %s %s total: %sms",
+            slot, timings, totalProcessingDuration);
+    warn(slowBlockPublishingLog, Color.YELLOW);
+  }
+
   public void executionLayerStubEnabled() {
     error(
         "Execution Layer Stub has been enabled! This is UNSAFE! You WILL fail to produce blocks and may follow an invalid chain.",

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -86,7 +86,8 @@ public class MetricsConfig {
     this.blockPerformanceEnabled = blockPerformanceEnabled;
     this.tickPerformanceEnabled = tickPerformanceEnabled;
     this.blobSidecarsStorageCountersEnabled = blobSidecarsStorageCountersEnabled;
-    this.blockProductionAndPublishingPerformanceEnabled = blockProductionAndPublishingPerformanceEnabled;
+    this.blockProductionAndPublishingPerformanceEnabled =
+        blockProductionAndPublishingPerformanceEnabled;
     this.blockProductionPerformanceWarningThreshold = blockProductionPerformanceWarningThreshold;
     this.blockPublishingPerformanceWarningThreshold = blockPublishingPerformanceWarningThreshold;
   }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -56,7 +56,7 @@ public class MetricsConfig {
   private final boolean blockPerformanceEnabled;
   private final boolean tickPerformanceEnabled;
   private final boolean blobSidecarsStorageCountersEnabled;
-  private final boolean blockProductionPerformanceEnabled;
+  private final boolean blockProductionAndPublishingPerformanceEnabled;
   private final int blockProductionPerformanceWarningThreshold;
   private final int blockPublishingPerformanceWarningThreshold;
 
@@ -72,7 +72,7 @@ public class MetricsConfig {
       final boolean blockPerformanceEnabled,
       final boolean tickPerformanceEnabled,
       final boolean blobSidecarsStorageCountersEnabled,
-      final boolean blockProductionPerformanceEnabled,
+      final boolean blockProductionAndPublishingPerformanceEnabled,
       final int blockProductionPerformanceWarningThreshold,
       final int blockPublishingPerformanceWarningThreshold) {
     this.metricsEnabled = metricsEnabled;
@@ -86,7 +86,7 @@ public class MetricsConfig {
     this.blockPerformanceEnabled = blockPerformanceEnabled;
     this.tickPerformanceEnabled = tickPerformanceEnabled;
     this.blobSidecarsStorageCountersEnabled = blobSidecarsStorageCountersEnabled;
-    this.blockProductionPerformanceEnabled = blockProductionPerformanceEnabled;
+    this.blockProductionAndPublishingPerformanceEnabled = blockProductionAndPublishingPerformanceEnabled;
     this.blockProductionPerformanceWarningThreshold = blockProductionPerformanceWarningThreshold;
     this.blockPublishingPerformanceWarningThreshold = blockPublishingPerformanceWarningThreshold;
   }
@@ -131,8 +131,8 @@ public class MetricsConfig {
     return blockPerformanceEnabled;
   }
 
-  public boolean isBlockProductionPerformanceEnabled() {
-    return blockProductionPerformanceEnabled;
+  public boolean isBlockProductionAndPublishingPerformanceEnabled() {
+    return blockProductionAndPublishingPerformanceEnabled;
   }
 
   public int getBlockProductionPerformanceWarningThreshold() {
@@ -162,7 +162,7 @@ public class MetricsConfig {
     private int metricsPublishInterval = DEFAULT_METRICS_PUBLICATION_INTERVAL;
     private int idleTimeoutSeconds = DEFAULT_IDLE_TIMEOUT_SECONDS;
     private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
-    private boolean blockProductionPerformanceEnabled =
+    private boolean blockProductionAndPublishingPerformanceEnabled =
         DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED;
     private int blockProductionPerformanceWarningThreshold =
         DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
@@ -232,8 +232,9 @@ public class MetricsConfig {
     }
 
     public MetricsConfigBuilder blockProductionAndPublishingPerformanceEnabled(
-        final boolean blockProductionPerformanceEnabled) {
-      this.blockProductionPerformanceEnabled = blockProductionPerformanceEnabled;
+        final boolean blockProductionAndPublishingPerformanceEnabled) {
+      this.blockProductionAndPublishingPerformanceEnabled =
+          blockProductionAndPublishingPerformanceEnabled;
       return this;
     }
 
@@ -273,7 +274,7 @@ public class MetricsConfig {
           blockPerformanceEnabled,
           tickPerformanceEnabled,
           blobSidecarsStorageCountersEnabled,
-          blockProductionPerformanceEnabled,
+          blockProductionAndPublishingPerformanceEnabled,
           blockProductionPerformanceWarningThreshold,
           blockPublishingPerformanceWarningThreshold);
     }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -40,8 +40,9 @@ public class MetricsConfig {
   public static final int DEFAULT_METRICS_PUBLICATION_INTERVAL = 60;
   public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = true;
   public static final boolean DEFAULT_TICK_PERFORMANCE_ENABLED = false;
-  public static final boolean DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_ENABLED = true;
+  public static final boolean DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED = true;
   public static final int DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD = 300;
+  public static final int DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD = 1000;
   public static final boolean DEFAULT_BLOB_SIDECARS_STORAGE_COUNTERS_ENABLED = false;
 
   private final boolean metricsEnabled;
@@ -57,6 +58,7 @@ public class MetricsConfig {
   private final boolean blobSidecarsStorageCountersEnabled;
   private final boolean blockProductionPerformanceEnabled;
   private final int blockProductionPerformanceWarningThreshold;
+  private final int blockPublishingPerformanceWarningThreshold;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -71,7 +73,8 @@ public class MetricsConfig {
       final boolean tickPerformanceEnabled,
       final boolean blobSidecarsStorageCountersEnabled,
       final boolean blockProductionPerformanceEnabled,
-      final int blockProductionPerformanceWarningThreshold) {
+      final int blockProductionPerformanceWarningThreshold,
+      final int blockPublishingPerformanceWarningThreshold) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -85,6 +88,7 @@ public class MetricsConfig {
     this.blobSidecarsStorageCountersEnabled = blobSidecarsStorageCountersEnabled;
     this.blockProductionPerformanceEnabled = blockProductionPerformanceEnabled;
     this.blockProductionPerformanceWarningThreshold = blockProductionPerformanceWarningThreshold;
+    this.blockPublishingPerformanceWarningThreshold = blockPublishingPerformanceWarningThreshold;
   }
 
   public static MetricsConfigBuilder builder() {
@@ -135,6 +139,10 @@ public class MetricsConfig {
     return blockProductionPerformanceWarningThreshold;
   }
 
+  public int getBlockPublishingPerformanceWarningThreshold() {
+    return blockPublishingPerformanceWarningThreshold;
+  }
+
   public boolean isTickPerformanceEnabled() {
     return tickPerformanceEnabled;
   }
@@ -155,9 +163,11 @@ public class MetricsConfig {
     private int idleTimeoutSeconds = DEFAULT_IDLE_TIMEOUT_SECONDS;
     private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
     private boolean blockProductionPerformanceEnabled =
-        DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_ENABLED;
+        DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED;
     private int blockProductionPerformanceWarningThreshold =
         DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
+    private int blockPublishingPerformanceWarningThreshold =
+        DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD;
     private boolean tickPerformanceEnabled = DEFAULT_TICK_PERFORMANCE_ENABLED;
     private boolean blobSidecarsStorageCountersEnabled =
         DEFAULT_BLOB_SIDECARS_STORAGE_COUNTERS_ENABLED;
@@ -221,7 +231,7 @@ public class MetricsConfig {
       return this;
     }
 
-    public MetricsConfigBuilder blockProductionPerformanceEnabled(
+    public MetricsConfigBuilder blockProductionAndPublishingPerformanceEnabled(
         final boolean blockProductionPerformanceEnabled) {
       this.blockProductionPerformanceEnabled = blockProductionPerformanceEnabled;
       return this;
@@ -230,6 +240,12 @@ public class MetricsConfig {
     public MetricsConfigBuilder blockProductionPerformanceWarningThreshold(
         final int blockProductionPerformanceWarningThreshold) {
       this.blockProductionPerformanceWarningThreshold = blockProductionPerformanceWarningThreshold;
+      return this;
+    }
+
+    public MetricsConfigBuilder blockPublishingPerformanceWarningThreshold(
+        final int blockPublishingPerformanceWarningThreshold) {
+      this.blockPublishingPerformanceWarningThreshold = blockPublishingPerformanceWarningThreshold;
       return this;
     }
 
@@ -258,7 +274,8 @@ public class MetricsConfig {
           tickPerformanceEnabled,
           blobSidecarsStorageCountersEnabled,
           blockProductionPerformanceEnabled,
-          blockProductionPerformanceWarningThreshold);
+          blockProductionPerformanceWarningThreshold,
+          blockPublishingPerformanceWarningThreshold);
     }
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -925,11 +925,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
     } else {
       blobSidecarGossipChannel = BlobSidecarGossipChannel.NOOP;
     }
-    final UInt64 genesisTime = recentChainData.getGenesisTime();
+
     final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory =
         new BlockProductionAndPublishingPerformanceFactory(
             timeProvider,
-            (slot) -> secondsToMillis(spec.computeTimeAtSlot(genesisTime, slot)),
+            (slot) ->
+                secondsToMillis(spec.computeTimeAtSlot(recentChainData.getGenesisTime(), slot)),
             beaconConfig.getMetricsConfig().isBlockProductionPerformanceEnabled(),
             beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningThreshold(),
             beaconConfig.getMetricsConfig().getBlockPublishingPerformanceWarningThreshold());

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -931,7 +931,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             timeProvider,
             (slot) -> secondsToMillis(spec.computeTimeAtSlot(genesisTime, slot)),
             beaconConfig.getMetricsConfig().isBlockProductionPerformanceEnabled(),
-            beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningThreshold());
+            beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningThreshold(),
+            beaconConfig.getMetricsConfig().getBlockPublishingPerformanceWarningThreshold());
 
     final ValidatorApiHandler validatorApiHandler =
         new ValidatorApiHandler(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -931,7 +931,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             timeProvider,
             (slot) ->
                 secondsToMillis(spec.computeTimeAtSlot(recentChainData.getGenesisTime(), slot)),
-            beaconConfig.getMetricsConfig().isBlockProductionPerformanceEnabled(),
+            beaconConfig.getMetricsConfig().isBlockProductionAndPublishingPerformanceEnabled(),
             beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningThreshold(),
             beaconConfig.getMetricsConfig().getBlockPublishingPerformanceWarningThreshold());
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.BEACON;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.millisToSeconds;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.DEFAULT_MAXIMUM_ATTESTATION_COUNT;
@@ -55,7 +56,7 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionClientVersionChannel;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionClientVersionProvider;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanceFactory;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionAndPublishingPerformanceFactory;
 import tech.pegasys.teku.ethereum.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
@@ -924,9 +925,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
     } else {
       blobSidecarGossipChannel = BlobSidecarGossipChannel.NOOP;
     }
-    final BlockProductionPerformanceFactory blockProductionPerformanceFactory =
-        new BlockProductionPerformanceFactory(
+    final UInt64 genesisTime = recentChainData.getGenesisTime();
+    final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory =
+        new BlockProductionAndPublishingPerformanceFactory(
             timeProvider,
+            (slot) -> secondsToMillis(spec.computeTimeAtSlot(genesisTime, slot)),
             beaconConfig.getMetricsConfig().isBlockProductionPerformanceEnabled(),
             beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningThreshold());
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -113,11 +113,12 @@ public class MetricsOptions {
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<BOOLEAN>",
-      description = "Whether block production timing metrics are tracked and reported",
+      description =
+          "Whether block production and publishing timing metrics are tracked and reported",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean blockProductionPerformanceEnabled =
-      MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_ENABLED;
+  private boolean blockProductionAndPublishingPerformanceEnabled =
+      MetricsConfig.DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED;
 
   @Option(
       names = {"--Xmetrics-block-production-timing-tracking-warning-threshold"},
@@ -130,6 +131,18 @@ public class MetricsOptions {
       arity = "0..1")
   private int blockProductionPerformanceWarningThreshold =
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
+
+  @Option(
+      names = {"--Xmetrics-block-publishing-timing-tracking-warning-threshold"},
+      hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
+      paramLabel = "<INTEGER>",
+      description =
+          "The time (in ms) at which block publishing is to be considered 'slow'. If set to 100, block publishing taking at least 100ms would raise a warning.",
+      fallbackValue = "true",
+      arity = "0..1")
+  private int blockPublishingPerformanceWarningThreshold =
+      MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD;
 
   @Option(
       names = {"--Xmetrics-blob-sidecars-storage-enabled"},
@@ -156,9 +169,12 @@ public class MetricsOptions {
                 .blockPerformanceEnabled(blockPerformanceEnabled)
                 .tickPerformanceEnabled(tickPerformanceEnabled)
                 .blobSidecarsStorageCountersEnabled(blobSidecarsStorageCountersEnabled)
-                .blockProductionPerformanceEnabled(blockProductionPerformanceEnabled)
+                .blockProductionAndPublishingPerformanceEnabled(
+                    blockProductionAndPublishingPerformanceEnabled)
                 .blockProductionPerformanceWarningThreshold(
-                    blockProductionPerformanceWarningThreshold));
+                    blockProductionPerformanceWarningThreshold)
+                .blockPublishingPerformanceWarningThreshold(
+                    blockPublishingPerformanceWarningThreshold));
   }
 
   private URL parseMetricsEndpointUrl() {


### PR DESCRIPTION
- Cleaner slot time calculation (applies to `BlockProductionPerformance` too)
- Introduces dedicated `BlockPublishingPerformance` to cover the last step of block production flow

examples:

```Slow Block Production *** Slot: 1397723 start 10ms, preparation_on_tick +0ms, preparation_apply_deferred_attestations +0ms, preparation_process_head +200ms, retrieve_state +1ms, beacon_block_prepared +293ms, local_get_payload +23ms, builder_get_header +169ms, builder_bid_validated +4ms, beacon_block_created +1ms, state_transition +161ms, state_hashing +14ms, complete +0ms total: 866ms```

```Slow Block Publishing *** Slot: 1397723 start 882ms, builder_get_payload +2300ms, blob_sidecars_prepared +10ms, block_and_blob_sidecars_publishing_initiated +0ms, block_import_completed +1ms, complete +0ms total: 2311ms```

fixes #5808

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
