### PR TITLE
add no-op bls signature verifier

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.ssz.SszCollection;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -39,7 +40,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
 
-  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final Spec spec =
+      TestSpecFactory.createMinimalDeneb(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszCollection;
@@ -45,7 +46,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
 
-  private final Spec spec = TestSpecFactory.createMinimalFulu();
+  private final Spec spec =
+      TestSpecFactory.createMinimalFulu(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
@@ -16,13 +16,21 @@ package tech.pegasys.teku.validator.coordinator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static tech.pegasys.teku.spec.SpecMilestone.ALTAIR;
+import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
+import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 import static tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateAssert.assertThatSyncAggregate;
+import static tech.pegasys.teku.spec.networks.Eth2Network.MINIMAL;
 
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
@@ -35,25 +43,37 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTrans
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
+
+  private final Consumer<SpecConfigBuilder> configAdapter =
+      builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP);
+
   @Test
   public void shouldCreateBlockAfterNormalSlot() {
-    assertBlockCreated(1, TestSpecFactory.createMinimalPhase0(), false, state -> {}, false);
+    assertBlockCreated(
+        1, TestSpecFactory.create(PHASE0, MINIMAL, configAdapter), false, state -> {}, false);
   }
 
   @Test
   public void shouldCreateBlockAfterSkippedSlot() {
-    assertBlockCreated(2, TestSpecFactory.createMinimalPhase0(), false, state -> {}, false);
+    assertBlockCreated(
+        2, TestSpecFactory.create(PHASE0, MINIMAL, configAdapter), false, state -> {}, false);
   }
 
   @Test
   public void shouldCreateBlockAfterMultipleSkippedSlot() {
-    assertBlockCreated(5, TestSpecFactory.createMinimalPhase0(), false, state -> {}, false);
+    assertBlockCreated(
+        5, TestSpecFactory.create(PHASE0, MINIMAL, configAdapter), false, state -> {}, false);
   }
 
   @Test
   void shouldIncludeSyncAggregateWhenAltairIsActive() {
     final BeaconBlock block =
-        assertBlockCreated(1, TestSpecFactory.createMinimalAltair(), false, state -> {}, false)
+        assertBlockCreated(
+                1,
+                TestSpecFactory.create(ALTAIR, MINIMAL, configAdapter),
+                false,
+                state -> {},
+                false)
             .blockContainer()
             .getBlock();
     final SyncAggregate result = getSyncAggregate(block);
@@ -64,7 +84,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void shouldIncludeExecutionPayloadWhenBellatrixIsActive() {
-    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final Spec spec = TestSpecFactory.create(BELLATRIX, MINIMAL, configAdapter);
     final BeaconBlock block =
         assertBlockCreated(1, spec, false, state -> prepareDefaultPayload(spec), false)
             .blockContainer()
@@ -75,7 +95,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void shouldCreateCapellaBlock() {
-    final Spec spec = TestSpecFactory.createMinimalCapella();
+    final Spec spec = TestSpecFactory.create(CAPELLA, MINIMAL, configAdapter);
     final BeaconBlock block =
         assertBlockCreated(1, spec, true, state -> prepareValidPayload(spec, state), false)
             .blockContainer()
@@ -87,7 +107,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void shouldIncludeExecutionPayloadHeaderWhenBellatrixIsActiveAndBlindedBlockRequested() {
-    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final Spec spec = TestSpecFactory.create(BELLATRIX, MINIMAL, configAdapter);
     final BeaconBlock block =
         assertBlockCreated(1, spec, false, state -> prepareDefaultPayload(spec), true)
             .blockContainer()
@@ -98,7 +118,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void shouldThrowPostMergeWithWrongPayload() {
-    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final Spec spec = TestSpecFactory.create(BELLATRIX, MINIMAL, configAdapter);
     assertThatThrownBy(
             () -> assertBlockCreated(1, spec, true, state -> prepareDefaultPayload(spec), false))
         .hasCauseInstanceOf(StateTransitionException.class);
@@ -106,7 +126,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void unblindSignedBlock_shouldThrowWhenUnblindingBlockWithInconsistentExecutionPayload() {
-    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final Spec spec = TestSpecFactory.create(BELLATRIX, MINIMAL, configAdapter);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
     final SignedBeaconBlock signedBlock = dataStructureUtil.randomSignedBlindedBeaconBlock(1);
@@ -118,7 +138,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void unblindSignedBlock_shouldPassthroughUnblindedBlocks() {
-    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final Spec spec = TestSpecFactory.create(BELLATRIX, MINIMAL, configAdapter);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
     final SignedBeaconBlock originalUnblindedSignedBlock =
@@ -132,7 +152,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void unblindSignedBlock_shouldPassthroughInNonBellatrixBlocks() {
-    final Spec spec = TestSpecFactory.createMinimalAltair();
+    final Spec spec = TestSpecFactory.create(ALTAIR, MINIMAL, configAdapter);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
     final SignedBeaconBlock originalAltairSignedBlock =
@@ -146,7 +166,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   void unblindSignedBlock_shouldUnblindBlockWhenBellatrixIsActive() {
-    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final Spec spec = TestSpecFactory.create(BELLATRIX, MINIMAL, configAdapter);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
     final SignedBeaconBlock originalUnblindedSignedBlock =
@@ -170,7 +190,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
   @Test
   void shouldCreateEmptyBlobSidecarsForBlock() {
     final BlockAndBlobSidecars blockAndBlobSidecars =
-        createBlockAndBlobSidecars(false, TestSpecFactory.createMinimalPhase0());
+        createBlockAndBlobSidecars(false, TestSpecFactory.create(PHASE0, MINIMAL, configAdapter));
 
     assertThat(blockAndBlobSidecars.blobSidecars()).isEmpty();
   }
@@ -178,7 +198,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
   @Test
   void shouldCreateEmptyBlobSidecarsForBlindedBlock() {
     final BlockAndBlobSidecars blockAndBlobSidecars =
-        createBlockAndBlobSidecars(true, TestSpecFactory.createMinimalPhase0());
+        createBlockAndBlobSidecars(true, TestSpecFactory.create(PHASE0, MINIMAL, configAdapter));
 
     assertThat(blockAndBlobSidecars.blobSidecars()).isEmpty();
   }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenalty;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
@@ -100,9 +99,10 @@ public class EpochTransitionBenchmark {
   @Setup(Level.Trial)
   @SuppressWarnings("deprecation")
   public void init() throws Exception {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-
-    spec = TestSpecFactory.createMainnetAltair();
+    spec =
+        TestSpecFactory.createMainnetAltair(
+            specConfigBuilder ->
+                specConfigBuilder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
     asyncRunner = DelayedExecutorAsyncRunner.create();
     String blocksFile =
         "/blocks/blocks_epoch_"

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProcessSyncAggregateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProcessSyncAggregateBenchmark.java
@@ -43,7 +43,6 @@ import tech.pegasys.teku.spec.datastructures.interop.GenesisStateBuilder;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -61,8 +60,9 @@ public class ProcessSyncAggregateBenchmark {
 
   @Setup(Level.Trial)
   public void init() throws Exception {
-    spec = TestSpecFactory.createMainnetAltair();
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
+    spec =
+        TestSpecFactory.createMainnetAltair(
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
 
     final List<BLSKeyPair> validatorKeys = KeyFileGenerator.readValidatorKeys(validatorsCount);
 

--- a/eth-benchmark-tests/src/testFixtures/java/tech/pegasys/teku/benchmarks/gen/BlockArchiveGenerator.java
+++ b/eth-benchmark-tests/src/testFixtures/java/tech/pegasys/teku/benchmarks/gen/BlockArchiveGenerator.java
@@ -38,7 +38,9 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class BlockArchiveGenerator {
   private final int validatorCount;
   private final int epochCount;
-  private final Spec spec = TestSpecFactory.createMainnetAltair();
+  private final Spec spec =
+      TestSpecFactory.createMainnetAltair(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final List<BLSKeyPair> validatorKeys;
   private final RecentChainData localStorage;
   private final AttestationGenerator attestationGenerator;

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.ethtests.finder;
 
 import java.nio.file.Path;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.TestSpecConfig;
 import tech.pegasys.teku.spec.Spec;
@@ -52,13 +53,17 @@ public class TestDefinition {
   }
 
   public Spec getSpec() {
+    return getSpec(true);
+  }
+
+  public Spec getSpec(final boolean blsSignatureVerificationEnabled) {
     if (spec == null) {
-      createSpec();
+      createSpec(blsSignatureVerificationEnabled);
     }
     return spec;
   }
 
-  private void createSpec() {
+  private void createSpec(final boolean blsSignatureVerificationEnabled) {
     final Eth2Network network =
         switch (configName) {
           case TestSpecConfig.MAINNET -> Eth2Network.MAINNET;
@@ -76,7 +81,11 @@ public class TestDefinition {
           case TestFork.FULU -> SpecMilestone.FULU;
           default -> throw new IllegalArgumentException("Unknown fork: " + fork);
         };
-    spec = TestSpecFactory.create(milestone, network);
+    final BLSSignatureVerifier blsSignatureVerifier =
+        blsSignatureVerificationEnabled ? BLSSignatureVerifier.SIMPLE : BLSSignatureVerifier.NO_OP;
+    spec =
+        TestSpecFactory.create(
+            milestone, network, builder -> builder.blsSignatureVerifier(blsSignatureVerifier));
   }
 
   public String getTestType() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
@@ -34,7 +34,9 @@ public class BuilderCircuitBreakerImplTest {
   private static final int ALLOWED_FAULTS = 5;
   private static final int ALLOWED_CONSECUTIVE_FAULTS = 2;
 
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final Spec spec =
+      TestSpecFactory.createMinimalBellatrix(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
 
   private final BuilderCircuitBreakerImpl builderCircuitBreaker =
       new BuilderCircuitBreakerImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.config;
 
 import java.util.Map;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -460,5 +461,10 @@ public class DelegatingSpecConfig implements SpecConfig {
   @Override
   public SpecMilestone getMilestone() {
     return specConfig.getMilestone();
+  }
+
+  @Override
+  public BLSSignatureVerifier getBLSSignatureVerifier() {
+    return specConfig.getBLSSignatureVerifier();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.config;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -225,4 +226,6 @@ public interface SpecConfig extends NetworkingSpecConfig {
   }
 
   SpecMilestone getMilestone();
+
+  BLSSignatureVerifier getBLSSignatureVerifier();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.config;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -121,6 +122,8 @@ public class SpecConfigPhase0 implements SpecConfig {
 
   private final UInt64 maxPerEpochActivationExitChurnLimit;
 
+  private final BLSSignatureVerifier blsSignatureVerifier;
+
   // altair fork information
   private final Bytes4 altairForkVersion;
   private final UInt64 altairForkEpoch;
@@ -217,6 +220,7 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int reorgHeadWeightThreshold,
       final int reorgParentWeightThreshold,
       final UInt64 maxPerEpochActivationExitChurnLimit,
+      final BLSSignatureVerifier blsSignatureVerifier,
       final Bytes4 altairForkVersion,
       final UInt64 altairForkEpoch,
       final Bytes4 bellatrixForkVersion,
@@ -313,6 +317,7 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.fuluForkEpoch = fuluForkEpoch;
     this.eip7805ForkVersion = eip7805ForkVersion;
     this.eip7805ForkEpoch = eip7805ForkEpoch;
+    this.blsSignatureVerifier = blsSignatureVerifier;
   }
 
   @Override
@@ -748,6 +753,11 @@ public class SpecConfigPhase0 implements SpecConfig {
   @Override
   public SpecMilestone getMilestone() {
     return SpecMilestone.PHASE0;
+  }
+
+  @Override
+  public BLSSignatureVerifier getBLSSignatureVerifier() {
+    return blsSignatureVerifier;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -154,6 +155,8 @@ public class SpecConfigBuilder {
   private UInt64 fuluForkEpoch = FAR_FUTURE_EPOCH;
   private UInt64 eip7805ForkEpoch = FAR_FUTURE_EPOCH;
 
+  private BLSSignatureVerifier blsSignatureVerifier = BLSSignatureVerifier.SIMPLE;
+
   private UInt64 maxPerEpochActivationExitChurnLimit = UInt64.valueOf(256000000000L);
   private final BuilderChain<SpecConfig, SpecConfigEip7805> builderChain =
       BuilderChain.create(altairBuilder)
@@ -255,6 +258,7 @@ public class SpecConfigBuilder {
                 reorgHeadWeightThreshold,
                 reorgParentWeightThreshold,
                 maxPerEpochActivationExitChurnLimit,
+                blsSignatureVerifier,
                 altairForkVersion,
                 altairForkEpoch,
                 bellatrixForkVersion,
@@ -900,6 +904,11 @@ public class SpecConfigBuilder {
 
   public SpecConfigBuilder reorgParentWeightThreshold(final Integer reorgParentWeightThreshold) {
     this.reorgParentWeightThreshold = reorgParentWeightThreshold;
+    return this;
+  }
+
+  public SpecConfigBuilder blsSignatureVerifier(final BLSSignatureVerifier blsSignatureVerifier) {
+    this.blsSignatureVerifier = blsSignatureVerifier;
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/MutableBeaconStateFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/MutableBeaconStateFulu.java
@@ -27,7 +27,7 @@ public interface MutableBeaconStateFulu extends MutableBeaconStateElectra, Beaco
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
-                    "Expected an Electra state but got: " + state.getClass().getSimpleName()));
+                    "Expected an Fulu state but got: " + state.getClass().getSimpleName()));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -702,7 +702,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         signatures.add(deposit.getData().getSignature());
       }
       // Overwhelmingly often we expect all the deposit signatures to be good
-      return depositSignatureVerifier.verify(publicKeys, messages, signatures);
+      return specConfig.getBLSSignatureVerifier().verify(publicKeys, messages, signatures);
     } catch (final BlsException e) {
       return false;
     }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecContext.java
@@ -36,4 +36,6 @@ public @interface TestSpecContext {
   boolean allNetworks() default false;
 
   boolean doNotGenerateSpec() default false;
+
+  boolean signatureVerifierNoop() default false;
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -186,7 +186,14 @@ public class TestSpecFactory {
    */
   public static Spec createMinimalWithDenebForkEpoch(final UInt64 denebForkEpoch) {
     final SpecConfigAndParent<? extends SpecConfig> config =
-        getDenebSpecConfig(Eth2Network.MINIMAL, UInt64.ZERO, denebForkEpoch);
+        getDenebSpecConfig(Eth2Network.MINIMAL, UInt64.ZERO, denebForkEpoch, __ -> {});
+    return create(config, SpecMilestone.DENEB);
+  }
+
+  public static Spec createMinimalWithDenebForkEpoch(
+      final UInt64 denebForkEpoch, final Consumer<SpecConfigBuilder> configAdapter) {
+    final SpecConfigAndParent<? extends SpecConfig> config =
+        getDenebSpecConfig(Eth2Network.MINIMAL, UInt64.ZERO, denebForkEpoch, configAdapter);
     return create(config, SpecMilestone.DENEB);
   }
 
@@ -233,6 +240,10 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.EIP7805);
   }
 
+  public static Spec createMinimalPhase0(final Consumer<SpecConfigBuilder> configAdapter) {
+    return create(SpecMilestone.PHASE0, Eth2Network.MINIMAL, configAdapter);
+  }
+
   public static Spec createMinimalPhase0() {
     final SpecConfigAndParent<? extends SpecConfig> configAndParent =
         SpecConfigLoader.loadConfig(Eth2Network.MINIMAL.configName());
@@ -255,6 +266,10 @@ public class TestSpecFactory {
     final SpecConfigAndParent<? extends SpecConfig> specConfig =
         getAltairSpecConfig(Eth2Network.MAINNET);
     return create(specConfig, SpecMilestone.ALTAIR);
+  }
+
+  public static Spec createMainnetAltair(final Consumer<SpecConfigBuilder> configAdapter) {
+    return create(SpecMilestone.ALTAIR, Eth2Network.MAINNET, configAdapter);
   }
 
   public static Spec createMainnetCapella() {
@@ -407,6 +422,23 @@ public class TestSpecFactory {
   private static SpecConfigAndParent<? extends SpecConfig> getDenebSpecConfig(
       final Eth2Network network) {
     return getDenebSpecConfig(network, ZERO, ZERO);
+  }
+
+  private static SpecConfigAndParent<? extends SpecConfig> getDenebSpecConfig(
+      final Eth2Network network,
+      final UInt64 capellaForkEpoch,
+      final UInt64 denebForkEpoch,
+      final Consumer<SpecConfigBuilder> configAdapter) {
+    return getDenebSpecConfig(
+        network,
+        builder -> {
+          builder
+              .altairForkEpoch(ZERO)
+              .bellatrixForkEpoch(ZERO)
+              .capellaForkEpoch(capellaForkEpoch)
+              .denebForkEpoch(denebForkEpoch);
+          configAdapter.accept(builder);
+        });
   }
 
   private static SpecConfigAndParent<? extends SpecConfig> getDenebSpecConfig(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -83,7 +83,9 @@ import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 public class BlockImporterTest {
   private final AsyncRunner asyncRunner = mock(AsyncRunner.class);
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final Spec spec =
+      TestSpecFactory.createMinimalPhase0(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final SpecConfig genesisConfig = spec.getGenesisSpecConfig();
   private final AttestationSchema<?> attestationSchema =
       spec.getGenesisSchemaDefinitions().getAttestationSchema();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -73,6 +73,7 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -88,6 +89,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.availability.Availabi
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
+import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
@@ -169,7 +171,9 @@ public class BlockManagerTest {
         .when(asyncRunner)
         .runAsync((ExceptionThrowingFutureSupplier<?>) any());
 
-    setupWithSpec(TestSpecFactory.createMinimalDeneb());
+    setupWithSpec(
+        TestSpecFactory.createMinimalDeneb(
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
   }
 
   private void setupWithSpec(final Spec spec) {
@@ -844,7 +848,10 @@ public class BlockManagerTest {
   @Test
   void onDeneb_shouldStoreBlobSidecarsAlongWithBlock() {
     // If we start genesis with Deneb, 0 will be earliestBlobSidecarSlot, so started on epoch 1
-    setupWithSpec(TestSpecFactory.createMinimalWithDenebForkEpoch(UInt64.valueOf(1)));
+    setupWithSpec(
+        TestSpecFactory.createMinimalWithDenebForkEpoch(
+            UInt64.valueOf(1),
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
     incrementSlotTo(slotsPerEpoch);
 
@@ -944,7 +951,10 @@ public class BlockManagerTest {
 
   @Test
   void onDeneb_shouldStoreEarliestBlobSidecarSlotCorrectlyWhenThereIsGap() {
-    setupWithSpec(TestSpecFactory.createMinimalWithDenebForkEpoch(UInt64.valueOf(1)));
+    setupWithSpec(
+        TestSpecFactory.createMinimalWithDenebForkEpoch(
+            UInt64.valueOf(1),
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
 
     currentSlot = currentSlot.plus(slotsPerEpoch.plus(2));
@@ -973,7 +983,10 @@ public class BlockManagerTest {
   @Test
   void onDeneb_shouldStoreBlockWhenBlobSidecarsNotRequired() {
     // If we start genesis with Deneb, 0 will be earliestBlobSidecarSlot, so started on epoch 1
-    setupWithSpec(TestSpecFactory.createMinimalWithDenebForkEpoch(UInt64.valueOf(1)));
+    setupWithSpec(
+        TestSpecFactory.createMinimalWithDenebForkEpoch(
+            UInt64.valueOf(1),
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
     incrementSlotTo(slotsPerEpoch);
 
@@ -1004,7 +1017,10 @@ public class BlockManagerTest {
   @Test
   void onDeneb_shouldNotStoreBlockWhenBlobSidecarsIsNotAvailable() {
     // If we start genesis with Deneb, 0 will be earliestBlobSidecarSlot, so started on epoch 1
-    setupWithSpec(TestSpecFactory.createMinimalWithDenebForkEpoch(UInt64.valueOf(1)));
+    setupWithSpec(
+        TestSpecFactory.createMinimalWithDenebForkEpoch(
+            UInt64.valueOf(1),
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
     incrementSlotTo(slotsPerEpoch);
 
@@ -1037,7 +1053,11 @@ public class BlockManagerTest {
 
   @Test
   void preDeneb_shouldNotWorryAboutBlobSidecars() {
-    setupWithSpec(TestSpecFactory.createMinimalCapella());
+    setupWithSpec(
+        TestSpecFactory.create(
+            SpecMilestone.CAPELLA,
+            Eth2Network.MAINNET,
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
     final SignedBlockAndState signedBlockAndState1 =
         localChain
             .chainBuilder()

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -73,7 +73,9 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 class ForkChoiceNotifierTest {
 
   private final InlineEventThread eventThread = new InlineEventThread();
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final Spec spec =
+      TestSpecFactory.createMinimalBellatrix(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(10_000);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
@@ -43,7 +43,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ForkChoicePayloadExecutorTest {
 
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final Spec spec =
+      TestSpecFactory.createMinimalBellatrix(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final SchemaDefinitionsBellatrix schemaDefinitionsBellatrix =
       spec.getGenesisSchemaDefinitions().toVersionBellatrix().orElseThrow();
   private final ExecutionPayload defaultPayload =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -46,11 +46,13 @@ class MergeTransitionBlockValidatorTest {
   private final UInt64 terminalEpoch = UInt64.ZERO;
   private final Spec spec =
       TestSpecFactory.createMinimalBellatrix(
-          b ->
-              b.bellatrixBuilder(
-                  bb ->
-                      bb.terminalBlockHash(terminalBlockHash)
-                          .terminalBlockHashActivationEpoch(terminalEpoch)));
+          b -> {
+            b.blsSignatureVerifier(BLSSignatureVerifier.NO_OP);
+            b.bellatrixBuilder(
+                bb ->
+                    bb.terminalBlockHash(terminalBlockHash)
+                        .terminalBlockHashActivationEpoch(terminalEpoch));
+          });
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ExecutionLayerChannelStub executionLayer =
       new ExecutionLayerChannelStub(spec, false);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import tech.pegasys.infrastructure.logging.LogCaptor;
@@ -46,7 +44,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -71,17 +68,6 @@ public class TerminalPowBlockMonitorTest {
   private RecentChainData recentChainData;
   private TerminalPowBlockMonitor terminalPowBlockMonitor;
 
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
-
   private void setUpTerminalBlockHashConfig() {
     setUpCommon(
         bellatrixBuilder ->
@@ -101,6 +87,7 @@ public class TerminalPowBlockMonitorTest {
                 "minimal",
                 phase0Builder ->
                     phase0Builder
+                        .blsSignatureVerifier(BLSSignatureVerifier.NO_OP)
                         .altairForkEpoch(UInt64.ZERO)
                         .bellatrixForkEpoch(BELLATRIX_FORK_EPOCH)
                         .bellatrixBuilder(bellatrixBuilder)));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractAttestationValidatorTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.validation;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationSchema;
@@ -73,7 +75,8 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 abstract class AbstractAttestationValidatorTest {
   private static final Logger LOG = LogManager.getLogger();
 
-  protected final Spec spec = createSpec();
+  protected final Spec spec =
+      createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   protected final AttestationSchema<?> attestationSchema =
       spec.getGenesisSchemaDefinitions().getAttestationSchema();
   protected final StorageSystem storageSystem =
@@ -109,7 +112,7 @@ abstract class AbstractAttestationValidatorTest {
     storageSystem.chainUpdater().initializeGenesis(false);
   }
 
-  public abstract Spec createSpec();
+  public abstract Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter);
 
   protected Predicate<? super CompletableFuture<InternalValidationResult>> rejected(
       final String messageContents) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
@@ -114,7 +114,9 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
  *
  * <p>The signature of aggregate is valid.
  */
-@TestSpecContext(milestone = {PHASE0, ELECTRA})
+@TestSpecContext(
+    milestone = {PHASE0, ELECTRA},
+    signatureVerifierNoop = true)
 class AggregateAttestationValidatorTest {
 
   private Spec spec;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelectorTest.java
@@ -44,7 +44,9 @@ import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 class AttestationStateSelectorTest {
-  private final Spec spec = TestSpecFactory.createDefault();
+  private final Spec spec =
+      TestSpecFactory.createDefault(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
   private final ChainBuilder chainBuilder = storageSystem.chainBuilder();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -54,7 +54,8 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
       SpecMilestone.BELLATRIX,
       SpecMilestone.DENEB,
       SpecMilestone.ELECTRA
-    })
+    },
+    signatureVerifierNoop = true)
 public class BlockGossipValidatorTest {
   private Spec spec;
   private RecentChainData recentChainData;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DenebAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DenebAttestationValidatorTest.java
@@ -19,17 +19,19 @@ import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.IGNORE;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.SAVE_FOR_FUTURE;
 
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 public class DenebAttestationValidatorTest extends AbstractAttestationValidatorTest {
 
   @Override
-  public Spec createSpec() {
-    return TestSpecFactory.createMinimalDeneb();
+  public Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter) {
+    return TestSpecFactory.createMinimalDeneb(configAdapter);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ElectraAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ElectraAttestationValidatorTest.java
@@ -15,18 +15,20 @@ package tech.pegasys.teku.statetransition.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 
 public class ElectraAttestationValidatorTest extends DenebAttestationValidatorTest {
 
   @Override
-  public Spec createSpec() {
-    return TestSpecFactory.createMinimalElectra();
+  public Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter) {
+    return TestSpecFactory.createMinimalElectra(configAdapter);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
-@TestSpecContext
+@TestSpecContext(signatureVerifierNoop = true)
 public class GossipValidationHelperTest {
   private Spec spec;
   private RecentChainData recentChainData;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
@@ -25,6 +25,7 @@ import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.REJECT;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.SAVE_FOR_FUTURE;
 
+import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -47,8 +49,8 @@ import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 public class Phase0AttestationValidatorTest extends AbstractAttestationValidatorTest {
 
   @Override
-  public Spec createSpec() {
-    return TestSpecFactory.createMinimalPhase0();
+  public Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter) {
+    return TestSpecFactory.createMinimalPhase0(configAdapter);
   }
 
   @Test

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -40,7 +40,9 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 public class PeerStatusIntegrationTest {
 
   private static final int VALIDATOR_COUNT = 16;
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final Spec spec =
+      TestSpecFactory.createMinimalPhase0(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
   private final RpcEncoding rpcEncoding =
       RpcEncoding.createSszSnappyEncoding(spec.getNetworkingConfig().getMaxPayloadSize());

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -68,7 +68,9 @@ import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 class RecentChainDataTest {
   private static final Logger LOG = LogManager.getLogger();
-  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final Spec spec =
+      TestSpecFactory.createMinimalDeneb(
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final SpecConfig genesisSpecConfig = spec.getGenesisSpecConfig();
   private StorageSystem storageSystem;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add the NOOP BLS signature verifier to the FOCIL Gloas revert PR

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce configurable BLS signature verifier in spec config and switch tests/benchmarks to use NO_OP via TestSpecFactory, removing reliance on global static overrides.
> 
> - **Spec/Config**:
>   - Add `BLSSignatureVerifier` to `SpecConfig` API and implementations (`SpecConfigPhase0`, `DelegatingSpecConfig`).
>   - Extend `SpecConfigBuilder` with `blsSignatureVerifier(...)` and plumb through construction.
> - **Block Processing**:
>   - `AbstractBlockProcessor` now uses `specConfig.getBLSSignatureVerifier()` for batch deposit signature verification (replacing static/global usage).
> - **Test Fixtures/Factory**:
>   - Expand `TestSpecFactory` creation methods to accept `Consumer<SpecConfigBuilder>`; add variants for forks (e.g., Deneb) and mainnet/minimal helpers.
>   - `TestSpecContext`/`TestSpecInvocationContextProvider`: add `signatureVerifierNoop` flag to toggle NO_OP verifier per test.
>   - `eth-tests` `TestDefinition`: support enabling/disabling BLS verification when creating specs.
> - **Tests/Benchmarks/Integration**:
>   - Update numerous tests/benchmarks to pass `BLSSignatureVerifier.NO_OP` via `TestSpecFactory` instead of setting `AbstractBlockProcessor.depositSignatureVerifier` directly.
>   - Adjust validator/coordinator, forkchoice, block import/manager, gossip validation, attestation validation, networking, storage, and JMH benchmarks accordingly.
> - **Misc**:
>   - Fix message in `MutableBeaconStateFulu.required` (Electra → Fulu).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3da222e409ee936ebdef8ce2e8e74ede7916257a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->