### PR TITLE
Use IPv6 address of discovery nodes when applicable

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
@@ -35,12 +35,18 @@ public class NodeRecordConverter {
   private static final Logger LOG = LogManager.getLogger();
 
   public Optional<DiscoveryPeer> convertToDiscoveryPeer(
-      final NodeRecord nodeRecord, final SchemaDefinitions schemaDefinitions) {
-    // TODO: https://github.com/Consensys/teku/issues/8069
-    return nodeRecord
-        .getTcpAddress()
-        .or(nodeRecord::getTcp6Address)
-        .map(address -> socketAddressToDiscoveryPeer(schemaDefinitions, nodeRecord, address));
+      final NodeRecord nodeRecord,
+      final boolean supportsIpv6,
+      final SchemaDefinitions schemaDefinitions) {
+    final Optional<InetSocketAddress> tcpAddress;
+    if (supportsIpv6) {
+      // prefer IPv6 address
+      tcpAddress = nodeRecord.getTcp6Address().or(nodeRecord::getTcpAddress);
+    } else {
+      tcpAddress = nodeRecord.getTcpAddress();
+    }
+    return tcpAddress.map(
+        address -> socketAddressToDiscoveryPeer(schemaDefinitions, nodeRecord, address));
   }
 
   private static DiscoveryPeer socketAddressToDiscoveryPeer(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
If local discovery node supports IPv6, use the IPv6 address of the discovery node (if it is available). The fallback will always be IPv4 (this could be the case in dual-stack mode where the discovery node does not advertise IPv6 address). 

## Fixed Issue(s)
fixes last of the tasks in #8069 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
