### PR TITLE
Change max execution proofs subnets constant to long

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.config;
 
 import java.time.Duration;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class Constants {
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -70,5 +70,5 @@ public class Constants {
   public static final int EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION = 1;
 
   // ZkChain prototype
-  public static final UInt64 MAX_EXECUTION_PROOF_SUBNETS = UInt64.valueOf(8);
+  public static final long MAX_EXECUTION_PROOF_SUBNETS = 8;
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionProofGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionProofGossipValidator.java
@@ -31,7 +31,7 @@ public class ExecutionProofGossipValidator {
   public static ExecutionProofGossipValidator create() {
     return new ExecutionProofGossipValidator(
         // max subnets * 2 epochs * slots per epoch 32 based on mainnet for now
-        LimitedSet.createSynchronized(MAX_EXECUTION_PROOF_SUBNETS.intValue() * 64));
+        LimitedSet.createSynchronized((int) MAX_EXECUTION_PROOF_SUBNETS * 64));
   }
 
   public ExecutionProofGossipValidator(final Set<ExecutionProof> receivedValidExecutionProofSet) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ExecutionProofGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/ExecutionProofGossipManager.java
@@ -29,7 +29,7 @@ public class ExecutionProofGossipManager implements GossipManager {
       final ExecutionProofSubnetSubscriptions executionProofSubnetSubscriptions) {
     this.executionProofSubnetSubscriptions = executionProofSubnetSubscriptions;
 
-    for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS.intValue(); i++) {
+    for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS; i++) {
       executionProofSubnetSubscriptions.subscribeToSubnetId(i);
     }
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
@@ -118,7 +118,7 @@ public class GossipTopics {
     topics.addAll(getAllDataColumnSidecarSubnetTopics(gossipEncoding, forkDigest, spec));
 
     if (p2pConfig.isExecutionProofTopicEnabled()) {
-      for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS.intValue(); i++) {
+      for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS; i++) {
         topics.add(getExecutionProofSubnetTopic(forkDigest, i, gossipEncoding));
       }
     }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilterTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/Eth2GossipTopicFilterTest.java
@@ -245,7 +245,7 @@ class Eth2GossipTopicFilterTest {
   @TestTemplate
   void shouldNotConsiderExecutionProofSubnetsRelevantByDefault() {
     assumeThat(nextSpecMilestone).isEqualTo(ELECTRA);
-    for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS.intValue(); i++) {
+    for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS; i++) {
       assertThat(filter.isRelevantTopic(getTopicName(getExecutionProofSubnetTopicName(i))))
           .isFalse();
     }
@@ -257,7 +257,7 @@ class Eth2GossipTopicFilterTest {
         P2PConfig.builder().specProvider(spec).executionProofTopicEnabled(true).build();
     filter = new Eth2GossipTopicFilter(recentChainData, SSZ_SNAPPY, spec, p2pConfigOverwritten);
     assumeThat(nextSpecMilestone).isEqualTo(ELECTRA);
-    for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS.intValue(); i++) {
+    for (int i = 0; i < Constants.MAX_EXECUTION_PROOF_SUBNETS; i++) {
       assertThat(filter.isRelevantTopic(getTopicName(getExecutionProofSubnetTopicName(i))))
           .isTrue();
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Simply change the constant to a long type

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches MAX_EXECUTION_PROOF_SUBNETS from UInt64 to long (8) and updates gossip/validation code and tests to use the primitive constant.
> 
> - **Config**:
>   - Change `Constants.MAX_EXECUTION_PROOF_SUBNETS` from `UInt64` to `long` with value `8`.
> - **Networking**:
>   - Update `ExecutionProofGossipManager` and `GossipTopics` to iterate using `Constants.MAX_EXECUTION_PROOF_SUBNETS` (primitive) instead of `.intValue()`.
> - **State Transition**:
>   - In `ExecutionProofGossipValidator`, compute set capacity with `(int) MAX_EXECUTION_PROOF_SUBNETS * 64`.
> - **Tests**:
>   - Adjust loops in `Eth2GossipTopicFilterTest` to use the primitive constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f62291b319e76edb6d804dc319deb97a02430318. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->