### PR TITLE
cleanup from start of sidecarRetriever rewrite

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequest.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequest.java
@@ -121,7 +121,6 @@ class PendingRecoveryRequest {
   }
 
   void complete(final DataColumnSidecar sidecar) {
-    onCompleted();
     future.complete(sidecar);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequest.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequest.java
@@ -113,9 +113,8 @@ class PendingRecoveryRequest {
   }
 
   private void onCompleted() {
-    if (!downloadFuture.isDone()) {
+    if (downloadFuture.isCompletedNormally()) {
       sidecarRecoveryMetric.labels(DOWNLOADED).inc();
-      downloadFuture.cancel(true);
     } else {
       sidecarRecoveryMetric.labels(RECOVERED).inc();
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequest.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequest.java
@@ -13,11 +13,17 @@
 
 package tech.pegasys.teku.statetransition.datacolumns.retriever.recovering;
 
+import static tech.pegasys.teku.statetransition.datacolumns.retriever.recovering.SidecarRetriever.CANCELLED;
+import static tech.pegasys.teku.statetransition.datacolumns.retriever.recovering.SidecarRetriever.DOWNLOADED;
+import static tech.pegasys.teku.statetransition.datacolumns.retriever.recovering.SidecarRetriever.RECOVERED;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
@@ -31,22 +37,36 @@ class PendingRecoveryRequest {
   private final UInt64 downloadTimeoutMillis;
   private final UInt64 taskTimeoutMillis;
   private final SafeFuture<DataColumnSidecar> downloadFuture;
+  private final LabelledMetric<Counter> sidecarRecoveryMetric;
 
   PendingRecoveryRequest(
       final DataColumnSlotAndIdentifier columnId,
       final SafeFuture<DataColumnSidecar> downloadFuture,
       final UInt64 timestamp,
       final Duration timeout,
-      final Duration downloadTimeout) {
+      final Duration downloadTimeout,
+      final LabelledMetric<Counter> sidecarRecoveryMetric,
+      final Runnable alwaysAfter) {
     this.downloadTimeoutMillis = timestamp.plus(downloadTimeout.toMillis());
     this.taskTimeoutMillis = timestamp.plus(timeout.toMillis());
     this.columnnId = columnId;
     this.downloadFuture = downloadFuture;
+    this.sidecarRecoveryMetric = sidecarRecoveryMetric;
 
     downloadFuture
         .thenRun(this::downloadCompleted)
         .exceptionally(this::failedDownload)
         .finishError(LOG);
+
+    future
+        .thenRun(this::onCompleted)
+        .exceptionally(
+            (err) -> {
+              LOG.debug("Failed recovery task for column {}", columnnId, err);
+              sidecarRecoveryMetric.labels(CANCELLED).inc();
+              return null;
+            })
+        .always(alwaysAfter);
   }
 
   private Void failedDownload(final Throwable throwable) {
@@ -54,6 +74,7 @@ class PendingRecoveryRequest {
     return null;
   }
 
+  // needed for the interface but generally should not be referenced
   SafeFuture<DataColumnSidecar> getFuture() {
     return future;
   }
@@ -91,9 +112,27 @@ class PendingRecoveryRequest {
     }
   }
 
+  private void onCompleted() {
+    if (!downloadFuture.isDone()) {
+      sidecarRecoveryMetric.labels(DOWNLOADED).inc();
+      downloadFuture.cancel(true);
+    } else {
+      sidecarRecoveryMetric.labels(RECOVERED).inc();
+    }
+  }
+
+  void complete(final DataColumnSidecar sidecar) {
+    onCompleted();
+    future.complete(sidecar);
+  }
+
   void cancel() {
     downloadFuture.cancel(true);
     future.cancel(true);
+  }
+
+  boolean isDone() {
+    return future.isDone();
   }
 
   private void downloadCompleted() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTask.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTask.java
@@ -75,7 +75,7 @@ class RebuildColumnsTask {
             pendingRequest.getSlotAndBlockRoot(),
             pendingRequest.getIndex());
 
-        pendingRequest.getFuture().complete(sidecar);
+        pendingRequest.complete(sidecar);
         return true;
       } else {
         pendingRequest.cancel();
@@ -88,7 +88,7 @@ class RebuildColumnsTask {
       }
     }
     if (pendingRequest.getBlockRoot().equals(slotAndBlockRoot.getBlockRoot())
-        && !pendingRequest.getFuture().isDone()) {
+        && !pendingRequest.isDone()) {
       // we are possibly downloading to rebuild, so the sidecar may be available
       final DataColumnSidecar sidecar = sidecarMap.get(pendingRequest.getIndex().intValue());
       if (sidecar == null) {
@@ -99,7 +99,7 @@ class RebuildColumnsTask {
             "Pending request (slotAndBlock: {}) for column {} was found while preparing to rebuild",
             pendingRequest.getSlotAndBlockRoot(),
             pendingRequest.getIndex());
-        pendingRequest.getFuture().complete(sidecar);
+        pendingRequest.complete(sidecar);
       }
     } else {
       pendingRequest.cancel();
@@ -158,9 +158,9 @@ class RebuildColumnsTask {
           .forEach(
               sidecar ->
                   tasks.stream()
-                      .filter(task -> !task.getFuture().isDone())
+                      .filter(task -> !task.isDone())
                       .filter(task -> sidecar.getIndex().equals(task.getIndex()))
-                      .forEach(task -> task.getFuture().complete(sidecar)));
+                      .forEach(task -> task.complete(sidecar)));
       reconstructedSidecars.forEach((k, v) -> sidecarMap.putIfAbsent(k.intValue(), v));
       done.compareAndSet(false, true);
       LOG.trace("Rebuilding columns DONE {}", slotAndBlockRoot);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequestTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/PendingRecoveryRequestTest.java
@@ -18,8 +18,12 @@ import static tech.pegasys.teku.statetransition.datacolumns.retriever.recovering
 
 import java.time.Duration;
 import java.util.Optional;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -34,6 +38,9 @@ public class PendingRecoveryRequestTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(1_000_000);
   private final DataColumnSidecar sidecar = dataStructureUtil.randomDataColumnSidecar();
+  private static final StubMetricsSystem METRICS = new StubMetricsSystem();
+  private static final LabelledMetric<Counter> METRIC =
+      METRICS.createLabelledCounter(TekuMetricCategory.BEACON, "FOO", "help", "result");
 
   @Test
   void checkTimeout_willNotTimeoutDownloadBeforeTime() {
@@ -164,6 +171,12 @@ public class PendingRecoveryRequestTest {
     final DataColumnSlotAndIdentifier id =
         maybeId.orElse(SidecarRetrieverTest.createId(dataStructureUtil.randomBeaconBlock(), 1));
     return new PendingRecoveryRequest(
-        id, downloadFuture, timeProvider.getTimeInMillis(), RECOVERY_TIMEOUT, DOWNLOAD_TIMEOUT);
+        id,
+        downloadFuture,
+        timeProvider.getTimeInMillis(),
+        RECOVERY_TIMEOUT,
+        DOWNLOAD_TIMEOUT,
+        METRIC,
+        () -> {});
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTaskTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/RebuildColumnsTaskTest.java
@@ -23,8 +23,12 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
@@ -50,6 +54,9 @@ class RebuildColumnsTaskTest {
   private final KZG kzg = mock(KZG.class);
   private final PendingRecoveryRequest request = mock(PendingRecoveryRequest.class);
   private final SafeFuture<DataColumnSidecar> future = new SafeFuture<>();
+  private static final StubMetricsSystem METRICS = new StubMetricsSystem();
+  private static final LabelledMetric<Counter> METRIC =
+      METRICS.createLabelledCounter(TekuMetricCategory.BEACON, "FOO", "help", "result");
 
   @Test
   void addTask_acceptsValidPendingRecoveryRequest() {
@@ -278,12 +285,18 @@ class RebuildColumnsTaskTest {
   }
 
   static class PendingRecoveryRequestTestArticle extends PendingRecoveryRequest {
-
     PendingRecoveryRequestTestArticle(
         final SafeFuture<DataColumnSidecar> downloadFuture,
         final DataColumnSlotAndIdentifier columnId,
         final UInt64 timestamp) {
-      super(columnId, downloadFuture, timestamp, RECOVERY_TIMEOUT.dividedBy(2), RECOVERY_TIMEOUT);
+      super(
+          columnId,
+          downloadFuture,
+          timestamp,
+          RECOVERY_TIMEOUT.dividedBy(2),
+          RECOVERY_TIMEOUT,
+          METRIC,
+          () -> {});
     }
 
     PendingRecoveryRequestTestArticle(
@@ -292,7 +305,7 @@ class RebuildColumnsTaskTest {
         final UInt64 timestamp,
         final Duration timeout,
         final Duration downloadTimeout) {
-      super(columnId, downloadFuture, timestamp, timeout, downloadTimeout);
+      super(columnId, downloadFuture, timestamp, timeout, downloadTimeout, METRIC, () -> {});
     }
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
@@ -149,8 +149,12 @@ public class SidecarRetrieverTest {
     dbColumnIndices.forEach(idx -> assertThat(db.addSidecar(sidecars.get(idx))).isDone());
 
     final SafeFuture<DataColumnSidecar> res0 = retriever.retrieve(createId(block, 0));
-    res0.complete(sidecars.getFirst());
+
+    // this will add the file to the delegate, which will finish the download task
+    delegateRetriever.addReadyColumnSidecar(sidecars.get(0));
+
     assertThat(retriever.pendingRequestCount()).isZero();
+    assertThat(res0).isDone();
     verifyMetrics(0, 1, 0);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -363,7 +363,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile Optional<DasCustodySync> dasCustodySync = Optional.empty();
   protected volatile Optional<DataColumnSidecarRetriever> recoveringSidecarRetriever =
       Optional.empty();
-  protected volatile Optional<SidecarRetriever> sidecarRetriever = Optional.empty();
   protected volatile AvailabilityCheckerFactory<UInt64> dasSamplerManager;
   protected volatile DataAvailabilitySampler dataAvailabilitySampler;
   protected volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();


### PR DESCRIPTION
 - removed redundant variable in BeaconChainController
 - fixed the metrics handling and future handling in the stack

addresses some outstanding comments from #9910

partially addresses #9979

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes sidecar recovery metrics and future handling in PendingRecoveryRequest, simplifies SidecarRetriever and RebuildColumnsTask interactions, updates tests, and removes an unused controller field.
> 
> - **State transition (data column recovery)**:
>   - **Metrics & lifecycle**: Move metrics and completion/cancellation handling into `PendingRecoveryRequest` (increments `DOWNLOADED`/`RECOVERED`/`CANCELLED`, add `complete(...)`, `isDone()`, and an `alwaysAfter` hook).
>   - **SidecarRetriever**: Simplify request setup to use new `PendingRecoveryRequest` hooks; drop explicit `DOWNLOAD_TIMEOUT` metric handling; auto-remove completed requests.
>   - **RebuildColumnsTask**: Use `PendingRecoveryRequest.complete(...)` and `isDone()`; minor flow tweaks for completing tasks after reconstruction.
> - **Tests**: Update tests to new APIs and metric expectations; remove assertions for `DOWNLOAD_TIMEOUT` metric.
> - **BeaconChainController**: Remove redundant `Optional<SidecarRetriever>` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f125cb485b153c647beeac559a2c198d3ec78b15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->