### PR TITLE
fix: type casting issue in memory and value methods

### DIFF
--- a/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
+++ b/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/PrometheusMetricsPublisherSource.java
@@ -129,34 +129,42 @@ public class PrometheusMetricsPublisherSource implements MetricsPublisherSource 
 
   private void readJvmCategoryItem(final Observation observation) {
     if ("memory_pool_bytes_used".equals(observation.metricName())) {
-      addToMemoryPoolBytesUsed((Double) observation.value());
+      addToMemoryPoolBytesUsed(observation.value());
     }
   }
 
   private void readValidatorCategoryItem(final Observation observation) {
     if ("local_validator_counts".equals(observation.metricName())) {
-      addToLocalValidators(observation.labels(), (Double) observation.value());
+      addToLocalValidators(observation.labels(), observation.value());
     }
   }
 
-  private void addToLocalValidators(final List<String> labels, final Double value) {
-    if (labels.contains("active_ongoing")) {
-      validatorsActive = value.intValue();
+  private void addToLocalValidators(final List<String> labels, final Object value) {
+    if (value instanceof Number number) {
+      if (labels.contains("active_ongoing")) {
+        validatorsActive = number.intValue();
+      }
+      validatorsTotal += number.intValue();
     }
-    validatorsTotal += value.intValue();
   }
 
-  private void addToMemoryPoolBytesUsed(final Double observedValue) {
-    memoryProcessBytes += observedValue.longValue();
+  private void addToMemoryPoolBytesUsed(final Object observedValue) {
+    if (observedValue instanceof Number number) {
+      memoryProcessBytes += number.longValue();
+    }
   }
 
   private long getLongValue(final Object value) {
-    Double current = (Double) value;
-    return current.longValue();
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    throw new IllegalArgumentException("Unexpected value type: " + value.getClass());
   }
 
   private int getIntValue(final Object value) {
-    Double current = (Double) value;
-    return current.intValue();
+    if (value instanceof Number number) {
+      return number.intValue();
+    }
+    throw new IllegalArgumentException("Unexpected value type: " + value.getClass());
   }
 }


### PR DESCRIPTION
## PR Description

updated `getLongValue`, `getIntValue`, and `addToMemoryPoolBytesUsed` to use `Number` instead of forcing a cast to `Double`.

this prevents `ClassCastException` when Prometheus returns `Integer`, `Long`, or `Float`.

the rest of the logic remains unchanged.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
