### PR TITLE
Cleaned up recovery map as tasks complete

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -152,7 +152,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   public synchronized void stop() {
     if (recoveryBySlotCleaner != null) {
       recoveryBySlotCleaner.cancel();
-      pendingRequestsChecker = null;
+      recoveryBySlotCleaner = null;
     }
     if (pendingRequestsChecker != null) {
       pendingRequestsChecker.cancel();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -23,11 +23,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.Cancellable;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -52,7 +54,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
 
   private final DataColumnSidecarRetriever delegate;
   private final KZG kzg;
-  private final MiscHelpersFulu specHelpers;
+  private final MiscHelpersFulu miscHelpersFulu;
   private final CanonicalBlockResolver blockResolver;
   private final DataColumnSidecarDbAccessor sidecarDB;
   private final AsyncRunner asyncRunner;
@@ -61,6 +63,8 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   private final Duration recoveryInitiationCheckInterval;
   private final int numberOfColumns;
   private final int numberOfColumnsRequiredToReconstruct;
+  private Cancellable recoveryBySlotCleaner;
+  private Cancellable pendingRequestsChecker;
 
   private final Set<DataColumnSidecarRequestWithTimestamp> pendingRequests =
       new ConcurrentSkipListSet<>(
@@ -68,8 +72,6 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
           Comparator.comparing(DataColumnSidecarRequestWithTimestamp::timestamp)
               .thenComparing(DataColumnSidecarRequestWithTimestamp::dataColumnSlotAndIdentifier));
   private final Map<UInt64, RecoveryEntry> recoveryBySlot = new ConcurrentHashMap<>();
-
-  private Cancellable cancellable;
 
   private record DataColumnSidecarRequestWithTimestamp(
       DataColumnSlotAndIdentifier dataColumnSlotAndIdentifier,
@@ -79,7 +81,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   public RecoveringSidecarRetriever(
       final DataColumnSidecarRetriever delegate,
       final KZG kzg,
-      final MiscHelpersFulu specHelpers,
+      final MiscHelpersFulu miscHelpersFulu,
       final CanonicalBlockResolver blockResolver,
       final DataColumnSidecarDbAccessor sidecarDB,
       final AsyncRunner asyncRunner,
@@ -89,7 +91,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       final int numberOfColumns) {
     this.delegate = delegate;
     this.kzg = kzg;
-    this.specHelpers = specHelpers;
+    this.miscHelpersFulu = miscHelpersFulu;
     this.blockResolver = blockResolver;
     this.sidecarDB = sidecarDB;
     this.asyncRunner = asyncRunner;
@@ -101,11 +103,35 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     this.numberOfColumnsRequiredToReconstruct = Math.ceilDiv(numberOfColumns, 2);
   }
 
+  private void pruneRecoveryBySlot() {
+    final List<UInt64> cleanEntries =
+        recoveryBySlot.entrySet().stream()
+            .filter(entry -> entry.getValue().isCancelled() || entry.getValue().isDone())
+            .map(Map.Entry::getKey)
+            .toList();
+    LOG.debug(
+        "Pruning recovery by slot, found {} of a total {} entries...",
+        cleanEntries.size(),
+        recoveryBySlot.size());
+
+    final int limit = Math.min(cleanEntries.size(), 500);
+    int count = 0;
+    for (; count < limit; count++) {
+      final RecoveryEntry entry = recoveryBySlot.remove(cleanEntries.get(count));
+      if (entry != null) {
+        entry.cancel();
+      }
+    }
+    if (!cleanEntries.isEmpty()) {
+      LOG.debug("Cleaned {} of {} items from recovery by slot map", count, cleanEntries.size());
+    }
+  }
+
   public synchronized void start() {
-    if (cancellable != null) {
+    if (pendingRequestsChecker != null) {
       return;
     }
-    cancellable =
+    pendingRequestsChecker =
         asyncRunner.runWithFixedDelay(
             this::checkPendingRequests,
             recoveryInitiationCheckInterval,
@@ -115,14 +141,23 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
                     "Failed to check if {} pending data column sidecars requests require recovery to be ran",
                     pendingRequests.size(),
                     error));
+
+    recoveryBySlotCleaner =
+        asyncRunner.runWithFixedDelay(
+            this::pruneRecoveryBySlot,
+            Duration.ofSeconds(90),
+            error -> LOG.warn("Failed to cleanup recoveryBySlot structure.", error));
   }
 
   public synchronized void stop() {
-    if (cancellable == null) {
+    if (pendingRequestsChecker == null) {
       return;
     }
-    cancellable.cancel();
-    cancellable = null;
+    recoveryBySlotCleaner.cancel();
+    recoveryBySlotCleaner = null;
+
+    pendingRequestsChecker.cancel();
+    pendingRequestsChecker = null;
   }
 
   @Override
@@ -202,28 +237,43 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
 
   private RecoveryEntry addRecovery(
       final DataColumnSlotAndIdentifier columnId, final BeaconBlock block) {
-    return recoveryBySlot.compute(
-        columnId.slot(),
-        (slot, existingRecovery) -> {
-          if (existingRecovery != null
-              && !existingRecovery.block.getRoot().equals(block.getRoot())) {
-            // we are recovering obsolete column which is no more on our canonical chain
-            existingRecovery.cancel();
-          }
-          if (existingRecovery == null || existingRecovery.cancelled) {
-            return createNewRecovery(block);
-          } else {
-            return existingRecovery;
-          }
-        });
+    final RecoveryEntry recoveryEntry =
+        recoveryBySlot.computeIfAbsent(columnId.slot(), (slot) -> createNewRecovery(block));
+
+    if (!recoveryEntry.blockRoot.equals(block.getRoot())) {
+      LOG.debug(
+          "Found a new block {} at slot {}, pivoting recovery.",
+          block.getRoot(),
+          recoveryEntry.blockRoot);
+      recoveryEntry.cancel();
+      final RecoveryEntry newRecoveryEntry = createNewRecovery(block);
+      recoveryBySlot.replace(columnId.slot(), recoveryEntry, newRecoveryEntry);
+      return newRecoveryEntry;
+    }
+    return recoveryEntry;
   }
 
   private RecoveryEntry createNewRecovery(final BeaconBlock block) {
-    final RecoveryEntry recoveryEntry = new RecoveryEntry(block, kzg, specHelpers);
+    final Consumer<UInt64> cleanup =
+        (slot) -> {
+          LOG.trace("Cleanup recovery for slot {}", slot);
+          final RecoveryEntry entry = recoveryBySlot.remove(slot);
+          if (entry != null
+              && !entry.isCancelled()
+              && !entry.isDone()
+              && !entry.responsesByColIdx.isEmpty()) {
+            LOG.trace(
+                "Cleaning up after completed task but recovery entry was not completed cleanly {}:{} ",
+                entry.slot,
+                entry.blockRoot);
+            entry.cancel();
+          }
+        };
+    final RecoveryEntry recoveryEntry = new RecoveryEntry(block, cleanup, kzg, miscHelpersFulu);
     LOG.trace(
         "Recovery: new RecoveryEntry for slot {} and block {} ",
-        recoveryEntry.block.getSlot(),
-        recoveryEntry.block.getRoot());
+        recoveryEntry.slot,
+        recoveryEntry.blockRoot);
     // check existing sidecars in DB as a start
     sidecarDB
         .getColumnIdentifiers(block.getSlotAndBlockRoot())
@@ -263,9 +313,11 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   }
 
   private class RecoveryEntry {
-    private final BeaconBlock block;
+    private final Bytes32 blockRoot;
+    private final UInt64 slot;
     private final KZG kzg;
-    private final MiscHelpersFulu specHelpers;
+    private final MiscHelpersFulu miscHelpers;
+    private final Consumer<UInt64> taskCleaner;
 
     private final Map<UInt64, DataColumnSidecar> existingSidecarsByColIdx =
         new ConcurrentHashMap<>();
@@ -277,10 +329,16 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
 
     private boolean cancelled = false;
 
-    RecoveryEntry(final BeaconBlock block, final KZG kzg, final MiscHelpersFulu specHelpers) {
-      this.block = block;
+    RecoveryEntry(
+        final BeaconBlock block,
+        final Consumer<UInt64> taskCleaner,
+        final KZG kzg,
+        final MiscHelpersFulu miscHelpersFulu) {
+      this.blockRoot = block.getRoot();
+      this.slot = block.getSlot();
       this.kzg = kzg;
-      this.specHelpers = specHelpers;
+      this.miscHelpers = miscHelpersFulu;
+      this.taskCleaner = taskCleaner;
     }
 
     void addRequest(final UInt64 columnIndex, final SafeFuture<DataColumnSidecar> response) {
@@ -292,7 +350,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     }
 
     void addSidecar(final DataColumnSidecar sidecar) {
-      if (!cancelled && sidecar.getBlockRoot().equals(block.getRoot())) {
+      if (!cancelled && sidecar.getBlockRoot().equals(blockRoot)) {
         existingSidecarsByColIdx.put(sidecar.getIndex(), sidecar);
         // attempt to complete any pending requests immediately
         final List<SafeFuture<DataColumnSidecar>> responses =
@@ -327,7 +385,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
 
     synchronized void attemptRecoveryViaPeers() {
       if (!cancelled && recoveryPeerRequests == null) {
-        LOG.trace("Initialising peer recovery requests for slot {}", block.getSlot());
+        LOG.trace("Initialising peer recovery requests for slot {}", slot);
         recoveryPeerRequests =
             IntStream.range(0, numberOfColumns)
                 .mapToObj(UInt64::valueOf)
@@ -335,8 +393,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
                 .map(
                     columnIdx -> {
                       final DataColumnSlotAndIdentifier columnId =
-                          new DataColumnSlotAndIdentifier(
-                              block.getSlot(), block.getRoot(), columnIdx);
+                          new DataColumnSlotAndIdentifier(slot, blockRoot, columnIdx);
                       final SafeFuture<DataColumnSidecar> sidecarFuture =
                           delegate.retrieve(columnId);
                       sidecarFuture
@@ -365,7 +422,12 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
           .flatMap(Collection::stream)
           .forEach(response -> response.cancel(true));
       if (recoveryPeerRequests != null) {
-        recoveryPeerRequests.forEach(request -> request.cancel(true));
+        recoveryPeerRequests.forEach(
+            request -> {
+              if (!request.isDone()) {
+                request.cancel(true);
+              }
+            });
       }
       if (reconstructionInProgress != null) {
         reconstructionInProgress.cancel(true);
@@ -407,12 +469,12 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     }
 
     private void reconstruct() {
-      LOG.trace(
+      LOG.debug(
           "Reconstruction started for slot {} ({} existing data column sidecars)",
-          block.getSlot(),
+          slot,
           existingSidecarsByColIdx.size());
       final Map<UInt64, DataColumnSidecar> reconstructedSidecars =
-          specHelpers
+          miscHelpers
               .reconstructAllDataColumnSidecars(existingSidecarsByColIdx.values(), kzg)
               .stream()
               .collect(
@@ -421,7 +483,8 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     }
 
     private void reconstructionComplete() {
-      LOG.trace("Reconstruction completed for slot {}", block.getSlot());
+      LOG.debug("Reconstruction completed for slot {}", slot);
+
       // complete all retrieval requests
       responsesByColIdx.forEach(
           (colIdx, responses) -> {
@@ -429,10 +492,22 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
             responses.forEach(response -> response.completeAsync(columnSidecar, asyncRunner));
           });
       responsesByColIdx.clear();
+
+      // cleanup parent map now that tasks are marked complete
+      taskCleaner.accept(slot);
+
       // cancel all pending recovery peer requests
       if (recoveryPeerRequests != null) {
         recoveryPeerRequests.forEach(request -> request.cancel(true));
       }
+    }
+
+    boolean isCancelled() {
+      return cancelled;
+    }
+
+    boolean isDone() {
+      return reconstructionInProgress != null && reconstructionInProgress.isDone();
     }
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
@@ -359,7 +359,7 @@ public class DasCustodySyncTest {
     assertThat(retrieveRequests)
         .allSatisfy(
             request2 -> {
-              assertThat(request2.promise()).isCancelled();
+              assertThat(request2.future()).isCancelled();
             });
     assertThat(retrieverStub.requests).hasSize(retrieveRequests.size() * 2);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -127,8 +127,8 @@ public class RecoveringSidecarRetrieverTest {
     assertThat(delegateRetriever.requests).hasSize(3);
     assertThat(recoverRetriever.pendingRequestsCount()).isEqualTo(3);
 
-    // id2 promise completes immediately
-    delegateRetriever.requests.get(2).promise().complete(sidecars.get(2));
+    // id2 future completes immediately
+    delegateRetriever.requests.get(2).future().complete(sidecars.get(2));
     assertThat(res2).isCompletedWithValue(sidecars.get(2));
     assertThat(recoverRetriever.pendingRequestsCount()).isEqualTo(2);
 
@@ -161,13 +161,14 @@ public class RecoveringSidecarRetrieverTest {
         .skip(50)
         .limit(columnCount / 2 - columnsInDbCount)
         .forEach(
-            req -> req.promise().complete(sidecars.get(req.columnId().columnIndex().intValue())));
+            req -> req.future().complete(sidecars.get(req.columnId().columnIndex().intValue())));
 
     stubAsyncRunner.executeDueActionsRepeatedly();
 
     assertThat(res0).isCompletedWithValue(sidecars.get(0));
     assertThat(res1).isCompletedWithValue(sidecars.get(1));
-    assertThat(delegateRetriever.requests).allMatch(r -> r.promise().isDone());
+
+    assertThat(delegateRetriever.requests).allMatch(r -> r.future().isDone());
   }
 
   @Test
@@ -239,12 +240,12 @@ public class RecoveringSidecarRetrieverTest {
         .limit(columnCount / 2 - columnsInDbCount)
         .forEach(
             req ->
-                req.promise().complete(sidecars_10_1.get(req.columnId().columnIndex().intValue())));
+                req.future().complete(sidecars_10_1.get(req.columnId().columnIndex().intValue())));
 
     stubAsyncRunner.executeDueActionsRepeatedly();
 
     assertThat(res0).isCompletedWithValue(sidecars_10_1.get(100));
-    assertThat(delegateRetriever.requests).allMatch(r -> r.promise().isDone());
+    assertThat(delegateRetriever.requests).allMatch(r -> r.future().isDone());
   }
 
   @Test
@@ -277,6 +278,6 @@ public class RecoveringSidecarRetrieverTest {
 
     stubAsyncRunner.executeQueuedActions();
 
-    assertThat(delegateRetriever.requests).allMatch(r -> r.promise().isCancelled());
+    assertThat(delegateRetriever.requests).allMatch(r -> r.future().isCancelled());
   }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetrieverStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetrieverStub.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 public class DataColumnSidecarRetrieverStub implements DataColumnSidecarRetriever {
 
   public record RetrieveRequest(
-      DataColumnSlotAndIdentifier columnId, SafeFuture<DataColumnSidecar> promise) {}
+      DataColumnSlotAndIdentifier columnId, SafeFuture<DataColumnSidecar> future) {}
 
   public List<RetrieveRequest> requests = new ArrayList<>();
   private final Map<DataColumnSlotAndIdentifier, DataColumnSidecar> readySidecars = new HashMap<>();
@@ -34,7 +34,7 @@ public class DataColumnSidecarRetrieverStub implements DataColumnSidecarRetrieve
     readySidecars.put(colId, sidecar);
     requests.stream()
         .filter(req -> req.columnId.equals(colId))
-        .forEach(req -> req.promise.complete(sidecar));
+        .forEach(req -> req.future.complete(sidecar));
   }
 
   @Override
@@ -43,9 +43,9 @@ public class DataColumnSidecarRetrieverStub implements DataColumnSidecarRetrieve
     requests.add(request);
     final DataColumnSidecar maybeSidecar = readySidecars.get(columnId);
     if (maybeSidecar != null) {
-      request.promise.complete(maybeSidecar);
+      request.future.complete(maybeSidecar);
     }
-    return request.promise;
+    return request.future;
   }
 
   @Override


### PR DESCRIPTION
Added a timed task in case we miss items going through completed, but generally speaking the completed cleanup should finish things off nicely.

Also addressed the issue of storing the block in the recoveryEntry when we only need the slot and root.

I do think there's more to do here but focused on the stated problem.

fixes #9875

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
