### PR TITLE
Modified `process_attestation` for Gloas

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -80,6 +80,7 @@ public class ReferenceTestFinder {
                                 "networking/",
                                 "rewards/",
                                 "epoch_processing/",
+                                "operations/attestation",
                                 "operations/withdrawals",
                                 "operations/proposer_slashing",
                                 "operations/execution_payload",

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPayment.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPayment.java
@@ -41,6 +41,10 @@ public class BuilderPendingPayment
     return getField1();
   }
 
+  public BuilderPendingPayment copyWithNewWeight(final UInt64 newWeight) {
+    return new BuilderPendingPayment(getSchema(), newWeight, getWithdrawal());
+  }
+
   @Override
   public BuilderPendingPaymentSchema getSchema() {
     return (BuilderPendingPaymentSchema) super.getSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
@@ -21,6 +21,8 @@ public interface AttestationDataValidator
   enum AttestationInvalidReason implements OperationInvalidReason {
     COMMITTEE_INDEX_TOO_HIGH("CommitteeIndex too high"),
     COMMITTEE_INDEX_MUST_BE_ZERO("CommitteeIndex must be set to zero"),
+    COMMITTEE_INDEX_MUST_BE_LESS_THAN_TWO(
+        "CommitteeIndex (used for payload availability) must be less than two"),
     PARTICIPANTS_COUNT_MISMATCH("Attesting participants count do not match aggregation bits"),
     NOT_FROM_CURRENT_OR_PREVIOUS_EPOCH("Attestation not from current or previous epoch"),
     SLOT_NOT_IN_EPOCH("Attestation slot not in specified epoch"),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
@@ -158,8 +158,10 @@ public class BlockRewardCalculatorUtil {
     return block.getBody().getAttestations().stream()
         .map(
             attestation ->
-                blockProcessor.processAttestationProposerReward(
-                    mutableBeaconStateAltair, attestation, indexedAttestationProvider))
+                blockProcessor
+                    .calculateAttestationProcessingResult(
+                        mutableBeaconStateAltair, attestation, indexedAttestationProvider)
+                    .proposerReward())
         .filter(Optional::isPresent)
         .map(Optional::get)
         .map(UInt64::longValue)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -190,9 +190,7 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
     final boolean isMatchingTarget =
         isMatchingSource
             && data.getTarget().getRoot().equals(getBlockRoot(state, data.getTarget().getEpoch()));
-    final boolean isMatchingHead =
-        isMatchingTarget
-            && data.getBeaconBlockRoot().equals(getBlockRootAtSlot(state, data.getSlot()));
+    final boolean isMatchingHead = computeIsMatchingHead(isMatchingTarget, data, state);
 
     // Participation flag indices
     final IntList participationFlagIndices = new IntArrayList();
@@ -208,6 +206,12 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
       participationFlagIndices.add(ParticipationFlags.TIMELY_HEAD_FLAG_INDEX);
     }
     return participationFlagIndices;
+  }
+
+  protected boolean computeIsMatchingHead(
+      final boolean isMatchingTarget, final AttestationData data, final BeaconState state) {
+    return isMatchingTarget
+        && data.getBeaconBlockRoot().equals(getBlockRootAtSlot(state, data.getSlot()));
   }
 
   protected boolean shouldSetTargetTimelinessFlag(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/AttestationDataValidatorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/AttestationDataValidatorElectra.java
@@ -64,10 +64,7 @@ public class AttestationDataValidatorElectra implements AttestationDataValidator
                         .compareTo(state.getSlot())
                     <= 0,
                 AttestationInvalidReason.SUBMITTED_TOO_QUICKLY),
-        () ->
-            check(
-                data.getIndex().equals(UInt64.ZERO),
-                AttestationInvalidReason.COMMITTEE_INDEX_MUST_BE_ZERO),
+        () -> checkCommitteeIndex(data),
         () -> {
           if (data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state))) {
             return check(
@@ -79,5 +76,10 @@ public class AttestationDataValidatorElectra implements AttestationDataValidator
                 AttestationInvalidReason.INCORRECT_PREVIOUS_JUSTIFIED_CHECKPOINT);
           }
         });
+  }
+
+  protected Optional<OperationInvalidReason> checkCommitteeIndex(final AttestationData data) {
+    return check(
+        data.getIndex().equals(UInt64.ZERO), AttestationInvalidReason.COMMITTEE_INDEX_MUST_BE_ZERO);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -21,9 +21,7 @@ import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadProcessor;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
-import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
@@ -37,7 +35,6 @@ import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.Opera
 import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
-import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.AttestationDataValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.BlindBlockUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.block.BlockProcessorGloas;
@@ -46,6 +43,7 @@ import tech.pegasys.teku.spec.logic.versions.gloas.forktransition.GloasStateUpgr
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.operations.validation.AttestationDataValidatorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch.EpochProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.AttestationUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.withdrawals.WithdrawalsHelpersGloas;
@@ -66,7 +64,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
       final OperationSignatureVerifier operationSignatureVerifier,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
-      final AttestationUtil attestationUtil,
+      final AttestationUtilGloas attestationUtil,
       final OperationValidator operationValidator,
       final ValidatorStatusFactoryAltair validatorStatusFactory,
       final EpochProcessorGloas epochProcessor,
@@ -130,8 +128,8 @@ public class SpecLogicGloas extends AbstractSpecLogic {
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtilGloas attestationUtil =
         new AttestationUtilGloas(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
-    final AttestationDataValidator attestationDataValidator =
-        new AttestationDataValidatorElectra(config, miscHelpers, beaconStateAccessors);
+    final AttestationDataValidatorGloas attestationDataValidator =
+        new AttestationDataValidatorGloas(config, miscHelpers, beaconStateAccessors);
     final VoluntaryExitValidatorElectra voluntaryExitValidatorElectra =
         new VoluntaryExitValidatorElectra(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/validation/AttestationDataValidatorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/validation/AttestationDataValidatorGloas.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.operations.validation;
+
+import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
+
+import java.util.Optional;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.AttestationDataValidatorElectra;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
+
+public class AttestationDataValidatorGloas extends AttestationDataValidatorElectra {
+
+  public AttestationDataValidatorGloas(
+      final SpecConfigGloas specConfig,
+      final MiscHelpersGloas miscHelpers,
+      final BeaconStateAccessorsGloas beaconStateAccessors) {
+    super(specConfig, miscHelpers, beaconStateAccessors);
+  }
+
+  /**
+   * <a
+   * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#modified-process_attestation">Modified
+   * process_attestation</a>
+   */
+  @Override
+  protected Optional<OperationInvalidReason> checkCommitteeIndex(final AttestationData data) {
+    return check(
+        // signalling payload availability
+        data.getIndex().isLessThan(2),
+        AttestationInvalidReason.COMMITTEE_INDEX_MUST_BE_LESS_THAN_TWO);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil.BlockRewardData;
 import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair.AttestationProcessingResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockRewardCalculatorUtilTest {
@@ -93,8 +94,8 @@ public class BlockRewardCalculatorUtilTest {
     // reward equals the number of attestations
     when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
         .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
-    when(blockProcessorAltair.processAttestationProposerReward(any(), any(), any()))
-        .thenReturn(Optional.of(UInt64.ONE));
+    when(blockProcessorAltair.calculateAttestationProcessingResult(any(), any(), any()))
+        .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), false, UInt64.ZERO));
     final BeaconState preState = data.randomBeaconState();
     final BeaconBlock block =
         data.blockBuilder(preState.getSlot().increment().longValue())
@@ -104,15 +105,16 @@ public class BlockRewardCalculatorUtilTest {
     final BlockRewardData reward =
         calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
     assertThat(reward.attestations()).isEqualTo(10L);
-    verify(blockProcessorAltair, times(10)).processAttestationProposerReward(any(), any(), any());
+    verify(blockProcessorAltair, times(10))
+        .calculateAttestationProcessingResult(any(), any(), any());
   }
 
   @Test
   void getBlockRewardData_shouldOutputRewardData() {
     when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
         .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
-    when(blockProcessorAltair.processAttestationProposerReward(any(), any(), any()))
-        .thenReturn(Optional.of(UInt64.ONE));
+    when(blockProcessorAltair.calculateAttestationProcessingResult(any(), any(), any()))
+        .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), false, UInt64.ZERO));
     final BeaconState preState = data.randomBeaconState();
     final BeaconBlock block =
         data.blockBuilder(preState.getSlot().increment().longValue())
@@ -133,7 +135,8 @@ public class BlockRewardCalculatorUtilTest {
                 140L,
                 3 * SINGLE_SLASHING_REWARD,
                 2 * SINGLE_SLASHING_REWARD));
-    verify(blockProcessorAltair, times(10)).processAttestationProposerReward(any(), any(), any());
+    verify(blockProcessorAltair, times(10))
+        .calculateAttestationProcessingResult(any(), any(), any());
   }
 
   @Test

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerCSV.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerCSV.java
@@ -316,8 +316,10 @@ public class AggregatingAttestationPoolProfilerCSV implements AggregatingAttesta
     attestations.forEach(
         attestation ->
             rewards.add(
-                blockProcessor.processAttestationProposerReward(
-                    mutableBeaconStateAltair, attestation, indexedAttestationProvider)));
+                blockProcessor
+                    .calculateAttestationProcessingResult(
+                        mutableBeaconStateAltair, attestation, indexedAttestationProvider)
+                    .proposerReward()));
 
     return rewards.stream()
         .map(maybeValue -> maybeValue.orElse(UInt64.ZERO))

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerLog.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerLog.java
@@ -135,8 +135,10 @@ public class AggregatingAttestationPoolProfilerLog implements AggregatingAttesta
     attestations.forEach(
         attestation ->
             rewards.add(
-                blockProcessor.processAttestationProposerReward(
-                    mutableBeaconStateAltair, attestation, indexedAttestationProvider)));
+                blockProcessor
+                    .calculateAttestationProcessingResult(
+                        mutableBeaconStateAltair, attestation, indexedAttestationProvider)
+                    .proposerReward()));
 
     return rewards.stream()
         .filter(Optional::isPresent)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#modified-process_attestation

**Passed reference tests:**
<img width="1528" height="378" alt="image" src="https://github.com/user-attachments/assets/b5ba64aa-eca9-41c4-9b3f-eff1c21fdd3c" />

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Gloas-modified process_attestation (payload availability, same-slot handling, builder payment weight), refactors Altair attestation processing API, adds Gloas validator, and updates utilities/tests accordingly.
> 
> - **Gloas**:
>   - **Validation**: Add `AttestationDataValidatorGloas` enforcing `data.index < 2`; wire into `SpecLogicGloas`.
>   - **Accessors**: `BeaconStateAccessorsGloas` adds `isAttestationSameSlot(...)` and overrides head matching to include payload-availability index logic.
>   - **Block Processing**: `BlockProcessorGloas` consumes attestation processing result to update builder pending payments; adds weight for same-slot attestations via `updateBuilderPaymentWeight(...)`.
>   - **Data Structure**: `BuilderPendingPayment` adds `copyWithNewWeight(...)`.
> - **Altair/Common**:
>   - **API Refactor**: Replace `processAttestationProposerReward(...)` with `calculateAttestationProcessingResult(...)` returning `proposerReward`, `currentEpochTarget`, and `builderPaymentWeightDelta`; add `consumeAttestationProcessingResult(...)`.
>   - **Accessors**: Extract `computeIsMatchingHead(...)` in `BeaconStateAccessorsAltair` for fork overrides.
>   - **Utilities/Profilers**: Update `BlockRewardCalculatorUtil` and attestation profiler tools to use new API.
>   - **Tests**: Adjust `BlockRewardCalculatorUtilTest` to new attestation processing result.
> - **Reference Tests**: Enable Gloas pyspec `operations/attestation` in `ReferenceTestFinder`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 702378007bf780d5ddea79eb5636e5b0486b428e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->