### PR TITLE
update attestation data api descriptions

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_attestation_data.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_attestation_data.json
@@ -3,7 +3,7 @@
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "produceAttestationData",
     "summary" : "Produce an AttestationData",
-    "description" : "Requests that the beacon node produce an AttestationData.",
+    "description" : "Requests that the beacon node produce an AttestationData. For `slot`s in Electra and later, this AttestationData must have a `committee_index` of 0.\n\nA 503 error must be returned if the block identified by the response `beacon_block_root` is optimistic (i.e. the attestation attests to a block that has not been fully verified by an execution engine).\n",
     "parameters" : [ {
       "name" : "slot",
       "in" : "query",
@@ -18,7 +18,7 @@
       "in" : "query",
       "schema" : {
         "type" : "string",
-        "description" : "`UInt64` The committee index for which an attestation data should be created.",
+        "description" : "`UInt64` The committee index for which an attestation data should be created. For `slot`s in Electra and later, this parameter MAY always be set to 0.",
         "example" : "1",
         "format" : "uint64"
       }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -62,12 +62,21 @@ public class GetAttestationData extends RestApiEndpoint {
         EndpointMetadata.get(ROUTE)
             .operationId("produceAttestationData")
             .summary("Produce an AttestationData")
-            .description("Requests that the beacon node produce an AttestationData.")
+            .description(
+                """
+                  Requests that the beacon node produce an AttestationData. For `slot`s in \
+                  Electra and later, this AttestationData must have a `committee_index` of 0.
+
+                  A 503 error must be returned if the block identified by the response \
+                  `beacon_block_root` is optimistic (i.e. the attestation attests to a block \
+                  that has not been fully verified by an execution engine).
+                  """)
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
             .queryParam(SLOT_PARAM)
             .queryParam(
                 COMMITTEE_INDEX_PARAMETER.withDescription(
-                    "`UInt64` The committee index for which an attestation data should be created."))
+                    "`UInt64` The committee index for which an attestation data should be created. For `slot`s in "
+                        + "Electra and later, this parameter MAY always be set to 0."))
             .response(
                 SC_OK,
                 "Request successful",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update `/eth/v1/validator/attestation_data` description and the `committee_index` query param description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#9993 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies `/eth/v1/validator/attestation_data` docs: `committee_index` is 0 for Electra+ slots and 503 must be returned for optimistic `beacon_block_root`; updates query param description accordingly.
> 
> - **API docs**:
>   - **Endpoint**: `/eth/v1/validator/attestation_data`
>     - Updates description to specify that for Electra and later `slot`s, `committee_index` must be `0`.
>     - Notes a `503` response when the response `beacon_block_root` is optimistic (not fully verified by an execution engine).
>     - Adjusts `committee_index` query parameter description to allow value `0` for Electra+.
>   - Applies changes in:
>     - `data/beaconrestapi/.../_eth_v1_validator_attestation_data.json`
>     - `GetAttestationData.java` endpoint metadata
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d523814a5c60eb2a408c85eda595bbf96547e7b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->