### PR TITLE
fix-DataColumnSidecarELRecoveryManager-pluming

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustody.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustody.java
@@ -27,11 +27,6 @@ public interface DataColumnSidecarRecoveringCustody
     extends DataColumnSidecarByRootCustody, DataColumnSidecarCustody, SlotEventsChannel {
   DataColumnSidecarRecoveringCustody NOOP =
       new DataColumnSidecarRecoveringCustody() {
-
-        @Override
-        public void subscribeToValidDataColumnSidecars(
-            DataColumnSidecarManager.ValidDataColumnSidecarsListener sidecarsListener) {}
-
         @Override
         public void onSlot(UInt64 slot) {}
 
@@ -64,7 +59,4 @@ public interface DataColumnSidecarRecoveringCustody
           return SafeFuture.completedFuture(false);
         }
       };
-
-  void subscribeToValidDataColumnSidecars(
-      DataColumnSidecarManager.ValidDataColumnSidecarsListener sidecarsListener);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
-import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -57,7 +57,7 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
   private final MiscHelpersFulu miscHelpers;
   private final KZG kzg;
   private final Spec spec;
-  private final Consumer<DataColumnSidecar> dataColumnSidecarPublisher;
+  private final BiConsumer<DataColumnSidecar, RemoteOrigin> dataColumnSidecarPublisher;
   private final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
 
   private final long columnCount;
@@ -77,7 +77,7 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
       final Spec spec,
       final MiscHelpersFulu miscHelpers,
       final KZG kzg,
-      final Consumer<DataColumnSidecar> dataColumnSidecarPublisher,
+      final BiConsumer<DataColumnSidecar, RemoteOrigin> dataColumnSidecarPublisher,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final int columnCount,
       final int groupCount,
@@ -244,7 +244,7 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
               delegate
                   .onNewValidatedDataColumnSidecar(dataColumnSidecar, RemoteOrigin.RECOVERED)
                   .finishError(LOG);
-              dataColumnSidecarPublisher.accept(dataColumnSidecar);
+              dataColumnSidecarPublisher.accept(dataColumnSidecar, RemoteOrigin.RECOVERED);
             });
     recoveryTask.existingSidecars.clear();
     LOG.debug(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -69,9 +69,6 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
   final Function<UInt64, Duration> slotToRecoveryDelay;
   private final Map<SlotAndBlockRoot, RecoveryTask> recoveryTasks;
 
-  private final Subscribers<DataColumnSidecarManager.ValidDataColumnSidecarsListener>
-      validDataColumnSidecarsSubscribers = Subscribers.create(true);
-
   private final Counter totalDataAvailabilityReconstructedColumns;
   private final MetricsHistogram dataAvailabilityReconstructionTimeSeconds;
 
@@ -205,12 +202,6 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
     return true;
   }
 
-  @Override
-  public void subscribeToValidDataColumnSidecars(
-      final DataColumnSidecarManager.ValidDataColumnSidecarsListener sidecarsListener) {
-    validDataColumnSidecarsSubscribers.subscribe(sidecarsListener);
-  }
-
   private boolean isActiveSuperNode(final UInt64 slot) {
     return isSuperNode.get()
         && spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU);
@@ -251,8 +242,6 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
         .filter(sidecar -> !existingSidecarsIndices.contains(sidecar.getIndex()))
         .forEach(
             dataColumnSidecar -> {
-              validDataColumnSidecarsSubscribers.forEach(
-                  l -> l.onNewValidSidecar(dataColumnSidecar, RemoteOrigin.RECOVERED));
               delegate
                   .onNewValidatedDataColumnSidecar(dataColumnSidecar, RemoteOrigin.RECOVERED)
                   .finishError(LOG);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
@@ -201,7 +201,7 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
     final SlotAndBlockRoot slotAndBlockRoot = dataColumnSidecar.getSlotAndBlockRoot();
 
     if (createRecoveryTaskFromDataColumnSidecar(dataColumnSidecar)) {
-      onFirstSeen(slotAndBlockRoot, Optional.of(remoteOrigin));
+      onFirstSeen(slotAndBlockRoot);
     }
   }
 
@@ -323,7 +323,7 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
       return;
     }
     if (createRecoveryTaskFromBlock(block)) {
-      onFirstSeen(block.getSlotAndBlockRoot(), remoteOrigin);
+      onFirstSeen(block.getSlotAndBlockRoot());
     }
   }
 
@@ -368,8 +368,7 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
     }
   }
 
-  private void onFirstSeen(
-      final SlotAndBlockRoot slotAndBlockRoot, final Optional<RemoteOrigin> remoteOrigin) {
+  private void onFirstSeen(final SlotAndBlockRoot slotAndBlockRoot) {
     LOG.debug("Data from {} is first seen, checking if recovery is needed", slotAndBlockRoot);
 
     asyncRunner

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
@@ -301,8 +301,6 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
           () -> remoteOrigin);
       return;
     }
-
-    LOG.debug("Received block {} from {}", block::getSlotAndBlockRoot, () -> remoteOrigin);
     final SpecMilestone milestone = spec.atSlot(block.getSlot()).getMilestone();
     // TODO-GLOAS: this could still be useful, but ignoring it for the moment since the recovery
     // task relies on blob kzg commitments
@@ -314,6 +312,9 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
           milestone::lowerCaseName);
       return;
     }
+
+    LOG.debug("Received block {} from {}", block::getSlotAndBlockRoot, () -> remoteOrigin);
+
     if (recentChainData.containsBlock(block.getRoot())) {
       LOG.debug("Block {} is already imported. Ignoring.", block::getSlotAndBlockRoot);
       return;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/FutureItems.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/FutureItems.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 /** Holds items with slots that are in the future relative to our node's current slot */
 public class FutureItems<T> implements SlotEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
-  static final UInt64 DEFAULT_FUTURE_SLOT_TOLERANCE = UInt64.valueOf(2);
+  public static final UInt64 DEFAULT_FUTURE_SLOT_TOLERANCE = UInt64.valueOf(2);
   private static final int MAX_ITEMS_PER_SLOT = 500;
 
   private final SettableLabelledGauge futureItemsCounter;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -17,7 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackerFactory;
+import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELRecoveryManager;
@@ -152,7 +153,7 @@ public class PoolFactory {
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final KZG kzg,
-      final Consumer<List<DataColumnSidecar>> dataColumnSidecarPublisher,
+      final BiConsumer<List<DataColumnSidecar>, RemoteOrigin> dataColumnSidecarPublisher,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
@@ -29,7 +29,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -73,7 +73,8 @@ public class DataColumnSidecarRecoveringCustodyTest {
   private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
 
   @SuppressWarnings("unchecked")
-  private final Consumer<DataColumnSidecar> dataColumnSidecarPublisher = mock(Consumer.class);
+  private final BiConsumer<DataColumnSidecar, RemoteOrigin> dataColumnSidecarPublisher =
+      mock(BiConsumer.class);
 
   private final Supplier<Stream<UInt64>> columnIndices =
       () ->
@@ -181,7 +182,8 @@ public class DataColumnSidecarRecoveringCustodyTest {
             i -> {
               verify(delegate)
                   .onNewValidatedDataColumnSidecar(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
-              verify(dataColumnSidecarPublisher).accept(eq(sidecars.get(i)));
+              verify(dataColumnSidecarPublisher)
+                  .accept(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
             });
     columnIndices
         .get()
@@ -190,7 +192,8 @@ public class DataColumnSidecarRecoveringCustodyTest {
             i -> {
               verify(delegate)
                   .onNewValidatedDataColumnSidecar(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
-              verify(dataColumnSidecarPublisher).accept(eq(sidecars.get(i)));
+              verify(dataColumnSidecarPublisher)
+                  .accept(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
             });
   }
 
@@ -262,7 +265,7 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
     // post reconstructed
     verify(delegate, times(58)).onNewValidatedDataColumnSidecar(any(), eq(RemoteOrigin.RECOVERED));
-    verify(dataColumnSidecarPublisher, times(58)).accept(any());
+    verify(dataColumnSidecarPublisher, times(58)).accept(any(), eq(RemoteOrigin.RECOVERED));
   }
 
   @Test
@@ -297,7 +300,7 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
     // post reconstructed
     verify(delegate, times(64)).onNewValidatedDataColumnSidecar(any(), eq(RemoteOrigin.RECOVERED));
-    verify(dataColumnSidecarPublisher, times(64)).accept(any());
+    verify(dataColumnSidecarPublisher, times(64)).accept(any(), eq(RemoteOrigin.RECOVERED));
   }
 
   @Test
@@ -358,6 +361,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
     stubAsyncRunner.executeDueActionsRepeatedly();
 
     verifyNoInteractions(miscHelpersFulu);
-    verify(dataColumnSidecarPublisher, never()).accept(any());
+    verify(dataColumnSidecarPublisher, never()).accept(any(), eq(RemoteOrigin.RECOVERED));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
@@ -69,8 +69,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
   private final DataColumnSidecarByRootCustody delegate =
       mock(DataColumnSidecarByRootCustody.class);
   private final MiscHelpersFulu miscHelpersFulu = mock(MiscHelpersFulu.class);
-  private final DataColumnSidecarManager.ValidDataColumnSidecarsListener listener =
-      mock(DataColumnSidecarManager.ValidDataColumnSidecarsListener.class);
 
   private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
 
@@ -108,7 +106,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
   @BeforeEach
   public void setup() {
-    custody.subscribeToValidDataColumnSidecars(listener);
     when(delegate.onNewValidatedDataColumnSidecar(any(), any())).thenReturn(SafeFuture.COMPLETE);
   }
 
@@ -184,7 +181,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
             i -> {
               verify(delegate)
                   .onNewValidatedDataColumnSidecar(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
-              verify(listener).onNewValidSidecar(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
               verify(dataColumnSidecarPublisher).accept(eq(sidecars.get(i)));
             });
     columnIndices
@@ -194,7 +190,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
             i -> {
               verify(delegate)
                   .onNewValidatedDataColumnSidecar(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
-              verify(listener).onNewValidSidecar(eq(sidecars.get(i)), eq(RemoteOrigin.RECOVERED));
               verify(dataColumnSidecarPublisher).accept(eq(sidecars.get(i)));
             });
   }
@@ -267,7 +262,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
     // post reconstructed
     verify(delegate, times(58)).onNewValidatedDataColumnSidecar(any(), eq(RemoteOrigin.RECOVERED));
-    verify(listener, times(58)).onNewValidSidecar(any(), eq(RemoteOrigin.RECOVERED));
     verify(dataColumnSidecarPublisher, times(58)).accept(any());
   }
 
@@ -303,7 +297,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
     // post reconstructed
     verify(delegate, times(64)).onNewValidatedDataColumnSidecar(any(), eq(RemoteOrigin.RECOVERED));
-    verify(listener, times(64)).onNewValidSidecar(any(), eq(RemoteOrigin.RECOVERED));
     verify(dataColumnSidecarPublisher, times(64)).accept(any());
   }
 
@@ -365,7 +358,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
     stubAsyncRunner.executeDueActionsRepeatedly();
 
     verifyNoInteractions(miscHelpersFulu);
-    verify(listener, never()).onNewValidSidecar(any(), eq(RemoteOrigin.RECOVERED));
     verify(dataColumnSidecarPublisher, never()).accept(any());
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImplTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.statetransition.util;
+package tech.pegasys.teku.statetransition.datacolumns.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.statetransition.datacolumns.DasCustodyStand.createCustodyGroupCountManager;
+import static tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELRecoveryManagerImpl.LOCAL_OR_RECOVERED_ORIGINS;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -64,7 +65,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarELRecoveryManager;
-import tech.pegasys.teku.statetransition.datacolumns.util.DataColumnSidecarELRecoveryManagerImpl;
+import tech.pegasys.teku.statetransition.util.FutureItems;
+import tech.pegasys.teku.statetransition.util.PoolFactory;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class DataColumnSidecarELRecoveryManagerImplTest {
@@ -172,10 +174,12 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(block, UInt64.ZERO);
     dataColumnSidecarELRecoveryManager.onSlot(currentSlot);
-    dataColumnSidecarELRecoveryManager.onNewDataColumnSidecar(
-        dataColumnSidecar, RemoteOrigin.LOCAL_PROPOSAL);
-    dataColumnSidecarELRecoveryManager.onNewDataColumnSidecar(
-        dataColumnSidecar, RemoteOrigin.RECOVERED);
+
+    LOCAL_OR_RECOVERED_ORIGINS.forEach(
+        origin -> {
+          dataColumnSidecarELRecoveryManager.onNewDataColumnSidecar(dataColumnSidecar, origin);
+        });
+
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
     verifyNoInteractions(executionLayer);
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1013,9 +1013,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               recentChainData,
               executionLayer,
               kzg,
-              sidecars ->
-                  dataColumnSidecarGossipChannel.publishDataColumnSidecars(
-                      sidecars, RemoteOrigin.LOCAL_EL),
+              dataColumnSidecarGossipChannel::publishDataColumnSidecars,
               this::getCustodyGroupCountManager,
               metricsSystem,
               timeProvider);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -832,9 +832,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             spec,
             miscHelpersFulu,
             kzg,
-            dataColumnSidecar ->
-                dataColumnSidecarGossipChannel.publishDataColumnSidecar(
-                    dataColumnSidecar, RemoteOrigin.RECOVERED),
+            dataColumnSidecarGossipChannel::publishDataColumnSidecar,
             this::getCustodyGroupCountManager,
             specConfigFulu.getNumberOfColumns(),
             specConfigFulu.getNumberOfCustodyGroups(),

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -825,8 +825,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             UInt64.valueOf(slotsPerEpoch)
                 .times(DataColumnSidecarByRootCustodyImpl.DEFAULT_MAX_CACHE_SIZE_EPOCHS));
 
-    final DataColumnSidecarGossipChannel publisher = eventChannels
-            .getPublisher(DataColumnSidecarGossipChannel.class);
+    final DataColumnSidecarGossipChannel publisher =
+        eventChannels.getPublisher(DataColumnSidecarGossipChannel.class);
 
     final DataColumnSidecarRecoveringCustody dataColumnSidecarRecoveringCustody =
         new DataColumnSidecarRecoveringCustodyImpl(
@@ -836,8 +836,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             miscHelpersFulu,
             kzg,
             dataColumnSidecar ->
-                    publisher
-                    .publishDataColumnSidecar(dataColumnSidecar, RemoteOrigin.RECOVERED),
+                publisher.publishDataColumnSidecar(dataColumnSidecar, RemoteOrigin.RECOVERED),
             this::getCustodyGroupCountManager,
             specConfigFulu.getNumberOfColumns(),
             specConfigFulu.getNumberOfCustodyGroups(),
@@ -1024,7 +1023,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
               metricsSystem,
               timeProvider);
       eventChannels.subscribe(SlotEventsChannel.class, recoveryManager);
-      dataColumnSidecarManager.subscribeToValidDataColumnSidecars(recoveryManager::onNewDataColumnSidecar);
+      dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
+          recoveryManager::onNewDataColumnSidecar);
       blockManager.subscribePreImportBlocks(recoveryManager::onNewBlock);
       dataColumnSidecarELRecoveryManager = recoveryManager;
     } else {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -824,6 +824,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
             combinedChainDataClient,
             UInt64.valueOf(slotsPerEpoch)
                 .times(DataColumnSidecarByRootCustodyImpl.DEFAULT_MAX_CACHE_SIZE_EPOCHS));
+
+    final DataColumnSidecarGossipChannel publisher = eventChannels
+            .getPublisher(DataColumnSidecarGossipChannel.class);
+
     final DataColumnSidecarRecoveringCustody dataColumnSidecarRecoveringCustody =
         new DataColumnSidecarRecoveringCustodyImpl(
             dataColumnSidecarByRootCustody,
@@ -832,8 +836,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             miscHelpersFulu,
             kzg,
             dataColumnSidecar ->
-                eventChannels
-                    .getPublisher(DataColumnSidecarGossipChannel.class)
+                    publisher
                     .publishDataColumnSidecar(dataColumnSidecar, RemoteOrigin.RECOVERED),
             this::getCustodyGroupCountManager,
             specConfigFulu.getNumberOfColumns(),
@@ -1021,8 +1024,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               metricsSystem,
               timeProvider);
       eventChannels.subscribe(SlotEventsChannel.class, recoveryManager);
-      getDataColumnSidecarCustody()
-          .subscribeToValidDataColumnSidecars(recoveryManager::onNewDataColumnSidecar);
+      dataColumnSidecarManager.subscribeToValidDataColumnSidecars(recoveryManager::onNewDataColumnSidecar);
       blockManager.subscribePreImportBlocks(recoveryManager::onNewBlock);
       dataColumnSidecarELRecoveryManager = recoveryManager;
     } else {


### PR DESCRIPTION
This PR
- makes `DataColumnSidecarELRecoveryManager` receive column sidecars from gossip
- removes the a subscriber from `DataColumnSidecarRecoveringCustody` which is not used anymore

Testing in fusaka devnet 3 locally joined, with additional logs:

```
2025-10-02 15:38:00.926 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 51, 1st cell 00000000000000, commitments 20, proofs 20] from GOSSIP
2025-10-02 15:38:00.926 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 46, 1st cell 0000fbe5fe50e9, commitments 20, proofs 20] from GOSSIP
2025-10-02 15:38:00.926 DEBUG - Data from SlotAndBlockRoot{slot=511540, blockRoot=0xf7de48ba11aa9425c7524695ee8e0fba45a713254a1d9f5e3127ba849effd82c} is first seen, checking if recovery is needed
2025-10-02 15:38:00.932 DEBUG - Received block SlotAndBlockRoot{slot=511540, blockRoot=0xf7de48ba11aa9425c7524695ee8e0fba45a713254a1d9f5e3127ba849effd82c} from Optional[GOSSIP]
2025-10-02 15:38:01.006 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 71, 1st cell 27ae85f662956a, commitments 20, proofs 20] from GOSSIP
2025-10-02 15:38:01.049 DEBUG - Found 20 blobs
2025-10-02 15:38:01.049 DEBUG - Collected all blobSidecars from EL for slot 511540, recovering data column sidecars
2025-10-02 15:38:01.059 DEBUG - Publishing 8 data column sidecars for SlotAndBlockRoot{slot=511540, blockRoot=0xf7de48ba11aa9425c7524695ee8e0fba45a713254a1d9f5e3127ba849effd82c}
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 44, 1st cell 007f38d6f7f56e, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 46, 1st cell 0000fbe5fe50e9, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 51, 1st cell 00000000000000, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 71, 1st cell 27ae85f662956a, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 77, 1st cell 1d57b1cce76460, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 96, 1st cell 65ef81d7c53419, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 109, 1st cell 357ebbbe4873ac, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:01.059 DEBUG - Received data column sidecar DataColumnSidecar[block f7de48..d82c (511540), index 112, 1st cell 56bcb581a6c751, commitments 20, proofs 20] from LOCAL_EL
2025-10-02 15:38:04.002 INFO  - Slot Event  *** Slot: 511540, Block: f7de48ba11aa9425c7524695ee8e0fba45a713254a1d9f5e3127ba849effd82c, Justified: 15984, Finalized: 15983, Peers: 16
```


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> EL recovery manager now consumes gossiped data column sidecars, fetches missing blobs from local EL, publishes recovered sidecars with origin, and removes the obsolete custody subscription.
> 
> - **Data Column EL Recovery**:
>   - Handle `onNewDataColumnSidecar` from gossip; ignore local/recovered origins; start recovery via local EL blobs; publish recovered sidecars with `RemoteOrigin.LOCAL_EL`.
>   - Improved debug logging and retry handling for EL blob fetches.
> - **Custody/Wiring**:
>   - Remove `subscribeToValidDataColumnSidecars` from `DataColumnSidecarRecoveringCustody` and its internal subscribers usage.
>   - Change sidecar publishers to `BiConsumer<..., RemoteOrigin>` and propagate through `PoolFactory` and `BeaconChainController` (`publishDataColumnSidecar(s)` now passes origin).
>   - `BeaconChainController` subscribes EL recovery manager to gossip via `DataColumnSidecarManager` instead of custody.
> - **API/Utils**:
>   - Expose `FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE` publicly.
> - **Tests**:
>   - Update tests to new publishers, origins, and package paths; add assertions for `LOCAL_EL` origin publishing and ignored local/recovered inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc36886b11cdb720f0f6f9fe6d149fe98c51e03a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->