### PR TITLE
Improve VC multiBN handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Additions and Improvements
 - Added `/eth/v1/beacon/states/{state_id}/validator_identities` endpoint to allow querying of validator identities.
+- Several improvements on how validator client handles multiple beacon nodes:
+  - reduced timeout for beacon node API calls down to 10 seconds
+  - improved handling of unresponsive\unreachable beacon nodes.
 
 ### Bug Fixes
 - Fixed validator client missing duties when secondary beacon nodes are not responsive. Happens only for validator clients configured with multiple `--beacon-node-api-endpoints`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@
 - Added `/eth/v1/beacon/states/{state_id}/validator_identities` endpoint to allow querying of validator identities.
 
 ### Bug Fixes
-- Fixed validator client missing duties when secondary beacon nodes are not responsive. Happens only for single process validator clients configured with multiple `--beacon-node-api-endpoints`.
+- Fixed validator client missing duties when secondary beacon nodes are not responsive. Happens only for validator clients configured with multiple `--beacon-node-api-endpoints`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@
 - Added `/eth/v1/beacon/states/{state_id}/validator_identities` endpoint to allow querying of validator identities.
 
 ### Bug Fixes
-- Fixed validator client to miss duties when secondary beacon nodes are not responsive. Applicable only to single process validator clients configured with multiple `--beacon-node-api-endpoints`.
+- Fixed validator client missing duties when secondary beacon nodes are not responsive. Happens only for single process validator clients configured with multiple `--beacon-node-api-endpoints`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Added `/eth/v1/beacon/states/{state_id}/validator_identities` endpoint to allow querying of validator identities.
 
 ### Bug Fixes
+- Fixed validator client to miss duties when secondary beacon nodes are not responsive. Applicable only to single process validator clients configured with multiple `--beacon-node-api-endpoints`.

--- a/validator/remote/build.gradle
+++ b/validator/remote/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':infrastructure:metrics'))
   testImplementation testFixtures(project(':infrastructure:ssz'))
+  testImplementation testFixtures(project(':infrastructure:time'))
   testImplementation 'com.squareup.okhttp3:mockwebserver'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -241,7 +241,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
                   "{} is NOT ready to accept requests because the syncing status request failed: {}",
                   beaconNodeApiEndpoint,
                   throwable);
-              return ReadinessWithErrorTimestamp.error(timeProvider.getTimeInMillis());
+              return ReadinessWithErrorTimestamp.errored(timeProvider.getTimeInMillis());
             })
         .thenAccept(
             readinessStatus -> {
@@ -285,7 +285,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   private enum Readiness {
-    ERROR(-1),
+    ERRORED(-1),
     NOT_READY(0),
     READY_OPTIMISTIC(1),
     READY_NOT_ENOUGH_PEERS(2),
@@ -304,8 +304,8 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
 
   private record ReadinessWithErrorTimestamp(
       Readiness readiness, Optional<UInt64> lastErrorTimestamp) {
-    static ReadinessWithErrorTimestamp error(final UInt64 errorTimestamp) {
-      return new ReadinessWithErrorTimestamp(Readiness.ERROR, Optional.of(errorTimestamp));
+    static ReadinessWithErrorTimestamp errored(final UInt64 errorTimestamp) {
+      return new ReadinessWithErrorTimestamp(Readiness.ERRORED, Optional.of(errorTimestamp));
     }
 
     static final ReadinessWithErrorTimestamp READY =

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.validator.remote;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
-import java.time.Duration;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -32,6 +32,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -47,10 +48,15 @@ import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 public class BeaconNodeReadinessManager extends Service implements ValidatorTimingChannel {
 
   private static final Logger LOG = LogManager.getLogger();
-  private static final Duration SYNCING_STATUS_CALL_TIMEOUT = Duration.ofSeconds(10);
   private static final UInt64 MIN_REQUIRED_CONNECTED_PEER_COUNT = UInt64.valueOf(50);
-  private final Map<RemoteValidatorApiChannel, ReadinessStatus> readinessStatusCache =
+  private static final UInt64 ERRORED_SECONDARY_READINESS_CHECK_INTERVAL_DELAY_MS =
+      UInt64.valueOf(60_000);
+
+  private final Map<RemoteValidatorApiChannel, ReadinessWithErrorTimestamp> readinessStatusCache =
       Maps.newConcurrentMap();
+
+  private final Map<RemoteValidatorApiChannel, SafeFuture<Void>> inflightReadinessCheckFutures =
+      Collections.synchronizedMap(Maps.newHashMap());
 
   private final AtomicBoolean latestPrimaryNodeReadiness = new AtomicBoolean(true);
 
@@ -58,12 +64,15 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   private final List<? extends RemoteValidatorApiChannel> failoverBeaconNodeApis;
   private final ValidatorLogger validatorLogger;
   private final BeaconNodeReadinessChannel beaconNodeReadinessChannel;
+  private final TimeProvider timeProvider;
 
   public BeaconNodeReadinessManager(
+      final TimeProvider timeProvider,
       final RemoteValidatorApiChannel primaryBeaconNodeApi,
       final List<? extends RemoteValidatorApiChannel> failoverBeaconNodeApis,
       final ValidatorLogger validatorLogger,
       final BeaconNodeReadinessChannel beaconNodeReadinessChannel) {
+    this.timeProvider = timeProvider;
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
     this.failoverBeaconNodeApis = failoverBeaconNodeApis;
     this.validatorLogger = validatorLogger;
@@ -71,17 +80,15 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   public boolean isReady(final RemoteValidatorApiChannel beaconNodeApi) {
-    final ReadinessStatus readinessStatus =
-        readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY);
+    final ReadinessWithErrorTimestamp readinessStatus =
+        readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessWithErrorTimestamp.READY);
     return readinessStatus.isReady();
   }
 
-  public ReadinessStatus getReadinessStatus(final RemoteValidatorApiChannel beaconNodeApi) {
-    return readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY);
-  }
-
   public int getReadinessStatusWeight(final RemoteValidatorApiChannel beaconNodeApi) {
-    return readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessStatus.READY).weight;
+    return readinessStatusCache.getOrDefault(beaconNodeApi, ReadinessWithErrorTimestamp.READY)
+        .readiness
+        .weight;
   }
 
   public Iterator<? extends RemoteValidatorApiChannel> getFailoversInOrderOfReadiness() {
@@ -91,7 +98,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   public SafeFuture<Void> performPrimaryReadinessCheck() {
-    return performReadinessCheck(primaryBeaconNodeApi, true);
+    return performReadinessCheckWithInflightCheck(primaryBeaconNodeApi, true);
   }
 
   @Override
@@ -155,12 +162,51 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   private SafeFuture<Void> performFailoverReadinessCheck(final RemoteValidatorApiChannel failover) {
-    return performReadinessCheck(failover, false);
+    return performReadinessCheckWithInflightCheck(failover, false);
+  }
+
+  private SafeFuture<Void> performReadinessCheckWithInflightCheck(
+      final RemoteValidatorApiChannel beaconNodeApi, final boolean isPrimaryNode) {
+    return inflightReadinessCheckFutures.compute(
+        beaconNodeApi,
+        (__, future) -> {
+          if (future != null && !future.isDone()) {
+            LOG.debug("Readiness check for {} is already in progress", beaconNodeApi.getEndpoint());
+            return future; // Return the existing future if it's already in progress
+          }
+          return performReadinessCheck(beaconNodeApi, isPrimaryNode);
+        });
+  }
+
+  private boolean isTimeToPerformReadinessCheck(
+      final RemoteValidatorApiChannel beaconNodeApi, final boolean isPrimaryNode) {
+    if (isPrimaryNode) {
+      return true; // Primary node readiness check is always performed
+    }
+
+    final Optional<UInt64> lastErrorTimestamp =
+        Optional.ofNullable(readinessStatusCache.get(beaconNodeApi))
+            .flatMap(ReadinessWithErrorTimestamp::lastErrorTimestamp);
+    if (lastErrorTimestamp.isEmpty()) {
+      return true; // No error recorded, so we can check readiness
+    }
+    final UInt64 currentTime = timeProvider.getTimeInMillis();
+    return currentTime.isGreaterThanOrEqualTo(
+        lastErrorTimestamp.get().plus(ERRORED_SECONDARY_READINESS_CHECK_INTERVAL_DELAY_MS));
   }
 
   private SafeFuture<Void> performReadinessCheck(
       final RemoteValidatorApiChannel beaconNodeApi, final boolean isPrimaryNode) {
     final HttpUrl beaconNodeApiEndpoint = beaconNodeApi.getEndpoint();
+
+    LOG.debug("Performing beacon node readiness check for {}", beaconNodeApiEndpoint);
+    if (!isTimeToPerformReadinessCheck(beaconNodeApi, isPrimaryNode)) {
+      LOG.info(
+          "Skipping readiness check for {} as it was already checked recently",
+          beaconNodeApiEndpoint);
+      return SafeFuture.COMPLETE;
+    }
+
     return beaconNodeApi
         .getSyncingStatus()
         .thenCombine(
@@ -171,25 +217,24 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
                     "{} is ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
                 final boolean optimistic = syncingStatus.getIsOptimistic().orElse(false);
                 if (optimistic) {
-                  return ReadinessStatus.READY_OPTIMISTIC;
+                  return ReadinessWithErrorTimestamp.READY_OPTIMISTIC;
                 }
                 if (!hasEnoughConnectedPeers(peerCount)) {
-                  return ReadinessStatus.READY_NOT_ENOUGH_PEERS;
+                  return ReadinessWithErrorTimestamp.READY_NOT_ENOUGH_PEERS;
                 }
-                return ReadinessStatus.READY;
+                return ReadinessWithErrorTimestamp.READY;
               }
               LOG.debug(
                   "{} is NOT ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
-              return ReadinessStatus.NOT_READY;
+              return ReadinessWithErrorTimestamp.NOT_READY;
             })
-        .orTimeout(SYNCING_STATUS_CALL_TIMEOUT)
         .exceptionally(
             throwable -> {
               LOG.debug(
-                  String.format(
-                      "%s is NOT ready to accept requests because the syncing status request failed: %s",
-                      beaconNodeApiEndpoint, throwable));
-              return ReadinessStatus.NOT_READY;
+                  "{} is NOT ready to accept requests because the syncing status request failed: {}",
+                  beaconNodeApiEndpoint,
+                  throwable);
+              return ReadinessWithErrorTimestamp.error(timeProvider.getTimeInMillis());
             })
         .thenAccept(
             readinessStatus -> {
@@ -232,7 +277,8 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     }
   }
 
-  public enum ReadinessStatus {
+  private enum Readiness {
+    ERROR(-1),
     NOT_READY(0),
     READY_OPTIMISTIC(1),
     READY_NOT_ENOUGH_PEERS(2),
@@ -240,12 +286,32 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
 
     private final int weight;
 
-    ReadinessStatus(final int weight) {
+    Readiness(final int weight) {
       this.weight = weight;
     }
 
     boolean isReady() {
       return this.weight > 0;
+    }
+  }
+
+  private record ReadinessWithErrorTimestamp(
+      Readiness readiness, Optional<UInt64> lastErrorTimestamp) {
+    static ReadinessWithErrorTimestamp error(final UInt64 errorTimestamp) {
+      return new ReadinessWithErrorTimestamp(Readiness.ERROR, Optional.of(errorTimestamp));
+    }
+
+    static final ReadinessWithErrorTimestamp READY =
+        new ReadinessWithErrorTimestamp(Readiness.READY, Optional.empty());
+    static final ReadinessWithErrorTimestamp NOT_READY =
+        new ReadinessWithErrorTimestamp(Readiness.NOT_READY, Optional.empty());
+    static final ReadinessWithErrorTimestamp READY_OPTIMISTIC =
+        new ReadinessWithErrorTimestamp(Readiness.READY_OPTIMISTIC, Optional.empty());
+    static final ReadinessWithErrorTimestamp READY_NOT_ENOUGH_PEERS =
+        new ReadinessWithErrorTimestamp(Readiness.READY_NOT_ENOUGH_PEERS, Optional.empty());
+
+    public boolean isReady() {
+      return readiness.isReady();
     }
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -145,6 +145,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
       final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
       final boolean possibleMissingEvents) {}
 
+  @SuppressWarnings("ReferenceComparison")
   private ReadinessWithErrorTimestamp getReadiness(final RemoteValidatorApiChannel beaconNodeApi) {
     return readinessStatusCache.computeIfAbsent(
         beaconNodeApi,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -361,6 +361,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
     final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions = new ConcurrentHashMap<>();
     final List<SafeFuture<T>> failoverResponses =
         failoverDelegates.stream()
+            .filter(beaconNodeReadinessManager::isReady)
             .map(
                 failover ->
                     runRequest(failover, request, method)
@@ -490,6 +491,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final RemoteValidatorApiChannel delegate,
       final ValidatorApiChannelRequest<T> request,
       final String method) {
+    LOG.info("runRequest {} to {}", method, delegate.getEndpoint());
     return request
         .run(delegate)
         .handleComposed(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -491,15 +491,13 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final RemoteValidatorApiChannel delegate,
       final ValidatorApiChannelRequest<T> request,
       final String method) {
-    LOG.info("runRequest {} to {}", method, delegate.getEndpoint());
+    LOG.trace("runRequest {} to {}", method, delegate.getEndpoint());
     return request
         .run(delegate)
         .handleComposed(
             (response, throwable) -> {
               if (throwable != null) {
-                LOG.trace(
-                    String.format("Request (%s) to %s failed", method, delegate.getEndpoint()),
-                    throwable);
+                LOG.debug("Request ({}) to {} failed", method, delegate.getEndpoint(), throwable);
                 recordFailedRequest(delegate, method);
                 return SafeFuture.failedFuture(throwable);
               }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.remote.eventsource;
 
 import static java.util.Collections.emptyMap;
-import static tech.pegasys.teku.validator.remote.BeaconNodeReadinessManager.ReadinessStatus.READY;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -183,9 +182,7 @@ public class EventSourceBeaconChainEventAdapter
       return false;
     }
     // No need to change anything if current node is READY
-    if (beaconNodeReadinessManager
-        .getReadinessStatus(currentBeaconNodeUsedForEventStreaming)
-        .equals(READY)) {
+    if (beaconNodeReadinessManager.isReady(currentBeaconNodeUsedForEventStreaming)) {
       return false;
     }
     return findReadyFailoverAndSwitch();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -94,6 +94,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
 
     final BeaconNodeReadinessManager beaconNodeReadinessManager =
         new BeaconNodeReadinessManager(
+            serviceConfig.getTimeProvider(),
             dutiesProviderPrimaryValidatorApiChannel,
             dutiesProviderFailoverValidatorApiChannel,
             ValidatorLogger.VALIDATOR_LOGGER,

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.ethereum.json.types.node.PeerCount;
 import tech.pegasys.teku.ethereum.json.types.node.PeerCountBuilder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
 
@@ -63,8 +64,11 @@ public class BeaconNodeReadinessManagerTest {
   private final BeaconNodeReadinessChannel beaconNodeReadinessChannel =
       mock(BeaconNodeReadinessChannel.class);
 
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
+
   private final BeaconNodeReadinessManager beaconNodeReadinessManager =
       new BeaconNodeReadinessManager(
+          timeProvider,
           beaconNodeApi,
           List.of(failoverBeaconNodeApi),
           validatorLogger,
@@ -217,6 +221,7 @@ public class BeaconNodeReadinessManagerTest {
 
     final BeaconNodeReadinessManager beaconNodeReadinessManager =
         new BeaconNodeReadinessManager(
+            timeProvider,
             primaryBeaconNodeApi,
             List.of(
                 syncingFailover,

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
@@ -123,15 +123,14 @@ public class EventSourceBeaconChainEventAdapterTest {
 
     eventSourceBeaconChainEventAdapter.currentBeaconNodeUsedForEventStreaming = failover1;
 
-    when(beaconNodeReadinessManager.getReadinessStatus(failover1))
-        .thenReturn(BeaconNodeReadinessManager.ReadinessStatus.READY);
+    when(beaconNodeReadinessManager.isReady(failover1)).thenReturn(true);
     final SafeFuture<SyncingStatus> someFuture = new SafeFuture<>();
     when(primaryNode.getSyncingStatus()).thenReturn(someFuture);
     eventSourceBeaconChainEventAdapter.onFailoverNodeNotReady(failover1);
 
-    verify(beaconNodeReadinessManager).getReadinessStatus(failover1);
+    verify(beaconNodeReadinessManager).isReady(failover1);
     // Shouldn't try failover2 when failover1 is good
-    verify(beaconNodeReadinessManager, never()).getReadinessStatus(failover2);
+    verify(beaconNodeReadinessManager, never()).isReady(failover2);
     verify(beaconNodeReadinessManager, never()).getReadinessStatusWeight(failover2);
     verify(beaconNodeReadinessManager, never()).isReady(any());
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapterTest.java
@@ -132,7 +132,6 @@ public class EventSourceBeaconChainEventAdapterTest {
     // Shouldn't try failover2 when failover1 is good
     verify(beaconNodeReadinessManager, never()).isReady(failover2);
     verify(beaconNodeReadinessManager, never()).getReadinessStatusWeight(failover2);
-    verify(beaconNodeReadinessManager, never()).isReady(any());
 
     // But will try to return to primaryNode when it's possible
     verify(beaconNodeReadinessManager).performPrimaryReadinessCheck();


### PR DESCRIPTION
Features:
- differentiate OkHttpClient among stream and rest calls, to handle timeout config independently
- introduce ERRORED readiness status
- reduce readiness checks for secondary errored BNs (once every 60s). Primary remains unchanged.
- handling of overlapping readiness checks
- do not try to relay on non-ready secondary BNs (probably a bug\oversight in previous implementation)
- only primary is READY by default (avoid to do a lot of calls at startup to potentially problematic nodes, so wait a successful readiness check before considering secondary nodes)

fixes #9560
fixes #9564
fixes #9565

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
