### PR TITLE
Update cgc in ENR using the data from CustodyGroupCountManager

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/CustodyGroupCountChannel.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/CustodyGroupCountChannel.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition;
 
+import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 
 public interface CustodyGroupCountChannel extends VoidReturningChannelInterface {
@@ -25,6 +26,19 @@ public interface CustodyGroupCountChannel extends VoidReturningChannelInterface 
         @Override
         public void onCustodyGroupCountSynced(final int groupCount) {}
       };
+
+  static CustodyGroupCountChannel createCustodyGroupCountSyncedSubscriber(
+      final Consumer<Integer> custodyGroupCountSyncedSubscriber) {
+    return new CustodyGroupCountChannel() {
+      @Override
+      public void onCustodyGroupCountUpdate(final int groupCount) {}
+
+      @Override
+      public void onCustodyGroupCountSynced(final int groupCount) {
+        custodyGroupCountSyncedSubscriber.accept(groupCount);
+      }
+    };
+  }
 
   void onCustodyGroupCountUpdate(int groupCount);
 

--- a/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannel.java
+++ b/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannel.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -99,6 +100,7 @@ class EventChannel<T> {
     final String illegalMethods =
         Stream.of(channelInterface.getMethods())
             .filter(method -> !isReturnTypeAllowed(method) || method.getExceptionTypes().length > 0)
+            .filter(method -> !Modifier.isStatic(method.getModifiers()))
             .map(Method::getName)
             .collect(joining(", "));
     checkArgument(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1576,6 +1576,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
         new LocalOperationAcceptedFilter<>(p2pNetwork::publishVoluntaryExit));
     blsToExecutionChangePool.subscribeOperationAdded(
         new LocalOperationAcceptedFilter<>(p2pNetwork::publishSignedBlsToExecutionChange));
+    eventChannels.subscribe(
+        CustodyGroupCountChannel.class,
+        CustodyGroupCountChannel.createCustodyGroupCountSyncedSubscriber(
+            cgcSynced ->
+                p2pNetwork
+                    .getDiscoveryNetwork()
+                    .ifPresent(
+                        discoveryNetwork ->
+                            discoveryNetwork.setDASTotalCustodySubnetCount(cgcSynced))));
 
     this.nodeId =
         p2pNetwork


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
It will be actually set very early just after node updated and first finalized (if FULU is supported == not FAR_FUTURE_EPOCH scheduled). But should we care? All not known fields in enr are ignored. The size is a bit bigger, it's the only thing we may care.
Also I'm not sure, what tests could be added.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
