### PR TITLE
bls-keystore: Use Teku sha256 instead of Tuweni

### DIFF
--- a/infrastructure/bls-keystore/build.gradle
+++ b/infrastructure/bls-keystore/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'io.consensys.tuweni:tuweni-bytes'
-  implementation 'io.consensys.tuweni:tuweni-crypto'
+  implementation project(":infrastructure:crypto")
 
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter-engine'

--- a/infrastructure/bls-keystore/src/main/java/tech/pegasys/teku/bls/keystore/KeyStore.java
+++ b/infrastructure/bls-keystore/src/main/java/tech/pegasys/teku/bls/keystore/KeyStore.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.crypto.Cipher.DECRYPT_MODE;
 import static javax.crypto.Cipher.ENCRYPT_MODE;
 import static org.apache.tuweni.bytes.Bytes.concatenate;
-import static org.apache.tuweni.crypto.Hash.sha2_256;
 
 import java.security.GeneralSecurityException;
 import java.util.Objects;
@@ -31,6 +30,7 @@ import tech.pegasys.teku.bls.keystore.model.Crypto;
 import tech.pegasys.teku.bls.keystore.model.Kdf;
 import tech.pegasys.teku.bls.keystore.model.KdfParam;
 import tech.pegasys.teku.bls.keystore.model.KeyStoreData;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
 
 /**
  * BLS Key Store implementation EIP-2335
@@ -140,7 +140,7 @@ public class KeyStore {
       final Bytes decryptionKey, final Bytes cipherMessage) {
     // aes-128-ctr needs first 16 bytes for its key. The 2nd 16 bytes are used to create checksum
     final Bytes dkSliceSecondHalf = decryptionKey.slice(16, 16);
-    return sha2_256(concatenate(dkSliceSecondHalf, cipherMessage));
+    return Hash.sha256(concatenate(dkSliceSecondHalf, cipherMessage));
   }
 
   private static Bytes applyCipherFunction(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
bls-keystore: Use Teku sha256 instead of Tuweni Crypto's sha256. This will allow to fix potential memory leakage from native usage of libsodium by Tuweni crypto that has been observed in Web3Signer.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
