### PR TITLE
ignore blob sidecars by range requests after FULU

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -133,6 +133,15 @@ public class BlobSidecarsByRangeMessageHandler
         startSlot);
     final UInt64 endSlotBeforeFulu = getEndSlotBeforeFulu(endSlot);
 
+    if (startSlot.isGreaterThan(endSlotBeforeFulu)) {
+      LOG.trace(
+          "Peer {} requested {} slots of blob sidecars starting at slot {} after FULU. BlobSidecarsByRange v1 is deprecated and the request will be ignored.",
+          peer.getId(),
+          message.getCount(),
+          startSlot);
+      return;
+    }
+
     final SpecConfigDeneb specConfig =
         SpecConfigDeneb.required(spec.atSlot(endSlotBeforeFulu).getConfig());
     final int requestedCount =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -169,7 +169,8 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
 
   @Test
   public void shouldIgnoreRequestsWhenStartSlotIsAfterFulu() {
-    final UInt64 startSlot = spec.computeStartSlotAtEpoch(fuluForkEpoch); // start slot after fulu
+    final UInt64 startSlot =
+        spec.computeStartSlotAtEpoch(fuluForkEpoch); // start slot at fulu boundary
     final UInt64 count = slotsPerEpoch.times(2); // count = 16
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -169,8 +169,7 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
 
   @Test
   public void shouldIgnoreRequestsWhenStartSlotIsAfterFulu() {
-    final UInt64 startSlot =
-        spec.computeStartSlotAtEpoch(fuluForkEpoch); // start slot after fulu
+    final UInt64 startSlot = spec.computeStartSlotAtEpoch(fuluForkEpoch); // start slot after fulu
     final UInt64 count = slotsPerEpoch.times(2); // count = 16
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -74,7 +74,6 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
 
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
-  private final ResponseCallback<BlobSidecar> listener = mock(ResponseCallback.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final UpdatableStore store = mock(UpdatableStore.class);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
@@ -177,9 +176,9 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
     final BlobSidecarsByRangeMessageHandler handler =
         new BlobSidecarsByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
-    handler.onIncomingMessage(protocolId, peer, request, listener);
+    handler.onIncomingMessage(protocolId, peer, request, callback);
     verifyNoInteractions(combinedChainDataClient);
-    verifyNoInteractions(listener);
+    verifyNoInteractions(callback);
   }
 
   public void runTestWith(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -67,7 +67,7 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
       RpcEncoding.createSszSnappyEncoding(
           TestSpecFactory.createDefault().getNetworkingConfig().getMaxPayloadSize());
   private final String protocolId =
-      BeaconChainMethodIds.getBlobSidecarsByRootMethodId(1, RPC_ENCODING);
+      BeaconChainMethodIds.getBlobSidecarsByRangeMethodId(1, RPC_ENCODING);
 
   @SuppressWarnings("unchecked")
   private final ResponseCallback<BlobSidecar> callback = mock(ResponseCallback.class);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -170,7 +170,7 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
   @Test
   public void shouldIgnoreRequestsWhenStartSlotIsAfterFulu() {
     final UInt64 startSlot =
-        spec.computeStartSlotAtEpoch(fuluForkEpoch.plus(7)); // start slot after fulu
+        spec.computeStartSlotAtEpoch(fuluForkEpoch); // start slot after fulu
     final UInt64 count = slotsPerEpoch.times(2); // count = 16
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,7 +64,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
-@TestSpecContext(milestone = {SpecMilestone.DENEB, SpecMilestone.ELECTRA, SpecMilestone.FULU})
+@TestSpecContext(milestone = {SpecMilestone.DENEB, SpecMilestone.ELECTRA})
 public class BlobSidecarsByRangeMessageHandlerTest {
 
   private static final RequestApproval ZERO_OBJECTS_REQUEST_APPROVAL =
@@ -240,7 +239,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @TestTemplate
   public void shouldNotSendBlobSidecarsIfPeerIsRateLimited() {
-    assumeThat(specMilestone).isLessThanOrEqualTo(SpecMilestone.ELECTRA);
+
     when(peer.approveBlobSidecarsRequest(listener, count.times(maxBlobsPerBlock).longValue()))
         .thenReturn(Optional.empty());
 
@@ -268,7 +267,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @TestTemplate
   public void shouldSendResourceUnavailableIfBlobSidecarsAreNotAvailable() {
-    assumeThat(specMilestone).isLessThanOrEqualTo(SpecMilestone.ELECTRA);
+
     // current epoch is 5020
     setCurrentEpoch(UInt64.valueOf(5020));
 
@@ -302,7 +301,6 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @TestTemplate
   public void shouldCompleteSuccessfullyIfNoBlobSidecarsInRange() {
-    assumeThat(specMilestone).isLessThanOrEqualTo(SpecMilestone.ELECTRA);
     when(combinedChainDataClient.getBlobSidecarKeys(any(), any(), anyLong()))
         .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
     final BlobSidecarsByRangeRequestMessage request =
@@ -327,7 +325,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @TestTemplate
   public void shouldSendToPeerRequestedNumberOfFinalizedBlobSidecars() {
-    assumeThat(specMilestone).isLessThanOrEqualTo(SpecMilestone.ELECTRA);
+
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
 
@@ -356,7 +354,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @TestTemplate
   public void shouldSendToPeerRequestedNumberOfCanonicalBlobSidecars() {
-    assumeThat(specMilestone).isLessThanOrEqualTo(SpecMilestone.ELECTRA);
+
     final UInt64 latestFinalizedSlot = startSlot.plus(count).minus(3);
     when(combinedChainDataClient.getFinalizedBlockSlot())
         .thenReturn(Optional.of(latestFinalizedSlot));
@@ -414,7 +412,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @TestTemplate
   public void shouldIgnoreRequestWhenCountIsZero() {
-    assumeThat(specMilestone).isLessThanOrEqualTo(SpecMilestone.ELECTRA);
+
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, ZERO, maxBlobsPerBlock);
 
@@ -440,7 +438,6 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @TestTemplate
   public void shouldIgnoreRequestWhenCountIsZeroAndHotSlotRequested() {
-    assumeThat(specMilestone).isLessThanOrEqualTo(SpecMilestone.ELECTRA);
     // not finalized
     final UInt64 hotStartSlot = startSlot.plus(7);
 
@@ -465,18 +462,6 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     verify(listener).completeSuccessfully();
 
     AssertionsForInterfaceTypes.assertThat(actualSent).isEmpty();
-  }
-
-  @TestTemplate
-  public void shouldIgnoreRequestWhenStartSlotIsAfterFulu() {
-    assumeThat(specMilestone).isGreaterThanOrEqualTo(SpecMilestone.FULU);
-    final BlobSidecarsByRangeRequestMessage request =
-        new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
-
-    handler.onIncomingMessage(protocolId, peer, request, listener);
-
-    verifyNoInteractions(combinedChainDataClient);
-    verifyNoInteractions(listener);
   }
 
   private void setCurrentEpoch(final UInt64 currentEpoch) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Ignore Blob Sidecars by range requests when the start slot if after FULU
https://github.com/ethereum/consensus-specs/blob/86a4df2edb2faf104aad51577cf5168c13da539c/specs/fulu/p2p-interface.md?plain=1#L312

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
