### PR TITLE
[DON'T MERGE] Incident intervals prototype

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -167,7 +167,8 @@ public class SyncingNodeManager {
             blockValidator,
             timeProvider,
             EVENT_LOG,
-            Optional.empty());
+            Optional.empty(),
+            spec);
 
     eventChannels
         .subscribe(SlotEventsChannel.class, blockManager)

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
@@ -90,6 +90,7 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
           final BroadcastValidationLevel broadcastValidationLevel,
           final BlockPublishingPerformance blockPublishingPerformance) {
 
+    LOG.info("BroadcastValidationLevel:{}", broadcastValidationLevel);
     if (broadcastValidationLevel == BroadcastValidationLevel.NOT_REQUIRED) {
       // when broadcast validation is disabled, we can publish the block (and blob sidecars)
       // immediately and then import
@@ -118,6 +119,7 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
         .thenAccept(
             broadcastValidationResult -> {
               if (broadcastValidationResult == BroadcastValidationResult.SUCCESS) {
+                LOG.info("Publishing block, {}", broadcastValidationResult);
                 publishBlockAndBlobs(block, blobSidecars, blockPublishingPerformance);
                 LOG.debug("Block (and blob sidecars) publishing initiated");
               } else {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfigDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfigDeneb.java
@@ -13,8 +13,10 @@
 
 package tech.pegasys.teku.spec.config;
 
+import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.collections.Interval;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class DelegatingSpecConfigDeneb extends DelegatingSpecConfigCapella
@@ -69,6 +71,11 @@ public class DelegatingSpecConfigDeneb extends DelegatingSpecConfigCapella
   @Override
   public int getEpochsStoreBlobs() {
     return specConfigDeneb.getEpochsStoreBlobs();
+  }
+
+  @Override
+  public List<Interval<UInt64>> getIncidentIntervals() {
+    return specConfigDeneb.getIncidentIntervals();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.spec.config;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.collections.Interval;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface SpecConfigDeneb extends SpecConfigCapella, NetworkingSpecConfigDeneb {
@@ -57,6 +59,8 @@ public interface SpecConfigDeneb extends SpecConfigCapella, NetworkingSpecConfig
   int getKzgCommitmentInclusionProofDepth();
 
   int getEpochsStoreBlobs();
+
+  List<Interval<UInt64>> getIncidentIntervals();
 
   @Override
   Optional<SpecConfigDeneb> toVersionDeneb();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDenebImpl.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.spec.config;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.collections.Interval;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 
@@ -34,6 +36,7 @@ public class SpecConfigDenebImpl extends DelegatingSpecConfigCapella implements 
   private final int minEpochsForBlobSidecarsRequests;
   private final int blobSidecarSubnetCount;
   private final Optional<Integer> maybeEpochsStoreBlobs;
+  private final List<Interval<UInt64>> incidentIntervals;
 
   public SpecConfigDenebImpl(
       final SpecConfigCapella specConfig,
@@ -48,7 +51,8 @@ public class SpecConfigDenebImpl extends DelegatingSpecConfigCapella implements 
       final int maxRequestBlobSidecars,
       final int minEpochsForBlobSidecarsRequests,
       final int blobSidecarSubnetCount,
-      final Optional<Integer> maybeEpochsStoreBlobs) {
+      final Optional<Integer> maybeEpochsStoreBlobs,
+      final List<Interval<UInt64>> incidentIntervals) {
     super(specConfig);
     this.denebForkVersion = denebForkVersion;
     this.denebForkEpoch = denebForkEpoch;
@@ -62,6 +66,7 @@ public class SpecConfigDenebImpl extends DelegatingSpecConfigCapella implements 
     this.minEpochsForBlobSidecarsRequests = minEpochsForBlobSidecarsRequests;
     this.blobSidecarSubnetCount = blobSidecarSubnetCount;
     this.maybeEpochsStoreBlobs = maybeEpochsStoreBlobs;
+    this.incidentIntervals = incidentIntervals;
   }
 
   @Override
@@ -127,6 +132,11 @@ public class SpecConfigDenebImpl extends DelegatingSpecConfigCapella implements 
   }
 
   @Override
+  public List<Interval<UInt64>> getIncidentIntervals() {
+    return incidentIntervals;
+  }
+
+  @Override
   public Optional<SpecConfigDeneb> toVersionDeneb() {
     return Optional.of(this);
   }
@@ -149,6 +159,7 @@ public class SpecConfigDenebImpl extends DelegatingSpecConfigCapella implements 
         && Objects.equals(denebForkVersion, that.denebForkVersion)
         && Objects.equals(denebForkEpoch, that.denebForkEpoch)
         && Objects.equals(maybeEpochsStoreBlobs, that.maybeEpochsStoreBlobs)
+        && Objects.equals(incidentIntervals, that.incidentIntervals)
         && fieldElementsPerBlob == that.fieldElementsPerBlob
         && maxBlobCommitmentsPerBlock == that.maxBlobCommitmentsPerBlock
         && maxBlobsPerBlock == that.maxBlobsPerBlock
@@ -173,6 +184,7 @@ public class SpecConfigDenebImpl extends DelegatingSpecConfigCapella implements 
         maxRequestBlobSidecars,
         minEpochsForBlobSidecarsRequests,
         blobSidecarSubnetCount,
-        maybeEpochsStoreBlobs);
+        maybeEpochsStoreBlobs,
+        incidentIntervals);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/DenebBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/DenebBuilder.java
@@ -17,10 +17,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.collections.Interval;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAndParent;
@@ -43,6 +45,7 @@ public class DenebBuilder implements ForkConfigBuilder<SpecConfigCapella, SpecCo
   private Integer minEpochsForBlobSidecarsRequests;
   private Integer blobSidecarSubnetCount;
   private Optional<Integer> epochsStoreBlobs = Optional.empty();
+  private List<Interval<UInt64>> incidentIntervals = List.of();
 
   DenebBuilder() {}
 
@@ -63,7 +66,8 @@ public class DenebBuilder implements ForkConfigBuilder<SpecConfigCapella, SpecCo
             maxRequestBlobSidecars,
             minEpochsForBlobSidecarsRequests,
             blobSidecarSubnetCount,
-            epochsStoreBlobs),
+            epochsStoreBlobs,
+            incidentIntervals),
         specConfigAndParent);
   }
 
@@ -130,6 +134,11 @@ public class DenebBuilder implements ForkConfigBuilder<SpecConfigCapella, SpecCo
 
   public DenebBuilder epochsStoreBlobs(final Optional<Integer> epochsStoreBlobs) {
     this.epochsStoreBlobs = epochsStoreBlobs;
+    return this;
+  }
+
+  public DenebBuilder incidentIntervals(final List<Interval<UInt64>> incidentIntervals) {
+    this.incidentIntervals = incidentIntervals;
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -452,6 +452,10 @@ public class MiscHelpers {
     return false;
   }
 
+  public boolean isEpochInIncidentInterval(final UInt64 epoch) {
+    return false;
+  }
+
   public Optional<MiscHelpersDeneb> toVersionDeneb() {
     return Optional.empty();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -37,6 +37,8 @@ public interface BlockImportResult {
 
   BlockImportResult FAILED_BROADCAST_VALIDATION =
       new FailedBlockImportResult(FailureReason.FAILED_BROADCAST_VALIDATION, Optional.empty());
+  BlockImportResult FAILED_INCIDENT_INTERVAL =
+      new FailedBlockImportResult(FailureReason.FAILED_INCIDENT_INTERVAL, Optional.empty());
 
   static BlockImportResult failedDataAvailabilityCheckInvalid(final Optional<Throwable> cause) {
     return new FailedBlockImportResult(FailureReason.FAILED_DATA_AVAILABILITY_CHECK_INVALID, cause);
@@ -87,6 +89,7 @@ public interface BlockImportResult {
     FAILED_DATA_AVAILABILITY_CHECK_INVALID,
     FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
     FAILED_BROADCAST_VALIDATION,
+    FAILED_INCIDENT_INTERVAL,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -516,6 +516,10 @@ public class ForkChoiceUtil {
     return Optional.empty();
   }
 
+  public boolean isEpochInIncidentInterval(final UInt64 epoch) {
+    return miscHelpers.isEpochInIncidentInterval(epoch);
+  }
+
   private boolean isBellatrixBlockOld(final ReadOnlyStore store, final UInt64 blockSlot) {
     final Optional<SpecConfigBellatrix> maybeConfig = specConfig.toVersionBellatrix();
     if (maybeConfig.isEmpty()) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -229,6 +229,12 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
         .orElse(0);
   }
 
+  @Override
+  public boolean isEpochInIncidentInterval(final UInt64 epoch) {
+    return SpecConfigDeneb.required(specConfig).getIncidentIntervals().stream()
+        .anyMatch(interval -> interval.contains(epoch));
+  }
+
   public int getBlobSidecarKzgCommitmentGeneralizedIndex(final UInt64 blobSidecarIndex) {
     final long blobKzgCommitmentsGeneralizedIndex =
         beaconBlockBodySchema.getBlobKzgCommitmentsGeneralizedIndex();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigDenebTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
@@ -97,6 +98,7 @@ public class SpecConfigDenebTest {
         dataStructureUtil.randomPositiveInt(),
         dataStructureUtil.randomPositiveInt(),
         dataStructureUtil.randomPositiveInt(),
-        Optional.empty());
+        Optional.empty(),
+        List.of());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -113,6 +113,10 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
   }
 
   public synchronized void add(final ValidatableAttestation attestation) {
+    LOG.info(
+        "Adding attestation source: {}, target: {}",
+        attestation.getData().getSource(),
+        attestation.getData().getTarget());
     final Optional<Int2IntMap> committeesSize =
         attestation.getCommitteesSize().or(() -> getCommitteesSize(attestation.getAttestation()));
     getOrCreateAttestationGroup(attestation.getAttestation(), committeesSize)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -408,6 +408,11 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final Optional<BlockImportPerformance> blockImportPerformance,
       final BlockBroadcastValidator blockBroadcastValidator,
       final ExecutionLayerChannel executionLayer) {
+    if (spec.atSlot(block.getSlot())
+        .getForkChoiceUtil()
+        .isEpochInIncidentInterval(spec.computeEpochAtSlot(block.getSlot()))) {
+      return SafeFuture.completedFuture(BlockImportResult.FAILED_INCIDENT_INTERVAL);
+    }
     if (blockSlotState.isEmpty()) {
       return SafeFuture.completedFuture(BlockImportResult.FAILED_UNKNOWN_PARENT);
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -212,7 +212,8 @@ public class BlockManagerTest {
             blockValidator,
             timeProvider,
             eventLogger,
-            Optional.of(mock(BlockImportMetrics.class)));
+            Optional.of(mock(BlockImportMetrics.class)),
+            spec);
     forwardBlockImportedNotificationsTo(blockManager);
     localChain
         .chainUpdater()
@@ -353,7 +354,8 @@ public class BlockManagerTest {
             blockValidator,
             timeProvider,
             eventLogger,
-            Optional.empty());
+            Optional.empty(),
+            spec);
     forwardBlockImportedNotificationsTo(blockManager);
     assertThat(blockManager.start()).isCompleted();
 
@@ -1129,7 +1131,8 @@ public class BlockManagerTest {
         blockValidator,
         timeProvider,
         eventLogger,
-        Optional.empty());
+        Optional.empty(),
+        spec);
   }
 
   private SafeFutureAssert<BlockImportResult> assertThatBlockImport(final SignedBeaconBlock block) {

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/Interval.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/Interval.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.collections;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+public record Interval<T extends Comparable<T>>(T start, T end) {
+  public Interval(final T start, final T end) {
+    if (start.compareTo(end) > 0) {
+      throw new IllegalArgumentException(
+          String.format("Interval start (%s) must be less or equal than end (%s)", start, end));
+    }
+    this.start = start;
+    this.end = end;
+  }
+
+  public boolean contains(final T value) {
+    return start.compareTo(value) <= 0 && end.compareTo(value) >= 0;
+  }
+
+  public static <T extends Comparable<T>> Interval<T> of(final T start, final T end) {
+    return new Interval<>(start, end);
+  }
+
+  @SafeVarargs
+  public static <T extends Comparable<T>> void checkIntervalsIntersection(
+      final Interval<T>... intervals) {
+    final List<Interval<T>> intervalList =
+        Arrays.stream(intervals).sorted(Comparator.comparing(Interval::start)).toList();
+    if (intervalList.size() < 2) {
+      return;
+    }
+    T currentEnd = intervalList.getFirst().end();
+    for (Interval<T> interval : intervalList.subList(1, intervalList.size())) {
+      if (interval.start().compareTo(currentEnd) <= 0) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Intervals shouldn't intersect, while previous interval end (%S), current interval start start (%s)",
+                currentEnd, interval.start()));
+      }
+      currentEnd = interval.end();
+    }
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1264,7 +1264,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             blockValidator,
             timeProvider,
             EVENT_LOG,
-            importMetrics);
+            importMetrics,
+            spec);
     if (spec.isMilestoneSupported(SpecMilestone.BELLATRIX)) {
       final FailedExecutionPool failedExecutionPool =
           new FailedExecutionPool(blockManager, beaconAsyncRunner);

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.cli;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,6 +74,7 @@ import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfigurator;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
 
 @SuppressWarnings("unused")
@@ -415,7 +418,13 @@ public class BeaconNodeCommand implements Callable<Integer> {
       metricsOptions.configure(builder);
       storeOptions.configure(builder);
 
-      return builder.build();
+      // TODO: hack, remove me
+      DataDirLayout dataDirLayout = DataDirLayout.createFrom(beaconNodeDataOptions.getDataConfig());
+      final Path beaconDataDir = dataDirLayout.getBeaconDataDirectory();
+      final Path dbDataDir = beaconDataDir.resolve("db");
+      boolean isDbExists = Files.exists(dbDataDir);
+
+      return builder.build(isDbExists);
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new InvalidConfigurationException(e);
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -269,6 +269,19 @@ public class Eth2NetworkOptions {
       arity = "0..1")
   private String epochsStoreBlobs;
 
+  @CommandLine.Option(
+      names = {"--Xincident-intervals"},
+      hidden = true,
+      paramLabel = "<STRING>",
+      description =
+          "Sets the interval where network is considered to be in incident. "
+              + "All the slots in these epochs should be empty. Any chain with blocks "
+              + "inside interval is considered invalid.",
+      fallbackValue = "",
+      showDefaultValue = Visibility.ALWAYS,
+      arity = "0..1")
+  private String incidentIntervals;
+
   public Eth2NetworkConfiguration getNetworkConfiguration() {
     return createEth2NetworkConfig(builder -> {});
   }
@@ -345,6 +358,9 @@ public class Eth2NetworkOptions {
     }
     if (eth1DepositContractDeployBlockOverride != null) {
       builder.eth1DepositContractDeployBlock(eth1DepositContractDeployBlockOverride);
+    }
+    if (incidentIntervals != null) {
+      builder.incidentIntervals(incidentIntervals);
     }
     builder
         .ignoreWeakSubjectivityPeriodEnabled(ignoreWeakSubjectivityPeriodEnabled)

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -197,9 +197,13 @@ public class TekuConfiguration {
     private Builder() {}
 
     public TekuConfiguration build() {
-      // Create spec, and pass spec to other builders that require it
+      return build(false);
+    }
+
+    // TODO: remove isDbExists hack
+    public TekuConfiguration build(final boolean isDbExists) {
       final Eth2NetworkConfiguration eth2NetworkConfiguration =
-          eth2NetworkConfigurationBuilder.build();
+          eth2NetworkConfigurationBuilder.build(isDbExists);
       final Spec spec = eth2NetworkConfiguration.getSpec();
       final DataConfig dataConfig = dataConfigBuilder.build();
 


### PR DESCRIPTION
Implementation of incident intervals in Teku

- Dirty hack is made to use incident intervals only after client restart, because I didn't find a better way to use different flags/config in Kurtosis only after restart in the middle.
- 2 changes are not yet added to the spec and should be clarified
  - exception when trying to produce `Attestation` in incident interval in `getGenericAttestationData`
  - failed broadcast validation in `BlockManager` for blocks inside incident interval, so local block produced during incident interval is not published (otherwise it will be published even with failed block import)

`recover.yaml` for Kurtosis
```bash
participants:
  - el_type: geth
    cl_type: teku
    cl_extra_params: [
        --validators-keystore-locking-enabled=false,
	--Xincident-intervals=1-2
    ]
    cl_image: consensys/teku:develop
    cl_min_cpu: 2000
    cl_min_mem: 2000
    count: 5
network_params:
  electra_fork_epoch: 1
global_log_level: info
additional_services:
  - dora
  - spamoor_blob
  - prometheus_grafana
```

Steps to reproduce expected scenario:
```bash
# build Teku and save in local Docker repository
% ./gradlew distDocker 
# start Kurtosis with the provided config
% ./kurtosis run --enclave my-testnet github.com/ethpandaops/ethereum-package --args-file recover.yaml
```
On the start of epoch 1 stop 2-5 nodes and start them again (so incident intervals will be applied after restart):
```bash
% kurtosis service stop my-testnet cl-2-teku-geth                                                  
% kurtosis service stop my-testnet cl-3-teku-geth
% kurtosis service stop my-testnet cl-4-teku-geth
% kurtosis service stop my-testnet cl-5-teku-geth


% kurtosis service start my-testnet cl-2-teku-geth
% kurtosis service start my-testnet cl-3-teku-geth
% kurtosis service start my-testnet cl-4-teku-geth
% kurtosis service start my-testnet cl-5-teku-geth
```
