### PR TITLE
moved bellatrix epoch and version to base spec config

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
@@ -63,9 +63,7 @@ public class GenesisGenerator {
   public GenesisGenerator withBellatrixEpoch(final UInt64 bellatrixForkEpoch) {
     specConfigModifier =
         specConfigModifier.andThen(
-            specConfigBuilder ->
-                specConfigBuilder.bellatrixBuilder(
-                    bellatrixBuilder -> bellatrixBuilder.bellatrixForkEpoch(bellatrixForkEpoch)));
+            specConfigBuilder -> specConfigBuilder.bellatrixForkEpoch(bellatrixForkEpoch));
     return this;
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -129,9 +129,7 @@ public class TekuNodeConfigBuilder {
     configMap.put("Xnetwork-bellatrix-fork-epoch", bellatrixForkEpoch.toString());
     specConfigModifier =
         specConfigModifier.andThen(
-            specConfigBuilder ->
-                specConfigBuilder.bellatrixBuilder(
-                    bellatrixBuilder -> bellatrixBuilder.bellatrixForkEpoch(bellatrixForkEpoch)));
+            specConfigBuilder -> specConfigBuilder.bellatrixForkEpoch(bellatrixForkEpoch));
     return this;
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
@@ -55,31 +55,29 @@ public class TransitionTestExecutor implements TestExecutor {
               switch (milestone) {
                 case ALTAIR -> builder.altairForkEpoch(forkEpoch);
                 case BELLATRIX ->
-                    builder
-                        .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(forkEpoch));
+                    builder.altairForkEpoch(UInt64.ZERO).bellatrixForkEpoch(forkEpoch);
                 case CAPELLA ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(forkEpoch));
                 case DENEB ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
                         .denebBuilder(d -> d.denebForkEpoch(forkEpoch));
                 case ELECTRA ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
                         .denebBuilder(d -> d.denebForkEpoch(UInt64.ZERO))
                         .electraBuilder(e -> e.electraForkEpoch(forkEpoch));
                 case FULU ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
                         .denebBuilder(d -> d.denebForkEpoch(UInt64.ZERO))
                         .electraBuilder(e -> e.electraForkEpoch(UInt64.ZERO))

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -521,11 +521,11 @@ public class Eth2NetworkConfiguration {
                     EphemeryNetwork.updateConfig(builder);
                   }
                   altairForkEpoch.ifPresent(builder::altairForkEpoch);
+                  bellatrixForkEpoch.ifPresent(builder::bellatrixForkEpoch);
                   builder.bellatrixBuilder(
                       bellatrixBuilder -> {
                         bellatrixBuilder.safeSlotsToImportOptimistically(
                             safeSlotsToImportOptimistically);
-                        bellatrixForkEpoch.ifPresent(bellatrixBuilder::bellatrixForkEpoch);
                         totalTerminalDifficultyOverride.ifPresent(
                             bellatrixBuilder::terminalTotalDifficulty);
                         terminalBlockHashEpochOverride.ifPresent(

--- a/ethereum/networks/src/test/resources/tech/pegasys/teku/networks/test-constants.yaml
+++ b/ethereum/networks/src/test/resources/tech/pegasys/teku/networks/test-constants.yaml
@@ -1,6 +1,16 @@
 # Minimal preset
 PRESET_BASE: minimal
+# Forking
+# ---------------------------------------------------------------
+# Values provided for illustrative purposes.
+# Individual tests/testnets may set different values.
 
+# Altair
+ALTAIR_FORK_VERSION: 0x01000001
+ALTAIR_FORK_EPOCH: 18446744073709551615
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x02000001
+BELLATRIX_FORK_EPOCH: 18446744073709551615
 # Misc
 # ---------------------------------------------------------------
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -163,6 +163,16 @@ public class DelegatingSpecConfig implements SpecConfig {
   }
 
   @Override
+  public Bytes4 getBellatrixForkVersion() {
+    return specConfig.getBellatrixForkVersion();
+  }
+
+  @Override
+  public UInt64 getBellatrixForkEpoch() {
+    return specConfig.getBellatrixForkEpoch();
+  }
+
+  @Override
   public int getSecondsPerSlot() {
     return specConfig.getSecondsPerSlot();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfigBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfigBellatrix.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.spec.config;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class DelegatingSpecConfigBellatrix extends DelegatingSpecConfigAltair
@@ -31,16 +30,6 @@ public class DelegatingSpecConfigBellatrix extends DelegatingSpecConfigAltair
   @Override
   public Optional<SpecConfigBellatrix> toVersionBellatrix() {
     return Optional.of(this);
-  }
-
-  @Override
-  public Bytes4 getBellatrixForkVersion() {
-    return specConfigBellatrix.getBellatrixForkVersion();
-  }
-
-  @Override
-  public UInt64 getBellatrixForkEpoch() {
-    return specConfigBellatrix.getBellatrixForkEpoch();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -47,6 +47,10 @@ public interface SpecConfig extends NetworkingSpecConfig {
 
   UInt64 getAltairForkEpoch();
 
+  Bytes4 getBellatrixForkVersion();
+
+  UInt64 getBellatrixForkEpoch();
+
   // Config: Time parameters
   int getSecondsPerSlot();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBellatrix.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.spec.config;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface SpecConfigBellatrix extends SpecConfigAltair {
@@ -33,10 +32,6 @@ public interface SpecConfigBellatrix extends SpecConfigAltair {
 
   @Override
   Optional<SpecConfigBellatrix> toVersionBellatrix();
-
-  Bytes4 getBellatrixForkVersion();
-
-  UInt64 getBellatrixForkEpoch();
 
   UInt64 getInactivityPenaltyQuotientBellatrix();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBellatrixImpl.java
@@ -157,8 +157,6 @@ public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
         && maxTransactionsPerPayload == that.maxTransactionsPerPayload
         && bytesPerLogsBloom == that.bytesPerLogsBloom
         && maxExtraDataBytes == that.maxExtraDataBytes
-        //        && Objects.equals(getBellatrixForkVersion(), that.getBellatrixForkVersion())
-        //        && Objects.equals(getBellatrixForkEpoch(), that.getBellatrixForkEpoch())
         && Objects.equals(
             inactivityPenaltyQuotientBellatrix, that.inactivityPenaltyQuotientBellatrix)
         && Objects.equals(terminalTotalDifficulty, that.terminalTotalDifficulty)
@@ -170,8 +168,6 @@ public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
   public int hashCode() {
     return Objects.hash(
         specConfig,
-        //            getBellatrixForkVersion(),
-        //            getBellatrixForkEpoch(),
         inactivityPenaltyQuotientBellatrix,
         minSlashingPenaltyQuotientBellatrix,
         proportionalSlashingMultiplierBellatrix,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBellatrixImpl.java
@@ -17,16 +17,12 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 
 public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
     implements SpecConfigBellatrix {
 
-  // Fork
-  private final Bytes4 bellatrixForkVersion;
-  private final UInt64 bellatrixForkEpoch;
   private final UInt64 inactivityPenaltyQuotientBellatrix;
   private final int minSlashingPenaltyQuotientBellatrix;
   private final int proportionalSlashingMultiplierBellatrix;
@@ -45,8 +41,6 @@ public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
 
   public SpecConfigBellatrixImpl(
       final SpecConfigAltair specConfig,
-      final Bytes4 bellatrixForkVersion,
-      final UInt64 bellatrixForkEpoch,
       final UInt64 inactivityPenaltyQuotientBellatrix,
       final int minSlashingPenaltyQuotientBellatrix,
       final int proportionalSlashingMultiplierBellatrix,
@@ -59,8 +53,6 @@ public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
       final UInt64 terminalBlockHashActivationEpoch,
       final int safeSlotsToImportOptimistically) {
     super(specConfig);
-    this.bellatrixForkVersion = bellatrixForkVersion;
-    this.bellatrixForkEpoch = bellatrixForkEpoch;
     this.inactivityPenaltyQuotientBellatrix = inactivityPenaltyQuotientBellatrix;
     this.minSlashingPenaltyQuotientBellatrix = minSlashingPenaltyQuotientBellatrix;
     this.proportionalSlashingMultiplierBellatrix = proportionalSlashingMultiplierBellatrix;
@@ -82,16 +74,6 @@ public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
                 new IllegalArgumentException(
                     "Expected bellatrix spec config but got: "
                         + specConfig.getClass().getSimpleName()));
-  }
-
-  @Override
-  public Bytes4 getBellatrixForkVersion() {
-    return bellatrixForkVersion;
-  }
-
-  @Override
-  public UInt64 getBellatrixForkEpoch() {
-    return bellatrixForkEpoch;
   }
 
   @Override
@@ -175,8 +157,8 @@ public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
         && maxTransactionsPerPayload == that.maxTransactionsPerPayload
         && bytesPerLogsBloom == that.bytesPerLogsBloom
         && maxExtraDataBytes == that.maxExtraDataBytes
-        && Objects.equals(bellatrixForkVersion, that.bellatrixForkVersion)
-        && Objects.equals(bellatrixForkEpoch, that.bellatrixForkEpoch)
+        //        && Objects.equals(getBellatrixForkVersion(), that.getBellatrixForkVersion())
+        //        && Objects.equals(getBellatrixForkEpoch(), that.getBellatrixForkEpoch())
         && Objects.equals(
             inactivityPenaltyQuotientBellatrix, that.inactivityPenaltyQuotientBellatrix)
         && Objects.equals(terminalTotalDifficulty, that.terminalTotalDifficulty)
@@ -188,8 +170,8 @@ public class SpecConfigBellatrixImpl extends DelegatingSpecConfigAltair
   public int hashCode() {
     return Objects.hash(
         specConfig,
-        bellatrixForkVersion,
-        bellatrixForkEpoch,
+        //            getBellatrixForkVersion(),
+        //            getBellatrixForkEpoch(),
         inactivityPenaltyQuotientBellatrix,
         minSlashingPenaltyQuotientBellatrix,
         proportionalSlashingMultiplierBellatrix,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -125,6 +125,10 @@ public class SpecConfigPhase0 implements SpecConfig {
   private final Bytes4 altairForkVersion;
   private final UInt64 altairForkEpoch;
 
+  // bellatrix fork
+  private final Bytes4 bellatrixForkVersion;
+  private final UInt64 bellatrixForkEpoch;
+
   public SpecConfigPhase0(
       final Map<String, Object> rawConfig,
       final UInt64 eth1FollowDistance,
@@ -194,7 +198,9 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int reorgParentWeightThreshold,
       final UInt64 maxPerEpochActivationExitChurnLimit,
       final Bytes4 altairForkVersion,
-      final UInt64 altairForkEpoch) {
+      final UInt64 altairForkEpoch,
+      final Bytes4 bellatrixForkVersion,
+      final UInt64 bellatrixForkEpoch) {
     this.rawConfig = rawConfig;
     this.eth1FollowDistance = eth1FollowDistance;
     this.maxCommitteesPerSlot = maxCommitteesPerSlot;
@@ -265,6 +271,8 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.maxPerEpochActivationExitChurnLimit = maxPerEpochActivationExitChurnLimit;
     this.altairForkVersion = altairForkVersion;
     this.altairForkEpoch = altairForkEpoch;
+    this.bellatrixForkVersion = bellatrixForkVersion;
+    this.bellatrixForkEpoch = bellatrixForkEpoch;
   }
 
   @Override
@@ -400,6 +408,16 @@ public class SpecConfigPhase0 implements SpecConfig {
   @Override
   public UInt64 getAltairForkEpoch() {
     return altairForkEpoch;
+  }
+
+  @Override
+  public Bytes4 getBellatrixForkVersion() {
+    return bellatrixForkVersion;
+  }
+
+  @Override
+  public UInt64 getBellatrixForkEpoch() {
+    return bellatrixForkEpoch;
   }
 
   @Override
@@ -707,6 +725,8 @@ public class SpecConfigPhase0 implements SpecConfig {
         && Objects.equals(genesisForkVersion, that.genesisForkVersion)
         && Objects.equals(altairForkVersion, that.altairForkVersion)
         && Objects.equals(altairForkEpoch, that.altairForkEpoch)
+        && Objects.equals(bellatrixForkVersion, that.bellatrixForkVersion)
+        && Objects.equals(bellatrixForkEpoch, that.bellatrixForkEpoch)
         && Objects.equals(genesisDelay, that.genesisDelay)
         && Objects.equals(minEpochsToInactivityPenalty, that.minEpochsToInactivityPenalty)
         && Objects.equals(shardCommitteePeriod, that.shardCommitteePeriod)
@@ -783,6 +803,8 @@ public class SpecConfigPhase0 implements SpecConfig {
         attestationSubnetExtraBits,
         altairForkVersion,
         altairForkEpoch,
+        bellatrixForkVersion,
+        bellatrixForkEpoch,
         attestationSubnetPrefixBits);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/BellatrixBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/BellatrixBuilder.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.spec.config.builder;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.DEFAULT_SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY;
 
 import java.math.BigInteger;
@@ -23,9 +21,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigAndParent;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
@@ -33,9 +29,6 @@ import tech.pegasys.teku.spec.config.SpecConfigBellatrixImpl;
 
 public class BellatrixBuilder implements ForkConfigBuilder<SpecConfigAltair, SpecConfigBellatrix> {
 
-  // Fork
-  private Bytes4 bellatrixForkVersion;
-  private UInt64 bellatrixForkEpoch;
   private UInt64 inactivityPenaltyQuotientBellatrix;
   private Integer minSlashingPenaltyQuotientBellatrix;
   private Integer proportionalSlashingMultiplierBellatrix;
@@ -60,8 +53,6 @@ public class BellatrixBuilder implements ForkConfigBuilder<SpecConfigAltair, Spe
     return SpecConfigAndParent.of(
         new SpecConfigBellatrixImpl(
             specConfigAndParent.specConfig(),
-            bellatrixForkVersion,
-            bellatrixForkEpoch,
             inactivityPenaltyQuotientBellatrix,
             minSlashingPenaltyQuotientBellatrix,
             proportionalSlashingMultiplierBellatrix,
@@ -78,11 +69,6 @@ public class BellatrixBuilder implements ForkConfigBuilder<SpecConfigAltair, Spe
 
   @Override
   public void validate() {
-    if (bellatrixForkEpoch == null) {
-      bellatrixForkEpoch = SpecConfig.FAR_FUTURE_EPOCH;
-      bellatrixForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
-    }
-
     // temporary, provide default values for backward compatibility
     if (terminalTotalDifficulty == null) {
       terminalTotalDifficulty =
@@ -97,19 +83,12 @@ public class BellatrixBuilder implements ForkConfigBuilder<SpecConfigAltair, Spe
       terminalBlockHashActivationEpoch = UInt64.valueOf("18446744073709551615");
     }
 
-    // Fill default zeros if fork is unsupported
-    if (bellatrixForkEpoch.equals(FAR_FUTURE_EPOCH)) {
-      SpecBuilderUtil.fillMissingValuesWithZeros(this);
-    }
-
     validateConstants();
   }
 
   @Override
   public Map<String, Object> getValidationMap() {
     final Map<String, Object> constants = new HashMap<>();
-    constants.put("bellatrixForkVersion", bellatrixForkVersion);
-    constants.put("bellatrixForkEpoch", bellatrixForkEpoch);
     constants.put("inactivityPenaltyQuotientBellatrix", inactivityPenaltyQuotientBellatrix);
     constants.put("minSlashingPenaltyQuotientBellatrix", minSlashingPenaltyQuotientBellatrix);
     constants.put(
@@ -123,22 +102,9 @@ public class BellatrixBuilder implements ForkConfigBuilder<SpecConfigAltair, Spe
 
   @Override
   public void addOverridableItemsToRawConfig(final BiConsumer<String, Object> rawConfig) {
-    rawConfig.accept("BELLATRIX_FORK_EPOCH", bellatrixForkEpoch);
     rawConfig.accept("TERMINAL_TOTAL_DIFFICULTY", terminalTotalDifficulty);
     rawConfig.accept("TERMINAL_BLOCK_HASH", terminalBlockHash);
     rawConfig.accept("TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH", terminalBlockHashActivationEpoch);
-  }
-
-  public BellatrixBuilder bellatrixForkVersion(final Bytes4 bellatrixForkVersion) {
-    checkNotNull(bellatrixForkVersion);
-    this.bellatrixForkVersion = bellatrixForkVersion;
-    return this;
-  }
-
-  public BellatrixBuilder bellatrixForkEpoch(final UInt64 bellatrixForkEpoch) {
-    checkNotNull(bellatrixForkEpoch);
-    this.bellatrixForkEpoch = bellatrixForkEpoch;
-    return this;
   }
 
   public BellatrixBuilder inactivityPenaltyQuotientBellatrix(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -137,6 +137,8 @@ public class SpecConfigBuilder {
   // altair fork information
   private Bytes4 altairForkVersion;
   private UInt64 altairForkEpoch;
+  private Bytes4 bellatrixForkVersion;
+  private UInt64 bellatrixForkEpoch;
 
   private UInt64 maxPerEpochActivationExitChurnLimit = UInt64.valueOf(256000000000L);
   private final BuilderChain<SpecConfig, SpecConfigFulu> builderChain =
@@ -174,6 +176,15 @@ public class SpecConfigBuilder {
     if (altairForkVersion == null) {
       altairForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
       rawConfig.put("ALTAIR_FORK_VERSION", altairForkVersion);
+    }
+    if (bellatrixForkEpoch == null) {
+      bellatrixForkEpoch = SpecConfig.FAR_FUTURE_EPOCH;
+      bellatrixForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
+    }
+    rawConfig.put("BELLATRIX_FORK_EPOCH", bellatrixForkEpoch);
+    if (bellatrixForkVersion == null) {
+      bellatrixForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
+      rawConfig.put("BELLATRIX_FORK_VERSION", bellatrixForkVersion);
     }
     validate();
     final SpecConfigAndParent<SpecConfig> config =
@@ -247,7 +258,9 @@ public class SpecConfigBuilder {
                 reorgParentWeightThreshold,
                 maxPerEpochActivationExitChurnLimit,
                 altairForkVersion,
-                altairForkEpoch));
+                altairForkEpoch,
+                bellatrixForkVersion,
+                bellatrixForkEpoch));
 
     return builderChain.build(config);
   }
@@ -321,6 +334,8 @@ public class SpecConfigBuilder {
     constants.put("reorgParentWeightThreshold", reorgParentWeightThreshold);
     constants.put("altairForkEpoch", altairForkEpoch);
     constants.put("altairForkVersion", altairForkVersion);
+    constants.put("bellatrixForkEpoch", bellatrixForkEpoch);
+    constants.put("bellatrixForkVersion", bellatrixForkVersion);
     return constants;
   }
 
@@ -468,6 +483,18 @@ public class SpecConfigBuilder {
   public SpecConfigBuilder altairForkEpoch(final UInt64 altairForkEpoch) {
     checkNotNull(altairForkEpoch);
     this.altairForkEpoch = altairForkEpoch;
+    return this;
+  }
+
+  public SpecConfigBuilder bellatrixForkVersion(final Bytes4 bellatrixForkVersion) {
+    checkNotNull(bellatrixForkVersion);
+    this.bellatrixForkVersion = bellatrixForkVersion;
+    return this;
+  }
+
+  public SpecConfigBuilder bellatrixForkEpoch(final UInt64 bellatrixForkEpoch) {
+    checkNotNull(bellatrixForkEpoch);
+    this.bellatrixForkEpoch = bellatrixForkEpoch;
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.config.builder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -168,24 +167,7 @@ public class SpecConfigBuilder {
         LOG.error("Failed to parse GOSSIP_MAX_SIZE", e);
       }
     }
-    if (altairForkEpoch == null) {
-      altairForkEpoch = FAR_FUTURE_EPOCH;
-      altairForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
-    }
-    rawConfig.put("ALTAIR_FORK_EPOCH", altairForkEpoch);
-    if (altairForkVersion == null) {
-      altairForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
-      rawConfig.put("ALTAIR_FORK_VERSION", altairForkVersion);
-    }
-    if (bellatrixForkEpoch == null) {
-      bellatrixForkEpoch = SpecConfig.FAR_FUTURE_EPOCH;
-      bellatrixForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
-    }
-    rawConfig.put("BELLATRIX_FORK_EPOCH", bellatrixForkEpoch);
-    if (bellatrixForkVersion == null) {
-      bellatrixForkVersion = SpecBuilderUtil.PLACEHOLDER_FORK_VERSION;
-      rawConfig.put("BELLATRIX_FORK_VERSION", bellatrixForkVersion);
-    }
+    applyForkVersions();
     validate();
     final SpecConfigAndParent<SpecConfig> config =
         SpecConfigAndParent.of(
@@ -337,6 +319,23 @@ public class SpecConfigBuilder {
     constants.put("bellatrixForkEpoch", bellatrixForkEpoch);
     constants.put("bellatrixForkVersion", bellatrixForkVersion);
     return constants;
+  }
+
+  private void applyForkVersions() {
+    // update raw config if epochs and fork versions are known
+    // if they're not known, they'll result in a validation error (expected)
+    if (altairForkEpoch != null) {
+      rawConfig.put("ALTAIR_FORK_EPOCH", altairForkEpoch);
+    }
+    if (altairForkVersion != null) {
+      rawConfig.put("ALTAIR_FORK_VERSION", altairForkVersion);
+    }
+    if (bellatrixForkEpoch != null) {
+      rawConfig.put("BELLATRIX_FORK_EPOCH", bellatrixForkEpoch);
+    }
+    if (bellatrixForkVersion != null) {
+      rawConfig.put("BELLATRIX_FORK_VERSION", bellatrixForkVersion);
+    }
   }
 
   private void validate() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
@@ -48,31 +48,29 @@ class SpecFactoryTest {
                 case PHASE0 -> LOG.info("PHASE0");
                 case ALTAIR -> builder.altairForkEpoch(forkEpoch);
                 case BELLATRIX ->
-                    builder
-                        .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(forkEpoch));
+                    builder.altairForkEpoch(UInt64.ZERO).bellatrixForkEpoch(forkEpoch);
                 case CAPELLA ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(forkEpoch));
                 case DENEB ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
                         .denebBuilder(d -> d.denebForkEpoch(forkEpoch));
                 case ELECTRA ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
                         .denebBuilder(d -> d.denebForkEpoch(UInt64.ZERO))
                         .electraBuilder(e -> e.electraForkEpoch(forkEpoch));
                 case FULU ->
                     builder
                         .altairForkEpoch(UInt64.ZERO)
-                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .bellatrixForkEpoch(UInt64.ZERO)
                         .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
                         .denebBuilder(d -> d.denebForkEpoch(UInt64.ZERO))
                         .electraBuilder(e -> e.electraForkEpoch(UInt64.ZERO))

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBellatrixTest.java
@@ -85,8 +85,6 @@ public class SpecConfigBellatrixTest {
 
     return new SpecConfigBellatrixImpl(
         altairConfig,
-        dataStructureUtil.randomBytes4(),
-        dataStructureUtil.randomUInt64(),
         dataStructureUtil.randomUInt64(),
         dataStructureUtil.randomPositiveInt(),
         dataStructureUtil.randomPositiveInt(),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
@@ -127,11 +127,7 @@ class SpecConfigBuilderTest {
     final Spec spec =
         getSpec(
             phase0Builder ->
-                phase0Builder
-                    .altairForkEpoch(randomEpoch)
-                    .bellatrixBuilder(
-                        bellatrixBuilder ->
-                            bellatrixBuilder.bellatrixForkEpoch(randomEpoch.plus(1))));
+                phase0Builder.altairForkEpoch(randomEpoch).bellatrixForkEpoch(randomEpoch.plus(1)));
 
     assertThat(spec.getGenesisSpec().getConfig().getRawConfig().get("ALTAIR_FORK_EPOCH"))
         .isEqualTo(randomEpoch);
@@ -140,11 +136,7 @@ class SpecConfigBuilderTest {
   @Test
   public void shouldLoadBellatrixForkEpoch() {
     final UInt64 randomEpoch = dataStructureUtil.randomUInt64(100_000);
-    final Spec spec =
-        getSpec(
-            phase0Builder ->
-                phase0Builder.bellatrixBuilder(
-                    mergeBuilder -> mergeBuilder.bellatrixForkEpoch(randomEpoch)));
+    final Spec spec = getSpec(phase0Builder -> phase0Builder.bellatrixForkEpoch(randomEpoch));
 
     assertThat(spec.getGenesisSpec().getConfig().getRawConfig().get("BELLATRIX_FORK_EPOCH"))
         .isEqualTo(randomEpoch);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -20,9 +20,11 @@ import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllBellat
 import static tech.pegasys.teku.spec.config.SpecConfigAssertions.assertAllFieldsSet;
 
 import com.google.common.io.Resources;
+import java.io.BufferedReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -131,6 +133,33 @@ public class SpecConfigLoaderTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "The specified network configuration had missing or invalid values for constants");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "ALTAIR_FORK_EPOCH",
+        "ALTAIR_FORK_VERSION",
+        "BELLATRIX_FORK_EPOCH",
+        "BELLATRIX_FORK_VERSION"
+      })
+  public void shouldFailToReadConfigMissingKeyVariablesIfStrict(
+      final String parameter, @TempDir final Path tempDir) throws Exception {
+    final Path file = tempDir.resolve("mainnet.yml");
+    try (final InputStream inputStream = getMainnetConfigAsStream();
+        final FileWriter writer = new FileWriter(file.toFile(), StandardCharsets.UTF_8)) {
+      final InputStreamReader isr = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+      final BufferedReader reader = new BufferedReader(isr);
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (!line.contains(parameter)) {
+          writer.write(line + "\n");
+        }
+      }
+    }
+    assertThatThrownBy(() -> SpecConfigLoader.loadConfig(file.toString(), true, true, __ -> {}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(parameter);
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigReaderTest.java
@@ -51,11 +51,7 @@ public class SpecConfigReaderTest {
             () ->
                 reader.build(
                     builder ->
-                        builder
-                            .altairForkEpoch(UInt64.ZERO)
-                            .bellatrixBuilder(
-                                bellatrixBuilder ->
-                                    bellatrixBuilder.bellatrixForkEpoch(UInt64.ZERO))))
+                        builder.altairForkEpoch(UInt64.ZERO).bellatrixForkEpoch(UInt64.ZERO)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("EPOCHS_PER_SYNC_COMMITTEE_PERIOD");
   }

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/missingAltairField.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/missingAltairField.yaml
@@ -35,7 +35,9 @@ DOMAIN_CONTRIBUTION_AND_PROOF: 0x09000000
 # ---------------------------------------------------------------
 ALTAIR_FORK_VERSION: 0x01000000
 ALTAIR_FORK_EPOCH: 18446744073709551615
-
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x02000001
+BELLATRIX_FORK_EPOCH: 18446744073709551615
 
 # Sync protocol
 # ---------------------------------------------------------------

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/unknownField.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/invalid/unknownField.yaml
@@ -40,7 +40,9 @@ DOMAIN_CONTRIBUTION_AND_PROOF: 0x09000000
 # ---------------------------------------------------------------
 ALTAIR_FORK_VERSION: 0x01000000
 ALTAIR_FORK_EPOCH: 18446744073709551615
-
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x02000001
+BELLATRIX_FORK_EPOCH: 18446744073709551615
 
 # Sync protocol
 # ---------------------------------------------------------------

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -281,9 +281,7 @@ public class TestSpecFactory {
       defaultModifier = defaultModifier.andThen(builder -> builder.altairForkEpoch(UInt64.ZERO));
     }
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX)) {
-      defaultModifier =
-          defaultModifier.andThen(
-              builder -> builder.bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO)));
+      defaultModifier = defaultModifier.andThen(builder -> builder.bellatrixForkEpoch(UInt64.ZERO));
     }
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
       defaultModifier =
@@ -338,10 +336,7 @@ public class TestSpecFactory {
       final Eth2Network network, final UInt64 altairForkEpoch, final UInt64 bellatrixForkEpoch) {
     return getBellatrixSpecConfig(
         network,
-        builder ->
-            builder
-                .altairForkEpoch(altairForkEpoch)
-                .bellatrixBuilder(b -> b.bellatrixForkEpoch(bellatrixForkEpoch)));
+        builder -> builder.altairForkEpoch(altairForkEpoch).bellatrixForkEpoch(bellatrixForkEpoch));
   }
 
   private static SpecConfigAndParent<? extends SpecConfig> getBellatrixSpecConfig(
@@ -350,7 +345,7 @@ public class TestSpecFactory {
         SpecConfigLoader.loadConfig(
             network.configName(),
             builder -> {
-              builder.altairForkEpoch(ZERO).bellatrixBuilder(b -> b.bellatrixForkEpoch(ZERO));
+              builder.altairForkEpoch(ZERO).bellatrixForkEpoch(ZERO);
               configAdapter.accept(builder);
             }));
   }
@@ -367,7 +362,7 @@ public class TestSpecFactory {
         builder ->
             builder
                 .altairForkEpoch(ZERO)
-                .bellatrixBuilder(b -> b.bellatrixForkEpoch(ZERO))
+                .bellatrixForkEpoch(ZERO)
                 .capellaBuilder(c -> c.capellaForkEpoch(capellaForkEpoch)));
   }
 
@@ -379,7 +374,7 @@ public class TestSpecFactory {
             builder -> {
               builder
                   .altairForkEpoch(ZERO)
-                  .bellatrixBuilder(b -> b.bellatrixForkEpoch(ZERO))
+                  .bellatrixForkEpoch(ZERO)
                   .capellaBuilder(c -> c.capellaForkEpoch(ZERO));
               configAdapter.accept(builder);
             }));
@@ -397,7 +392,7 @@ public class TestSpecFactory {
         builder ->
             builder
                 .altairForkEpoch(ZERO)
-                .bellatrixBuilder(b -> b.bellatrixForkEpoch(ZERO))
+                .bellatrixForkEpoch(ZERO)
                 .capellaBuilder(c -> c.capellaForkEpoch(capellaForkEpoch))
                 .denebBuilder(d -> d.denebForkEpoch(denebForkEpoch)));
   }
@@ -410,7 +405,7 @@ public class TestSpecFactory {
             builder -> {
               builder
                   .altairForkEpoch(ZERO)
-                  .bellatrixBuilder(b -> b.bellatrixForkEpoch(ZERO))
+                  .bellatrixForkEpoch(ZERO)
                   .capellaBuilder(c -> c.capellaForkEpoch(ZERO))
                   .denebBuilder(d -> d.denebForkEpoch(ZERO));
               configAdapter.accept(builder);
@@ -432,7 +427,7 @@ public class TestSpecFactory {
         builder ->
             builder
                 .altairForkEpoch(ZERO)
-                .bellatrixBuilder(b -> b.bellatrixForkEpoch(ZERO))
+                .bellatrixForkEpoch(ZERO)
                 .capellaBuilder(c -> c.capellaForkEpoch(capellaForkEpoch))
                 .denebBuilder(d -> d.denebForkEpoch(denebForkEpoch))
                 .electraBuilder(e -> e.electraForkEpoch(electraForkEpoch)));
@@ -446,7 +441,7 @@ public class TestSpecFactory {
             builder -> {
               builder
                   .altairForkEpoch(ZERO)
-                  .bellatrixBuilder(b -> b.bellatrixForkEpoch(ZERO))
+                  .bellatrixForkEpoch(ZERO)
                   .capellaBuilder(c -> c.capellaForkEpoch(ZERO))
                   .denebBuilder(d -> d.denebForkEpoch(ZERO))
                   .electraBuilder(e -> e.electraForkEpoch(ZERO));
@@ -470,7 +465,7 @@ public class TestSpecFactory {
         builder ->
             builder
                 .altairForkEpoch(ZERO)
-                .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                .bellatrixForkEpoch(UInt64.ZERO)
                 .capellaBuilder(c -> c.capellaForkEpoch(capellaForkEpoch))
                 .denebBuilder(d -> d.denebForkEpoch(denebForkEpoch))
                 .electraBuilder(e -> e.electraForkEpoch(electraForkEpoch))
@@ -485,7 +480,7 @@ public class TestSpecFactory {
             builder -> {
               builder
                   .altairForkEpoch(ZERO)
-                  .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                  .bellatrixForkEpoch(UInt64.ZERO)
                   .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
                   .denebBuilder(d -> d.denebForkEpoch(UInt64.ZERO))
                   .electraBuilder(e -> e.electraForkEpoch(UInt64.ZERO))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
@@ -86,15 +86,12 @@ public class TerminalPowBlockMonitorTest {
     setUpCommon(
         bellatrixBuilder ->
             bellatrixBuilder
-                .bellatrixForkEpoch(BELLATRIX_FORK_EPOCH)
                 .terminalBlockHash(TERMINAL_BLOCK_HASH)
                 .terminalBlockHashActivationEpoch(TERMINAL_BLOCK_EPOCH));
   }
 
   private void setUpTTDConfig() {
-    setUpCommon(
-        bellatrixBuilder ->
-            bellatrixBuilder.bellatrixForkEpoch(BELLATRIX_FORK_EPOCH).terminalTotalDifficulty(TTD));
+    setUpCommon(bellatrixBuilder -> bellatrixBuilder.terminalTotalDifficulty(TTD));
   }
 
   private void setUpCommon(final Consumer<BellatrixBuilder> bellatrixBuilder) {
@@ -103,7 +100,10 @@ public class TerminalPowBlockMonitorTest {
             SpecConfigLoader.loadConfig(
                 "minimal",
                 phase0Builder ->
-                    phase0Builder.altairForkEpoch(UInt64.ZERO).bellatrixBuilder(bellatrixBuilder)));
+                    phase0Builder
+                        .altairForkEpoch(UInt64.ZERO)
+                        .bellatrixForkEpoch(BELLATRIX_FORK_EPOCH)
+                        .bellatrixBuilder(bellatrixBuilder)));
     dataStructureUtil = new DataStructureUtil(spec);
     storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     storageSystem.chainUpdater().initializeGenesis(false);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
@@ -63,19 +63,8 @@ public class ActiveEth2P2PNetworkTest {
   private final UInt64 altairForkEpoch = UInt64.valueOf(2);
   private final UInt64 fuluForkEpoch = UInt64.valueOf(7);
   private final UInt64 bpoForkEpoch = UInt64.valueOf(8);
-  private final Spec spec =
-      TestSpecFactory.createMinimalFulu(
-          b ->
-              b.altairForkEpoch(altairForkEpoch)
-                  .bellatrixBuilder(bb -> bb.bellatrixForkEpoch(UInt64.valueOf(3)))
-                  .capellaBuilder(cb -> cb.capellaForkEpoch(UInt64.valueOf(4)))
-                  .denebBuilder(db -> db.denebForkEpoch(UInt64.valueOf(5)))
-                  .electraBuilder(eb -> eb.electraForkEpoch(UInt64.valueOf(6)))
-                  .fuluBuilder(
-                      fb ->
-                          fb.fuluForkEpoch(fuluForkEpoch)
-                              .blobSchedule(List.of(new BlobScheduleEntry(bpoForkEpoch, 64)))));
-  private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
+  private Spec spec;
+  private StorageSystem storageSystem;
 
   // Stubs and mocks
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
@@ -118,7 +107,7 @@ public class ActiveEth2P2PNetworkTest {
         TestSpecFactory.createMinimalFulu(
             b ->
                 b.altairForkEpoch(altairForkEpoch)
-                    .bellatrixBuilder(bb -> bb.bellatrixForkEpoch(UInt64.valueOf(3)))
+                    .bellatrixForkEpoch(UInt64.valueOf(3))
                     .capellaBuilder(cb -> cb.capellaForkEpoch(UInt64.valueOf(4)))
                     .denebBuilder(db -> db.denebForkEpoch(UInt64.valueOf(5)))
                     .electraBuilder(eb -> eb.electraForkEpoch(UInt64.valueOf(6)))
@@ -228,7 +217,7 @@ public class ActiveEth2P2PNetworkTest {
         TestSpecFactory.createMinimalFulu(
             b ->
                 b.altairForkEpoch(altairForkEpoch)
-                    .bellatrixBuilder(bb -> bb.bellatrixForkEpoch(UInt64.valueOf(3)))
+                    .bellatrixForkEpoch(UInt64.valueOf(3))
                     .capellaBuilder(cb -> cb.capellaForkEpoch(UInt64.valueOf(4)))
                     .denebBuilder(db -> db.denebForkEpoch(UInt64.valueOf(5)))
                     .electraBuilder(eb -> eb.electraForkEpoch(UInt64.valueOf(6)))

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
@@ -66,7 +66,7 @@ public class ActiveEth2P2PNetworkTest {
       TestSpecFactory.createMinimalFulu(
           b ->
               b.altairForkEpoch(altairForkEpoch)
-                  .bellatrixBuilder(bb -> bb.bellatrixForkEpoch(UInt64.valueOf(3)))
+                  .bellatrixForkEpoch(UInt64.valueOf(3))
                   .capellaBuilder(cb -> cb.capellaForkEpoch(UInt64.valueOf(4)))
                   .denebBuilder(db -> db.denebForkEpoch(UInt64.valueOf(5)))
                   .electraBuilder(eb -> eb.electraForkEpoch(UInt64.valueOf(6)))

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
@@ -73,7 +73,7 @@ class DiscoveryNetworkTest {
       TestSpecFactory.createMinimalFulu(
           b ->
               b.altairForkEpoch(UInt64.valueOf(10_000))
-                  .bellatrixBuilder(bb -> bb.bellatrixForkEpoch(UInt64.valueOf(20_000)))
+                  .bellatrixForkEpoch(UInt64.valueOf(20_000))
                   .capellaBuilder(cb -> cb.capellaForkEpoch(UInt64.valueOf(30_000)))
                   .denebBuilder(db -> db.denebForkEpoch(UInt64.valueOf(40_000)))
                   .electraBuilder(eb -> eb.electraForkEpoch(UInt64.valueOf(50_000)))

--- a/teku/src/test/resources/tech/pegasys/teku/cli/options/constants.yaml
+++ b/teku/src/test/resources/tech/pegasys/teku/cli/options/constants.yaml
@@ -1,6 +1,16 @@
 # Minimal preset
 PRESET_BASE: "minimal"
+# Forking
+# ---------------------------------------------------------------
+# Values provided for illustrative purposes.
+# Individual tests/testnets may set different values.
 
+# Altair
+ALTAIR_FORK_VERSION: 0x01000001
+ALTAIR_FORK_EPOCH: 18446744073709551615
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x02000001
+BELLATRIX_FORK_EPOCH: 18446744073709551615
 # Misc
 # ---------------------------------------------------------------
 


### PR DESCRIPTION
In both of these, (bellatrix and altair) we don't really have  enough context to determine that values should be defaulted. So far it's been fine, but we'll likely need a better solution once we get closer to fulu, or potentially in the G fork.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
