### PR TITLE
Skip custody group computation if all groups are custodied

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/BlobAndProofV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/BlobAndProofV2.java
@@ -75,7 +75,7 @@ public class BlobAndProofV2 {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("blob", bytesToBriefString(blob))
-        .add("proof", proofs.stream().map(this::bytesToBriefString).toList())
+        .add("proofs", proofs.stream().map(this::bytesToBriefString).toList())
         .toString();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -207,6 +208,11 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
           String.format(
               "Custody group count (%s) cannot exceed number of groups (%s)",
               custodyGroupCount, specConfigFulu.getNumberOfCustodyGroups()));
+    }
+
+    // Skip computation if all groups are custodied
+    if (custodyGroupCount == specConfigFulu.getNumberOfCustodyGroups()) {
+      return LongStream.range(0, custodyGroupCount).mapToObj(UInt64::valueOf).toList();
     }
 
     return Stream.iterate(nodeId, this::incrementByModule)


### PR DESCRIPTION
## PR Description

In `getCustodyGroups`, we can simply return `[0..127]` if the node custodies everything.

* https://github.com/ethereum/consensus-specs/pull/4459

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
