### PR TITLE
Normalize metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@
 
 - Add User-Agent header to requests initiated from the Validator Client with the client identifier and version.
 - Increase Default validator registration Gas Limit 60M for all networks.
+- Rename Fulu metric for data_column_sidecar_by_root RPC request to `network_rpc_data_column_sidecars_by_root_requested_sidecars_total`.  
 
 ### Bug Fixes

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -96,7 +96,7 @@ public class DataColumnSidecarsByRootMessageHandler
     this.totalDataColumnSidecarsRequestedCounter =
         metricsSystem.createCounter(
             TekuMetricCategory.NETWORK,
-            "rpc_data_column_sidecars_by_root_requested_data_column_sidecars_total",
+            "rpc_data_column_sidecars_by_root_requested_sidecars_total",
             "Total number of data column sidecars requested in accepted data column sidecars by root requests from peers");
   }
 


### PR DESCRIPTION
## PR Description

Just wanted to normalize the name of the metrics for datacolumn_by_range and datacolumn_by_root.

For ByRange, we use: `rpc_data_column_sidecars_by_range_requested_sidecars_total`. This PR changes the ByRoot to `rpc_data_column_sidecars_by_root_requested_sidecars_total`.

Given this metric is for a fork under development and we haven't released our updated dashboard yet, I didn't mark it as a backwards incompatible change.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the DataColumnSidecarsByRoot requested sidecars metric and updates the changelog accordingly.
> 
> - **Metrics**:
>   - Rename counter in `DataColumnSidecarsByRootMessageHandler`: `rpc_data_column_sidecars_by_root_requested_data_column_sidecars_total` → `rpc_data_column_sidecars_by_root_requested_sidecars_total`.
> - **Changelog**:
>   - Note renamed Fulu metric to `network_rpc_data_column_sidecars_by_root_requested_sidecars_total`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97c5c89d9296adabda65fc4b63784df8de45e648. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->