### PR TITLE
Remove `banNode` method from DataColumnPeerManager

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnPeerManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnPeerManager.java
@@ -19,8 +19,6 @@ public interface DataColumnPeerManager {
 
   void addPeerListener(PeerListener listener);
 
-  void banNode(UInt256 node);
-
   interface PeerListener {
 
     void peerConnected(UInt256 nodeId);

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnPeerManagerStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnPeerManagerStub.java
@@ -14,28 +14,16 @@
 package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.apache.tuweni.units.bigints.UInt256;
 
 public class DataColumnPeerManagerStub implements DataColumnPeerManager {
 
-  private final Set<UInt256> bannedNodes = new HashSet<>();
   private final List<PeerListener> listeners = new ArrayList<>();
 
   @Override
   public void addPeerListener(final PeerListener listener) {
     listeners.add(listener);
-  }
-
-  @Override
-  public void banNode(final UInt256 node) {
-    bannedNodes.add(node);
-  }
-
-  public Set<UInt256> getBannedNodes() {
-    return bannedNodes;
   }
 
   public void addNode(final UInt256 nodeId) {

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
@@ -54,15 +54,6 @@ public class TestPeer {
     return nodeId;
   }
 
-  public void onDisconnect() {
-    requests.stream()
-        .filter(r -> !r.response.isDone())
-        .forEach(
-            r ->
-                r.response.completeExceptionally(
-                    new DataColumnReqResp.DasPeerDisconnectedException()));
-  }
-
   public SafeFuture<DataColumnSidecar> requestSidecar(
       final DataColumnIdentifier dataColumnIdentifier) {
     final SafeFuture<DataColumnSidecar> promise = new SafeFuture<>();

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
@@ -54,6 +54,15 @@ public class TestPeer {
     return nodeId;
   }
 
+  public void onDisconnect() {
+    requests.stream()
+        .filter(r -> !r.response.isDone())
+        .forEach(
+            r ->
+                r.response.completeExceptionally(
+                    new DataColumnReqResp.DasPeerDisconnectedException()));
+  }
+
   public SafeFuture<DataColumnSidecar> requestSidecar(
       final DataColumnIdentifier dataColumnIdentifier) {
     final SafeFuture<DataColumnSidecar> promise = new SafeFuture<>();

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeerManager.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeerManager.java
@@ -31,16 +31,10 @@ public class TestPeerManager implements DataColumnPeerManager, DataColumnReqResp
     connectedPeers.put(peer.getNodeId(), peer);
   }
 
-  public void disconnectPeer(final TestPeer peer) {
-    dataColumnPeerManagerStub.removeNode(peer.getNodeId());
-    peer.onDisconnect();
-    connectedPeers.remove(peer.getNodeId());
-  }
-
   @Override
   public SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
       final UInt256 nodeId, final DataColumnSlotAndIdentifier columnIdentifier) {
-    TestPeer peer = connectedPeers.get(nodeId);
+    final TestPeer peer = connectedPeers.get(nodeId);
     if (peer == null) {
       return SafeFuture.failedFuture(new DasPeerDisconnectedException());
     } else {
@@ -53,7 +47,7 @@ public class TestPeerManager implements DataColumnPeerManager, DataColumnReqResp
 
   @Override
   public int getCurrentRequestLimit(final UInt256 nodeId) {
-    TestPeer peer = connectedPeers.get(nodeId);
+    final TestPeer peer = connectedPeers.get(nodeId);
     if (peer == null) {
       return 0;
     } else {
@@ -64,10 +58,5 @@ public class TestPeerManager implements DataColumnPeerManager, DataColumnReqResp
   @Override
   public void addPeerListener(final PeerListener listener) {
     dataColumnPeerManagerStub.addPeerListener(listener);
-  }
-
-  @Override
-  public void banNode(final UInt256 node) {
-    dataColumnPeerManagerStub.banNode(node);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
@@ -62,11 +62,6 @@ public class DataColumnPeerManagerImpl
   }
 
   @Override
-  public void banNode(final UInt256 node) {
-    // TODO-fulu (https://github.com/Consensys/teku/issues/9460)
-  }
-
-  @Override
   public AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRoot(
       final UInt256 nodeId, final List<DataColumnsByRootIdentifier> byRootIdentifiers) {
     final Eth2Peer eth2Peer = connectedPeers.get(nodeId);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Remove `banNode` since we are already disconnecting false ENR peers in https://github.com/Consensys/teku/pull/9773

## Fixed Issue(s)
closes #9460

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
