### PR TITLE
Update Prysm API documentation link

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/README.md
@@ -4,7 +4,7 @@
 
 * [consensus-specs](https://github.com/ethereum/consensus-specs)
 * [beacon-APIs](https://github.com/ethereum/beacon-APIs)
-* [Prysm API](https://docs.prylabs.network/docs/how-prysm-works/ethereum-public-api)
+* [Prysm API](https://prysm.offchainlabs.com/docs/apis/prysm-public-api/)
 * [Lighthouse API](https://lighthouse-book.sigmaprime.io/api-bn.html)
 
 ## /node/genesis_time


### PR DESCRIPTION
The PR updates the outdated Prysm API documentation link from https://docs.prylabs.network/docs/how-prysm-works/ethereum-public-api to the new location at https://prysm.offchainlabs.com/docs/apis/prysm-public-api. This ensures the README maintains up-to-date references to the Prysm documentation.
