### PR TITLE
Allow spec to be lazily initialized with additional dependencies

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -122,7 +122,6 @@ public class SyncingNodeManager {
             spec,
             new InlineEventThread(),
             recentChainData,
-            BlobSidecarManager.NOOP,
             new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             new StubMetricsSystem());

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFulu.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFulu.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.validator.coordinator;
 
 import java.util.Collections;
 import java.util.List;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFulu.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFulu.java
@@ -15,7 +15,8 @@ package tech.pegasys.teku.validator.coordinator;
 
 import java.util.Collections;
 import java.util.List;
-import tech.pegasys.teku.kzg.KZG;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -23,12 +24,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 
 public class BlockFactoryFulu extends BlockFactoryDeneb {
 
-  private final KZG kzg;
-
-  public BlockFactoryFulu(
-      final Spec spec, final BlockOperationSelectorFactory operationSelector, final KZG kzg) {
+  public BlockFactoryFulu(final Spec spec, final BlockOperationSelectorFactory operationSelector) {
     super(spec, operationSelector);
-    this.kzg = kzg;
   }
 
   // No blob sidecars in Fulu
@@ -40,6 +37,6 @@ public class BlockFactoryFulu extends BlockFactoryDeneb {
   @Override
   public List<DataColumnSidecar> createDataColumnSidecars(
       final SignedBlockContainer blockContainer) {
-    return operationSelector.createDataColumnSidecarsSelector(kzg).apply(blockContainer);
+    return operationSelector.createDataColumnSidecarsSelector().apply(blockContainer);
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
@@ -573,8 +572,8 @@ public class BlockOperationSelectorFactory {
     };
   }
 
-  public Function<SignedBlockContainer, List<DataColumnSidecar>> createDataColumnSidecarsSelector(
-      final KZG kzg) {
+  public Function<SignedBlockContainer, List<DataColumnSidecar>>
+      createDataColumnSidecarsSelector() {
     return blockContainer -> {
       final Optional<BlobsAndProofs> maybeBlobsAndProofs =
           getBlobsAndProofs(
@@ -608,7 +607,7 @@ public class BlockOperationSelectorFactory {
 
       try (MetricsHistogram.Timer ignored = dataColumnSidecarComputationTimeSeconds.startTimer()) {
         return miscHelpersFulu.constructDataColumnSidecars(
-            blockContainer.getSignedBlock(), blobAndCellProofsList, kzg);
+            blockContainer.getSignedBlock(), blobAndCellProofsList);
       } catch (final Throwable t) {
         throw new RuntimeException(t);
       }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanc
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -46,7 +45,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
   private final Spec spec;
 
   public MilestoneBasedBlockFactory(
-      final Spec spec, final BlockOperationSelectorFactory operationSelector, final KZG kzg) {
+      final Spec spec, final BlockOperationSelectorFactory operationSelector) {
     this.spec = spec;
     final BlockFactoryPhase0 blockFactoryPhase0 = new BlockFactoryPhase0(spec, operationSelector);
 
@@ -54,7 +53,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
     final Supplier<BlockFactoryDeneb> blockFactoryDenebSupplier =
         Suppliers.memoize(() -> new BlockFactoryDeneb(spec, operationSelector));
     final Supplier<BlockFactoryFulu> blockFactoryFuluSupplier =
-        Suppliers.memoize(() -> new BlockFactoryFulu(spec, operationSelector, kzg));
+        Suppliers.memoize(() -> new BlockFactoryFulu(spec, operationSelector));
     final Supplier<BlockFactoryGloas> blockFactoryGloasSupplier =
         Suppliers.memoize(() -> new BlockFactoryGloas(spec, operationSelector));
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
@@ -174,6 +175,10 @@ public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
     when(kzg.computeCells(any()))
         .thenReturn(
             IntStream.range(0, 128).mapToObj(__ -> dataStructureUtil.randomKZGCell()).toList());
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     return new BlockFactoryFulu(
         spec,
         new BlockOperationSelectorFactory(
@@ -190,7 +195,6 @@ public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
             forkChoiceNotifier,
             executionLayer,
             metricsSystem,
-            timeProvider),
-        kzg);
+            timeProvider));
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
@@ -68,6 +68,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
@@ -280,8 +281,12 @@ class BlockOperationSelectorFactoryFuluTest {
     when(kzg.computeCells(any()))
         .thenReturn(
             IntStream.range(0, 128).mapToObj(__ -> dataStructureUtil.randomKZGCell()).toList());
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     final List<DataColumnSidecar> dataColumnSidecars =
-        factory.createDataColumnSidecarsSelector(kzg).apply(signedBlockContents);
+        factory.createDataColumnSidecarsSelector().apply(signedBlockContents);
 
     final SszList<SszKZGProof> expectedProofs = signedBlockContents.getKzgProofs().orElseThrow();
     final SszList<SszKZGCommitment> expectedCommitments =
@@ -337,8 +342,12 @@ class BlockOperationSelectorFactoryFuluTest {
     when(kzg.computeCells(any()))
         .thenReturn(
             IntStream.range(0, 128).mapToObj(__ -> dataStructureUtil.randomKZGCell()).toList());
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     final List<DataColumnSidecar> dataColumnSidecars =
-        factory.createDataColumnSidecarsSelector(kzg).apply(signedBlindedBeaconBlock);
+        factory.createDataColumnSidecarsSelector().apply(signedBlindedBeaconBlock);
 
     final SszList<SszKZGProof> expectedProofs = blobsBundle.getProofs();
     final SszList<SszKZGCommitment> expectedCommitments =

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -69,7 +69,6 @@ import tech.pegasys.teku.statetransition.MappedOperationPool;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -193,7 +192,6 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
                 spec,
                 new InlineEventThread(),
                 recentChainData,
-                BlobSidecarManager.NOOP,
                 new NoopForkChoiceNotifier(),
                 new MergeTransitionBlockValidator(spec, recentChainData),
                 storageSystem.getMetricsSystem());

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -55,7 +55,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.Validato
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -127,7 +126,6 @@ public class EpochTransitionBenchmark {
             spec,
             new InlineEventThread(),
             recentChainData,
-            BlobSidecarManager.NOOP,
             new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             metricsSystem);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -47,7 +47,6 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -104,7 +103,6 @@ public class ProfilingRun {
               spec,
               new InlineEventThread(),
               recentChainData,
-              BlobSidecarManager.NOOP,
               new NoopForkChoiceNotifier(),
               transitionBlockValidator,
               metricsSystem);
@@ -196,7 +194,6 @@ public class ProfilingRun {
               spec,
               new InlineEventThread(),
               recentChainData,
-              BlobSidecarManager.NOOP,
               new NoopForkChoiceNotifier(),
               transitionBlockValidator,
               metricsSystem);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -44,7 +44,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -103,7 +102,6 @@ public abstract class TransitionBenchmark {
             spec,
             new InlineEventThread(),
             recentChainData,
-            BlobSidecarManager.NOOP,
             new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             new StubMetricsSystem());

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/kzg/SidecarBenchmarkConfig.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/kzg/SidecarBenchmarkConfig.java
@@ -54,14 +54,15 @@ public class SidecarBenchmarkConfig {
       SchemaDefinitionsDeneb.required(spec.atSlot(UInt64.ONE).getSchemaDefinitions())
           .getBlobKzgCommitmentsSchema();
 
-  SidecarBenchmarkConfig(final boolean precompute) {
+  SidecarBenchmarkConfig(final boolean precompute, final boolean useRustLibrary) {
     kzgBenchmark = new KzgInstances(precompute ? 9 : 0);
     kzgCommitments =
         blobs.stream()
             .map(blob -> getKzg(false).blobToKzgCommitment(blob.getBytes()))
             .map(SszKZGCommitment::new)
             .toList();
-    extendedMatrix = miscHelpersFulu.computeExtendedMatrixAndProofs(blobs, getKzg(false));
+    miscHelpersFulu.setKzg(getKzg(useRustLibrary));
+    extendedMatrix = miscHelpersFulu.computeExtendedMatrixAndProofs(blobs);
     signedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(
             blobKzgCommitmentsSchema.createFromElements(kzgCommitments));

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/kzg/WithPrecomputeBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/kzg/WithPrecomputeBenchmark.java
@@ -40,14 +40,13 @@ public class WithPrecomputeBenchmark {
 
     @Setup(Level.Invocation)
     public void setup() {
-      config = new SidecarBenchmarkConfig(isPrecompute);
+      config = new SidecarBenchmarkConfig(isPrecompute, isRustEnabled);
     }
   }
 
   @Benchmark
   public void computeExtendedMatrixAndProofs(final ExecutionPlan plan) {
-    plan.config.miscHelpersFulu.computeExtendedMatrixAndProofs(
-        plan.config.blobs, plan.config.getKzg(plan.isRustEnabled));
+    plan.config.miscHelpersFulu.computeExtendedMatrixAndProofs(plan.config.blobs);
   }
 
   @Benchmark
@@ -63,7 +62,6 @@ public class WithPrecomputeBenchmark {
     final int size = plan.config.dataColumnSidecars.size();
     final int halfSize = size / 2;
     plan.config.miscHelpersFulu.reconstructAllDataColumnSidecars(
-        plan.config.dataColumnSidecars.subList(halfSize, size),
-        plan.config.getKzg(plan.isRustEnabled));
+        plan.config.dataColumnSidecars.subList(halfSize, size));
   }
 }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/kzg/WithoutPrecomputeBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/kzg/WithoutPrecomputeBenchmark.java
@@ -37,20 +37,19 @@ public class WithoutPrecomputeBenchmark {
 
     @Setup(Level.Invocation)
     public void setup() {
-      config = new SidecarBenchmarkConfig(false);
+      config = new SidecarBenchmarkConfig(false, isRustEnabled);
     }
   }
 
   @Benchmark
   public void verifyDataColumnSidecarKzgProofsBatch(final ExecutionPlan plan) {
     plan.config.miscHelpersFulu.verifyDataColumnSidecarKzgProofsBatch(
-        plan.config.getKzg(plan.isRustEnabled), plan.config.dataColumnSidecars);
+        plan.config.dataColumnSidecars);
   }
 
   @Benchmark
   public void verifyDataColumnSidecarKzgProofs(final ExecutionPlan plan) {
     plan.config.miscHelpersFulu.verifyDataColumnSidecarKzgProofs(
-        plan.config.getKzg(plan.isRustEnabled),
         plan.config.dataColumnSidecars.stream().findAny().orElseThrow());
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -155,13 +155,12 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         new StubDataColumnSidecarManager(spec, recentChainData, kzg, dasSampler);
     // forkChoiceLateBlockReorgEnabled is true here always because this is the reference test
     // executor
+    spec.initialize(blobSidecarManager, dataColumnSidecarManager);
     final ForkChoice forkChoice =
         new ForkChoice(
             spec,
             eventThread,
             recentChainData,
-            blobSidecarManager,
-            dataColumnSidecarManager,
             new NoopForkChoiceNotifier(),
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -155,7 +155,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         new StubDataColumnSidecarManager(spec, recentChainData, kzg, dasSampler);
     // forkChoiceLateBlockReorgEnabled is true here always because this is the reference test
     // executor
-    spec.initialize(blobSidecarManager, dataColumnSidecarManager);
+    spec.reinitializeForTesting(blobSidecarManager, dataColumnSidecarManager);
     final ForkChoice forkChoice =
         new ForkChoice(
             spec,

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -152,10 +152,10 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             // and fetching from the config would break when not in fulu
             () -> DasCustodyStand.createCustodyGroupCountManager(4, 8));
     final StubDataColumnSidecarManager dataColumnSidecarManager =
-        new StubDataColumnSidecarManager(spec, recentChainData, kzg, dasSampler);
+        new StubDataColumnSidecarManager(spec, recentChainData, dasSampler);
     // forkChoiceLateBlockReorgEnabled is true here always because this is the reference test
     // executor
-    spec.reinitializeForTesting(blobSidecarManager, dataColumnSidecarManager);
+    spec.reinitializeForTesting(blobSidecarManager, dataColumnSidecarManager, kzg);
     final ForkChoice forkChoice =
         new ForkChoice(
             spec,

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubDataColumnSidecarManager.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubDataColumnSidecarManager.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -44,7 +43,6 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class StubDataColumnSidecarManager implements AvailabilityCheckerFactory<UInt64> {
   private final Spec spec;
   private final RecentChainData recentChainData;
-  private final KZG kzg;
   private DataColumnSidecarGossipValidator validator;
   private final Map<UInt64, List<DataColumnSidecar>> dataColumnSidecarBySlot =
       new ConcurrentHashMap<>();
@@ -60,11 +58,9 @@ public class StubDataColumnSidecarManager implements AvailabilityCheckerFactory<
   public StubDataColumnSidecarManager(
       final Spec spec,
       final RecentChainData recentChainData,
-      final KZG kzg,
       final DataAvailabilitySampler dataAvailabilitySampler) {
     this.spec = spec;
     this.recentChainData = recentChainData;
-    this.kzg = kzg;
     this.dataAvailabilitySampler = dataAvailabilitySampler;
   }
 
@@ -101,7 +97,6 @@ public class StubDataColumnSidecarManager implements AvailabilityCheckerFactory<
                     new ConcurrentHashMap<>(),
                     new GossipValidationHelper(spec, recentChainData),
                     helpers,
-                    kzg,
                     new StubMetricsSystem(),
                     recentChainData.getStore());
             validationResult.complete(validateDataColumnSidecar());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -220,6 +220,14 @@ public class Spec {
     return new Spec(specConfigAndParent, specVersions, forkSchedule);
   }
 
+  public KZG getKzg() {
+    return Optional.ofNullable(forMilestone(DENEB))
+        .map(SpecVersion::miscHelpers)
+        .flatMap(MiscHelpers::toVersionDeneb)
+        .map(MiscHelpersDeneb::getKzg)
+        .orElse(KZG.DISABLED);
+  }
+
   public SpecVersion forMilestone(final SpecMilestone milestone) {
     return specVersions.get(milestone);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -220,12 +220,14 @@ public class Spec {
     return new Spec(specConfigAndParent, specVersions, forkSchedule);
   }
 
-  public KZG getKzg() {
+  public Optional<KZG> getKzg() {
+    if (!initialized) {
+      throw new IllegalStateException("Spec must be initialized to access KZG");
+    }
     return Optional.ofNullable(forMilestone(DENEB))
         .map(SpecVersion::miscHelpers)
         .flatMap(MiscHelpers::toVersionDeneb)
-        .map(MiscHelpersDeneb::getKzg)
-        .orElse(KZG.DISABLED);
+        .map(MiscHelpersDeneb::getKzg);
   }
 
   public SpecVersion forMilestone(final SpecMilestone milestone) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -149,7 +149,7 @@ public class Spec {
 
   // This method must be called once after constructing the Spec to initialize any additional
   // dependencies lazily created during initialization in BeaconChainController
-  public void initialize(
+  public synchronized void initialize(
       final AvailabilityCheckerFactory<BlobSidecar> blobSidecarAvailabilityCheckerFactory,
       final AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory,
       final KZG kzg) {
@@ -161,7 +161,7 @@ public class Spec {
   }
 
   @VisibleForTesting
-  public void reinitializeForTesting(
+  public synchronized void reinitializeForTesting(
       final AvailabilityCheckerFactory<BlobSidecar> blobSidecarAvailabilityCheckerFactory,
       final AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory,
       final KZG kzg) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -152,6 +153,21 @@ public class Spec {
     if (initialized) {
       throw new IllegalStateException("Spec already initialized");
     }
+    initializeInternal(
+        blobSidecarAvailabilityCheckerFactory, dataColumnSidecarAvailabilityCheckerFactory);
+  }
+
+  @VisibleForTesting
+  public void reinitializeForTesting(
+      final AvailabilityCheckerFactory<BlobSidecar> blobSidecarAvailabilityCheckerFactory,
+      final AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory) {
+    initializeInternal(
+        blobSidecarAvailabilityCheckerFactory, dataColumnSidecarAvailabilityCheckerFactory);
+  }
+
+  private void initializeInternal(
+      final AvailabilityCheckerFactory<BlobSidecar> blobSidecarAvailabilityCheckerFactory,
+      final AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory) {
     initialized = true;
 
     specVersions

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -27,6 +27,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCellAndProof;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
@@ -58,6 +59,10 @@ public class BlobsUtil {
     this.spec = spec;
   }
 
+  private KZG getKzg() {
+    return spec.getKzg().orElseThrow();
+  }
+
   public Bytes generateRawBlobTransactionFromKzgCommitments(
       final List<KZGCommitment> kzgCommitments) {
 
@@ -77,16 +82,16 @@ public class BlobsUtil {
     return blobs.stream()
         .parallel()
         .map(Blob::getBytes)
-        .map(spec.getKzg()::blobToKzgCommitment)
+        .map(getKzg()::blobToKzgCommitment)
         .toList();
   }
 
   public KZGProof computeKzgProof(final Blob blob, final KZGCommitment kzgCommitment) {
-    return spec.getKzg().computeBlobKzgProof(blob.getBytes(), kzgCommitment);
+    return getKzg().computeBlobKzgProof(blob.getBytes(), kzgCommitment);
   }
 
   public List<KZGProof> computeKzgCellProofs(final Blob blob) {
-    return spec.getKzg().computeCellsAndProofs(blob.getBytes()).stream()
+    return getKzg().computeCellsAndProofs(blob.getBytes()).stream()
         .map(KZGCellAndProof::proof)
         .toList();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -56,9 +56,9 @@ public class BlobsUtil {
   private final Spec spec;
   private final KZG kzg;
 
-  public BlobsUtil(final Spec spec, final KZG kzg) {
+  public BlobsUtil(final Spec spec) {
     this.spec = spec;
-    this.kzg = kzg;
+    this.kzg = spec.getKzg();
   }
 
   public Bytes generateRawBlobTransactionFromKzgCommitments(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -27,7 +27,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCellAndProof;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
@@ -75,7 +74,11 @@ public class BlobsUtil {
   }
 
   public List<KZGCommitment> blobsToKzgCommitments(final List<Blob> blobs) {
-    return blobs.stream().parallel().map(Blob::getBytes).map(spec.getKzg()::blobToKzgCommitment).toList();
+    return blobs.stream()
+        .parallel()
+        .map(Blob::getBytes)
+        .map(spec.getKzg()::blobToKzgCommitment)
+        .toList();
   }
 
   public KZGProof computeKzgProof(final Blob blob, final KZGCommitment kzgCommitment) {
@@ -83,7 +86,9 @@ public class BlobsUtil {
   }
 
   public List<KZGProof> computeKzgCellProofs(final Blob blob) {
-    return spec.getKzg().computeCellsAndProofs(blob.getBytes()).stream().map(KZGCellAndProof::proof).toList();
+    return spec.getKzg().computeCellsAndProofs(blob.getBytes()).stream()
+        .map(KZGCellAndProof::proof)
+        .toList();
   }
 
   public List<KZGProof> computeKzgProofs(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -54,11 +54,9 @@ public class BlobsUtil {
               + "0000000000000000000000000000c100000000");
 
   private final Spec spec;
-  private final KZG kzg;
 
   public BlobsUtil(final Spec spec) {
     this.spec = spec;
-    this.kzg = spec.getKzg();
   }
 
   public Bytes generateRawBlobTransactionFromKzgCommitments(
@@ -77,15 +75,15 @@ public class BlobsUtil {
   }
 
   public List<KZGCommitment> blobsToKzgCommitments(final List<Blob> blobs) {
-    return blobs.stream().parallel().map(Blob::getBytes).map(kzg::blobToKzgCommitment).toList();
+    return blobs.stream().parallel().map(Blob::getBytes).map(spec.getKzg()::blobToKzgCommitment).toList();
   }
 
   public KZGProof computeKzgProof(final Blob blob, final KZGCommitment kzgCommitment) {
-    return kzg.computeBlobKzgProof(blob.getBytes(), kzgCommitment);
+    return spec.getKzg().computeBlobKzgProof(blob.getBytes(), kzgCommitment);
   }
 
   public List<KZGProof> computeKzgCellProofs(final Blob blob) {
-    return kzg.computeCellsAndProofs(blob.getBytes()).stream().map(KZGCellAndProof::proof).toList();
+    return spec.getKzg().computeCellsAndProofs(blob.getBytes()).stream().map(KZGCellAndProof::proof).toList();
   }
 
   public List<KZGProof> computeKzgProofs(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.spec.Spec;
@@ -127,14 +126,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     this.spec = spec;
     this.timeProvider = timeProvider;
     this.transitionEmulationEnabled = enableTransitionEmulation;
-    final KZG kzg;
-    if (spec.isMilestoneSupported(SpecMilestone.DENEB)) {
-      // trusted setup loading will be handled by the BeaconChainController
-      kzg = KZG.getInstance(false);
-    } else {
-      kzg = KZG.DISABLED;
-    }
-    this.blobsUtil = new BlobsUtil(spec, kzg);
+    this.blobsUtil = new BlobsUtil(spec);
 
     applyAdditionalConfig(additionalConfigs);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.Domain;
@@ -447,11 +446,11 @@ public class MiscHelpers {
     return false;
   }
 
-  public boolean verifyBlobKzgProof(final KZG kzg, final BlobSidecar blobSidecar) {
+  public boolean verifyBlobKzgProof(final BlobSidecar blobSidecar) {
     return false;
   }
 
-  public boolean verifyBlobKzgProofBatch(final KZG kzg, final List<BlobSidecar> blobSidecars) {
+  public boolean verifyBlobKzgProofBatch(final List<BlobSidecar> blobSidecars) {
     return false;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityChecker.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecution
 
 public interface AvailabilityChecker<Data> {
 
-  AvailabilityChecker<BlobSidecar> NOOP_BLOBSIDECAR =
+  AvailabilityChecker<?> NOOP =
       new AvailabilityChecker<>() {
         @Override
         public boolean initiateDataAvailabilityCheck() {
@@ -32,23 +32,16 @@ public interface AvailabilityChecker<Data> {
         }
 
         @Override
-        public SafeFuture<DataAndValidationResult<BlobSidecar>> getAvailabilityCheckResult() {
+        public SafeFuture<DataAndValidationResult<Object>> getAvailabilityCheckResult() {
           return notRequiredResultFuture();
         }
       };
 
-  AvailabilityChecker<UInt64> NOOP_DATACOLUMN_SIDECAR =
-      new AvailabilityChecker<>() {
-        @Override
-        public boolean initiateDataAvailabilityCheck() {
-          return true;
-        }
+  @SuppressWarnings("unchecked")
+  AvailabilityChecker<BlobSidecar> NOOP_BLOB_SIDECAR = (AvailabilityChecker<BlobSidecar>) NOOP;
 
-        @Override
-        public SafeFuture<DataAndValidationResult<UInt64>> getAvailabilityCheckResult() {
-          return notRequiredResultFuture();
-        }
-      };
+  @SuppressWarnings("unchecked")
+  AvailabilityChecker<UInt64> NOOP_DATACOLUMN_SIDECAR = (AvailabilityChecker<UInt64>) NOOP;
 
   /**
    * Similar to {@link OptimisticExecutionPayloadExecutor#optimisticallyExecute(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityChecker.java
@@ -23,45 +23,23 @@ import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
 
 public interface AvailabilityChecker<Data> {
+  class NOOP<Data> implements AvailabilityChecker<Data> {
+    private NOOP() {}
 
-  AvailabilityChecker<?> NOOP =
-      new AvailabilityChecker<>() {
-        @Override
-        public boolean initiateDataAvailabilityCheck() {
-          return true;
-        }
+    @Override
+    public boolean initiateDataAvailabilityCheck() {
+      return true;
+    }
 
-        @Override
-        public SafeFuture<DataAndValidationResult<Object>> getAvailabilityCheckResult() {
-          return notRequiredResultFuture();
-        }
-      };
+    @Override
+    public SafeFuture<DataAndValidationResult<Data>> getAvailabilityCheckResult() {
+      return notRequiredResultFuture();
+    }
+  }
 
-  AvailabilityChecker<BlobSidecar> NOOP_BLOB_SIDECAR =
-      new AvailabilityChecker<>() {
-        @Override
-        public boolean initiateDataAvailabilityCheck() {
-          return true;
-        }
-
-        @Override
-        public SafeFuture<DataAndValidationResult<BlobSidecar>> getAvailabilityCheckResult() {
-          return notRequiredResultFuture();
-        }
-      };
-
-  AvailabilityChecker<UInt64> NOOP_DATACOLUMN_SIDECAR =
-      new AvailabilityChecker<>() {
-        @Override
-        public boolean initiateDataAvailabilityCheck() {
-          return true;
-        }
-
-        @Override
-        public SafeFuture<DataAndValidationResult<UInt64>> getAvailabilityCheckResult() {
-          return notRequiredResultFuture();
-        }
-      };
+  AvailabilityChecker<?> NOOP = new NOOP<>();
+  AvailabilityChecker<BlobSidecar> NOOP_BLOB_SIDECAR = new NOOP<>();
+  AvailabilityChecker<UInt64> NOOP_DATACOLUMN_SIDECAR = new NOOP<>();
 
   /**
    * Similar to {@link OptimisticExecutionPayloadExecutor#optimisticallyExecute(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityChecker.java
@@ -37,11 +37,31 @@ public interface AvailabilityChecker<Data> {
         }
       };
 
-  @SuppressWarnings("unchecked")
-  AvailabilityChecker<BlobSidecar> NOOP_BLOB_SIDECAR = (AvailabilityChecker<BlobSidecar>) NOOP;
+  AvailabilityChecker<BlobSidecar> NOOP_BLOB_SIDECAR =
+      new AvailabilityChecker<>() {
+        @Override
+        public boolean initiateDataAvailabilityCheck() {
+          return true;
+        }
 
-  @SuppressWarnings("unchecked")
-  AvailabilityChecker<UInt64> NOOP_DATACOLUMN_SIDECAR = (AvailabilityChecker<UInt64>) NOOP;
+        @Override
+        public SafeFuture<DataAndValidationResult<BlobSidecar>> getAvailabilityCheckResult() {
+          return notRequiredResultFuture();
+        }
+      };
+
+  AvailabilityChecker<UInt64> NOOP_DATACOLUMN_SIDECAR =
+      new AvailabilityChecker<>() {
+        @Override
+        public boolean initiateDataAvailabilityCheck() {
+          return true;
+        }
+
+        @Override
+        public SafeFuture<DataAndValidationResult<UInt64>> getAvailabilityCheckResult() {
+          return notRequiredResultFuture();
+        }
+      };
 
   /**
    * Similar to {@link OptimisticExecutionPayloadExecutor#optimisticallyExecute(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityCheckerFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityCheckerFactory.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.logic.common.statetransition.availability;
 
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 @FunctionalInterface
@@ -21,6 +23,11 @@ public interface AvailabilityCheckerFactory<T> {
   AvailabilityCheckerFactory<?> NOOP =
       (AvailabilityCheckerFactory<Object>)
           block -> (AvailabilityChecker<Object>) AvailabilityChecker.NOOP;
+
+  AvailabilityCheckerFactory<BlobSidecar> NOOP_BLOB_SIDECAR =
+      block -> AvailabilityChecker.NOOP_BLOB_SIDECAR;
+  AvailabilityCheckerFactory<UInt64> NOOP_DATACOLUMN_SIDECAR =
+      block -> AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
 
   AvailabilityChecker<T> createAvailabilityChecker(SignedBeaconBlock block);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityCheckerFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityCheckerFactory.java
@@ -17,5 +17,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 @FunctionalInterface
 public interface AvailabilityCheckerFactory<T> {
+  @SuppressWarnings("unchecked")
+  AvailabilityCheckerFactory<?> NOOP =
+      (AvailabilityCheckerFactory<Object>)
+          block -> (AvailabilityChecker<Object>) AvailabilityChecker.NOOP;
+
   AvailabilityChecker<T> createAvailabilityChecker(SignedBeaconBlock block);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityCheckerFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityCheckerFactory.java
@@ -19,11 +19,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 @FunctionalInterface
 public interface AvailabilityCheckerFactory<T> {
-  @SuppressWarnings("unchecked")
-  AvailabilityCheckerFactory<?> NOOP =
-      (AvailabilityCheckerFactory<Object>)
-          block -> (AvailabilityChecker<Object>) AvailabilityChecker.NOOP;
-
   AvailabilityCheckerFactory<BlobSidecar> NOOP_BLOB_SIDECAR =
       block -> AvailabilityChecker.NOOP_BLOB_SIDECAR;
   AvailabilityCheckerFactory<UInt64> NOOP_DATACOLUMN_SIDECAR =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/DataAndValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/DataAndValidationResult.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 
 public record DataAndValidationResult<Data>(
     AvailabilityValidationResult validationResult, List<Data> data, Optional<Throwable> cause) {
@@ -79,6 +80,15 @@ public record DataAndValidationResult<Data>(
 
   public boolean isSuccess() {
     return isValid() || isNotRequired();
+  }
+
+  public Optional<List<BlobSidecar>> getDataAsBlobSidecars() {
+    if (data != null && !data.isEmpty() && data.getFirst() instanceof BlobSidecar) {
+      @SuppressWarnings("unchecked")
+      final List<BlobSidecar> blobSidecars = (List<BlobSidecar>) data;
+      return Optional.of(blobSidecars);
+    }
+    return Optional.empty();
   }
 
   public String toLogString() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 
@@ -534,5 +535,9 @@ public class ForkChoiceUtil {
     final Optional<Bytes32> parentExecutionRoot =
         store.getForkChoiceStrategy().executionBlockHash(block.getParentRoot());
     return parentExecutionRoot.isPresent() && !parentExecutionRoot.get().isZero();
+  }
+
+  public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+    return AvailabilityChecker.NOOP;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -57,6 +57,8 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
   private final BlobSidecarSchema blobSidecarSchema;
   private final SpecConfigDeneb specConfigDeneb;
 
+  protected volatile KZG kzg;
+
   public static MiscHelpersDeneb required(final MiscHelpers miscHelpers) {
     return miscHelpers
         .toVersionDeneb()
@@ -65,6 +67,10 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
                 new IllegalArgumentException(
                     "Expected Deneb misc helpers but got: "
                         + miscHelpers.getClass().getSimpleName()));
+  }
+
+  public void setKzg(final KZG kzg) {
+    this.kzg = kzg;
   }
 
   public MiscHelpersDeneb(
@@ -84,12 +90,11 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
    * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof">verify_blob_kzg_proof</a>
    * on the given blob sidecar
    *
-   * @param kzg the kzg implementation which will be used for verification
    * @param blobSidecar blob sidecar to verify
    * @return true if blob sidecar is valid
    */
   @Override
-  public boolean verifyBlobKzgProof(final KZG kzg, final BlobSidecar blobSidecar) {
+  public boolean verifyBlobKzgProof(final BlobSidecar blobSidecar) {
     if (blobSidecar.isKzgValidated()) {
       return true;
     }
@@ -111,12 +116,11 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
    * href="https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch">verify_blob_kzg_proof_batch</a>
    * on the given blob sidecars
    *
-   * @param kzg the kzg implementation which will be used for verification
    * @param blobSidecars blob sidecars to verify, can be a partial set
    * @return true if all blob sidecars are valid
    */
   @Override
-  public boolean verifyBlobKzgProofBatch(final KZG kzg, final List<BlobSidecar> blobSidecars) {
+  public boolean verifyBlobKzgProofBatch(final List<BlobSidecar> blobSidecars) {
     final List<Bytes> blobs = new ArrayList<>();
     final List<KZGCommitment> kzgCommitments = new ArrayList<>();
     final List<KZGProof> kzgProofs = new ArrayList<>();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -57,7 +57,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
   private final BlobSidecarSchema blobSidecarSchema;
   private final SpecConfigDeneb specConfigDeneb;
 
-  protected volatile KZG kzg;
+  private volatile KZG kzg;
 
   public static MiscHelpersDeneb required(final MiscHelpers miscHelpers) {
     return miscHelpers
@@ -71,6 +71,14 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
 
   public void setKzg(final KZG kzg) {
     this.kzg = kzg;
+  }
+
+  public KZG getKzg() {
+    final KZG kzg = this.kzg;
+    if (kzg == null) {
+      throw new IllegalStateException("KZG not set");
+    }
+    return kzg;
   }
 
   public MiscHelpersDeneb(
@@ -99,10 +107,11 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
       return true;
     }
     final boolean result =
-        kzg.verifyBlobKzgProof(
-            blobSidecar.getBlob().getBytes(),
-            blobSidecar.getKZGCommitment(),
-            blobSidecar.getKZGProof());
+        getKzg()
+            .verifyBlobKzgProof(
+                blobSidecar.getBlob().getBytes(),
+                blobSidecar.getKZGCommitment(),
+                blobSidecar.getKZGProof());
 
     if (result) {
       blobSidecar.markKzgAsValidated();
@@ -138,7 +147,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
       return true;
     }
 
-    final boolean result = kzg.verifyBlobKzgProofBatch(blobs, kzgCommitments, kzgProofs);
+    final boolean result = getKzg().verifyBlobKzgProofBatch(blobs, kzgCommitments, kzgProofs);
 
     if (result) {
       blobSidecars.stream()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
@@ -79,6 +79,11 @@ public class ForkChoiceUtilDeneb extends ForkChoiceUtil {
 
   @Override
   public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+    final AvailabilityCheckerFactory<BlobSidecar> factory =
+        this.blobSidecarAvailabilityCheckerFactory;
+    if (factory == null) {
+      throw new IllegalStateException("blobSidecarAvailabilityCheckerFactory not initialized");
+    }
     return blobSidecarAvailabilityCheckerFactory.createAvailabilityChecker(block);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
@@ -20,14 +20,20 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 
 public class ForkChoiceUtilDeneb extends ForkChoiceUtil {
+
+  private volatile AvailabilityCheckerFactory<BlobSidecar> blobSidecarAvailabilityCheckerFactory;
 
   public ForkChoiceUtilDeneb(
       final SpecConfig specConfig,
@@ -36,6 +42,11 @@ public class ForkChoiceUtilDeneb extends ForkChoiceUtil {
       final AttestationUtil attestationUtil,
       final MiscHelpers miscHelpers) {
     super(specConfig, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
+  }
+
+  public void setBlobSidecarAvailabilityCheckerFactory(
+      final AvailabilityCheckerFactory<BlobSidecar> factory) {
+    this.blobSidecarAvailabilityCheckerFactory = factory;
   }
 
   @Override
@@ -64,5 +75,10 @@ public class ForkChoiceUtilDeneb extends ForkChoiceUtil {
             .getRight();
 
     return maybeAvailabilityWindowStartSlot.max(firstDenebSlot);
+  }
+
+  @Override
+  public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+    return blobSidecarAvailabilityCheckerFactory.createAvailabilityChecker(block);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
@@ -84,6 +84,6 @@ public class ForkChoiceUtilDeneb extends ForkChoiceUtil {
     if (factory == null) {
       throw new IllegalStateException("blobSidecarAvailabilityCheckerFactory not initialized");
     }
-    return blobSidecarAvailabilityCheckerFactory.createAvailabilityChecker(block);
+    return factory.createAvailabilityChecker(block);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BeaconStateMutato
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
-import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
@@ -54,6 +53,7 @@ import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFu
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.statetransition.epoch.EpochProcessorFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.BlindBlockUtilFulu;
+import tech.pegasys.teku.spec.logic.versions.fulu.util.ForkChoiceUtilFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 
 public class SpecLogicFulu extends AbstractSpecLogic {
@@ -198,7 +198,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
             executionRequestsDataCodec,
             executionRequestsProcessor);
     final ForkChoiceUtil forkChoiceUtil =
-        new ForkChoiceUtilDeneb(
+        new ForkChoiceUtilFulu(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
         new BlockProposalUtil(schemaDefinitions, blockProcessor);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -273,12 +273,13 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
                         new KZGCell(dataColumnSidecar.getColumn().get(rowIndex).getBytes()),
                         dataColumnSidecar.getIndex().intValue()))
             .collect(Collectors.toList());
-    return kzg.verifyCellProofBatch(
-        dataColumnSidecar.getKzgCommitments().stream()
-            .map(SszKZGCommitment::getKZGCommitment)
-            .toList(),
-        cellWithIds,
-        dataColumnSidecar.getKzgProofs().stream().map(SszKZGProof::getKZGProof).toList());
+    return getKzg()
+        .verifyCellProofBatch(
+            dataColumnSidecar.getKzgCommitments().stream()
+                .map(SszKZGCommitment::getKZGCommitment)
+                .toList(),
+            cellWithIds,
+            dataColumnSidecar.getKzgProofs().stream().map(SszKZGProof::getKZGProof).toList());
   }
 
   public boolean verifyDataColumnSidecarKzgProofsBatch(
@@ -296,16 +297,17 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
                                         dataColumnSidecar.getColumn().get(rowIndex).getBytes()),
                                     dataColumnSidecar.getIndex().intValue())))
             .toList();
-    return kzg.verifyCellProofBatch(
-        dataColumnSidecars.stream()
-            .flatMap(sidecar -> sidecar.getKzgCommitments().stream())
-            .map(SszKZGCommitment::getKZGCommitment)
-            .toList(),
-        cellWithIds,
-        dataColumnSidecars.stream()
-            .flatMap(sidecar -> sidecar.getKzgProofs().stream())
-            .map(SszKZGProof::getKZGProof)
-            .toList());
+    return getKzg()
+        .verifyCellProofBatch(
+            dataColumnSidecars.stream()
+                .flatMap(sidecar -> sidecar.getKzgCommitments().stream())
+                .map(SszKZGCommitment::getKZGCommitment)
+                .toList(),
+            cellWithIds,
+            dataColumnSidecars.stream()
+                .flatMap(sidecar -> sidecar.getKzgProofs().stream())
+                .map(SszKZGProof::getKZGProof)
+                .toList());
   }
 
   public boolean verifyDataColumnSidecarInclusionProof(final DataColumnSidecar dataColumnSidecar) {
@@ -374,7 +376,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
         .mapToObj(
             blobIndex -> {
               final List<KZGCellAndProof> kzgCellAndProofs =
-                  kzg.computeCellsAndProofs(blobs.get(blobIndex).getBytes());
+                  getKzg().computeCellsAndProofs(blobs.get(blobIndex).getBytes());
               final List<MatrixEntry> row = new ArrayList<>();
               for (int cellIndex = 0; cellIndex < kzgCellAndProofs.size(); ++cellIndex) {
                 row.add(
@@ -398,7 +400,8 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
         .mapToObj(
             blobIndex -> {
               final BlobAndCellProofs blobAndCellProofs = blobAndCellProofsList.get(blobIndex);
-              final List<KZGCell> kzgCells = kzg.computeCells(blobAndCellProofs.blob().getBytes());
+              final List<KZGCell> kzgCells =
+                  getKzg().computeCells(blobAndCellProofs.blob().getBytes());
               final List<MatrixEntry> row = new ArrayList<>();
               for (int cellIndex = 0; cellIndex < kzgCells.size(); ++cellIndex) {
                 row.add(
@@ -551,7 +554,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
                                   new KZGCellID(entry.getColumnIndex())))
                       .toList();
               final List<KZGCellAndProof> kzgCellAndProofs =
-                  kzg.recoverCellsAndProofs(cellWithColumnIds);
+                  getKzg().recoverCellsAndProofs(cellWithColumnIds);
               return IntStream.range(0, kzgCellAndProofs.size())
                   .mapToObj(
                       kzgCellAndProofIndex ->

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.fulu.util;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
+
+public class ForkChoiceUtilFulu extends ForkChoiceUtilDeneb {
+
+  private volatile AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory;
+
+  public ForkChoiceUtilFulu(
+      final SpecConfig specConfig,
+      final BeaconStateAccessors beaconStateAccessors,
+      final EpochProcessor epochProcessor,
+      final AttestationUtil attestationUtil,
+      final MiscHelpers miscHelpers) {
+    super(specConfig, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
+  }
+
+  public void setDataColumnSidecarAvailabilityCheckerFactory(
+      final AvailabilityCheckerFactory<UInt64> factory) {
+    this.dataColumnSidecarAvailabilityCheckerFactory = factory;
+  }
+
+  @Override
+  public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+    return dataColumnSidecarAvailabilityCheckerFactory.createAvailabilityChecker(block);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
@@ -44,6 +44,12 @@ public class ForkChoiceUtilFulu extends ForkChoiceUtilDeneb {
 
   @Override
   public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
-    return dataColumnSidecarAvailabilityCheckerFactory.createAvailabilityChecker(block);
+    final AvailabilityCheckerFactory<UInt64> factory =
+        this.dataColumnSidecarAvailabilityCheckerFactory;
+    if (factory == null) {
+      throw new IllegalStateException(
+          "DataColumnSidecarAvailabilityCheckerFactory not initialized");
+    }
+    return factory.createAvailabilityChecker(block);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.spec.logic.common.withdrawals.WithdrawalsHelpers;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
-import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
@@ -46,6 +45,7 @@ import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.operations.validation.AttestationDataValidatorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch.EpochProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.AttestationUtilGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.withdrawals.WithdrawalsHelpersGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
@@ -204,7 +204,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
             executionRequestsDataCodec,
             executionRequestsProcessor);
     final ForkChoiceUtil forkChoiceUtil =
-        new ForkChoiceUtilDeneb(
+        new ForkChoiceUtilGloas(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
         new BlockProposalUtil(schemaDefinitions, blockProcessor);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -35,8 +35,10 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
 
   @Override
   public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
-    // checking of blob data availability is delayed until the processing of the execution
-    // payload in ePBS
+    // TODO(GLOAS): in ePBS, data availability is delayed until the processing of the execution
+    // payload.
+    // We may have a dedicated availability checker for the execution stage.
+    // If it will be the case, this will remain a NOOP
     return AvailabilityChecker.NOOP;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.util;
+
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.versions.fulu.util.ForkChoiceUtilFulu;
+
+public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
+
+  public ForkChoiceUtilGloas(
+      final SpecConfig specConfig,
+      final BeaconStateAccessors beaconStateAccessors,
+      final EpochProcessor epochProcessor,
+      final AttestationUtil attestationUtil,
+      final MiscHelpers miscHelpers) {
+    super(specConfig, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
+  }
+
+  @Override
+  public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+    // checking of blob data availability is delayed until the processing of the execution
+    // payload in ePBS
+    return AvailabilityChecker.NOOP;
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebPropertyTest.java
@@ -21,18 +21,18 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.From;
 import net.jqwik.api.Property;
 import net.jqwik.api.lifecycle.AddLifecycleHook;
+import net.jqwik.api.lifecycle.BeforeProperty;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
-import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.propertytest.suppliers.SpecSupplier;
 import tech.pegasys.teku.spec.propertytest.suppliers.blobs.versions.deneb.BlobSidecarIndexSupplier;
@@ -40,25 +40,28 @@ import tech.pegasys.teku.spec.propertytest.suppliers.blobs.versions.deneb.BlobSi
 import tech.pegasys.teku.spec.propertytest.suppliers.blobs.versions.deneb.BlobSupplier;
 import tech.pegasys.teku.spec.propertytest.suppliers.type.KZGCommitmentSupplier;
 import tech.pegasys.teku.spec.propertytest.suppliers.type.SszKZGProofSupplier;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 /**
  * blob_kzg_commitments are removed in Gloas so for testing this class, we only consider Spec and
  * SignedBeaconBlock until Fulu.
  */
+@AddLifecycleHook(KzgResolver.class)
 public class MiscHelpersDenebPropertyTest {
 
   private final Spec spec =
       Objects.requireNonNull(new SpecSupplier(SpecMilestone.DENEB, SpecMilestone.FULU).get())
           .sample();
-  private final SpecConfigDeneb specConfig =
-      spec.getGenesisSpecConfig().toVersionDeneb().orElseThrow();
-  private final Predicates predicates = spec.getGenesisSpec().predicates();
-  private final SchemaDefinitionsDeneb schemaDefinitionsDeneb =
-      spec.getGenesisSchemaDefinitions().toVersionDeneb().orElseThrow();
   private final MiscHelpersDeneb miscHelpers =
-      new MiscHelpersDeneb(specConfig, predicates, schemaDefinitionsDeneb);
+      (MiscHelpersDeneb) spec.getGenesisSpec().miscHelpers();
+
+  @BeforeProperty
+  void beforeProperty(final KZG kzg) {
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
+  }
 
   @Property(tries = 100)
   void fuzzKzgCommitmentToVersionedHash(
@@ -66,24 +69,21 @@ public class MiscHelpersDenebPropertyTest {
     miscHelpers.kzgCommitmentToVersionedHash(commitment);
   }
 
-  @AddLifecycleHook(KzgResolver.class)
   @Property(tries = 100)
   void fuzzVerifyBlobKzgProof(
-      final KZG kzg, @ForAll(supplier = BlobSidecarSupplier.class) final BlobSidecar blobSidecar) {
+      @ForAll(supplier = BlobSidecarSupplier.class) final BlobSidecar blobSidecar) {
     try {
-      miscHelpers.verifyBlobKzgProof(kzg, blobSidecar);
+      miscHelpers.verifyBlobKzgProof(blobSidecar);
     } catch (Exception e) {
       assertThat(e).isInstanceOf(KZGException.class);
     }
   }
 
-  @AddLifecycleHook(KzgResolver.class)
   @Property(tries = 100)
   void fuzzVerifyBlobKzgProofBatch(
-      final KZG kzg,
       @ForAll final List<@From(supplier = BlobSidecarSupplier.class) BlobSidecar> blobSidecars) {
     try {
-      miscHelpers.verifyBlobKzgProofBatch(kzg, blobSidecars);
+      miscHelpers.verifyBlobKzgProofBatch(blobSidecars);
     } catch (Exception e) {
       assertThat(e).isInstanceOf(KZGException.class);
     }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -31,11 +31,14 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -45,6 +48,8 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreFactory;
 import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreImpl;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.spec.util.RandomChainBuilder;
 import tech.pegasys.teku.spec.util.RandomChainBuilderForkChoiceStrategy;
@@ -269,6 +274,39 @@ class ForkChoiceUtilTest {
     }
 
     return args.stream();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SpecMilestone.class)
+  void createAvailabilityChecker_shouldCreateExpectedChecker(final SpecMilestone milestone) {
+    final Spec spec = TestSpecFactory.createMinimal(milestone);
+    final ForkChoiceUtil util = spec.getGenesisSpec().getForkChoiceUtil();
+    @SuppressWarnings("unchecked")
+    final AvailabilityCheckerFactory<BlobSidecar> blobSidecarAvailabilityCheckerFactory =
+        mock(AvailabilityCheckerFactory.class);
+    @SuppressWarnings("unchecked")
+    final AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory =
+        mock(AvailabilityCheckerFactory.class);
+
+    final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
+
+    spec.reinitializeForTesting(
+        blobSidecarAvailabilityCheckerFactory,
+        dataColumnSidecarAvailabilityCheckerFactory,
+        KZG.DISABLED);
+
+    final AvailabilityChecker<?> availabilityChecker = util.createAvailabilityChecker(block);
+
+    if (milestone.isLessThan(SpecMilestone.DENEB) || milestone.isGreaterThan(SpecMilestone.FULU)) {
+      assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP);
+    } else if (milestone.isGreaterThanOrEqualTo(SpecMilestone.DENEB)
+        && milestone.isLessThan(SpecMilestone.FULU)) {
+      verify(blobSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
+    } else if (milestone.equals(SpecMilestone.FULU)) {
+      verify(dataColumnSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
+    } else {
+      throw new IllegalStateException("Unexpected milestone " + milestone);
+    }
   }
 
   @ParameterizedTest

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -297,15 +297,15 @@ class ForkChoiceUtilTest {
 
     final AvailabilityChecker<?> availabilityChecker = util.createAvailabilityChecker(block);
 
-    if (milestone.isLessThan(SpecMilestone.DENEB) || milestone.isGreaterThan(SpecMilestone.FULU)) {
-      assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP);
-    } else if (milestone.isGreaterThanOrEqualTo(SpecMilestone.DENEB)
-        && milestone.isLessThan(SpecMilestone.FULU)) {
-      verify(blobSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
-    } else if (milestone.equals(SpecMilestone.FULU)) {
-      verify(dataColumnSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
-    } else {
-      throw new IllegalStateException("Unexpected milestone " + milestone);
+    switch (milestone) {
+      case PHASE0, ALTAIR, BELLATRIX, CAPELLA ->
+          assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP);
+      case DENEB, ELECTRA ->
+          verify(blobSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
+      case FULU ->
+          verify(dataColumnSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
+      case GLOAS -> assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP); // TODO
+      default -> throw new IllegalStateException("Unexpected milestone " + milestone);
     }
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFuluTest.java
@@ -39,8 +39,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
-import tech.pegasys.teku.kzg.trusted_setups.TrustedSetupLoader;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.BlobScheduleEntry;
@@ -73,13 +71,12 @@ public class MiscHelpersFuluTest {
                           .balancePerAdditionalCustodyGroup(UInt64.valueOf(32000000000L))
                           .samplesPerSlot(16)));
   private final SpecConfig specConfig = spec.atSlot(ZERO).getConfig();
-  private final PredicatesElectra predicates = new PredicatesElectra(spec.getGenesisSpecConfig());
   private final SchemaDefinitionsFulu schemaDefinitionsFulu =
       SchemaDefinitionsFulu.required(spec.getGenesisSchemaDefinitions());
   private final SpecConfigFulu specConfigFulu =
       SpecConfigFulu.required(spec.getGenesisSpecConfig());
   private final MiscHelpersFulu miscHelpersFulu =
-      new MiscHelpersFulu(specConfigFulu, predicates, schemaDefinitionsFulu);
+      spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow();
 
   @ParameterizedTest
   @MethodSource("getComputeForkDigestFuluScenarios")
@@ -299,14 +296,10 @@ public class MiscHelpersFuluTest {
 
   @Test
   public void verifyKzgProofExampleFromDevnet() throws Exception {
-    final KZG kzg = KZG.getInstance(false);
-    TrustedSetupLoader.loadTrustedSetupForTests(kzg);
-
     final byte[] sidecarSsz =
         Resources.toByteArray(Resources.getResource(MiscHelpersFuluTest.class, "sidecar.ssz"));
     assertThat(
             miscHelpersFulu.verifyDataColumnSidecarKzgProofs(
-                kzg,
                 schemaDefinitionsFulu
                     .getDataColumnSidecarSchema()
                     .sszDeserialize(Bytes.wrap(sidecarSsz))))

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -19,8 +19,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import com.google.common.base.Preconditions;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
-import tech.pegasys.teku.kzg.trusted_setups.TrustedSetupLoader;
+import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAndParent;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
@@ -367,14 +366,12 @@ public class TestSpecFactory {
   public static Spec create(
       final SpecConfigAndParent<? extends SpecConfig> config,
       final SpecMilestone highestSupportedMilestone) {
-    var spec = Spec.create(config, highestSupportedMilestone);
-    var kzg = KZG.getInstance(false);
-    TrustedSetupLoader.loadTrustedSetupForTests(kzg);
+    final Spec spec = Spec.create(config, highestSupportedMilestone);
 
     spec.initialize(
         AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
         AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
-        kzg);
+        NoOpKZG.INSTANCE);
     return spec;
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -19,6 +19,8 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import com.google.common.base.Preconditions;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
+import tech.pegasys.teku.kzg.trusted_setups.TrustedSetupLoader;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAndParent;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
@@ -366,9 +368,13 @@ public class TestSpecFactory {
       final SpecConfigAndParent<? extends SpecConfig> config,
       final SpecMilestone highestSupportedMilestone) {
     var spec = Spec.create(config, highestSupportedMilestone);
+    var kzg = KZG.getInstance(false);
+    TrustedSetupLoader.loadTrustedSetupForTests(kzg);
+
     spec.initialize(
         AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
-        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR);
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     return spec;
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAndParent;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
 public class TestSpecFactory {
@@ -364,7 +365,11 @@ public class TestSpecFactory {
   public static Spec create(
       final SpecConfigAndParent<? extends SpecConfig> config,
       final SpecMilestone highestSupportedMilestone) {
-    return Spec.create(config, highestSupportedMilestone);
+    var spec = Spec.create(config, highestSupportedMilestone);
+    spec.initialize(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR);
+    return spec;
   }
 
   private static SpecConfigAndParent<? extends SpecConfig> getAltairSpecConfig(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SyncAsyncRunner;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.kzg.NoOpKZG;
@@ -110,7 +109,6 @@ public class ChainBuilder {
       new TreeMap<>();
   private final Map<Bytes32, List<DataColumnSidecar>> dataColumnSidecarsByHash = new HashMap<>();
   private final BlockProposalTestUtil blockProposalTestUtil;
-  private final KZG kzg;
   private final BlobsUtil blobsUtil;
 
   private ChainBuilder(
@@ -122,8 +120,7 @@ public class ChainBuilder {
       final Map<SlotAndBlockRoot, List<DataColumnSidecar>> existingDataColumnSidecars) {
     this.spec = spec;
     this.validatorKeys = validatorKeys;
-    this.kzg = NoOpKZG.INSTANCE;
-    this.blobsUtil = new BlobsUtil(spec, kzg);
+    this.blobsUtil = new BlobsUtil(spec, NoOpKZG.INSTANCE);
     this.attestationGenerator = new AttestationGenerator(spec, validatorKeys);
     this.attesterSlashingGenerator = new AttesterSlashingGenerator(spec, validatorKeys);
     this.proposerSlashingGenerator = new ProposerSlashingGenerator(spec, validatorKeys);
@@ -919,7 +916,7 @@ public class ChainBuilder {
               .toList();
       final List<DataColumnSidecar> dataColumnSidecars =
           miscHelpersFulu.constructDataColumnSidecars(
-              nextBlockAndState.getBlock(), blobAndCellProofsList, kzg);
+              nextBlockAndState.getBlock(), blobAndCellProofsList);
 
       trackDataColumnSidecars(nextBlockAndState.getSlotAndBlockRoot(), dataColumnSidecars);
     }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -43,7 +43,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
-import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -120,7 +119,7 @@ public class ChainBuilder {
       final Map<SlotAndBlockRoot, List<DataColumnSidecar>> existingDataColumnSidecars) {
     this.spec = spec;
     this.validatorKeys = validatorKeys;
-    this.blobsUtil = new BlobsUtil(spec, NoOpKZG.INSTANCE);
+    this.blobsUtil = new BlobsUtil(spec);
     this.attestationGenerator = new AttestationGenerator(spec, validatorKeys);
     this.attesterSlashingGenerator = new AttesterSlashingGenerator(spec, validatorKeys);
     this.proposerSlashingGenerator = new ProposerSlashingGenerator(spec, validatorKeys);

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.generator.AggregateGenerator;
 import tech.pegasys.teku.statetransition.attestation.utils.AggregatingAttestationPoolProfiler;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
@@ -87,7 +86,6 @@ class AttestationManagerIntegrationTest {
           spec,
           new InlineEventThread(),
           recentChainData,
-          BlobSidecarManager.NOOP,
           new NoopForkChoiceNotifier(),
           transitionBlockValidator,
           storageSystem.getMetricsSystem());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
@@ -50,7 +50,7 @@ public interface BlobSidecarManager extends AvailabilityCheckerFactory<BlobSidec
         @Override
         public AvailabilityChecker<BlobSidecar> createAvailabilityChecker(
             final SignedBeaconBlock block) {
-          return AvailabilityChecker.NOOP_BLOBSIDECAR;
+          return AvailabilityChecker.NOOP_BLOB_SIDECAR;
         }
 
         @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -138,15 +138,6 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
 
   @Override
   public AvailabilityChecker<BlobSidecar> createAvailabilityChecker(final SignedBeaconBlock block) {
-    // Block is pre-Deneb, blobs are not supported yet
-    if (block.getMessage().getBody().toVersionDeneb().isEmpty()) {
-      return AvailabilityChecker.NOOP_BLOBSIDECAR;
-    }
-    // Block is post-BlobSidecars
-    if (spec.atSlot(block.getSlot()).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
-      return AvailabilityChecker.NOOP_BLOBSIDECAR;
-    }
-
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
         blockBlobSidecarsTrackersPool.getOrCreateBlockBlobSidecarsTracker(block);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -22,7 +22,6 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -55,7 +54,6 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
       final RecentChainData recentChainData,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final BlobSidecarGossipValidator validator,
-      final KZG kzg,
       final FutureItems<BlobSidecar> futureBlobSidecars,
       final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots) {
     this(
@@ -65,7 +63,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
         validator,
         futureBlobSidecars,
         invalidBlobSidecarRoots,
-        (tracker) -> new BlobSidecarsAvailabilityChecker(spec, recentChainData, tracker, kzg),
+        (tracker) -> new BlobSidecarsAvailabilityChecker(spec, recentChainData, tracker),
         (block) -> new BlockBlobSidecarsTracker(block.getSlotAndBlockRoot()));
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerManager.java
@@ -22,8 +22,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.availability.Availabi
 import tech.pegasys.teku.statetransition.forkchoice.DataColumnSidecarAvailabilityChecker;
 
 public class DasSamplerManager implements AvailabilityCheckerFactory<UInt64> {
-  public static final AvailabilityCheckerFactory<UInt64> NOOP =
-      block -> AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
+  public static final AvailabilityCheckerFactory<UInt64> NOOP =  NOOP_DATACOLUMN_SIDECAR;
   private final Supplier<DataAvailabilitySampler> dataAvailabilitySamplerSupplier;
   final Spec spec;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerManager.java
@@ -17,12 +17,11 @@ import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.statetransition.forkchoice.DataColumnSidecarAvailabilityChecker;
 
 public class DasSamplerManager implements AvailabilityCheckerFactory<UInt64> {
-  public static final AvailabilityCheckerFactory<UInt64> NOOP =  NOOP_DATACOLUMN_SIDECAR;
+  public static final AvailabilityCheckerFactory<UInt64> NOOP = NOOP_DATACOLUMN_SIDECAR;
   private final Supplier<DataAvailabilitySampler> dataAvailabilitySamplerSupplier;
   final Spec spec;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerManager.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
@@ -26,15 +25,11 @@ public class DasSamplerManager implements AvailabilityCheckerFactory<UInt64> {
   public static final AvailabilityCheckerFactory<UInt64> NOOP =
       block -> AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
   private final Supplier<DataAvailabilitySampler> dataAvailabilitySamplerSupplier;
-  final KZG kzg;
   final Spec spec;
 
   public DasSamplerManager(
-      final Supplier<DataAvailabilitySampler> dataAvailabilitySamplerSupplier,
-      final KZG kzg,
-      final Spec spec) {
+      final Supplier<DataAvailabilitySampler> dataAvailabilitySamplerSupplier, final Spec spec) {
     this.dataAvailabilitySamplerSupplier = dataAvailabilitySamplerSupplier;
-    this.kzg = kzg;
     this.spec = spec;
   }
 
@@ -42,6 +37,6 @@ public class DasSamplerManager implements AvailabilityCheckerFactory<UInt64> {
   public DataColumnSidecarAvailabilityChecker createAvailabilityChecker(
       final SignedBeaconBlock block) {
     return new DataColumnSidecarAvailabilityChecker(
-        dataAvailabilitySamplerSupplier.get(), kzg, spec, block);
+        dataAvailabilitySamplerSupplier.get(), spec, block);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -39,7 +39,6 @@ import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -55,7 +54,6 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
   private final DataColumnSidecarByRootCustody delegate;
   private final AsyncRunner asyncRunner;
   private final MiscHelpersFulu miscHelpers;
-  private final KZG kzg;
   private final Spec spec;
   private final BiConsumer<DataColumnSidecar, RemoteOrigin> dataColumnSidecarPublisher;
   private final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
@@ -76,7 +74,6 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
       final AsyncRunner asyncRunner,
       final Spec spec,
       final MiscHelpersFulu miscHelpers,
-      final KZG kzg,
       final BiConsumer<DataColumnSidecar, RemoteOrigin> dataColumnSidecarPublisher,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final int columnCount,
@@ -87,7 +84,6 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
     this.delegate = delegate;
     this.asyncRunner = asyncRunner;
     this.miscHelpers = miscHelpers;
-    this.kzg = kzg;
     this.spec = spec;
     this.dataColumnSidecarPublisher = dataColumnSidecarPublisher;
     this.custodyGroupCountManagerSupplier = custodyGroupCountManagerSupplier;
@@ -231,7 +227,7 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
       final Collection<DataColumnSidecar> sidecars,
       final MetricsHistogram.Timer timer) {
     final List<DataColumnSidecar> recoveredSidecars =
-        miscHelpers.reconstructAllDataColumnSidecars(sidecars, kzg);
+        miscHelpers.reconstructAllDataColumnSidecars(sidecars);
     timer.closeUnchecked().run();
 
     final Set<UInt64> existingSidecarsIndices =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTask.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTask.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
@@ -43,7 +42,6 @@ class RebuildColumnsTask {
   private boolean isReadyToRebuild = false;
   private final MiscHelpersFulu miscHelpers;
   protected final Map<Integer, DataColumnSidecar> sidecarMap = new ConcurrentSkipListMap<>();
-  private final KZG kzg;
   protected final AtomicBoolean done = new AtomicBoolean(false);
 
   RebuildColumnsTask(
@@ -52,14 +50,12 @@ class RebuildColumnsTask {
       final Duration timeout,
       final int minimumColumnsForRebuild,
       final DataColumnSidecarDbAccessor sidecarDB,
-      final MiscHelpersFulu miscHelpers,
-      final KZG kzg) {
+      final MiscHelpersFulu miscHelpers) {
     this.slotAndBlockRoot = slotAndBlockRoot;
     this.timeoutMillis = timestampMillis.plus(timeout.toMillis());
     this.minimumColumnsForRebuild = minimumColumnsForRebuild;
     this.sidecarDB = sidecarDB;
     this.miscHelpers = miscHelpers;
-    this.kzg = kzg;
     query = SafeFuture.COMPLETE;
   }
 
@@ -148,7 +144,7 @@ class RebuildColumnsTask {
       LOG.trace(
           "Rebuilding columns at {}, {} columns in cache", slotAndBlockRoot, sidecarMap.size());
       final Map<UInt64, DataColumnSidecar> reconstructedSidecars =
-          miscHelpers.reconstructAllDataColumnSidecars(sidecarMap.values(), kzg).stream()
+          miscHelpers.reconstructAllDataColumnSidecars(sidecarMap.values()).stream()
               .collect(
                   Collectors.toUnmodifiableMap(DataColumnSidecar::getIndex, Function.identity()));
       LOG.debug(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
@@ -40,7 +39,6 @@ public class SidecarRetriever implements DataColumnSidecarRetriever {
   private static final Logger LOG = LogManager.getLogger();
 
   private final DataColumnSidecarRetriever downloader;
-  private final KZG kzg;
   private final MiscHelpersFulu miscHelpersFulu;
   private final DataColumnSidecarDbAccessor sidecarDB;
   private final AsyncRunner asyncRunner;
@@ -64,7 +62,6 @@ public class SidecarRetriever implements DataColumnSidecarRetriever {
 
   public SidecarRetriever(
       final DataColumnSidecarRetriever delegate,
-      final KZG kzg,
       final MiscHelpersFulu miscHelpersFulu,
       final DataColumnSidecarDbAccessor sidecarDB,
       final AsyncRunner asyncRunner,
@@ -74,7 +71,6 @@ public class SidecarRetriever implements DataColumnSidecarRetriever {
       final int numberOfColumns,
       final MetricsSystem metricsSystem) {
     downloader = delegate;
-    this.kzg = kzg;
     this.miscHelpersFulu = miscHelpersFulu;
     this.sidecarDB = sidecarDB;
     this.asyncRunner = asyncRunner;
@@ -204,8 +200,7 @@ public class SidecarRetriever implements DataColumnSidecarRetriever {
                               recoveryTimeout.dividedBy(2),
                               numberOfColumnsRequiredToReconstruct,
                               sidecarDB,
-                              miscHelpersFulu,
-                              kzg));
+                              miscHelpersFulu));
               LOG.debug(
                   "Rebuilding columns for slot {} root {}",
                   request.getSlot(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImpl.java
@@ -44,7 +44,6 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -94,7 +93,6 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
   private final int maxTrackers;
   private final BiConsumer<List<DataColumnSidecar>, RemoteOrigin> dataColumnSidecarPublisher;
   private final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
-  private final KZG kzg;
 
   private final MetricsHistogram dataColumnSidecarComputationTimeSeconds;
   private final Counter getBlobsV2RequestsCounter;
@@ -122,7 +120,6 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
       final UInt64 historicalSlotTolerance,
       final UInt64 futureSlotTolerance,
       final int maxTrackers,
-      final KZG kzg,
       final BiConsumer<List<DataColumnSidecar>, RemoteOrigin> dataColumnSidecarPublisher,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final MetricsSystem metricsSystem,
@@ -135,7 +132,6 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
     this.recentChainData = recentChainData;
     this.executionLayer = executionLayer;
     this.maxTrackers = maxTrackers;
-    this.kzg = kzg;
     this.dataColumnSidecarPublisher = dataColumnSidecarPublisher;
     this.custodyGroupCountManagerSupplier = custodyGroupCountManagerSupplier;
     this.localElBlobsFetchingRetryDelay = localElBlobsFetchingRetryDelay;
@@ -262,8 +258,7 @@ public class DataColumnSidecarELRecoveryManagerImpl extends AbstractIgnoringFutu
                   recoveryTask.signedBeaconBlockHeader(),
                   recoveryTask.sszKZGCommitments(),
                   recoveryTask.kzgCommitmentsInclusionProof(),
-                  blobAndCellProofs,
-                  kzg);
+                  blobAndCellProofs);
     } catch (final Throwable t) {
       throw new RuntimeException(t);
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/BlobSidecarsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/BlobSidecarsAvailabilityChecker.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeoutException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -38,7 +37,6 @@ public class BlobSidecarsAvailabilityChecker implements AvailabilityChecker<Blob
   private final Spec spec;
   private final RecentChainData recentChainData;
   private final BlockBlobSidecarsTracker blockBlobSidecarsTracker;
-  private final KZG kzg;
 
   private final SafeFuture<DataAndValidationResult<BlobSidecar>> validationResult =
       new SafeFuture<>();
@@ -48,12 +46,10 @@ public class BlobSidecarsAvailabilityChecker implements AvailabilityChecker<Blob
   public BlobSidecarsAvailabilityChecker(
       final Spec spec,
       final RecentChainData recentChainData,
-      final BlockBlobSidecarsTracker blockBlobSidecarsTracker,
-      final KZG kzg) {
+      final BlockBlobSidecarsTracker blockBlobSidecarsTracker) {
     this.spec = spec;
     this.recentChainData = recentChainData;
     this.blockBlobSidecarsTracker = blockBlobSidecarsTracker;
-    this.kzg = kzg;
     this.waitForTrackerCompletionTimeout =
         calculateCompletionTimeout(spec, blockBlobSidecarsTracker.getSlotAndBlockRoot().getSlot());
   }
@@ -63,12 +59,10 @@ public class BlobSidecarsAvailabilityChecker implements AvailabilityChecker<Blob
       final Spec spec,
       final RecentChainData recentChainData,
       final BlockBlobSidecarsTracker blockBlobSidecarsTracker,
-      final KZG kzg,
       final Duration waitForTrackerCompletionTimeout) {
     this.spec = spec;
     this.recentChainData = recentChainData;
     this.blockBlobSidecarsTracker = blockBlobSidecarsTracker;
-    this.kzg = kzg;
     this.waitForTrackerCompletionTimeout = waitForTrackerCompletionTimeout;
   }
 
@@ -110,7 +104,7 @@ public class BlobSidecarsAvailabilityChecker implements AvailabilityChecker<Blob
     final SignedBeaconBlock block = blockBlobSidecarsTracker.getBlock().orElseThrow();
 
     try {
-      if (!miscHelpers.verifyBlobKzgProofBatch(kzg, blobSidecars)) {
+      if (!miscHelpers.verifyBlobKzgProofBatch(blobSidecars)) {
         return DataAndValidationResult.invalidResult(blobSidecars);
       }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
@@ -17,7 +17,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
@@ -29,18 +28,15 @@ public class DataColumnSidecarAvailabilityChecker implements AvailabilityChecker
 
   private final DataAvailabilitySampler dataAvailabilitySampler;
   private final SafeFuture<DataAndValidationResult<UInt64>> validationResult = new SafeFuture<>();
-  final KZG kzg;
   final Spec spec;
 
   private final SignedBeaconBlock block;
 
   public DataColumnSidecarAvailabilityChecker(
       final DataAvailabilitySampler dataAvailabilitySampler,
-      final KZG kzg,
       final Spec spec,
       final SignedBeaconBlock block) {
     this.dataAvailabilitySampler = dataAvailabilitySampler;
-    this.kzg = kzg;
     this.spec = spec;
     this.block = block;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -648,20 +648,16 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
   private Optional<List<BlobSidecar>> extractBlobSidecarsFromValidationResults(
       final DataAndValidationResult<?> dataAndValidationResult, final SignedBeaconBlock block) {
-    final Optional<List<BlobSidecar>> blobSidecars;
     if (dataAndValidationResult.isNotRequired()) {
       // Outside availability window or pre-Deneb
-      blobSidecars = Optional.empty();
+      return Optional.empty();
     } else if (dataAndValidationResult.isValid()) {
       return dataAndValidationResult.getDataAsBlobSidecars();
-    } else {
-      throw new IllegalStateException(
-          String.format(
-              "Unexpected attempt to store invalid sidecars (%s) for block: %s",
-              dataAndValidationResult.data().size(), block.toLogString()));
     }
-
-    return blobSidecars;
+    throw new IllegalStateException(
+        String.format(
+            "Unexpected attempt to store invalid sidecars (%s) for block: %s",
+            dataAndValidationResult.data().size(), block.toLogString()));
   }
 
   /**

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.cache.CapturingIndexedAttestationCache;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
@@ -66,16 +65,13 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
-import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.statetransition.attestation.DeferredAttestations;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImportPerformance;
-import tech.pegasys.teku.statetransition.datacolumns.DasSamplerManager;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AttestationStateSelector;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
@@ -96,8 +92,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   private final EventThread forkChoiceExecutor;
   private final ForkChoiceStateProvider forkChoiceStateProvider;
   private final RecentChainData recentChainData;
-  private final BlobSidecarManager blobSidecarManager;
-  private final AvailabilityCheckerFactory<UInt64> dasSamplerManager;
   private final ForkChoiceNotifier forkChoiceNotifier;
   private final MergeTransitionBlockValidator transitionBlockValidator;
   private final AttestationStateSelector attestationStateSelector;
@@ -119,8 +113,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final Spec spec,
       final EventThread forkChoiceExecutor,
       final RecentChainData recentChainData,
-      final BlobSidecarManager blobSidecarManager,
-      final AvailabilityCheckerFactory<UInt64> dasSamplerManager,
       final ForkChoiceNotifier forkChoiceNotifier,
       final ForkChoiceStateProvider forkChoiceStateProvider,
       final TickProcessor tickProcessor,
@@ -130,8 +122,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final MetricsSystem metricsSystem) {
     this.spec = spec;
     this.forkChoiceExecutor = forkChoiceExecutor;
-    this.blobSidecarManager = blobSidecarManager;
-    this.dasSamplerManager = dasSamplerManager;
     this.forkChoiceStateProvider = forkChoiceStateProvider;
     this.recentChainData = recentChainData;
     this.forkChoiceNotifier = forkChoiceNotifier;
@@ -158,7 +148,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final Spec spec,
       final EventThread forkChoiceExecutor,
       final RecentChainData recentChainData,
-      final BlobSidecarManager blobSidecarManager,
       final ForkChoiceNotifier forkChoiceNotifier,
       final MergeTransitionBlockValidator transitionBlockValidator,
       final MetricsSystem metricsSystem) {
@@ -166,8 +155,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         spec,
         forkChoiceExecutor,
         recentChainData,
-        blobSidecarManager,
-        DasSamplerManager.NOOP,
         forkChoiceNotifier,
         new ForkChoiceStateProvider(forkChoiceExecutor, recentChainData),
         new TickProcessor(spec, recentChainData),
@@ -451,18 +438,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final CapturingIndexedAttestationCache indexedAttestationCache =
         IndexedAttestationCache.capturing();
 
-    final AvailabilityChecker<?> availabilityChecker;
-    final SpecMilestone milestone = spec.atSlot(block.getSlot()).getMilestone();
-    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
-      // checking of blob data availability is delayed until the processing of the execution
-      // payload in ePBS
-      availabilityChecker = AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
-    } else if (milestone.isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
-      LOG.debug("Created DAS availabilityChecker for slot {}", block.getSlot());
-      availabilityChecker = dasSamplerManager.createAvailabilityChecker(block);
-    } else {
-      availabilityChecker = blobSidecarManager.createAvailabilityChecker(block);
-    }
+    final AvailabilityChecker<?> availabilityChecker =
+        forkChoiceUtil.createAvailabilityChecker(block);
 
     availabilityChecker.initiateDataAvailabilityCheck();
 
@@ -531,7 +508,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             });
   }
 
-  @SuppressWarnings("unchecked")
   private BlockImportResult importBlockAndState(
       final SignedBeaconBlock block,
       final BeaconState blockSlotState,
@@ -670,7 +646,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     return transaction.getProposerBoostRoot().isEmpty();
   }
 
-  @SuppressWarnings("unchecked")
   private Optional<List<BlobSidecar>> extractBlobSidecarsFromValidationResults(
       final DataAndValidationResult<?> dataAndValidationResult, final SignedBeaconBlock block) {
     final Optional<List<BlobSidecar>> blobSidecars;
@@ -678,12 +653,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       // Outside availability window or pre-Deneb
       blobSidecars = Optional.empty();
     } else if (dataAndValidationResult.isValid()) {
-      final List<?> sidecars = dataAndValidationResult.data();
-      if (!sidecars.isEmpty() && sidecars.getFirst() instanceof BlobSidecar) {
-        blobSidecars = Optional.of((List<BlobSidecar>) sidecars);
-      } else {
-        blobSidecars = Optional.empty();
-      }
+      return dataAndValidationResult.getDataAsBlobSidecars();
     } else {
       throw new IllegalStateException(
           String.format(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -152,7 +151,6 @@ public class PoolFactory {
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
-      final KZG kzg,
       final BiConsumer<List<DataColumnSidecar>, RemoteOrigin> dataColumnSidecarPublisher,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final MetricsSystem metricsSystem,
@@ -165,7 +163,6 @@ public class PoolFactory {
         DEFAULT_HISTORICAL_SLOT_TOLERANCE,
         FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
         EL_RECOVERY_TASKS_LIMIT,
-        kzg,
         dataColumnSidecarPublisher,
         custodyGroupCountManagerSupplier,
         metricsSystem,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -31,7 +31,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -54,14 +53,12 @@ public class BlobSidecarGossipValidator {
   private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
   private final MiscHelpersDeneb miscHelpersDeneb;
-  private final KZG kzg;
 
   public static BlobSidecarGossipValidator create(
       final Spec spec,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final GossipValidationHelper validationHelper,
-      final MiscHelpersDeneb miscHelpersDeneb,
-      final KZG kzg) {
+      final MiscHelpersDeneb miscHelpersDeneb) {
 
     final Optional<Integer> maybeMaxBlobsPerBlock = spec.getMaxBlobsPerBlockForHighestMilestone();
 
@@ -75,7 +72,6 @@ public class BlobSidecarGossipValidator {
         invalidBlockRoots,
         validationHelper,
         miscHelpersDeneb,
-        kzg,
         LimitedSet.createSynchronized(validInfoSize),
         LimitedSet.createSynchronized(validSignedBlockHeadersSize));
   }
@@ -90,14 +86,12 @@ public class BlobSidecarGossipValidator {
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final GossipValidationHelper gossipValidationHelper,
       final MiscHelpersDeneb miscHelpersDeneb,
-      final KZG kzg,
       final Set<SlotProposerIndexAndBlobIndex> receivedValidBlobSidecarInfoSet,
       final Set<Bytes32> validSignedBlockHeaders) {
     this.spec = spec;
     this.invalidBlockRoots = invalidBlockRoots;
     this.gossipValidationHelper = gossipValidationHelper;
     this.miscHelpersDeneb = miscHelpersDeneb;
-    this.kzg = kzg;
     this.receivedValidBlobSidecarInfoSet = receivedValidBlobSidecarInfoSet;
     this.validSignedBlockHeaders = validSignedBlockHeaders;
   }
@@ -218,7 +212,7 @@ public class BlobSidecarGossipValidator {
      * [REJECT] The sidecar's blob is valid as verified by
      * `verify_blob_kzg_proof(blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
      */
-    if (!miscHelpersDeneb.verifyBlobKzgProof(kzg, blobSidecar)) {
+    if (!miscHelpersDeneb.verifyBlobKzgProof(blobSidecar)) {
       return completedFuture(reject("BlobSidecar does not pass kzg validation"));
     }
 
@@ -300,7 +294,7 @@ public class BlobSidecarGossipValidator {
      * [REJECT] The sidecar's blob is valid as verified by
      * `verify_blob_kzg_proof(blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
      */
-    if (!miscHelpersDeneb.verifyBlobKzgProof(kzg, blobSidecar)) {
+    if (!miscHelpersDeneb.verifyBlobKzgProof(blobSidecar)) {
       return completedFuture(reject("BlobSidecar does not pass kzg validation"));
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -109,7 +108,6 @@ public class DataColumnSidecarGossipValidator {
   private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
   private final MiscHelpersFulu miscHelpersFulu;
-  private final KZG kzg;
   private final Counter totalDataColumnSidecarsProcessingRequestsCounter;
   private final Counter totalDataColumnSidecarsProcessingSuccessesCounter;
   private final MetricsHistogram dataColumnSidecarInclusionProofVerificationTimeSeconds;
@@ -120,7 +118,6 @@ public class DataColumnSidecarGossipValidator {
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final GossipValidationHelper validationHelper,
       final MiscHelpersFulu miscHelpersFulu,
-      final KZG kzg,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {
 
@@ -136,7 +133,6 @@ public class DataColumnSidecarGossipValidator {
         invalidBlockRoots,
         validationHelper,
         miscHelpersFulu,
-        kzg,
         metricsSystem,
         timeProvider,
         LimitedSet.createSynchronized(validInfoSize),
@@ -154,7 +150,6 @@ public class DataColumnSidecarGossipValidator {
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final GossipValidationHelper gossipValidationHelper,
       final MiscHelpersFulu miscHelpersFulu,
-      final KZG kzg,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
       final Set<SlotProposerIndexAndColumnIndex> receivedValidDataColumnSidecarInfoSet,
@@ -164,7 +159,6 @@ public class DataColumnSidecarGossipValidator {
     this.invalidBlockRoots = invalidBlockRoots;
     this.gossipValidationHelper = gossipValidationHelper;
     this.miscHelpersFulu = miscHelpersFulu;
-    this.kzg = kzg;
     this.receivedValidDataColumnSidecarInfoSet = receivedValidDataColumnSidecarInfoSet;
     this.totalDataColumnSidecarsProcessingRequestsCounter =
         metricsSystem.createCounter(
@@ -295,7 +289,7 @@ public class DataColumnSidecarGossipValidator {
      */
     try (MetricsHistogram.Timer ignored =
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer()) {
-      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar)) {
+      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(dataColumnSidecar)) {
         return completedFuture(reject("DataColumnSidecar does not pass kzg validation"));
       }
     } catch (final Throwable t) {
@@ -390,7 +384,7 @@ public class DataColumnSidecarGossipValidator {
      */
     try (MetricsHistogram.Timer ignored =
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer()) {
-      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar)) {
+      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(dataColumnSidecar)) {
         return completedFuture(reject("DataColumnSidecar does not pass kzg validation"));
       }
     } catch (final Throwable t) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
@@ -204,7 +204,7 @@ public class BlobSidecarManagerTest {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
 
     assertThat(blobSidecarManager.createAvailabilityChecker(block))
-        .isEqualTo(AvailabilityChecker.NOOP_BLOBSIDECAR);
+        .isEqualTo(AvailabilityChecker.NOOP_BLOB_SIDECAR);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
@@ -198,16 +198,6 @@ public class BlobSidecarManagerTest {
   }
 
   @Test
-  void createAvailabilityChecker_shouldReturnANoOpAvailabilityCheckerWhenBlockIsPreDeneb() {
-    final Spec spec = TestSpecFactory.createMainnetCapella();
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
-
-    assertThat(blobSidecarManager.createAvailabilityChecker(block))
-        .isEqualTo(AvailabilityChecker.NOOP_BLOB_SIDECAR);
-  }
-
-  @Test
   void
       createAvailabilityCheckerAndValidateImmediately_shouldReturnANotRequiredAvailabilityCheckerWhenBlockIsPreDeneb() {
     final Spec spec = TestSpecFactory.createMainnetCapella();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager.ReceivedBlobSidecarListener;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -65,7 +65,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportRe
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -103,7 +102,6 @@ public class BlockImporterTest {
           spec,
           new InlineEventThread(),
           recentChainData,
-          BlobSidecarManager.NOOP,
           forkChoiceNotifier,
           transitionBlockValidator,
           metricsSystem);
@@ -461,7 +459,6 @@ public class BlockImporterTest {
             spec,
             new InlineEventThread(),
             storageSystem.recentChainData(),
-            BlobSidecarManager.NOOP,
             forkChoiceNotifier,
             transitionBlockValidator,
             storageSystem.getMetricsSystem());
@@ -507,7 +504,6 @@ public class BlockImporterTest {
             spec,
             new InlineEventThread(),
             storageSystem.recentChainData(),
-            BlobSidecarManager.NOOP,
             forkChoiceNotifier,
             transitionBlockValidator,
             storageSystem.getMetricsSystem());
@@ -561,7 +557,6 @@ public class BlockImporterTest {
             spec,
             new InlineEventThread(),
             storageSystem.recentChainData(),
-            BlobSidecarManager.NOOP,
             forkChoiceNotifier,
             transitionBlockValidator,
             storageSystem.getMetricsSystem());
@@ -607,7 +602,6 @@ public class BlockImporterTest {
             spec,
             new InlineEventThread(),
             storageSystem.recentChainData(),
-            BlobSidecarManager.NOOP,
             forkChoiceNotifier,
             transitionBlockValidator,
             storageSystem.getMetricsSystem());
@@ -641,7 +635,6 @@ public class BlockImporterTest {
             spec,
             new InlineEventThread(),
             storageSystem.recentChainData(),
-            BlobSidecarManager.NOOP,
             forkChoiceNotifier,
             transitionBlockValidator,
             storageSystem.getMetricsSystem());
@@ -696,7 +689,6 @@ public class BlockImporterTest {
             spec,
             new InlineEventThread(),
             storageSystem.recentChainData(),
-            BlobSidecarManager.NOOP,
             forkChoiceNotifier,
             transitionBlockValidator,
             storageSystem.getMetricsSystem());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -32,6 +32,7 @@ import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 import static tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel.GOSSIP;
+import static tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR;
 import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason.FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE;
 import static tech.pegasys.teku.statetransition.block.BlockImportPerformance.ARRIVAL_EVENT_LABEL;
 import static tech.pegasys.teku.statetransition.block.BlockImportPerformance.BEGIN_IMPORTING_LABEL;
@@ -71,7 +72,6 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -86,7 +86,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.availability.Availabi
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
-import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
@@ -163,6 +162,7 @@ public class BlockManagerTest {
   }
 
   private void setupWithSpec(final Spec spec) {
+    spec.initialize(blobSidecarManager, NOOP_DATACOLUMN_SIDECAR);
     this.spec = spec;
     this.dataStructureUtil = new DataStructureUtil(spec);
     final StubMetricsSystem metricsSystem = new StubMetricsSystem();
@@ -178,7 +178,6 @@ public class BlockManagerTest {
             spec,
             new InlineEventThread(),
             localRecentChainData,
-            blobSidecarManager,
             forkChoiceNotifier,
             transitionBlockValidator,
             metricsSystem);
@@ -1035,39 +1034,6 @@ public class BlockManagerTest {
     assertThat(localRecentChainData.retrieveEarliestBlobSidecarSlot())
         .isCompletedWithValueMatching(Optional::isEmpty);
     assertThat(invalidBlockRoots).doesNotContainKeys(block1.getRoot());
-  }
-
-  @Test
-  void preDeneb_shouldNotWorryAboutBlobSidecars() {
-    setupWithSpec(
-        TestSpecFactory.create(
-            SpecMilestone.CAPELLA,
-            Eth2Network.MAINNET,
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
-    final SignedBlockAndState signedBlockAndState1 =
-        localChain
-            .chainBuilder()
-            .generateBlockAtSlot(
-                incrementSlot(), BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 =
-        localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
-    assertThatNothingStoredForSlotRoot(signedBlockAndState1.getSlotAndBlockRoot());
-    assertThat(blobSidecars1).isEmpty();
-    assertThat(localRecentChainData.retrieveEarliestBlobSidecarSlot())
-        .isCompletedWithValueMatching(Optional::isEmpty);
-
-    final SignedBeaconBlock block1 = signedBlockAndState1.getBlock();
-    // pre-Deneb is used NOOP with default not required
-    final AvailabilityChecker<BlobSidecar> blobSidecarsAvailabilityChecker1 =
-        createAvailabilityCheckerWithNotRequiredBlobSidecars(block1);
-
-    assertThatBlockImport(block1).isCompletedWithValueMatching(BlockImportResult::isSuccessful);
-    verify(blobSidecarsAvailabilityChecker1).getAvailabilityCheckResult();
-    assertThat(localRecentChainData.retrieveBlockByRoot(block1.getRoot()))
-        .isCompletedWithValue(Optional.of(block1.getMessage()));
-    assertThat(localRecentChainData.getBlobSidecars(block1.getSlotAndBlockRoot())).isEmpty();
-    assertThat(localRecentChainData.retrieveEarliestBlobSidecarSlot())
-        .isCompletedWithValueMatching(Optional::isEmpty);
   }
 
   private AvailabilityChecker<BlobSidecar> createAvailabilityCheckerWithValidBlobSidecars(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -71,7 +71,7 @@ import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
+import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -163,7 +163,7 @@ public class BlockManagerTest {
   }
 
   private void setupWithSpec(final Spec spec) {
-    spec.reinitializeForTesting(blobSidecarManager, NOOP_DATACOLUMN_SIDECAR, KZG.DISABLED);
+    spec.reinitializeForTesting(blobSidecarManager, NOOP_DATACOLUMN_SIDECAR, NoOpKZG.INSTANCE);
     this.spec = spec;
     this.dataStructureUtil = new DataStructureUtil(spec);
     final StubMetricsSystem metricsSystem = new StubMetricsSystem();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -162,7 +162,7 @@ public class BlockManagerTest {
   }
 
   private void setupWithSpec(final Spec spec) {
-    spec.initialize(blobSidecarManager, NOOP_DATACOLUMN_SIDECAR);
+    spec.reinitializeForTesting(blobSidecarManager, NOOP_DATACOLUMN_SIDECAR);
     this.spec = spec;
     this.dataStructureUtil = new DataStructureUtil(spec);
     final StubMetricsSystem metricsSystem = new StubMetricsSystem();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -71,6 +71,7 @@ import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -162,7 +163,7 @@ public class BlockManagerTest {
   }
 
   private void setupWithSpec(final Spec spec) {
-    spec.reinitializeForTesting(blobSidecarManager, NOOP_DATACOLUMN_SIDECAR);
+    spec.reinitializeForTesting(blobSidecarManager, NOOP_DATACOLUMN_SIDECAR, KZG.DISABLED);
     this.spec = spec;
     this.dataStructureUtil = new DataStructureUtil(spec);
     final StubMetricsSystem metricsSystem = new StubMetricsSystem();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -210,7 +210,7 @@ public class BlockManagerTest {
         .initializeGenesisWithPayload(false, dataStructureUtil.randomExecutionPayloadHeader());
     assertThat(blockManager.start()).isCompleted();
     when(blobSidecarManager.createAvailabilityChecker(any()))
-        .thenReturn(AvailabilityChecker.NOOP_BLOBSIDECAR);
+        .thenReturn(AvailabilityChecker.NOOP_BLOB_SIDECAR);
     when(blockValidator.initiateBroadcastValidation(any(), any()))
         .thenReturn(blockBroadcastValidator);
     when(blockBroadcastValidator.getResult()).thenReturn(SafeFuture.completedFuture(SUCCESS));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -94,7 +93,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
           stubAsyncRunner,
           spec,
           miscHelpersFulu,
-          NoOpKZG.INSTANCE,
           dataColumnSidecarPublisher,
           () ->
               createCustodyGroupCountManager(
@@ -119,7 +117,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
             stubAsyncRunner,
             spec,
             miscHelpersFulu,
-            NoOpKZG.INSTANCE,
             dataColumnSidecarPublisher,
             () -> createCustodyGroupCountManager(0, config.getSamplesPerSlot()),
             config.getNumberOfColumns(),
@@ -140,7 +137,6 @@ public class DataColumnSidecarRecoveringCustodyTest {
             stubAsyncRunner,
             spec,
             miscHelpersFulu,
-            NoOpKZG.INSTANCE,
             dataColumnSidecarPublisher,
             () -> CustodyGroupCountManager.NOOP,
             config.getNumberOfColumns(),
@@ -168,12 +164,12 @@ public class DataColumnSidecarRecoveringCustodyTest {
         .limit(70)
         .forEach(sidecar -> custody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC));
 
-    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection(), any()))
+    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection()))
         .thenReturn(sidecars.values().stream().toList());
     stubAsyncRunner.executeQueuedActions();
     stubAsyncRunner.executeQueuedActions();
 
-    verify(miscHelpersFulu).reconstructAllDataColumnSidecars(anyCollection(), any());
+    verify(miscHelpersFulu).reconstructAllDataColumnSidecars(anyCollection());
 
     columnIndices
         .get()
@@ -255,13 +251,13 @@ public class DataColumnSidecarRecoveringCustodyTest {
         .limit(70)
         .forEach(sidecar -> custody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC));
 
-    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection(), any()))
+    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection()))
         .thenReturn(sidecars.values().stream().toList());
     stubAsyncRunner.executeDueActionsRepeatedly();
     stubTimeProvider.advanceTimeBySeconds(2);
     stubAsyncRunner.executeDueActionsRepeatedly();
 
-    verify(miscHelpersFulu).reconstructAllDataColumnSidecars(anyCollection(), any());
+    verify(miscHelpersFulu).reconstructAllDataColumnSidecars(anyCollection());
 
     // post reconstructed
     verify(delegate, times(58)).onNewValidatedDataColumnSidecar(any(), eq(RemoteOrigin.RECOVERED));
@@ -283,7 +279,7 @@ public class DataColumnSidecarRecoveringCustodyTest {
         .limit(63)
         .forEach(sidecar -> custody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC));
 
-    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection(), any()))
+    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection()))
         .thenReturn(sidecars.values().stream().toList());
     stubAsyncRunner.executeDueActionsRepeatedly();
     stubTimeProvider.advanceTimeBySeconds(1);
@@ -296,7 +292,7 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
     stubAsyncRunner.executeDueActionsRepeatedly();
 
-    verify(miscHelpersFulu).reconstructAllDataColumnSidecars(anyCollection(), any());
+    verify(miscHelpersFulu).reconstructAllDataColumnSidecars(anyCollection());
 
     // post reconstructed
     verify(delegate, times(64)).onNewValidatedDataColumnSidecar(any(), eq(RemoteOrigin.RECOVERED));
@@ -315,7 +311,7 @@ public class DataColumnSidecarRecoveringCustodyTest {
     assertThat(stubAsyncRunner.hasDelayedActions()).isFalse();
     custody.scheduleRecoveryTask(task);
     assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
-    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection(), any()))
+    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection()))
         .thenReturn(Collections.emptyList());
     stubAsyncRunner.executeDueActionsRepeatedly();
     assertThat(task.recoveryStarted()).isTrue();
@@ -333,7 +329,7 @@ public class DataColumnSidecarRecoveringCustodyTest {
     assertThat(stubAsyncRunner.hasDelayedActions()).isFalse();
     custody.scheduleRecoveryTask(task);
     assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
-    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection(), any()))
+    when(miscHelpersFulu.reconstructAllDataColumnSidecars(anyCollection()))
         .thenThrow(new RuntimeException("Simulated exception"));
     stubAsyncRunner.executeDueActionsRepeatedly();
     assertThat(task.recoveryStarted()).isFalse();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -89,7 +89,6 @@ public class RecoveringSidecarRetrieverTest {
     recoverRetriever =
         new RecoveringSidecarRetriever(
             delegateRetriever,
-            kzg,
             miscHelpers,
             blockResolver,
             dbAccessor,
@@ -112,7 +111,7 @@ public class RecoveringSidecarRetrieverTest {
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars =
-        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs, kzg);
+        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs);
 
     List<Integer> dbColumnIndices =
         IntStream.range(10, Integer.MAX_VALUE).limit(columnsInDbCount).boxed().toList();
@@ -182,7 +181,7 @@ public class RecoveringSidecarRetrieverTest {
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars =
-        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs, kzg);
+        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs);
 
     List<Integer> dbColumnIndices =
         IntStream.range(10, Integer.MAX_VALUE).limit(columnsInDbCount).boxed().toList();
@@ -215,14 +214,14 @@ public class RecoveringSidecarRetrieverTest {
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block_10_0 = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars_10_0 =
-        miscHelpers.constructDataColumnSidecarsOld(createSigned(block_10_0), blobs_10_0, kzg);
+        miscHelpers.constructDataColumnSidecarsOld(createSigned(block_10_0), blobs_10_0);
     sidecars_10_0.forEach(sidecar -> assertThat(db.addSidecar(sidecar)).isDone());
 
     List<Blob> blobs_10_1 =
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block_10_1 = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars_10_1 =
-        miscHelpers.constructDataColumnSidecarsOld(createSigned(block_10_1), blobs_10_1, kzg);
+        miscHelpers.constructDataColumnSidecarsOld(createSigned(block_10_1), blobs_10_1);
     sidecars_10_1.stream()
         .limit(columnsInDbCount)
         .forEach(sidecar -> assertThat(db.addSidecar(sidecar)).isDone());
@@ -261,7 +260,7 @@ public class RecoveringSidecarRetrieverTest {
         Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars =
-        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs, kzg);
+        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs);
 
     List<Integer> dbColumnIndices =
         IntStream.range(10, Integer.MAX_VALUE).limit(columnsInDbCount).boxed().toList();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -132,7 +132,7 @@ public class SimpleSidecarRetrieverTest {
     final List<Blob> blobs = Stream.generate(dataStructureUtil::randomValidBlob).limit(1).toList();
     final BeaconBlock block = blockResolver.addBlock(10, 1);
     final List<DataColumnSidecar> sidecars =
-        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs, kzg);
+        miscHelpers.constructDataColumnSidecarsOld(createSigned(block), blobs);
     final DataColumnSidecar sidecar0 = sidecars.get(columnIndex.intValue());
 
     final DataColumnSlotAndIdentifier id0 = createId(block, columnIndex.intValue());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTaskTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTaskTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -47,7 +46,6 @@ class RebuildColumnsTaskTest {
   private final DataColumnSidecarDB db = new DataColumnSidecarDBStub();
   private final DataColumnSidecarDbAccessor dbAccessor =
       DataColumnSidecarDbAccessor.builder(db).spec(spec).build();
-  private final KZG kzg = mock(KZG.class);
   private final PendingRecoveryRequest request = mock(PendingRecoveryRequest.class);
   private final SafeFuture<DataColumnSidecar> future = new SafeFuture<>();
 
@@ -62,8 +60,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
 
     final PendingRecoveryRequestTestArticle pendingRequest =
         createPendingRecovery(slotAndBlockRoot, UInt64.ONE, true);
@@ -84,8 +81,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
 
     final PendingRecoveryRequestTestArticle pendingRequest =
         createPendingRecovery(slotAndBlockRoot, UInt64.ONE, false);
@@ -105,8 +101,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
 
     final PendingRecoveryRequestTestArticle pendingRequest =
         createPendingRecovery(slotAndBlockRoot, UInt64.ONE, false);
@@ -126,8 +121,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
 
     final PendingRecoveryRequestTestArticle pendingRequest =
         createPendingRecovery(slotAndBlockRoot, UInt64.ONE, true);
@@ -149,8 +143,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             2,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
 
     final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
     when(sidecar.getSlot()).thenReturn(slotAndBlockRoot.getSlot());
@@ -178,8 +171,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
 
     // when done and sidecar present
     final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
@@ -206,8 +198,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
 
     final PendingRecoveryRequestTestArticle pendingRequest =
         createPendingRecovery(slotAndBlockRoot, UInt64.ONE, true);
@@ -232,8 +223,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
     final PendingRecoveryRequestTestArticle pendingRequest =
         createPendingRecovery(slotAndBlockRoot, UInt64.ONE, true);
 
@@ -255,8 +245,7 @@ class RebuildColumnsTaskTest {
             RECOVERY_TIMEOUT,
             1,
             dbAccessor,
-            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow(),
-            kzg);
+            spec.getGenesisSpec().miscHelpers().toVersionFulu().orElseThrow());
     final PendingRecoveryRequestTestArticle pendingRequest =
         createPendingRecovery(slotAndBlockRoot, UInt64.ONE, true);
 
@@ -304,16 +293,14 @@ class RebuildColumnsTaskTest {
         final Duration timeout,
         final int minimumColumnsForRebuild,
         final DataColumnSidecarDbAccessor sidecarDB,
-        final MiscHelpersFulu miscHelpers,
-        final KZG kzg) {
+        final MiscHelpersFulu miscHelpers) {
       super(
           slotAndBlockRoot,
           timestampMillis,
           timeout,
           minimumColumnsForRebuild,
           sidecarDB,
-          miscHelpers,
-          kzg);
+          miscHelpers);
     }
 
     AtomicBoolean getDone() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
@@ -32,8 +32,6 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
-import tech.pegasys.teku.kzg.trusted_setups.TrustedSetupLoader;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -67,7 +65,7 @@ public class SidecarRetrieverTest {
   final MiscHelpersFulu miscHelpers =
       MiscHelpersFulu.required(spec.forMilestone(SpecMilestone.FULU).miscHelpers());
   final int columnCount = config.getNumberOfColumns();
-  final KZG kzg = KZG.getInstance(false);
+  // final KZG kzg = KZG.getInstance(false);
   final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(0, spec);
@@ -78,7 +76,6 @@ public class SidecarRetrieverTest {
   private final SidecarRetriever retriever =
       new SidecarRetriever(
           delegateRetriever,
-          kzg,
           miscHelpers,
           dbAccessor,
           stubAsyncRunner,
@@ -87,10 +84,6 @@ public class SidecarRetrieverTest {
           timeProvider,
           columnCount,
           metricsSystem);
-
-  public SidecarRetrieverTest() {
-    TrustedSetupLoader.loadTrustedSetupForTests(kzg);
-  }
 
   @BeforeEach
   void setUp() {
@@ -142,9 +135,7 @@ public class SidecarRetrieverTest {
     final BeaconBlock block = blockResolver.addBlock(10, blobCount);
     final List<DataColumnSidecar> sidecars =
         miscHelpers.constructDataColumnSidecarsOld(
-            dataStructureUtil.signedBlock(block),
-            List.of(dataStructureUtil.randomValidBlob()),
-            kzg);
+            dataStructureUtil.signedBlock(block), List.of(dataStructureUtil.randomValidBlob()));
     final List<Integer> dbColumnIndices =
         IntStream.range(10, Integer.MAX_VALUE).limit(columnsInDbCount).boxed().toList();
     dbColumnIndices.forEach(idx -> assertThat(db.addSidecar(sidecars.get(idx))).isDone());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELRecoveryManagerImplTest.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -104,7 +105,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
               asyncRunner,
               recentChainData,
               executionLayer,
-              kzg,
               dataColumnSidecarPublisher,
               custodyGroupCountManagerSupplier,
               metricsSystem,
@@ -114,6 +114,10 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
 
   @BeforeEach
   public void setup() {
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     when(executionLayer.engineGetBlobAndProofs(any(), eq(currentSlot)))
         .thenReturn(SafeFuture.completedFuture(List.of()));
     when(kzg.computeCells(any())).thenReturn(kzgCells);
@@ -137,7 +141,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
                 asyncRunner,
                 recentChainData,
                 executionLayer,
-                kzg,
                 dataColumnSidecarPublisher,
                 custodyGroupCountManagerSupplier,
                 metricsSystem,
@@ -268,7 +271,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             UInt64.valueOf(320),
             FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
             10,
-            kzg,
             dataColumnSidecarPublisher,
             custodyGroupCountManagerSupplier,
             metricsSystem,
@@ -302,7 +304,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             UInt64.valueOf(320),
             FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
             10,
-            kzg,
             dataColumnSidecarPublisher,
             custodyGroupCountManagerSupplier,
             metricsSystem,
@@ -351,7 +352,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             UInt64.valueOf(320),
             FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
             10,
-            kzg,
             dataColumnSidecarPublisher,
             custodyGroupCountManagerSupplier,
             metricsSystem,
@@ -388,7 +388,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             UInt64.valueOf(320),
             FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
             10,
-            kzg,
             dataColumnSidecarPublisher,
             custodyGroupCountManagerSupplier,
             metricsSystem,
@@ -446,7 +445,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             UInt64.valueOf(320),
             FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
             10,
-            kzg,
             dataColumnSidecarPublisher,
             custodyGroupCountManagerSupplier,
             metricsSystem,
@@ -488,7 +486,6 @@ public class DataColumnSidecarELRecoveryManagerImplTest {
             UInt64.valueOf(320),
             FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
             10,
-            kzg,
             dataColumnSidecarPublisher,
             custodyGroupCountManagerSupplier,
             metricsSystem,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/BlobSidecarsAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/BlobSidecarsAvailabilityCheckerTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -56,7 +55,6 @@ public class BlobSidecarsAvailabilityCheckerTest {
   private final Spec spec = mock(Spec.class);
   private final SpecVersion specVersion = mock(SpecVersion.class);
   private final MiscHelpers miscHelpers = mock(MiscHelpers.class);
-  private final KZG kzg = mock(KZG.class);
   private final UpdatableStore store = mock(UpdatableStore.class);
   private final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
       mock(BlockBlobSidecarsTracker.class);
@@ -81,7 +79,7 @@ public class BlobSidecarsAvailabilityCheckerTest {
   void shouldVerifyValidAvailableBlobs() throws Exception {
     prepareInitialAvailability();
 
-    when(miscHelpers.verifyBlobKzgProofBatch(any(), any())).thenReturn(true);
+    when(miscHelpers.verifyBlobKzgProofBatch(any())).thenReturn(true);
     when(miscHelpers.verifyBlobSidecarBlockHeaderSignatureViaValidatedSignedBlock(anyList(), any()))
         .thenReturn(true);
 
@@ -95,7 +93,7 @@ public class BlobSidecarsAvailabilityCheckerTest {
   void shouldVerifyInvalidBlobsDueToWrongBlockHeader() throws Exception {
     prepareInitialAvailability();
 
-    when(miscHelpers.verifyBlobKzgProofBatch(any(), any())).thenReturn(true);
+    when(miscHelpers.verifyBlobKzgProofBatch(any())).thenReturn(true);
     when(miscHelpers.verifyBlobSidecarBlockHeaderSignatureViaValidatedSignedBlock(anyList(), any()))
         .thenReturn(false);
 
@@ -113,7 +111,7 @@ public class BlobSidecarsAvailabilityCheckerTest {
   void shouldVerifyInvalidBlobsDueToWrongKzg() throws Exception {
     prepareInitialAvailability();
 
-    when(miscHelpers.verifyBlobKzgProofBatch(any(), any())).thenReturn(false);
+    when(miscHelpers.verifyBlobKzgProofBatch(any())).thenReturn(false);
     when(miscHelpers.verifyBlobSidecarBlockHeaderSignatureViaValidatedSignedBlock(anyList(), any()))
         .thenReturn(true);
 
@@ -129,7 +127,7 @@ public class BlobSidecarsAvailabilityCheckerTest {
 
     final RuntimeException error = new RuntimeException("oops");
 
-    when(miscHelpers.verifyBlobKzgProofBatch(any(), any())).thenThrow(error);
+    when(miscHelpers.verifyBlobKzgProofBatch(any())).thenThrow(error);
 
     final SafeFuture<DataAndValidationResult<BlobSidecar>> availabilityCheckResult =
         runAvailabilityCheck();
@@ -143,7 +141,7 @@ public class BlobSidecarsAvailabilityCheckerTest {
 
     final RuntimeException error = new RuntimeException("oops");
 
-    when(miscHelpers.verifyBlobKzgProofBatch(any(), any())).thenReturn(true);
+    when(miscHelpers.verifyBlobKzgProofBatch(any())).thenReturn(true);
     when(miscHelpers.verifyBlobSidecarBlockHeaderSignatureViaValidatedSignedBlock(anyList(), any()))
         .thenReturn(true);
     doThrow(error).when(miscHelpers).verifyBlobSidecarCompleteness(anyList(), any());
@@ -345,7 +343,7 @@ public class BlobSidecarsAvailabilityCheckerTest {
 
     blobSidecarsAvailabilityChecker =
         new BlobSidecarsAvailabilityChecker(
-            spec, recentChainData, blockBlobSidecarsTracker, kzg, timeout);
+            spec, recentChainData, blockBlobSidecarsTracker, timeout);
   }
 
   private void completeTrackerWith(final List<BlobSidecar> blobSidecars) {
@@ -373,6 +371,6 @@ public class BlobSidecarsAvailabilityCheckerTest {
 
     blobSidecarsAvailabilityChecker =
         new BlobSidecarsAvailabilityChecker(
-            spec, recentChainData, blockBlobSidecarsTracker, kzg, Duration.ZERO);
+            spec, recentChainData, blockBlobSidecarsTracker, Duration.ZERO);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -33,9 +32,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndV
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 
 class DataColumnSidecarAvailabilityCheckerTest {
-
-  private final KZG kzg = mock(KZG.class);
-
   private final Spec spec = mock(Spec.class);
 
   private final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
@@ -47,7 +43,7 @@ class DataColumnSidecarAvailabilityCheckerTest {
 
   @BeforeEach
   void setup() {
-    checker = new DataColumnSidecarAvailabilityChecker(das, kzg, spec, block);
+    checker = new DataColumnSidecarAvailabilityChecker(das, spec, block);
     when(block.getMessage()).thenReturn(beaconBlock);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -86,6 +86,7 @@ import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
@@ -141,7 +142,9 @@ class ForkChoiceTest {
   }
 
   private void setupWithSpec(final Spec unmockedSpec) {
-    unmockedSpec.initialize((block) -> blobSidecarsAvailabilityChecker, null);
+    unmockedSpec.reinitializeForTesting(
+        (block) -> blobSidecarsAvailabilityChecker,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR);
     // Setting up spec and all dependants
     this.spec = spy(unmockedSpec);
     this.dataStructureUtil = new DataStructureUtil(spec);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -60,6 +60,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -144,7 +145,8 @@ class ForkChoiceTest {
   private void setupWithSpec(final Spec unmockedSpec) {
     unmockedSpec.reinitializeForTesting(
         (block) -> blobSidecarsAvailabilityChecker,
-        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR);
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        KZG.DISABLED);
     // Setting up spec and all dependants
     this.spec = spy(unmockedSpec);
     this.dataStructureUtil = new DataStructureUtil(spec);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -201,7 +201,7 @@ class ForkChoiceTest {
               SafeFuture.completedFuture(DataAndValidationResult.validResult(blobSidecars)));
     } else {
       when(blobSidecarManager.createAvailabilityChecker(any()))
-          .thenReturn(AvailabilityChecker.NOOP_BLOBSIDECAR);
+          .thenReturn(AvailabilityChecker.NOOP_BLOB_SIDECAR);
     }
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -52,7 +51,6 @@ public class BlobSidecarGossipValidatorTest {
   private final Map<Bytes32, BlockImportResult> invalidBlocks = new HashMap<>();
   private final GossipValidationHelper gossipValidationHelper = mock(GossipValidationHelper.class);
   private final MiscHelpersDeneb miscHelpersDeneb = mock(MiscHelpersDeneb.class);
-  private final KZG kzg = mock(KZG.class);
   private DataStructureUtil dataStructureUtil;
   private BlobSidecarGossipValidator blobSidecarValidator;
 
@@ -73,7 +71,7 @@ public class BlobSidecarGossipValidatorTest {
 
     blobSidecarValidator =
         BlobSidecarGossipValidator.create(
-            specContext.getSpec(), invalidBlocks, gossipValidationHelper, miscHelpersDeneb, kzg);
+            specContext.getSpec(), invalidBlocks, gossipValidationHelper, miscHelpersDeneb);
 
     parentSlot = UInt64.valueOf(1);
 
@@ -111,7 +109,7 @@ public class BlobSidecarGossipValidatorTest {
     when(gossipValidationHelper.isSignatureValidWithRespectToProposerIndex(
             any(), eq(proposerIndex), any(), eq(postState)))
         .thenReturn(true);
-    when(miscHelpersDeneb.verifyBlobKzgProof(any(), any(BlobSidecar.class))).thenReturn(true);
+    when(miscHelpersDeneb.verifyBlobKzgProof(any(BlobSidecar.class))).thenReturn(true);
     when(miscHelpersDeneb.verifyBlobKzgCommitmentInclusionProof(any())).thenReturn(true);
   }
 
@@ -148,7 +146,7 @@ public class BlobSidecarGossipValidatorTest {
 
     blobSidecarValidator =
         BlobSidecarGossipValidator.create(
-            spec, invalidBlocks, gossipValidationHelper, miscHelpersDeneb, kzg);
+            spec, invalidBlocks, gossipValidationHelper, miscHelpersDeneb);
 
     SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
@@ -236,7 +234,7 @@ public class BlobSidecarGossipValidatorTest {
 
   @TestTemplate
   void shouldRejectIfKzgVerificationFailed() {
-    when(miscHelpersDeneb.verifyBlobKzgProof(any(), any(BlobSidecar.class))).thenReturn(false);
+    when(miscHelpersDeneb.verifyBlobKzgProof(any(BlobSidecar.class))).thenReturn(false);
 
     SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
@@ -297,7 +295,7 @@ public class BlobSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersDeneb).verifyBlobKzgCommitmentInclusionProof(blobSidecar);
-    verify(miscHelpersDeneb).verifyBlobKzgProof(kzg, blobSidecar);
+    verify(miscHelpersDeneb).verifyBlobKzgProof(blobSidecar);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper)
@@ -309,7 +307,7 @@ public class BlobSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
 
     verify(miscHelpersDeneb, never()).verifyBlobKzgCommitmentInclusionProof(blobSidecar);
-    verify(miscHelpersDeneb, never()).verifyBlobKzgProof(kzg, blobSidecar);
+    verify(miscHelpersDeneb, never()).verifyBlobKzgProof(blobSidecar);
     verify(gossipValidationHelper, never()).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper, never()).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper, never())
@@ -322,7 +320,7 @@ public class BlobSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersDeneb).verifyBlobKzgCommitmentInclusionProof(blobSidecar);
-    verify(miscHelpersDeneb).verifyBlobKzgProof(kzg, blobSidecar);
+    verify(miscHelpersDeneb).verifyBlobKzgProof(blobSidecar);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper)
@@ -341,7 +339,7 @@ public class BlobSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersDeneb).verifyBlobKzgCommitmentInclusionProof(blobSidecar0);
-    verify(miscHelpersDeneb).verifyBlobKzgProof(kzg, blobSidecar0);
+    verify(miscHelpersDeneb).verifyBlobKzgProof(blobSidecar0);
     verify(gossipValidationHelper, never()).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper, never()).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper, never())
@@ -373,7 +371,7 @@ public class BlobSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
 
     verify(miscHelpersDeneb).verifyBlobKzgCommitmentInclusionProof(blobSidecarNew);
-    verify(miscHelpersDeneb).verifyBlobKzgProof(kzg, blobSidecarNew);
+    verify(miscHelpersDeneb).verifyBlobKzgProof(blobSidecarNew);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
   }
 
@@ -390,7 +388,7 @@ public class BlobSidecarGossipValidatorTest {
         .thenReturn(specContext.getSpec().getMaxBlobsPerBlockAtSlot(ZERO));
     this.blobSidecarValidator =
         BlobSidecarGossipValidator.create(
-            specMock, invalidBlocks, gossipValidationHelper, miscHelpersDeneb, kzg);
+            specMock, invalidBlocks, gossipValidationHelper, miscHelpersDeneb);
     // Accept everything
     when(gossipValidationHelper.isSlotFinalized(any())).thenReturn(false);
     when(gossipValidationHelper.isSlotFromFuture(any())).thenReturn(false);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorTest.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
@@ -52,7 +51,6 @@ public class DataColumnSidecarGossipValidatorTest {
   private final Map<Bytes32, BlockImportResult> invalidBlocks = new HashMap<>();
   private final GossipValidationHelper gossipValidationHelper = mock(GossipValidationHelper.class);
   private final MiscHelpersFulu miscHelpersFulu = mock(MiscHelpersFulu.class);
-  private final KZG kzg = mock(KZG.class);
   private final MetricsSystem metricsSystemStub = new StubMetricsSystem();
   private final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(0);
   private DataStructureUtil dataStructureUtil;
@@ -78,7 +76,6 @@ public class DataColumnSidecarGossipValidatorTest {
             invalidBlocks,
             gossipValidationHelper,
             miscHelpersFulu,
-            kzg,
             metricsSystemStub,
             stubTimeProvider);
 
@@ -112,7 +109,7 @@ public class DataColumnSidecarGossipValidatorTest {
     when(gossipValidationHelper.isSignatureValidWithRespectToProposerIndex(
             any(), eq(proposerIndex), any(), eq(postState)))
         .thenReturn(true);
-    when(miscHelpersFulu.verifyDataColumnSidecarKzgProofs(any(), any(DataColumnSidecar.class)))
+    when(miscHelpersFulu.verifyDataColumnSidecarKzgProofs(any(DataColumnSidecar.class)))
         .thenReturn(true);
     when(miscHelpersFulu.verifyDataColumnSidecarInclusionProof(any())).thenReturn(true);
     when(miscHelpersFulu.verifyDataColumnSidecar(any())).thenReturn(true);
@@ -217,7 +214,7 @@ public class DataColumnSidecarGossipValidatorTest {
 
   @TestTemplate
   void shouldRejectIfKzgVerificationFailed() {
-    when(miscHelpersFulu.verifyDataColumnSidecarKzgProofs(any(), any(DataColumnSidecar.class)))
+    when(miscHelpersFulu.verifyDataColumnSidecarKzgProofs(any(DataColumnSidecar.class)))
         .thenReturn(false);
 
     SafeFutureAssert.assertThatSafeFuture(validator.validate(dataColumnSidecar))
@@ -269,7 +266,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(dataColumnSidecar);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper)
@@ -281,7 +278,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
 
     verify(miscHelpersFulu, never()).verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
-    verify(miscHelpersFulu, never()).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
+    verify(miscHelpersFulu, never()).verifyDataColumnSidecarKzgProofs(dataColumnSidecar);
     verify(gossipValidationHelper, never()).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper, never()).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper, never())
@@ -294,7 +291,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(dataColumnSidecar);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper)
@@ -310,7 +307,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecar0);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar0);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(dataColumnSidecar0);
     verify(gossipValidationHelper, never()).getParentStateInBlockEpoch(any(), any(), any());
     verify(gossipValidationHelper, never()).isProposerTheExpectedProposer(any(), any(), any());
     verify(gossipValidationHelper, never())
@@ -343,7 +340,7 @@ public class DataColumnSidecarGossipValidatorTest {
         .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
 
     verify(miscHelpersFulu).verifyDataColumnSidecarInclusionProof(dataColumnSidecarNew);
-    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecarNew);
+    verify(miscHelpersFulu).verifyDataColumnSidecarKzgProofs(dataColumnSidecarNew);
     verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
   }
 
@@ -361,7 +358,6 @@ public class DataColumnSidecarGossipValidatorTest {
             invalidBlocks,
             gossipValidationHelper,
             miscHelpersFulu,
-            kzg,
             metricsSystemStub,
             stubTimeProvider);
     // Accept everything

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -45,7 +45,6 @@ import tech.pegasys.teku.spec.generator.BlockProposalTestUtil;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.signatures.LocalSigner;
 import tech.pegasys.teku.spec.signatures.Signer;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
@@ -105,7 +104,6 @@ public class BeaconChainUtil {
             spec,
             new InlineEventThread(),
             storageClient,
-            BlobSidecarManager.NOOP,
             new NoopForkChoiceNotifier(),
             new MergeTransitionBlockValidator(spec, storageClient),
             new StubMetricsSystem()),
@@ -125,7 +123,6 @@ public class BeaconChainUtil {
             spec,
             new InlineEventThread(),
             storageClient,
-            BlobSidecarManager.NOOP,
             new NoopForkChoiceNotifier(),
             new MergeTransitionBlockValidator(spec, storageClient),
             new StubMetricsSystem()),
@@ -321,7 +318,6 @@ public class BeaconChainUtil {
                 spec,
                 forkChoiceExecutor,
                 recentChainData,
-                BlobSidecarManager.NOOP,
                 new NoopForkChoiceNotifier(),
                 new MergeTransitionBlockValidator(spec, recentChainData),
                 new StubMetricsSystem());

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -51,7 +51,6 @@ import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
-import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
@@ -177,7 +176,6 @@ public class ForkChoiceIntegrationTest {
             SPEC,
             forkChoiceExecutor,
             storageClient,
-            BlobSidecarManager.NOOP,
             new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             new StubMetricsSystem());

--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   integrationTestImplementation testFixtures(project(':ethereum:statetransition'))
   integrationTestImplementation testFixtures(project(':networking:eth2'))
   integrationTestImplementation testFixtures(project(':infrastructure:events'))
+  integrationTestImplementation testFixtures(project(':infrastructure:kzg'))
 
   testFixturesImplementation testFixtures(project(':ethereum:spec'))
   testFixturesImplementation testFixtures(project(':ethereum:statetransition'))

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -38,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 
 @TestSpecContext(milestone = {CAPELLA, DENEB, ELECTRA})
 public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegrationTest {
@@ -47,6 +49,12 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
 
   @BeforeEach
   public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    specContext
+        .getSpec()
+        .reinitializeForTesting(
+            AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+            AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+            NoOpKZG.INSTANCE);
     peer = createPeer(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
   }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/DataColumnSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/DataColumnSidecarsByRangeIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -38,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 
 @TestSpecContext(milestone = {ELECTRA, FULU})
 public class DataColumnSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegrationTest {
@@ -47,6 +49,12 @@ public class DataColumnSidecarsByRangeIntegrationTest extends AbstractRpcMethodI
 
   @BeforeEach
   public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    specContext
+        .getSpec()
+        .reinitializeForTesting(
+            AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+            AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+            NoOpKZG.INSTANCE);
     peer = createPeer(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.forks.GossipForkManager;
 import tech.pegasys.teku.networking.eth2.gossip.forks.GossipForkSubscriptions;
@@ -155,7 +154,6 @@ public class Eth2P2PNetworkBuilder {
   protected OperationProcessor<DataColumnSidecar> dataColumnSidecarOperationProcessor;
   protected OperationProcessor<ExecutionProof> executionProofOperationProcessor;
   protected StatusMessageFactory statusMessageFactory;
-  protected KZG kzg;
   protected boolean recordMessageArrival;
   protected DebugDataDumper debugDataDumper;
   private DasGossipLogger dasGossipLogger;
@@ -212,7 +210,6 @@ public class Eth2P2PNetworkBuilder {
             config.getPeerBlobSidecarsRateLimit(),
             config.getPeerRequestLimit(),
             spec,
-            kzg,
             discoveryNodeIdExtractor,
             dasTotalCustodyGroupCount,
             dasReqRespLogger);
@@ -867,12 +864,6 @@ public class Eth2P2PNetworkBuilder {
       final StatusMessageFactory statusMessageFactory) {
     checkNotNull(statusMessageFactory);
     this.statusMessageFactory = statusMessageFactory;
-    return this;
-  }
-
-  public Eth2P2PNetworkBuilder kzg(final KZG kzg) {
-    checkNotNull(kzg);
-    this.kzg = kzg;
     return this;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -23,7 +23,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
@@ -58,7 +57,6 @@ public interface Eth2Peer extends Peer, SyncSource {
       final RateTracker blobSidecarsRequestTracker,
       final RateTracker dataColumnSidecarsRequestTracker,
       final RateTracker requestTracker,
-      final KZG kzg,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {
     return new DefaultEth2Peer(
@@ -73,7 +71,6 @@ public interface Eth2Peer extends Peer, SyncSource {
         blobSidecarsRequestTracker,
         dataColumnSidecarsRequestTracker,
         requestTracker,
-        kzg,
         metricsSystem,
         timeProvider);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.networking.eth2.peers;
 import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
@@ -38,7 +37,6 @@ public class Eth2PeerFactory {
   private final int peerBlocksRateLimit;
   private final int peerBlobSidecarsRateLimit;
   private final int peerRequestLimit;
-  private final KZG kzg;
   private final DiscoveryNodeIdExtractor discoveryNodeIdExtractor;
 
   public Eth2PeerFactory(
@@ -52,7 +50,6 @@ public class Eth2PeerFactory {
       final int peerBlocksRateLimit,
       final int peerBlobSidecarsRateLimit,
       final int peerRequestLimit,
-      final KZG kzg,
       final DiscoveryNodeIdExtractor discoveryNodeIdExtractor) {
     this.spec = spec;
     this.metricsSystem = metricsSystem;
@@ -64,7 +61,6 @@ public class Eth2PeerFactory {
     this.peerBlocksRateLimit = peerBlocksRateLimit;
     this.peerBlobSidecarsRateLimit = peerBlobSidecarsRateLimit;
     this.peerRequestLimit = peerRequestLimit;
-    this.kzg = kzg;
     this.discoveryNodeIdExtractor = discoveryNodeIdExtractor;
   }
 
@@ -85,7 +81,6 @@ public class Eth2PeerFactory {
             timeProvider,
             "dataColumns"),
         RateTracker.create(peerRequestLimit, TIME_OUT, timeProvider, "requestTracker"),
-        kzg,
         metricsSystem,
         timeProvider);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.SubnetSubscriptionService;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
@@ -132,7 +131,6 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final int peerBlobSidecarsRateLimit,
       final int peerRequestLimit,
       final Spec spec,
-      final KZG kzg,
       final DiscoveryNodeIdExtractor discoveryNodeIdExtractor,
       final Optional<UInt64> custodyGroupCount,
       final DasReqRespLogger dasLogger) {
@@ -162,7 +160,6 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
             peerBlocksRateLimit,
             peerBlobSidecarsRateLimit,
             peerRequestLimit,
-            kzg,
             discoveryNodeIdExtractor),
         statusMessageFactory,
         metadataMessagesFactory,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSide
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -30,12 +29,10 @@ public class AbstractBlobSidecarsValidator {
 
   protected final Peer peer;
   protected final Spec spec;
-  protected final KZG kzg;
 
-  public AbstractBlobSidecarsValidator(final Peer peer, final Spec spec, final KZG kzg) {
+  public AbstractBlobSidecarsValidator(final Peer peer, final Spec spec) {
     this.peer = peer;
     this.spec = spec;
-    this.kzg = kzg;
   }
 
   protected void verifyKzg(final BlobSidecar blobSidecar) {
@@ -54,7 +51,7 @@ public class AbstractBlobSidecarsValidator {
 
   private boolean verifyBlobKzgProof(final BlobSidecar blobSidecar) {
     try {
-      return spec.atSlot(blobSidecar.getSlot()).miscHelpers().verifyBlobKzgProof(kzg, blobSidecar);
+      return spec.atSlot(blobSidecar.getSlot()).miscHelpers().verifyBlobKzgProof(blobSidecar);
     } catch (final Exception ex) {
       LOG.debug("KZG verification failed for BlobSidecar {}", blobSidecar.toLogString());
       throw new BlobSidecarsResponseInvalidResponseException(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
@@ -17,7 +17,6 @@ import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColu
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -28,13 +27,11 @@ public abstract class AbstractDataColumnSidecarValidator {
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
-  private final KZG kzg;
   final Peer peer;
 
-  public AbstractDataColumnSidecarValidator(final Peer peer, final Spec spec, final KZG kzg) {
+  public AbstractDataColumnSidecarValidator(final Peer peer, final Spec spec) {
     this.peer = peer;
     this.spec = spec;
-    this.kzg = kzg;
   }
 
   void verifyValidity(final DataColumnSidecar dataColumnSidecar) {
@@ -65,7 +62,7 @@ public abstract class AbstractDataColumnSidecarValidator {
   private boolean verifyDataColumnSidecarKzgProofs(final DataColumnSidecar dataColumnSidecar) {
     try {
       return MiscHelpersFulu.required(spec.atSlot(dataColumnSidecar.getSlot()).miscHelpers())
-          .verifyDataColumnSidecarKzgProofs(kzg, dataColumnSidecar);
+          .verifyDataColumnSidecarKzgProofs(dataColumnSidecar);
     } catch (final Exception ex) {
       LOG.debug(
           "KZG verification failed for DataColumnSidecar {}", dataColumnSidecar.toLogString());

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
@@ -43,10 +42,9 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
       final Peer peer,
       final RpcResponseListener<BlobSidecar> blobSidecarResponseListener,
       final Integer maxBlobsPerBlock,
-      final KZG kzg,
       final UInt64 startSlot,
       final UInt64 count) {
-    super(peer, spec, kzg);
+    super(peer, spec);
     this.blobSidecarResponseListener = blobSidecarResponseListener;
     this.maxBlobsPerBlock = maxBlobsPerBlock;
     this.startSlot = startSlot;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
@@ -31,9 +30,8 @@ public class BlobSidecarsByRootListenerValidatingProxy extends BlobSidecarsByRoo
       final Peer peer,
       final Spec spec,
       final RpcResponseListener<BlobSidecar> listener,
-      final KZG kzg,
       final List<BlobIdentifier> expectedBlobIdentifiers) {
-    super(peer, spec, kzg, expectedBlobIdentifiers);
+    super(peer, spec, expectedBlobIdentifiers);
     this.listener = listener;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
@@ -28,11 +27,8 @@ public class BlobSidecarsByRootValidator extends AbstractBlobSidecarsValidator {
   private final Set<BlobIdentifier> expectedBlobIdentifiers;
 
   public BlobSidecarsByRootValidator(
-      final Peer peer,
-      final Spec spec,
-      final KZG kzg,
-      final List<BlobIdentifier> expectedBlobIdentifiers) {
-    super(peer, spec, kzg);
+      final Peer peer, final Spec spec, final List<BlobIdentifier> expectedBlobIdentifiers) {
+    super(peer, spec);
     this.expectedBlobIdentifiers = ConcurrentHashMap.newKeySet();
     this.expectedBlobIdentifiers.addAll(expectedBlobIdentifiers);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
@@ -48,13 +47,12 @@ public class DataColumnSidecarsByRangeListenerValidatingProxy
       final Spec spec,
       final Peer peer,
       final RpcResponseListener<DataColumnSidecar> dataColumnSidecarResponseListener,
-      final KZG kzg,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
       final UInt64 startSlot,
       final UInt64 count,
       final List<UInt64> columns) {
-    super(peer, spec, kzg);
+    super(peer, spec);
     this.dataColumnSidecarResponseListener = dataColumnSidecarResponseListener;
     this.startSlot = startSlot;
     this.endSlot = startSlot.plus(count).minusMinZero(1);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
@@ -17,7 +17,6 @@ import java.util.List;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
@@ -34,14 +33,12 @@ public class DataColumnSidecarsByRootListenerValidatingProxy
       final Peer peer,
       final Spec spec,
       final RpcResponseListener<DataColumnSidecar> listener,
-      final KZG kzg,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
       final List<DataColumnsByRootIdentifier> expectedByRootIdentifiers) {
     super(
         peer,
         spec,
-        kzg,
         metricsSystem,
         timeProvider,
         expectedByRootIdentifiers.stream()

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -38,11 +37,10 @@ public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecar
   public DataColumnSidecarsByRootValidator(
       final Peer peer,
       final Spec spec,
-      final KZG kzg,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
       final List<DataColumnIdentifier> expectedDataColumnIdentifiers) {
-    super(peer, spec, kzg);
+    super(peer, spec);
     this.expectedDataColumnIdentifiers = ConcurrentHashMap.newKeySet();
     this.expectedDataColumnIdentifiers.addAll(expectedDataColumnIdentifiers);
     this.dataColumnSidecarInclusionProofVerificationTimeSeconds =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -31,7 +31,6 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer.PeerStatusSubscriber;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
@@ -69,7 +68,6 @@ class Eth2PeerTest {
   private final RateTracker blobSidecarsRateTracker = mock(RateTracker.class);
   private final RateTracker dataColumnSidecarsRateTracker = mock(RateTracker.class);
   private final RateTracker rateTracker = mock(RateTracker.class);
-  private final KZG kzg = mock(KZG.class);
   private final MetricsSystem metricsSystem = mock(MetricsSystem.class);
   private final TimeProvider timeProvider = mock(TimeProvider.class);
 
@@ -88,7 +86,6 @@ class Eth2PeerTest {
           blobSidecarsRateTracker,
           dataColumnSidecarsRateTracker,
           rateTracker,
-          kzg,
           metricsSystem,
           timeProvider);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsByRootValidatorTest.breakInclusionProof;
-import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
 import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 
@@ -39,6 +38,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @SuppressWarnings("JavaCase")
@@ -75,6 +75,11 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     dataStructureUtil = new DataStructureUtil(spec);
     maxBlobsPerBlock = spec.getMaxBlobsPerBlockForHighestMilestone().orElseThrow();
 
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
+
     when(listener.onResponse(any())).thenReturn(SafeFuture.completedFuture(null));
     when(kzg.verifyBlobKzgProof(any(), any(), any())).thenReturn(true);
   }
@@ -86,7 +91,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(
@@ -109,7 +114,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(
@@ -133,7 +138,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar0_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(
@@ -156,7 +161,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final SignedBeaconBlock block1 =
         dataStructureUtil.randomSignedBeaconBlock(currentForkFirstSlot);
@@ -194,7 +199,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     // This requests 8 slots (1, 2, 3, 4, 5, 6, 7, 8) so 9 will be unexpected.
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(
@@ -236,7 +241,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(
@@ -265,7 +270,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
 
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final int exceedingBlobCount = spec.getMaxBlobsPerBlockForHighestMilestone().orElseThrow() + 1;
     final int exceedingBlobIndex = exceedingBlobCount - 1;
@@ -300,7 +305,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
 
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final SignedBeaconBlock block1 =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(currentForkFirstSlot, 3);
@@ -329,7 +334,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
 
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final SignedBeaconBlock block1 =
         dataStructureUtil.randomSignedBeaconBlock(currentForkFirstSlot);
@@ -352,7 +357,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar1_1 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(
@@ -375,7 +380,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(
@@ -405,7 +410,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final UInt64 count = UInt64.valueOf(4);
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
-            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+            spec, peer, listener, maxBlobsPerBlock, startSlot, count);
 
     final BlobSidecar blobSidecar2_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxyTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @SuppressWarnings("JavaCase")
@@ -72,6 +73,10 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
         };
     dataStructureUtil = new DataStructureUtil(spec);
     currentForkFirstSlot = spec.computeStartSlotAtEpoch(currentForkEpoch);
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     when(listener.onResponse(any())).thenReturn(SafeFuture.completedFuture(null));
     when(kzg.verifyBlobKzgProof(any(), any(), any())).thenReturn(true);
   }
@@ -95,7 +100,7 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
             new BlobIdentifier(block3.getRoot(), UInt64.ZERO),
             new BlobIdentifier(block4.getRoot(), UInt64.ZERO));
     listenerWrapper =
-        new BlobSidecarsByRootListenerValidatingProxy(peer, spec, listener, kzg, blobIdentifiers);
+        new BlobSidecarsByRootListenerValidatingProxy(peer, spec, listener, blobIdentifiers);
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
@@ -126,7 +131,7 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
             new BlobIdentifier(block1.getRoot(), UInt64.ZERO),
             new BlobIdentifier(block1.getRoot(), UInt64.ONE));
     listenerWrapper =
-        new BlobSidecarsByRootListenerValidatingProxy(peer, spec, listener, kzg, blobIdentifiers);
+        new BlobSidecarsByRootListenerValidatingProxy(peer, spec, listener, blobIdentifiers);
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
@@ -158,7 +163,7 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
             block1.getRoot(), spec.computeStartSlotAtEpoch(currentForkEpoch.minus(1)));
     listenerWrapper =
         new BlobSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, List.of(blobIdentifier));
+            peer, spec, listener, List.of(blobIdentifier));
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
@@ -183,7 +188,7 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
             block1.getRoot(), spec.computeStartSlotAtEpoch(currentForkEpoch.minus(1)));
     listenerWrapper =
         new BlobSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, List.of(blobIdentifier));
+            peer, spec, listener, List.of(blobIdentifier));
 
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @SuppressWarnings("JavaCase")
@@ -65,6 +66,10 @@ public class BlobSidecarsByRootValidatorTest {
         };
     currentForkFirstSlot = spec.computeStartSlotAtEpoch(currentForkEpoch);
     dataStructureUtil = new DataStructureUtil(spec);
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     when(kzg.verifyBlobKzgProof(any(), any(), any())).thenReturn(true);
   }
 
@@ -76,7 +81,7 @@ public class BlobSidecarsByRootValidatorTest {
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1_0));
+    validator = new BlobSidecarsByRootValidator(peer, spec, List.of(blobIdentifier1_0));
     assertDoesNotThrow(() -> validator.validate(blobSidecar1_0));
   }
 
@@ -89,7 +94,7 @@ public class BlobSidecarsByRootValidatorTest {
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier2_0));
+    validator = new BlobSidecarsByRootValidator(peer, spec, List.of(blobIdentifier2_0));
     assertThatThrownBy(() -> validator.validate(blobSidecar1_0))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)
         .hasMessageContaining(
@@ -107,7 +112,7 @@ public class BlobSidecarsByRootValidatorTest {
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1_0));
+    validator = new BlobSidecarsByRootValidator(peer, spec, List.of(blobIdentifier1_0));
     assertThatThrownBy(() -> validator.validate(blobSidecar1_0))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)
         .hasMessageContaining(
@@ -125,7 +130,7 @@ public class BlobSidecarsByRootValidatorTest {
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
     final BlobSidecar blobSidecar1_0_modified = breakInclusionProof(blobSidecar1_0);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1_0));
+    validator = new BlobSidecarsByRootValidator(peer, spec, List.of(blobIdentifier1_0));
     assertThatThrownBy(() -> validator.validate(blobSidecar1_0_modified))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)
         .hasMessageContaining(
@@ -142,7 +147,7 @@ public class BlobSidecarsByRootValidatorTest {
     final BlobSidecar blobSidecar1_0 =
         dataStructureUtil.randomBlobSidecarWithValidInclusionProofForBlock(block1, 0);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1_0));
+    validator = new BlobSidecarsByRootValidator(peer, spec, List.of(blobIdentifier1_0));
     assertDoesNotThrow(() -> validator.validate(blobSidecar1_0));
     assertThatThrownBy(() -> validator.validate(blobSidecar1_0))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumnSidec
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifierSchema;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -68,6 +69,10 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
 
   @BeforeEach
   void setUp() {
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
     when(listener.onResponse(any())).thenReturn(SafeFuture.completedFuture(null));
     when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(true);
   }
@@ -87,7 +92,11 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
             byRootIdentifierSchema.create(block4.getRoot(), ZERO));
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, metricsSystem, timeProvider, dataColumnIdentifiers);
+            peer, spec, listener, metricsSystem, timeProvider, dataColumnIdentifiers);
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        kzg);
 
     final DataColumnSidecar dataColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(block1, ZERO);
@@ -115,7 +124,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
         List.of(byRootIdentifierSchema.create(block1.getRoot(), List.of(ZERO, ONE)));
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, metricsSystem, timeProvider, dataColumnIdentifiers);
+            peer, spec, listener, metricsSystem, timeProvider, dataColumnIdentifiers);
 
     final DataColumnSidecar datColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(block1, ZERO);
@@ -144,7 +153,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
         byRootIdentifierSchema.create(block1.getRoot(), ZERO);
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
+            peer, spec, listener, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(
@@ -185,7 +194,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
         byRootIdentifierSchema.create(block1.getRoot(), ZERO);
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
+            peer, spec, listener, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(
@@ -209,7 +218,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
         byRootIdentifierSchema.create(block1.getRoot(), ZERO);
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
+            peer, spec, listener, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -47,7 +47,6 @@ import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.network.p2p.jvmlibp2p.PrivateKeyGenerator;
 import tech.pegasys.teku.networking.eth2.gossip.config.GossipConfigurator;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
@@ -269,7 +268,6 @@ public class Eth2P2PNetworkFactory {
                 P2PConfig.DEFAULT_PEER_BLOB_SIDECARS_RATE_LIMIT,
                 P2PConfig.DEFAULT_PEER_REQUEST_LIMIT,
                 spec,
-                NoOpKZG.INSTANCE,
                 __ -> Optional.of(discoveryNodeId),
                 dasTotalCustodySubnetCount,
                 DasReqRespLogger.NOOP);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -584,6 +584,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
         .thenRun(this::initAll)
         .thenRun(
             () -> {
+              // complete spec initialization
+              spec.initialize(blobSidecarManager, dasSamplerManager);
+
               recentChainData.subscribeStoreInitialized(this::onStoreInitialized);
               recentChainData.subscribeBestBlockInitialized(this::startServices);
             })
@@ -1252,8 +1255,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
             spec,
             forkChoiceExecutor,
             recentChainData,
-            blobSidecarManager,
-            dasSamplerManager,
             forkChoiceNotifier,
             forkChoiceStateProvider,
             new TickProcessor(spec, recentChainData),

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -924,7 +924,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
       recoveringSidecarRetriever =
           new SidecarRetriever(
               sidecarRetriever,
-              kzg,
               miscHelpersFulu,
               dbAccessor,
               dasAsyncRunner,
@@ -938,13 +937,14 @@ public class BeaconChainController extends Service implements BeaconChainControl
           new RecoveringSidecarRetriever(
               sidecarRetriever,
               miscHelpersFulu,
-            canonicalBlockResolver,
-            dbAccessor,
-            dasAsyncRunner,
-            Duration.ofMinutes(5),
-            Duration.ofSeconds(30),
-            timeProvider,
-            specConfigFulu.getNumberOfColumns());}
+              canonicalBlockResolver,
+              dbAccessor,
+              dasAsyncRunner,
+              Duration.ofMinutes(5),
+              Duration.ofSeconds(30),
+              timeProvider,
+              specConfigFulu.getNumberOfColumns());
+    }
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
         (dataColumnSidecar, remoteOrigin) ->
             recoveringSidecarRetriever.onNewValidatedSidecar(dataColumnSidecar));


### PR DESCRIPTION
lazily inject availability checker dependencies and KZG into spec.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce lazy Spec initialization to inject KZG and availability checker factories, refactor code to use them (removing explicit KZG/manager params), and update fork choice, validators, networking, and tests accordingly.
> 
> - **Spec/Initialization**:
>   - Add `Spec.initialize/reinitializeForTesting` to inject `KZG` and availability checker factories; expose `getKzg()`.
>   - Wire dependencies into `MiscHelpersDeneb/Fulu` and `ForkChoiceUtil*` (new `ForkChoiceUtilFulu/Gloas`).
> - **Fork Choice**:
>   - Create availability checkers via `ForkChoiceUtil.createAvailabilityChecker`; remove direct `BlobSidecarManager`/DAS wiring; use `DataAndValidationResult.getDataAsBlobSidecars()`.
> - **KZG Refactor**:
>   - Remove explicit `KZG` params across validators, factories, recoveries, retrievers, benchmarks, and networking; methods now use spec-injected KZG.
>   - Update helpers (`MiscHelpersDeneb/Fulu`, `BlobsUtil`, data column reconstruction) to fetch KZG internally.
> - **Networking**:
>   - Drop KZG from peer/network classes and RPC validators; validation pulls via spec.
> - **Validators/Factories**:
>   - Simplify `BlockFactoryFulu`/`MilestoneBasedBlockFactory` and `BlockOperationSelectorFactory` by removing KZG args.
> - **Availability API**:
>   - Consolidate NOOP availability checkers; add factory NOOPs; enhance `DataAndValidationResult` with typed blob accessor.
> - **Tests/Benchmarks**:
>   - Rework tests to `spec.reinitializeForTesting(...)`; update invocations and expectations; add minor build dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b5edfbb9169b1cb37bf04c6238d6974b563dcd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->