### PR TITLE
Refactor ValidatorIsConnected

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -33,7 +33,5 @@ public interface ForkChoiceNotifier {
 
   void onTerminalBlockReached(Bytes32 executionBlockHash);
 
-  boolean validatorIsConnected(UInt64 validatorIndex, UInt64 currentSlot);
-
   void subscribeToForkChoiceUpdatedResult(ForkChoiceUpdatedResultSubscriber subscriber);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -104,11 +104,6 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
     eventThread.execute(() -> internalTerminalBlockReached(executionBlockHash));
   }
 
-  @Override
-  public boolean validatorIsConnected(final UInt64 validatorIndex, final UInt64 currentSlot) {
-    return proposersDataManager.validatorIsConnected(validatorIndex, currentSlot);
-  }
-
   private void internalTerminalBlockReached(final Bytes32 executionBlockHash) {
     eventThread.checkOnEventThread();
     LOG.debug("internalTerminalBlockReached executionBlockHash {}", executionBlockHash);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -148,9 +148,8 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
               if (maybeState.isEmpty()) {
                 return false;
               }
-              final BeaconState state = maybeState.get();
-
-              return isValidatorConnected(spec.getBeaconProposerIndex(state, blockSlot), blockSlot);
+              return isValidatorConnected(
+                  spec.getBeaconProposerIndex(maybeState.get(), blockSlot), blockSlot);
             });
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -41,8 +41,9 @@ import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.client.ValidatorIsConnectedProvider;
 
-public class ProposersDataManager implements SlotEventsChannel {
+public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConnectedProvider {
   private static final Logger LOG = LogManager.getLogger();
   private static final long PROPOSER_PREPARATION_EXPIRATION_EPOCHS = 3;
   private static final long VALIDATOR_REGISTRATION_EXPIRATION_EPOCHS = 2;
@@ -131,10 +132,26 @@ public class ProposersDataManager implements SlotEventsChannel {
                     headState, signedValidatorRegistrations, currentSlot));
   }
 
-  // used in ForkChoice validator_is_connected
-  public boolean validatorIsConnected(final UInt64 validatorIndex, final UInt64 currentSlot) {
-    final PreparedProposerInfo info = preparedProposerInfoByValidatorIndex.get(validatorIndex);
+  @Override
+  public boolean isValidatorConnected(final int validatorIndex, final UInt64 currentSlot) {
+    final PreparedProposerInfo info =
+        preparedProposerInfoByValidatorIndex.get(UInt64.valueOf(validatorIndex));
     return info != null && !info.hasExpired(currentSlot);
+  }
+
+  @Override
+  public SafeFuture<Boolean> isBlockProposerConnected(final UInt64 blockSlot) {
+    final UInt64 epoch = spec.computeEpochAtSlot(blockSlot);
+    return getStateInEpoch(epoch)
+        .thenApply(
+            maybeState -> {
+              if (maybeState.isEmpty()) {
+                return false;
+              }
+              final BeaconState state = maybeState.get();
+
+              return isValidatorConnected(spec.getBeaconProposerIndex(state, blockSlot), blockSlot);
+            });
   }
 
   private void updatePreparedProposerCache(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
@@ -14,7 +14,13 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,15 +29,18 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 @TestSpecContext(allMilestones = true)
@@ -43,6 +52,8 @@ class ProposersDataManagerTest {
   private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
   private List<BeaconPreparableProposer> proposers;
 
+  private final ChainHead chainHead = mock(ChainHead.class);
+
   private Spec spec;
   private DataStructureUtil dataStructureUtil;
   private ProposersDataManager manager;
@@ -51,15 +62,17 @@ class ProposersDataManagerTest {
   @BeforeEach
   public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
     spec =
-        switch (specContext.getSpecMilestone()) {
-          case PHASE0 -> TestSpecFactory.createMinimalPhase0();
-          case ALTAIR -> TestSpecFactory.createMinimalWithAltairForkEpoch(currentForkEpoch);
-          case BELLATRIX -> TestSpecFactory.createMinimalWithBellatrixForkEpoch(currentForkEpoch);
-          case CAPELLA -> TestSpecFactory.createMinimalWithCapellaForkEpoch(currentForkEpoch);
-          case DENEB -> TestSpecFactory.createMinimalWithDenebForkEpoch(currentForkEpoch);
-          case ELECTRA -> TestSpecFactory.createMinimalWithElectraForkEpoch(currentForkEpoch);
-          case FULU -> TestSpecFactory.createMinimalWithFuluForkEpoch(currentForkEpoch);
-        };
+        spy(
+            switch (specContext.getSpecMilestone()) {
+              case PHASE0 -> TestSpecFactory.createMinimalPhase0();
+              case ALTAIR -> TestSpecFactory.createMinimalWithAltairForkEpoch(currentForkEpoch);
+              case BELLATRIX ->
+                  TestSpecFactory.createMinimalWithBellatrixForkEpoch(currentForkEpoch);
+              case CAPELLA -> TestSpecFactory.createMinimalWithCapellaForkEpoch(currentForkEpoch);
+              case DENEB -> TestSpecFactory.createMinimalWithDenebForkEpoch(currentForkEpoch);
+              case ELECTRA -> TestSpecFactory.createMinimalWithElectraForkEpoch(currentForkEpoch);
+              case FULU -> TestSpecFactory.createMinimalWithFuluForkEpoch(currentForkEpoch);
+            });
     dataStructureUtil = specContext.getDataStructureUtil();
     defaultAddress = dataStructureUtil.randomEth1Address();
     manager =
@@ -75,6 +88,13 @@ class ProposersDataManagerTest {
         List.of(
             new BeaconPreparableProposer(UInt64.ONE, dataStructureUtil.randomEth1Address()),
             new BeaconPreparableProposer(UInt64.ZERO, defaultAddress));
+
+    when(chainHead.getSlot()).thenReturn(UInt64.ONE);
+    when(chainHead.getState()).thenReturn(SafeFuture.completedFuture(mock(BeaconState.class)));
+
+    when(recentChainData.retrieveStateAtSlot(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mock(BeaconState.class))));
+    when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
   }
 
   @TestTemplate
@@ -98,5 +118,41 @@ class ProposersDataManagerTest {
   void isValidatorConnected_notFound_withExpiredPreparedProposer() {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
     assertThat(manager.isValidatorConnected(1, UInt64.valueOf(26))).isFalse();
+  }
+
+  @TestTemplate
+  void isBlockProposerConnected_notFound_currentEpoch() {
+    doReturn(2).when(spec).getBeaconProposerIndex(any(), any());
+    manager.updatePreparedProposers(proposers, UInt64.ONE);
+
+    assertThat(manager.isBlockProposerConnected(UInt64.ONE)).isCompletedWithValue(false);
+    verify(recentChainData, never()).retrieveStateAtSlot(any());
+  }
+
+  @TestTemplate
+  void isBlockProposerConnected_found_currentEpoch() {
+    doReturn(1).when(spec).getBeaconProposerIndex(any(), any());
+    manager.updatePreparedProposers(proposers, UInt64.ONE);
+
+    assertThat(manager.isBlockProposerConnected(UInt64.ONE)).isCompletedWithValue(true);
+    verify(recentChainData, never()).retrieveStateAtSlot(any());
+  }
+
+  @TestTemplate
+  void isBlockProposerConnected_notFound_nextEpoch() {
+    doReturn(2).when(spec).getBeaconProposerIndex(any(), any());
+    manager.updatePreparedProposers(proposers, UInt64.ONE);
+
+    assertThat(manager.isBlockProposerConnected(UInt64.valueOf(10))).isCompletedWithValue(false);
+    verify(recentChainData).retrieveStateAtSlot(any());
+  }
+
+  @TestTemplate
+  void isBlockProposerConnected_found_nextEpoch() {
+    doReturn(1).when(spec).getBeaconProposerIndex(any(), any());
+    manager.updatePreparedProposers(proposers, UInt64.ONE);
+
+    assertThat(manager.isBlockProposerConnected(UInt64.valueOf(10))).isCompletedWithValue(true);
+    verify(recentChainData).retrieveStateAtSlot(any());
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
@@ -78,25 +78,25 @@ class ProposersDataManagerTest {
   }
 
   @TestTemplate
-  void validatorIsConnected_notFound_withEmptyPreparedList() {
-    assertThat(manager.validatorIsConnected(UInt64.ZERO, UInt64.ZERO)).isFalse();
+  void isValidatorConnected_notFound_withEmptyPreparedList() {
+    assertThat(manager.isValidatorConnected(0, UInt64.ZERO)).isFalse();
   }
 
   @TestTemplate
-  void validatorIsConnected_found_withPreparedProposer() {
+  void isValidatorConnected_found_withPreparedProposer() {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
-    assertThat(manager.validatorIsConnected(UInt64.ONE, UInt64.valueOf(1))).isTrue();
+    assertThat(manager.isValidatorConnected(1, UInt64.valueOf(1))).isTrue();
   }
 
   @TestTemplate
-  void validatorIsConnected_notFound_withDifferentPreparedProposer() {
+  void isValidatorConnected_notFound_withDifferentPreparedProposer() {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
-    assertThat(manager.validatorIsConnected(UInt64.valueOf(2), UInt64.valueOf(2))).isFalse();
+    assertThat(manager.isValidatorConnected(2, UInt64.valueOf(2))).isFalse();
   }
 
   @TestTemplate
-  void validatorIsConnected_notFound_withExpiredPreparedProposer() {
+  void isValidatorConnected_notFound_withExpiredPreparedProposer() {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
-    assertThat(manager.validatorIsConnected(UInt64.ONE, UInt64.valueOf(26))).isFalse();
+    assertThat(manager.isValidatorConnected(1, UInt64.valueOf(26))).isFalse();
   }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/NoopForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/NoopForkChoiceNotifier.java
@@ -44,9 +44,4 @@ public class NoopForkChoiceNotifier implements ForkChoiceNotifier {
 
   @Override
   public void onTerminalBlockReached(final Bytes32 executionBlockHash) {}
-
-  @Override
-  public boolean validatorIsConnected(final UInt64 validatorIndex, final UInt64 currentSlot) {
-    return true;
-  }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -529,7 +529,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     final VoteUpdateChannel voteUpdateChannel = eventChannels.getPublisher(VoteUpdateChannel.class);
 
     final ValidatorIsConnectedProvider validatorIsConnectedProvider =
-        new ValidatorIsConnectedProviderImpl(() -> forkChoiceNotifier);
+        new ValidatorIsConnectedProviderReference(() -> proposersDataManager);
     // Init other services
     return initWeakSubjectivity(storageQueryChannel, storageUpdateChannel)
         .thenCompose(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConnectedProviderReference.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConnectedProviderReference.java
@@ -14,19 +14,25 @@
 package tech.pegasys.teku.services.beaconchain;
 
 import java.util.function.Supplier;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.ValidatorIsConnectedProvider;
 
-public class ValidatorIsConnectedProviderImpl implements ValidatorIsConnectedProvider {
-  private final Supplier<ForkChoiceNotifier> forkChoiceNotifier;
+public class ValidatorIsConnectedProviderReference implements ValidatorIsConnectedProvider {
+  private final Supplier<ValidatorIsConnectedProvider> validatorIsConnectedProvider;
 
-  public ValidatorIsConnectedProviderImpl(final Supplier<ForkChoiceNotifier> forkChoiceNotifier) {
-    this.forkChoiceNotifier = forkChoiceNotifier;
+  public ValidatorIsConnectedProviderReference(
+      final Supplier<ValidatorIsConnectedProvider> validatorIsConnectedProvider) {
+    this.validatorIsConnectedProvider = validatorIsConnectedProvider;
   }
 
   @Override
   public boolean isValidatorConnected(final int validatorId, final UInt64 slot) {
-    return forkChoiceNotifier.get().validatorIsConnected(UInt64.valueOf(validatorId), slot);
+    return validatorIsConnectedProvider.get().isValidatorConnected(validatorId, slot);
+  }
+
+  @Override
+  public SafeFuture<Boolean> isBlockProposerConnected(final UInt64 slot) {
+    return validatorIsConnectedProvider.get().isBlockProposerConnected(slot);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
@@ -277,7 +277,7 @@ public class LateBlockReorgLogic {
     try {
       final BeaconState proposerPreState = spec.processSlots(maybeParentState.get(), proposalSlot);
       final int proposerIndex = getProposerIndex(proposerPreState, proposalSlot);
-      if (!recentChainData.validatorIsConnected(proposerIndex, proposalSlot)) {
+      if (!recentChainData.isValidatorConnected(proposerIndex, proposalSlot)) {
         LOG.debug(
             "shouldOverrideForkChoiceUpdate isValidatorConnected({}) {}, ", proposerIndex, false);
         return false;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -77,7 +77,7 @@ import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreUpdateHandler;
 
 /** This class is the ChainStorage client-side logic */
-public abstract class RecentChainData implements StoreUpdateHandler {
+public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIsConnectedProvider {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -751,8 +751,14 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return lateBlockReorgLogic.shouldOverrideForkChoiceUpdate(headRoot);
   }
 
-  public boolean validatorIsConnected(final int validatorIndex, final UInt64 slot) {
+  @Override
+  public boolean isValidatorConnected(final int validatorIndex, final UInt64 slot) {
     return validatorIsConnectedProvider.isValidatorConnected(validatorIndex, slot);
+  }
+
+  @Override
+  public SafeFuture<Boolean> isBlockProposerConnected(final UInt64 slot) {
+    return validatorIsConnectedProvider.isBlockProposerConnected(slot);
   }
 
   public void setBlockTimelinessFromArrivalTime(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
@@ -17,7 +17,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ValidatorIsConnectedProvider {
-  ValidatorIsConnectedProvider NOOP =
+  ValidatorIsConnectedProvider NEVER =
       new ValidatorIsConnectedProvider() {
         @Override
         public boolean isValidatorConnected(final int validatorId, final UInt64 slot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
@@ -13,10 +13,24 @@
 
 package tech.pegasys.teku.storage.client;
 
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ValidatorIsConnectedProvider {
-  ValidatorIsConnectedProvider NOOP = (validatorId, slot) -> true;
+  ValidatorIsConnectedProvider NOOP =
+      new ValidatorIsConnectedProvider() {
+        @Override
+        public boolean isValidatorConnected(final int validatorId, final UInt64 slot) {
+          return false;
+        }
+
+        @Override
+        public SafeFuture<Boolean> isBlockProposerConnected(final UInt64 slot) {
+          return SafeFuture.completedFuture(false);
+        }
+      };
 
   boolean isValidatorConnected(int validatorId, UInt64 slot);
+
+  SafeFuture<Boolean> isBlockProposerConnected(UInt64 slot);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
@@ -17,16 +17,16 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ValidatorIsConnectedProvider {
-  ValidatorIsConnectedProvider NEVER =
+  ValidatorIsConnectedProvider ALWAYS =
       new ValidatorIsConnectedProvider() {
         @Override
         public boolean isValidatorConnected(final int validatorId, final UInt64 slot) {
-          return false;
+          return true;
         }
 
         @Override
         public SafeFuture<Boolean> isBlockProposerConnected(final UInt64 slot) {
-          return SafeFuture.completedFuture(false);
+          return SafeFuture.completedFuture(true);
         }
       };
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/LateBlockReorgLogicTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/LateBlockReorgLogicTest.java
@@ -420,7 +420,7 @@ class LateBlockReorgLogicTest {
 
     final Optional<BeaconState> maybeParentState = Optional.of(signedBlockAndState.getState());
     when(store.getBlockStateIfAvailable(any())).thenReturn(maybeParentState);
-    when(recentChainData.validatorIsConnected(anyInt(), any())).thenReturn(false);
+    when(recentChainData.isValidatorConnected(anyInt(), any())).thenReturn(false);
     assertThat(
             reorgLogicInstrumented.shouldOverrideFcuCheckProposerPreState(
                 UInt64.valueOf(2), dataStructureUtil.randomBytes32()))
@@ -432,7 +432,7 @@ class LateBlockReorgLogicTest {
 
     final Optional<BeaconState> maybeParentState = Optional.of(signedBlockAndState.getState());
     when(store.getBlockStateIfAvailable(any())).thenReturn(maybeParentState);
-    when(recentChainData.validatorIsConnected(anyInt(), any())).thenReturn(true);
+    when(recentChainData.isValidatorConnected(anyInt(), any())).thenReturn(true);
     assertThat(
             reorgLogicInstrumented.shouldOverrideFcuCheckProposerPreState(
                 UInt64.valueOf(2), dataStructureUtil.randomBytes32()))

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -66,7 +66,7 @@ public class StorageBackedRecentChainDataTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private final ValidatorIsConnectedProvider validatorIsConnectedProvider =
-      ValidatorIsConnectedProvider.NEVER;
+      ValidatorIsConnectedProvider.ALWAYS;
 
   @Test
   public void storageBackedClient_storeInitializeViaGetStoreRequest()

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -66,7 +66,7 @@ public class StorageBackedRecentChainDataTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private final ValidatorIsConnectedProvider validatorIsConnectedProvider =
-      ValidatorIsConnectedProvider.NOOP;
+      ValidatorIsConnectedProvider.NEVER;
 
   @Test
   public void storageBackedClient_storeInitializeViaGetStoreRequest()

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
@@ -89,7 +89,7 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
     private ChainHeadChannel chainHeadChannel = new StubChainHeadChannel();
 
     private ValidatorIsConnectedProvider validatorIsConnectedProvider =
-        ValidatorIsConnectedProvider.NEVER;
+        ValidatorIsConnectedProvider.ALWAYS;
 
     public RecentChainData build() {
       return new MemoryOnlyRecentChainData(

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
@@ -89,7 +89,7 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
     private ChainHeadChannel chainHeadChannel = new StubChainHeadChannel();
 
     private ValidatorIsConnectedProvider validatorIsConnectedProvider =
-        ValidatorIsConnectedProvider.NOOP;
+        ValidatorIsConnectedProvider.NEVER;
 
     public RecentChainData build() {
       return new MemoryOnlyRecentChainData(

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -115,7 +115,7 @@ public class StorageSystem implements AutoCloseable {
             chainStorageServer,
             finalizedCheckpointChannel,
             chainHeadChannel,
-            ValidatorIsConnectedProvider.NEVER,
+            ValidatorIsConnectedProvider.ALWAYS,
             spec);
 
     // Create combined client

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -115,7 +115,7 @@ public class StorageSystem implements AutoCloseable {
             chainStorageServer,
             finalizedCheckpointChannel,
             chainHeadChannel,
-            ValidatorIsConnectedProvider.NOOP,
+            ValidatorIsConnectedProvider.NEVER,
             spec);
 
     // Create combined client


### PR DESCRIPTION
Removes the unnecessary forkchoiceNotifier passthrough.
Adds a method which allows checking if the proposer is connected just passing the slot.
This is done in a way that is working also on epoch boundary, in which case it is able to retrieve the state primed by `EpochCachePrimer`. It will be used here: https://github.com/Consensys/teku/pull/9787#discussion_r2288783182

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
