### PR TITLE
Added exception reporting to recover sidecars

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -292,7 +292,6 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
                         new KZGCell(dataColumnSidecar.getDataColumn().get(rowIndex).getBytes()),
                         dataColumnSidecar.getIndex().intValue()))
             .collect(Collectors.toList());
-
     return kzg.verifyCellProofBatch(
         dataColumnSidecar.getSszKZGCommitments().stream()
             .map(SszKZGCommitment::getKZGCommitment)
@@ -485,8 +484,11 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
   public List<DataColumnSidecar> reconstructAllDataColumnSidecars(
       final Collection<DataColumnSidecar> existingSidecars, final KZG kzg) {
     if (existingSidecars.size() < (specConfigFulu.getNumberOfColumns() / 2)) {
+      final Optional<DataColumnSidecar> maybeSidecar = existingSidecars.stream().findAny();
       throw new IllegalArgumentException(
-          "Number of sidecars must be greater than or equal to the half of column count");
+          String.format(
+              "Number of sidecars must be greater than or equal to the half of column count, slot: %s",
+              maybeSidecar.isPresent() ? maybeSidecar.get().getSlot().toString() : "unknown"));
     }
     final List<List<MatrixEntry>> columnBlobEntries =
         existingSidecars.stream()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -279,12 +279,9 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
                   block.getSlotAndBlockRoot());
             })
         .alwaysRun(timer.closeUnchecked())
-        .exceptionally(
-            error -> {
-              LOG.error("Failed to recover columns, encountered error: {}", error.getMessage());
-              return null;
-            })
-        .ifExceptionGetsHereRaiseABug();
+        .finish(
+            error ->
+                LOG.error("Failed to recover columns, encountered error: {}", error.getMessage()));
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -279,6 +279,11 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
                   block.getSlotAndBlockRoot());
             })
         .alwaysRun(timer.closeUnchecked())
+        .exceptionally(
+            error -> {
+              LOG.error("Failed to recover columns, encountered error: {}", error.getMessage());
+              return null;
+            })
         .ifExceptionGetsHereRaiseABug();
   }
 


### PR DESCRIPTION
Without any error catching the recovery would always print 'PLEASE FIX OR REPORT', and I'd like to avoid that.

It still looks like `onNewValidatedDataColumnSidecar` can potentially do that, but the ones i saw were in `reconstructAllDataColumnSidecars`.

Also added the slot number as context for the error.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
