### PR TITLE
Generate self-built bid for Gloas (ePBS)

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -196,6 +196,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
             graffitiBuilder,
             forkChoiceNotifier,
             executionLayer,
+            executionPayloadBidManager,
             metricsSystem,
             timeProvider));
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
@@ -194,6 +194,7 @@ public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
             graffitiBuilder,
             forkChoiceNotifier,
             executionLayer,
+            executionPayloadBidManager,
             metricsSystem,
             timeProvider));
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
@@ -36,8 +36,12 @@ public class BlockFactoryGloasTest extends AbstractBlockFactoryTest {
 
   @Test
   void shouldCreateBlock() {
+    prepareBlobsBundle(spec, 3);
+
     final BlockContainer blockContainer =
-        assertBlockCreated(1, spec, false, state -> {}, false).blockContainer();
+        assertBlockCreated(1, spec, false, state -> prepareValidPayload(spec, state), false)
+            .blockContainer();
+
     assertThat(blockContainer).isInstanceOf(BeaconBlock.class);
     assertThat(blockContainer.getBlock().getBody()).isInstanceOf(BeaconBlockBodyGloas.class);
   }
@@ -78,6 +82,7 @@ public class BlockFactoryGloasTest extends AbstractBlockFactoryTest {
             graffitiBuilder,
             forkChoiceNotifier,
             executionLayer,
+            executionPayloadBidManager,
             metricsSystem,
             timeProvider));
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
@@ -219,6 +219,7 @@ class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
             graffitiBuilder,
             forkChoiceNotifier,
             executionLayer,
+            executionPayloadBidManager,
             metricsSystem,
             timeProvider));
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.SimpleOperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
@@ -129,6 +130,8 @@ class BlockOperationSelectorFactoryBellatrixTest {
   private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   private final ExecutionLayerBlockProductionManager executionLayer =
       mock(ExecutionLayerBlockProductionManager.class);
+  private final ExecutionPayloadBidManager executionPayloadBidManager =
+      mock(ExecutionPayloadBidManager.class);
 
   private final CapturingBeaconBlockBodyBuilder bodyBuilder =
       new CapturingBeaconBlockBodyBuilder(false, false) {
@@ -160,6 +163,7 @@ class BlockOperationSelectorFactoryBellatrixTest {
           graffitiBuilder,
           forkChoiceNotifier,
           executionLayer,
+          executionPayloadBidManager,
           metricsSystem,
           timeProvider);
   private ExecutionPayloadContext executionPayloadContext;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
@@ -77,6 +77,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.SimpleOperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
@@ -152,6 +153,8 @@ class BlockOperationSelectorFactoryDenebTest {
   private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   private final ExecutionLayerBlockProductionManager executionLayer =
       mock(ExecutionLayerBlockProductionManager.class);
+  private final ExecutionPayloadBidManager executionPayloadBidManager =
+      mock(ExecutionPayloadBidManager.class);
 
   private final GraffitiBuilder graffitiBuilder =
       new GraffitiBuilder(ClientGraffitiAppendFormat.DISABLED);
@@ -170,6 +173,7 @@ class BlockOperationSelectorFactoryDenebTest {
           graffitiBuilder,
           forkChoiceNotifier,
           executionLayer,
+          executionPayloadBidManager,
           metricsSystem,
           timeProvider);
   private ExecutionPayloadContext executionPayloadContext;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
@@ -74,6 +74,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.SimpleOperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
@@ -149,6 +150,8 @@ class BlockOperationSelectorFactoryFuluTest {
   private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   private final ExecutionLayerBlockProductionManager executionLayer =
       mock(ExecutionLayerBlockProductionManager.class);
+  private final ExecutionPayloadBidManager executionPayloadBidManager =
+      mock(ExecutionPayloadBidManager.class);
 
   private final GraffitiBuilder graffitiBuilder =
       new GraffitiBuilder(ClientGraffitiAppendFormat.DISABLED);
@@ -167,6 +170,7 @@ class BlockOperationSelectorFactoryFuluTest {
           graffitiBuilder,
           forkChoiceNotifier,
           executionLayer,
+          executionPayloadBidManager,
           metricsSystem,
           timeProvider);
   private ExecutionPayloadContext executionPayloadContext;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -87,6 +87,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.SimpleOperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
@@ -164,6 +165,8 @@ class BlockOperationSelectorFactoryTest {
   private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   private final ExecutionLayerBlockProductionManager executionLayer =
       mock(ExecutionLayerBlockProductionManager.class);
+  private final ExecutionPayloadBidManager executionPayloadBidManager =
+      mock(ExecutionPayloadBidManager.class);
 
   private final CapturingBeaconBlockBodyBuilder bodyBuilder =
       new CapturingBeaconBlockBodyBuilder(false, false);
@@ -185,6 +188,7 @@ class BlockOperationSelectorFactoryTest {
           graffitiBuilder,
           forkChoiceNotifier,
           executionLayer,
+          executionPayloadBidManager,
           metricsSystem,
           timeProvider);
   private ExecutionPayloadContext executionPayloadContext;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockAndCheckpoints.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockAndCheckpoints.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 
 public class BlockAndCheckpoints implements BeaconBlockSummary {
@@ -90,7 +91,10 @@ public class BlockAndCheckpoints implements BeaconBlockSummary {
   }
 
   public Optional<Bytes32> getExecutionBlockHash() {
-    return getExecutionPayload().map(ExecutionPayload::getBlockHash);
+    return getExecutionPayload()
+        .map(ExecutionPayload::getBlockHash)
+        // Gloas
+        .or(() -> getSignedExecutionPayloadBid().map(bid -> bid.getMessage().getBlockHash()));
   }
 
   @Override
@@ -121,5 +125,9 @@ public class BlockAndCheckpoints implements BeaconBlockSummary {
 
   private Optional<ExecutionPayload> getExecutionPayload() {
     return block.getMessage().getBody().getOptionalExecutionPayload();
+  }
+
+  private Optional<SignedExecutionPayloadBid> getSignedExecutionPayloadBid() {
+    return block.getMessage().getBody().getOptionalSignedExecutionPayloadBid();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.epbs.versions.gloas;
 
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOB_KZG_COMMITMENTS_ROOT;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_HASH;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BUILDER_INDEX;
@@ -33,6 +34,9 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 
 public class ExecutionPayloadBidSchema
     extends ContainerSchema9<
@@ -89,7 +93,23 @@ public class ExecutionPayloadBidSchema
     return new ExecutionPayloadBid(this, node);
   }
 
-  public int getBlobKzgCommitmentsRootGeneralizedIndex() {
-    return (int) getChildGeneralizedIndex(getFieldIndex(BLOB_KZG_COMMITMENTS_ROOT));
+  public ExecutionPayloadBid createLocalSelfBuiltBid(
+      final UInt64 builderIndex,
+      final UInt64 slot,
+      final BeaconState state,
+      final ExecutionPayload executionPayload,
+      final Bytes32 blobKzgCommitmentsRoot) {
+    return new ExecutionPayloadBid(
+        this,
+        BeaconStateGloas.required(state).getLatestBlockHash(),
+        state.getLatestBlockHeader().getRoot(),
+        executionPayload.getBlockHash(),
+        executionPayload.getFeeRecipient(),
+        executionPayload.getGasLimit(),
+        builderIndex,
+        slot,
+        // amount must be zero for self-build blocks
+        ZERO,
+        blobKzgCommitmentsRoot);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBidSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBidSchema.java
@@ -17,7 +17,6 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYL
 
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
-import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
@@ -41,15 +40,5 @@ public class SignedExecutionPayloadBidSchema
   @Override
   public SignedExecutionPayloadBid createFromBackingNode(final TreeNode node) {
     return new SignedExecutionPayloadBid(this, node);
-  }
-
-  public ExecutionPayloadBidSchema getMessageSchema() {
-    return (ExecutionPayloadBidSchema) getChildSchema(getFieldIndex("message"));
-  }
-
-  public long getBlobKzgCommitmentsRootGeneralizedIndex() {
-    return GIndexUtil.gIdxCompose(
-        getChildGeneralizedIndex(getFieldIndex("message")),
-        getMessageSchema().getBlobKzgCommitmentsRootGeneralizedIndex());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import java.util.Optional;
@@ -57,6 +59,13 @@ public class ExecutionPayloadResult {
 
   public ExecutionPayloadContext getExecutionPayloadContext() {
     return executionPayloadContext;
+  }
+
+  public SafeFuture<GetPayloadResponse> getPayloadResponseFutureFromLocalFlowRequired() {
+    checkState(
+        getPayloadResponseFuture.isPresent(),
+        "GetPayloadResponse from local flow has been requested but it's not present");
+    return getPayloadResponseFuture.get();
   }
 
   public Optional<SafeFuture<ExecutionPayload>> getExecutionPayloadFutureFromLocalFlow() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderFulu.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderFulu.java
@@ -219,6 +219,9 @@ public class BeaconStateBuilderFulu
         dataStructureUtil.randomSszUInt64Vector(
             schema.getProposerLookaheadSchema(),
             schema.getProposerLookaheadSchema().getMaxLength(),
-            () -> dataStructureUtil.randomUInt64(defaultValidatorCount));
+            () ->
+                defaultValidatorCount > 0
+                    ? dataStructureUtil.randomUInt64(defaultValidatorCount)
+                    : UInt64.ZERO);
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderFulu.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderFulu.java
@@ -218,6 +218,7 @@ public class BeaconStateBuilderFulu
     this.proposerLookahead =
         dataStructureUtil.randomSszUInt64Vector(
             schema.getProposerLookaheadSchema(),
-            schema.getProposerLookaheadSchema().getMaxLength());
+            schema.getProposerLookaheadSchema().getMaxLength(),
+            () -> dataStructureUtil.randomUInt64(defaultValidatorCount));
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
@@ -273,7 +273,10 @@ public class BeaconStateBuilderGloas
         dataStructureUtil.randomSszUInt64Vector(
             schema.getProposerLookaheadSchema(),
             schema.getProposerLookaheadSchema().getMaxLength(),
-            () -> dataStructureUtil.randomUInt64(defaultValidatorCount));
+            () ->
+                defaultValidatorCount > 0
+                    ? dataStructureUtil.randomUInt64(defaultValidatorCount)
+                    : UInt64.ZERO);
 
     this.latestExecutionPayloadBid = dataStructureUtil.randomExecutionPayloadBid();
     this.executionPayloadAvailability =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
@@ -272,7 +272,8 @@ public class BeaconStateBuilderGloas
     this.proposerLookahead =
         dataStructureUtil.randomSszUInt64Vector(
             schema.getProposerLookaheadSchema(),
-            schema.getProposerLookaheadSchema().getMaxLength());
+            schema.getProposerLookaheadSchema().getMaxLength(),
+            () -> dataStructureUtil.randomUInt64(defaultValidatorCount));
 
     this.latestExecutionPayloadBid = dataStructureUtil.randomExecutionPayloadBid();
     this.executionPayloadAvailability =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -25,7 +25,6 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
+import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatAbbreviatedHashRoot;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.Constants;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+
+public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidManager {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+
+  public DefaultExecutionPayloadBidManager(final Spec spec) {
+    this.spec = spec;
+  }
+
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9960 (not required for devnet-0)
+  @Override
+  public SafeFuture<InternalValidationResult> validateAndAddBid(
+      final SignedExecutionPayloadBid signedBid, final RemoteBidOrigin remoteBidOrigin) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadBid>> getBidForBlock(
+      final BeaconState state,
+      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
+      final BlockProductionPerformance blockProductionPerformance) {
+    final UInt64 slot = state.getSlot();
+    // only local self-built bids for devnet-0
+    return getLocalSelfBuiltBid(slot, state, getPayloadResponseFuture).thenApply(Optional::of);
+  }
+
+  private SafeFuture<SignedExecutionPayloadBid> getLocalSelfBuiltBid(
+      final UInt64 slot,
+      final BeaconState state,
+      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
+    return getPayloadResponseFuture.thenApply(
+        getPayloadResponse -> {
+          final SignedExecutionPayloadBid localSelfBuiltSignedBid =
+              createLocalSelfBuiltSignedBid(getPayloadResponse, slot, state);
+          LOG.info(
+              "Considering self-built bid (value: {} ETH, EL block: {}) for block at slot {}",
+              weiToEth(getPayloadResponse.getExecutionPayloadValue()),
+              formatAbbreviatedHashRoot(localSelfBuiltSignedBid.getMessage().getBlockHash()),
+              slot);
+          return localSelfBuiltSignedBid;
+        });
+  }
+
+  private SignedExecutionPayloadBid createLocalSelfBuiltSignedBid(
+      final GetPayloadResponse getPayloadResponse, final UInt64 slot, final BeaconState state) {
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    final ExecutionPayload executionPayload = getPayloadResponse.getExecutionPayload();
+    final ExecutionPayloadBid bid =
+        schemaDefinitions
+            .getExecutionPayloadBidSchema()
+            .create(
+                BeaconStateGloas.required(state).getLatestBlockHash(),
+                state.getLatestBlockHeader().getRoot(),
+                executionPayload.getBlockHash(),
+                executionPayload.getFeeRecipient(),
+                executionPayload.getGasLimit(),
+                // proposer is the builder
+                UInt64.valueOf(spec.getBeaconProposerIndex(state, slot)),
+                slot,
+                ZERO,
+                schemaDefinitions
+                    .getBlobKzgCommitmentsSchema()
+                    .createFromBlobsBundle(getPayloadResponse.getBlobsBundle().orElseThrow())
+                    .hashTreeRoot());
+    // Using G2_POINT_AT_INFINITY as signature for self-builds
+    return schemaDefinitions
+        .getSignedExecutionPayloadBidSchema()
+        .create(bid, BLSSignature.infinity());
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadBidManager.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import java.util.Optional;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+
+public interface ExecutionPayloadBidManager {
+
+  enum RemoteBidOrigin {
+    P2P,
+    BUILDER
+  }
+
+  ExecutionPayloadBidManager NOOP =
+      new ExecutionPayloadBidManager() {
+
+        @Override
+        public SafeFuture<InternalValidationResult> validateAndAddBid(
+            final SignedExecutionPayloadBid signedBid, final RemoteBidOrigin remoteBidOrigin) {
+          return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
+        }
+
+        @Override
+        public SafeFuture<Optional<SignedExecutionPayloadBid>> getBidForBlock(
+            final BeaconState state,
+            final SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
+            final BlockProductionPerformance blockProductionPerformance) {
+          return SafeFuture.completedFuture(Optional.empty());
+        }
+      };
+
+  SafeFuture<InternalValidationResult> validateAndAddBid(
+      SignedExecutionPayloadBid signedBid, RemoteBidOrigin remoteBidOrigin);
+
+  SafeFuture<Optional<SignedExecutionPayloadBid>> getBidForBlock(
+      BeaconState state,
+      SafeFuture<GetPayloadResponse> getPayloadResponseFuture,
+      BlockProductionPerformance blockProductionPerformance);
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class DefaultExecutionPayloadBidManagerTest {
+
+  private final Spec spec = TestSpecFactory.createMainnetGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private final BlockProductionPerformance blockProductionPerformance =
+      mock(BlockProductionPerformance.class);
+
+  private final DefaultExecutionPayloadBidManager executionPayloadBidManager =
+      new DefaultExecutionPayloadBidManager(spec);
+
+  @Test
+  public void createsLocalBidForBlock() {
+    final BeaconState state = dataStructureUtil.randomBeaconState();
+
+    final ExecutionPayload executionPayload =
+        dataStructureUtil.randomExecutionPayload(state.getSlot());
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(3);
+
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(state.getSlot()).getSchemaDefinitions());
+
+    final GetPayloadResponse getPayloadResponse =
+        new GetPayloadResponse(
+            executionPayload,
+            UInt256.valueOf(42),
+            blobsBundle,
+            false,
+            dataStructureUtil.randomExecutionRequests());
+
+    final Optional<SignedExecutionPayloadBid> maybeSignedBid =
+        SafeFutureAssert.safeJoin(
+            executionPayloadBidManager.getBidForBlock(
+                state, SafeFuture.completedFuture(getPayloadResponse), blockProductionPerformance));
+
+    assertThat(maybeSignedBid).isPresent();
+
+    final SignedExecutionPayloadBid signedBid = maybeSignedBid.get();
+
+    assertThat(signedBid.getSignature()).isEqualTo(BLSSignature.infinity());
+
+    final ExecutionPayloadBid bid = signedBid.getMessage();
+
+    assertThat(bid.getParentBlockHash())
+        .isEqualTo(BeaconStateGloas.required(state).getLatestBlockHash());
+    assertThat(bid.getParentBlockRoot()).isEqualTo(state.getLatestBlockHeader().getRoot());
+    assertThat(bid.getBlockHash()).isEqualTo(executionPayload.getBlockHash());
+    assertThat(bid.getGasLimit()).isEqualTo(executionPayload.getGasLimit());
+    assertThat(bid.getBuilderIndex().intValue())
+        .isEqualTo(spec.getBeaconProposerIndex(state, state.getSlot()));
+    assertThat(bid.getSlot()).isEqualTo(state.getSlot());
+    assertThat(bid.getBlobKzgCommitmentsRoot())
+        .isEqualTo(
+            schemaDefinitions
+                .getBlobKzgCommitmentsSchema()
+                .createFromBlobsBundle(blobsBundle)
+                .hashTreeRoot());
+    assertThat(bid.getValue()).isEqualTo(UInt64.ZERO);
+    assertThat(bid.getFeeRecipient())
+        .isEqualTo(Eth1Address.fromBytes(executionPayload.getFeeRecipient().getWrappedBytes()));
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -192,6 +192,9 @@ import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecar
 import tech.pegasys.teku.statetransition.datacolumns.retriever.RecoveringSidecarRetriever;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.SimpleSidecarRetriever;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.recovering.SidecarRetriever;
+import tech.pegasys.teku.statetransition.execution.DefaultExecutionPayloadBidManager;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBidOrigin;
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManagerImpl;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -359,6 +362,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile BlobSidecarManager blobSidecarManager;
   protected volatile BlobSidecarGossipValidator blobSidecarValidator;
   protected volatile DataColumnSidecarManager dataColumnSidecarManager;
+  protected volatile ExecutionPayloadBidManager executionPayloadBidManager;
   protected volatile ExecutionProofManager executionProofManager;
   protected volatile Optional<DasCustodySync> dasCustodySync = Optional.empty();
   protected volatile Optional<DataColumnSidecarRetriever> recoveringSidecarRetriever =
@@ -642,6 +646,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     initGenesisHandler();
     initAttestationManager();
     initBlockManager();
+    initExecutionPayloadBidManager();
     initSyncCommitteePools();
     initP2PNetwork();
     initCustodyGroupCountManager();
@@ -788,6 +793,14 @@ public class BeaconChainController extends Service implements BeaconChainControl
           dataColumnSidecarManager::onDataColumnSidecarPublish);
     } else {
       dataColumnSidecarManager = DataColumnSidecarManager.NOOP;
+    }
+  }
+
+  protected void initExecutionPayloadBidManager() {
+    if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      executionPayloadBidManager = new DefaultExecutionPayloadBidManager(spec);
+    } else {
+      executionPayloadBidManager = ExecutionPayloadBidManager.NOOP;
     }
   }
 
@@ -1394,6 +1407,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             graffitiBuilder,
             forkChoiceNotifier,
             executionLayerBlockProductionManager,
+            executionPayloadBidManager,
             metricsSystem,
             timeProvider);
     final BlockFactory blockFactory = new MilestoneBasedBlockFactory(spec, operationSelector);
@@ -1650,7 +1664,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
             // TODO-GLOAS: https://github.com/Consensys/teku/issues/9960
             .gossipedExecutionPayloadProcessor(OperationProcessor.noop())
             .gossipedPayloadAttestationMessageProcessor(OperationProcessor.noop())
-            .gossipedExecutionPayloadBidProcessor(OperationProcessor.noop())
+            .gossipedExecutionPayloadBidProcessor(
+                (signedBid, arrivalTimestamp) ->
+                    executionPayloadBidManager.validateAndAddBid(signedBid, RemoteBidOrigin.P2P))
             .gossipDasLogger(dasGossipLogger)
             .reqRespDasLogger(dasReqRespLogger)
             .processedAttestationSubscriptionProvider(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Introduce `ExecutionPayloadBidManager` which calls a real EL to retrieve a bid. No payload broadcasting has been implemented yet.

Also added a method to the manager to accept P2P bids with no implementation. Can change later.

Note: Self-built bids use infinite signature, so no VC communication needed. Next step is for the `BlockProductionDuty` in VC to notify the VC that a local bid has been selected (I guess either by correlating the public key with the builder index or when the signature is infinity, that's a sign as well), so that it can get the payload from the BN, sign it, import it and broadcast it to all peers

Tested on interop:
<img width="1772" height="745" alt="image" src="https://github.com/user-attachments/assets/3257891e-78c3-4d07-a506-31ccec0f6dd9" />

## Fixed Issue(s)
related to #9959 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an ExecutionPayloadBidManager to produce and include self-built signed execution payload bids for Gloas, wiring it into block production, P2P validation, and tests, with supporting spec/schema updates.
> 
> - **Gloas ePBS Integration**:
>   - Add `ExecutionPayloadBidManager` (with `DefaultExecutionPayloadBidManager`) to create local self-built bids from EL `GetPayloadResponse` and return `SignedExecutionPayloadBid` (G2 infinity signature).
>   - Wire into block production: `BlockOperationSelectorFactory` now fetches a payload response and sets `signedExecutionPayloadBid`; preparation waits on both execution data and bid.
>   - Beacon node init: `BeaconChainController` initializes the bid manager for Gloas and routes gossiped bids to `validateAndAddBid`.
> - **Spec/Schema Updates**:
>   - `ExecutionPayloadBidSchema`: add `createLocalSelfBuiltBid(...)` helper.
>   - `ExecutionPayloadResult`: add `getPayloadResponseFutureFromLocalFlowRequired()`.
>   - `BlockAndCheckpoints`: include execution block hash from bid when payload absent.
>   - Minor schema cleanups in `SignedExecutionPayloadBidSchema`.
> - **Validator/Tests**:
>   - Update block factory/tests to use the bid manager, assert bid inclusion, and adapt payload parent hash handling for Gloas states.
>   - Add unit tests for `DefaultExecutionPayloadBidManager`.
>   - Initialize/inject bid manager across validator/selector factory tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaf8b70ecadc570726c5677dc844feb2a0716f22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->