### PR TITLE
Added data_column_sidecar topics peer count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Add User-Agent header to requests initiated from the Validator Client with the client identifier and version.
 - Increase Default validator registration Gas Limit 60M for all networks.
-- Rename Fulu metric for data_column_sidecar_by_root RPC request to `network_rpc_data_column_sidecars_by_root_requested_sidecars_total`.  
+- Rename Fulu metric for data_column_sidecar_by_root RPC request to `network_rpc_data_column_sidecars_by_root_requested_sidecars_total`.
+- Add peer count per topic metric for data_column_sidecar subnet.
 
 ### Bug Fixes

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -358,14 +358,12 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
 
   @Override
   public void subscribeToDataColumnSidecarSubnetId(final int subnetId) {
-    LOG.info(">>> Subscribing to data column sidecar subnet {}", subnetId);
     gossipForkManager.subscribeToDataColumnSidecarSubnetId(subnetId);
     dataColumnSidecarSubnetService.addSubscription(subnetId);
   }
 
   @Override
   public void unsubscribeFromDataColumnSidecarSubnetId(final int subnetId) {
-    LOG.info(">>> Unsubscribing data column sidecar subnet {}", subnetId);
     gossipForkManager.unsubscribeFromDataColumnSidecarSubnetId(subnetId);
     dataColumnSidecarSubnetService.removeSubscription(subnetId);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -358,12 +358,14 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
 
   @Override
   public void subscribeToDataColumnSidecarSubnetId(final int subnetId) {
+    LOG.info(">>> Subscribing to data column sidecar subnet {}", subnetId);
     gossipForkManager.subscribeToDataColumnSidecarSubnetId(subnetId);
     dataColumnSidecarSubnetService.addSubscription(subnetId);
   }
 
   @Override
   public void unsubscribeFromDataColumnSidecarSubnetId(final int subnetId) {
+    LOG.info(">>> Unsubscribing data column sidecar subnet {}", subnetId);
     gossipForkManager.unsubscribeFromDataColumnSidecarSubnetId(subnetId);
     dataColumnSidecarSubnetService.removeSubscription(subnetId);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptions.java
@@ -75,8 +75,8 @@ public class PeerSubnetSubscriptions {
       final SettableLabelledGauge subnetPeerCountGauge) {
     final Map<String, Collection<NodeId>> subscribersByTopic = network.getSubscribersByTopic();
 
-    SchemaDefinitionsSupplier currentSchemaDefinitions = currentVersion::getSchemaDefinitions;
-    Integer dataColumnSidecarSubnetCount =
+    final SchemaDefinitionsSupplier currentSchemaDefinitions = currentVersion::getSchemaDefinitions;
+    final int dataColumnSidecarSubnetCount =
         currentVersion
             .getConfig()
             .toVersionFulu()
@@ -134,14 +134,19 @@ public class PeerSubnetSubscriptions {
                                   .forEach(subscriber -> b.addSubscriber(columnSubnet, subscriber));
                             }))
             .build();
-    updateMetrics(currentSchemaDefinitions, subnetPeerCountGauge, subscriptions);
+    updateMetrics(
+        currentSchemaDefinitions,
+        subnetPeerCountGauge,
+        subscriptions,
+        dataColumnSidecarSubnetCount);
     return subscriptions;
   }
 
   private static void updateMetrics(
       final SchemaDefinitionsSupplier currentSchemaDefinitions,
       final SettableLabelledGauge subnetPeerCountGauge,
-      final PeerSubnetSubscriptions subscriptions) {
+      final PeerSubnetSubscriptions subscriptions,
+      final int dataColumnSidecarSubnetCount) {
     streamAllAttestationSubnetIds(currentSchemaDefinitions)
         .forEach(
             subnetId ->
@@ -156,6 +161,14 @@ public class PeerSubnetSubscriptions {
                     subscriptions.syncCommitteeSubnetSubscriptions.subscriberCountBySubnetId
                         .getOrDefault(subnetId, 0),
                     "sync_committee_" + subnetId));
+
+    IntStream.range(0, dataColumnSidecarSubnetCount)
+        .forEach(
+            subnetId ->
+                subnetPeerCountGauge.set(
+                    subscriptions.dataColumnSidecarSubnetSubscriptions.subscriberCountBySubnetId
+                        .getOrDefault(subnetId, 0),
+                    "data_column_sidecar_" + subnetId));
   }
 
   private static IntStream streamAllAttestationSubnetIds(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptions.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
@@ -43,8 +41,6 @@ import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 
 public class PeerSubnetSubscriptions {
-
-  private static final Logger LOG = LogManager.getLogger();
 
   private final SubnetSubscriptions attestationSubnetSubscriptions;
   private final SubnetSubscriptions syncCommitteeSubnetSubscriptions;
@@ -78,8 +74,6 @@ public class PeerSubnetSubscriptions {
       final int targetSubnetSubscriberCount,
       final SettableLabelledGauge subnetPeerCountGauge) {
     final Map<String, Collection<NodeId>> subscribersByTopic = network.getSubscribersByTopic();
-
-    LOG.info(">>> Creating PeerSubnetSubscriptions");
 
     final SchemaDefinitionsSupplier currentSchemaDefinitions = currentVersion::getSchemaDefinitions;
     final int dataColumnSidecarSubnetCount =
@@ -131,8 +125,6 @@ public class PeerSubnetSubscriptions {
                         .getSubnets()
                         .forEach(
                             columnSubnet -> {
-                              LOG.info(
-                                  ">>> Adding data column subnet {} as relevant", columnSubnet);
                               b.addRelevantSubnet(columnSubnet);
                               subscribersByTopic
                                   .getOrDefault(
@@ -155,8 +147,6 @@ public class PeerSubnetSubscriptions {
       final SettableLabelledGauge subnetPeerCountGauge,
       final PeerSubnetSubscriptions subscriptions,
       final int dataColumnSidecarSubnetCount) {
-    LOG.info(">>> Updating metrics");
-
     streamAllAttestationSubnetIds(currentSchemaDefinitions)
         .forEach(
             subnetId ->

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptions.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
@@ -41,6 +43,8 @@ import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 
 public class PeerSubnetSubscriptions {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   private final SubnetSubscriptions attestationSubnetSubscriptions;
   private final SubnetSubscriptions syncCommitteeSubnetSubscriptions;
@@ -74,6 +78,8 @@ public class PeerSubnetSubscriptions {
       final int targetSubnetSubscriberCount,
       final SettableLabelledGauge subnetPeerCountGauge) {
     final Map<String, Collection<NodeId>> subscribersByTopic = network.getSubscribersByTopic();
+
+    LOG.info(">>> Creating PeerSubnetSubscriptions");
 
     final SchemaDefinitionsSupplier currentSchemaDefinitions = currentVersion::getSchemaDefinitions;
     final int dataColumnSidecarSubnetCount =
@@ -125,6 +131,8 @@ public class PeerSubnetSubscriptions {
                         .getSubnets()
                         .forEach(
                             columnSubnet -> {
+                              LOG.info(
+                                  ">>> Adding data column subnet {} as relevant", columnSubnet);
                               b.addRelevantSubnet(columnSubnet);
                               subscribersByTopic
                                   .getOrDefault(
@@ -147,6 +155,8 @@ public class PeerSubnetSubscriptions {
       final SettableLabelledGauge subnetPeerCountGauge,
       final PeerSubnetSubscriptions subscriptions,
       final int dataColumnSidecarSubnetCount) {
+    LOG.info(">>> Updating metrics");
+
     streamAllAttestationSubnetIds(currentSchemaDefinitions)
         .forEach(
             subnetId ->

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
@@ -30,14 +30,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.SubnetSubscriptionService;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
@@ -62,7 +60,6 @@ class PeerSubnetSubscriptionsTest {
   private final Spec spec = TestSpecFactory.createMinimalFulu();
   private final SettableLabelledGauge subnetPeerCountGauge = mock(SettableLabelledGauge.class);
   final Supplier<SpecVersion> currentSpecVersionSupplier = spec::getGenesisSpec;
-  final Supplier<Optional<UInt64>> currentSlotSupplier = Optional::empty;
   private final SchemaDefinitionsSupplier currentSchemaDefinitions =
       spec::getGenesisSchemaDefinitions;
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
@@ -14,8 +14,12 @@
 package tech.pegasys.teku.networking.eth2.gossip.subnets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Supplier;
@@ -41,15 +45,21 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 
 class PeerSubnetSubscriptionsTest {
+  private static final String BEACON_BLOCK_SUBNET_TOPIC = "beacon_block";
+  private static final String ATTESTATION_SUBNET_TOPIC_PREFIX = "attestation_";
+  private static final String SYNC_COMMITTEE_SUBNET_TOPIC_PREFIX = "sync_committee_";
+  private static final String DATA_COLUMN_SIDECAR_SUBNET_TOPIC_PREFIX = "data_column_sidecar_";
+
   private static final NodeId PEER1 = new MockNodeId(1);
   private static final NodeId PEER2 = new MockNodeId(2);
   private static final NodeId PEER3 = new MockNodeId(3);
   private static final int TARGET_SUBSCRIBER_COUNT = 2;
 
-  private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final Spec spec = TestSpecFactory.createMinimalFulu();
   private final SettableLabelledGauge subnetPeerCountGauge = mock(SettableLabelledGauge.class);
   final Supplier<SpecVersion> currentSpecVersionSupplier = spec::getGenesisSpec;
   final Supplier<Optional<UInt64>> currentSlotSupplier = Optional::empty;
@@ -68,9 +78,12 @@ class PeerSubnetSubscriptionsTest {
   @BeforeEach
   public void setUp() {
     when(attestationTopicProvider.getTopicForSubnet(anyInt()))
-        .thenAnswer(invocation -> "attnet_" + invocation.getArgument(0));
+        .thenAnswer(invocation -> ATTESTATION_SUBNET_TOPIC_PREFIX + invocation.getArgument(0));
     when(syncCommitteeTopicProvider.getTopicForSubnet(anyInt()))
-        .thenAnswer(invocation -> "syncnet_" + invocation.getArgument(0));
+        .thenAnswer(invocation -> SYNC_COMMITTEE_SUBNET_TOPIC_PREFIX + invocation.getArgument(0));
+    when(dataColumnSidecarSubnetTopicProvider.getTopicForSubnet(anyInt()))
+        .thenAnswer(
+            invocation -> DATA_COLUMN_SIDECAR_SUBNET_TOPIC_PREFIX + invocation.getArgument(0));
   }
 
   @Test
@@ -80,11 +93,11 @@ class PeerSubnetSubscriptionsTest {
 
     final Map<String, Collection<NodeId>> subscribersByTopic =
         ImmutableMap.<String, Collection<NodeId>>builder()
-            .put("attnet_0", Set.of(PEER1, PEER2, PEER3))
-            .put("attnet_1", Set.of(PEER1))
-            .put("attnet_2", Set.of(PEER1, PEER3))
-            .put("syncnet_1", Set.of(PEER2))
-            .put("blocks", Set.of(PEER1, PEER2, PEER3))
+            .put(ATTESTATION_SUBNET_TOPIC_PREFIX + "0", Set.of(PEER1, PEER2, PEER3))
+            .put(ATTESTATION_SUBNET_TOPIC_PREFIX + "1", Set.of(PEER1))
+            .put(ATTESTATION_SUBNET_TOPIC_PREFIX + "2", Set.of(PEER1, PEER3))
+            .put(SYNC_COMMITTEE_SUBNET_TOPIC_PREFIX + "1", Set.of(PEER2))
+            .put(BEACON_BLOCK_SUBNET_TOPIC, Set.of(PEER1, PEER2, PEER3))
             .build();
     when(gossipNetwork.getSubscribersByTopic()).thenReturn(subscribersByTopic);
     final PeerSubnetSubscriptions subscriptions = createPeerSubnetSubscriptions();
@@ -202,6 +215,38 @@ class PeerSubnetSubscriptionsTest {
 
     assertThat(subscriptions.isAttestationSubnetRelevant(attSubnetsCount)).isFalse();
     assertThat(subscriptions.isAttestationSubnetRelevant(attSubnetsCount + 1)).isFalse();
+  }
+
+  @Test
+  public void isDataColumnSidecarSubnetRelevant() {
+    dataColumnSubscriptions.setSubscriptions(IntList.of(1, 2, 3));
+    final PeerSubnetSubscriptions subscriptions = createPeerSubnetSubscriptions();
+
+    assertThat(subscriptions.isDataColumnSidecarSubnetRelevant(0)).isFalse();
+    assertThat(subscriptions.isDataColumnSidecarSubnetRelevant(1)).isTrue();
+    assertThat(subscriptions.isDataColumnSidecarSubnetRelevant(2)).isTrue();
+    assertThat(subscriptions.isDataColumnSidecarSubnetRelevant(3)).isTrue();
+    assertThat(subscriptions.isDataColumnSidecarSubnetRelevant(4)).isFalse();
+  }
+
+  @Test
+  public void shouldCreatePeerCountPerSubnetMetrics() {
+    createPeerSubnetSubscriptions();
+
+    verify(
+            subnetPeerCountGauge,
+            times(currentSchemaDefinitions.getAttnetsENRFieldSchema().getLength()))
+        .set(anyDouble(), matches(ATTESTATION_SUBNET_TOPIC_PREFIX));
+    verify(
+            subnetPeerCountGauge,
+            times(currentSchemaDefinitions.getSyncnetsENRFieldSchema().getLength()))
+        .set(anyDouble(), matches(SYNC_COMMITTEE_SUBNET_TOPIC_PREFIX));
+    verify(
+            subnetPeerCountGauge,
+            times(
+                SpecConfigFulu.required(spec.getGenesisSpecConfig())
+                    .getDataColumnSidecarSubnetCount()))
+        .set(anyDouble(), matches(DATA_COLUMN_SIDECAR_SUBNET_TOPIC_PREFIX));
   }
 
   private PeerSubnetSubscriptions createPeerSubnetSubscriptions() {


### PR DESCRIPTION
## PR Description

Update our `PeerSubnetSubscriptions` to report peer count for `data_column_sidecar_{n}`.

## Fixed Issue(s)
#9973

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reports per-subnet peer counts for `data_column_sidecar_{n}` topics and updates tests and changelog accordingly.
> 
> - **Metrics (PeerSubnetSubscriptions)**:
>   - Add per-topic peer count gauge updates for `data_column_sidecar_{n}` in `updateMetrics`, iterating over configured subnet count.
>   - Pass `dataColumnSidecarSubnetCount` into `updateMetrics`; use `final` and primitives for related locals.
> - **Tests**:
>   - Switch to minimal Fulu spec and standardize topic prefixes.
>   - Add coverage for `isDataColumnSidecarSubnetRelevant` and verify per-subnet gauge updates for all categories.
> - **Changelog**:
>   - Note addition of peer count per topic metric for data_column_sidecar subnet and tidy a metric rename entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7046431da2dcc3d1e092ba600f1ff65308add00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->