### PR TITLE
Fix config provider to fix spec config api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 ### Additions and Improvements
 
 ### Bug Fixes
+- Fixed an issue with the `/eth/v1/config/spec` API not returning all previously included configuration parameters.

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpec.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpec.java
@@ -53,7 +53,7 @@ public class GetSpec extends RestApiEndpoint {
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     try {
-      final SpecConfigData responseContext = new SpecConfigData(configProvider.getGenesisSpec());
+      final SpecConfigData responseContext = new SpecConfigData(configProvider.getSpecConfig());
       request.respondOk(responseContext.getConfigMap());
     } catch (JsonProcessingException e) {
       String message =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpecTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpecTest.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 
 class GetSpecTest extends AbstractMigratedBeaconHandlerTest {
   private final ConfigProvider configProvider = new ConfigProvider(spec);
-  private final SpecConfigData response = new SpecConfigData(configProvider.getGenesisSpecConfig());
+  private final SpecConfigData response = new SpecConfigData(configProvider.getSpecConfig());
 
   @BeforeEach
   void setUp() {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ConfigProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ConfigProvider.java
@@ -30,12 +30,13 @@ public class ConfigProvider {
   }
 
   public Map<String, String> getConfig() {
-    final SpecConfigData configuration = new SpecConfigData(spec.getGenesisSpecConfig());
+    final SpecConfigData configuration =
+        new SpecConfigData(spec.getSpecConfigAndParent().specConfig());
     return configuration.getConfigMap();
   }
 
-  public SpecConfig getGenesisSpec() {
-    return spec.atEpoch(UInt64.ZERO).getConfig();
+  public SpecConfig getSpecConfig() {
+    return spec.getSpecConfigAndParent().specConfig();
   }
 
   public static String formatValue(final Object v) {


### PR DESCRIPTION
This brings back all missing values from the spec config api

related to #8917

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
