### PR TITLE
fix: Bytes32Converter to catch IllegalArgumentException for hex parsing

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/converter/Bytes32Converter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/converter/Bytes32Converter.java
@@ -22,7 +22,7 @@ public class Bytes32Converter implements ITypeConverter<Bytes32> {
   public Bytes32 convert(final String value) {
     try {
       return Bytes32.fromHexStringStrict(value);
-    } catch (final NumberFormatException e) {
+    } catch (final IllegalArgumentException e) {
       throw new TypeConversionException(
           "Invalid format: must be a 32 bytes in hex format but was " + value);
     }


### PR DESCRIPTION
Previously, Bytes32Converter only caught NumberFormatException when parsing a hex string to Bytes32. However, Bytes32.fromHexStringStrict can throw IllegalArgumentException for various invalid inputs (e.g., incorrect length, missing 0x prefix).  
This commit updates the converter to catch IllegalArgumentException, ensuring all invalid hex formats are properly handled and reported as a TypeConversionException.