### PR TITLE
Added Gloas fork transition

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -65,10 +65,13 @@ public class ReferenceTestFinder {
               // TODO-GLOAS: Short circuit to limit what tests we run for Gloas while it is under
               // development
               // This is temporary and should be removed once we are up-to-date with Gloas specs
-              // (see
-              // https://github.com/Consensys/teku-internal/issues/221)
+              // (see https://github.com/Consensys/teku-internal/issues/221)
               if (fork.equals(TestFork.GLOAS)) {
-                return Stream.of(new SszTestFinder("ssz_generic"), new SszTestFinder("ssz_static"))
+                return Stream.of(
+                        new SszTestFinder("ssz_generic"),
+                        new SszTestFinder("ssz_static"),
+                        // Temporarily adding only specific test types that we support
+                        new PyspecTestFinder("fork/fork", "networking/", "rewards/"))
                     .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
               }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -13,8 +13,13 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.forktransition;
 
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingPayment;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
@@ -77,6 +82,26 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
               state.setPendingPartialWithdrawals(preStateFulu.getPendingPartialWithdrawals());
               state.setPendingConsolidations(preStateFulu.getPendingConsolidations());
               state.setProposerLookahead(preStateFulu.getProposerLookahead());
+              // New in Gloas
+              final SszBitvector executionPayloadAvailability =
+                  schemaDefinitions
+                      .getExecutionPayloadAvailabilitySchema()
+                      .ofBits(IntStream.range(0, specConfig.getSlotsPerHistoricalRoot()).toArray());
+              state.setExecutionPayloadAvailability(executionPayloadAvailability);
+              final List<BuilderPendingPayment> builderPendingPayments =
+                  IntStream.range(0, 2 * specConfig.getSlotsPerEpoch())
+                      .mapToObj(
+                          __ -> schemaDefinitions.getBuilderPendingPaymentSchema().getDefault())
+                      .toList();
+              state.setBuilderPendingPayments(
+                  schemaDefinitions
+                      .getBuilderPendingPaymentsSchema()
+                      .createFromElements(builderPendingPayments));
+              state.setBuilderPendingWithdrawals(
+                  schemaDefinitions.getBuilderPendingWithdrawalsSchema().getDefault());
+              state.setLatestBlockHash(
+                  preStateFulu.getLatestExecutionPayloadHeader().getBlockHash());
+              state.setLatestWithdrawalsRoot(Bytes32.ZERO);
             });
   }
 }


### PR DESCRIPTION
## PR Description

Implemented Gloas fork transition from Fulu (reference: https://github.com/ethereum/consensus-specs/blob/365320e778965631cbef11fd93328e82a746b1f6/specs/gloas/fork.md)

I have also updated `PyspecTestFinder` to allow for extra reference tests being run for Gloas. Now we have the option of adding specific test types that we want to run.

## Fixed Issue(s)
fixes #9879

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
