### PR TITLE
Introduce `BuilderApiChannel`

### DIFF
--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -79,6 +79,7 @@ import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
+import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisher;
 import tech.pegasys.teku.validator.coordinator.publisher.MilestoneBasedBlockPublisher;
 
 @TestSpecContext(milestone = {SpecMilestone.PHASE0, SpecMilestone.DENEB})
@@ -114,6 +115,10 @@ public class ValidatorApiHandlerIntegrationTest {
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
+  private final ExecutionPayloadFactory executionPayloadFactory =
+      mock(ExecutionPayloadFactory.class);
+  private final ExecutionPayloadPublisher executionPayloadPublisher =
+      mock(ExecutionPayloadPublisher.class);
 
   private final ChainUpdater chainUpdater = storageSystem.chainUpdater();
   private final SyncCommitteeMessagePool syncCommitteeMessagePool =
@@ -203,7 +208,9 @@ public class ValidatorApiHandlerIntegrationTest {
                 blobSidecarGossipChannel,
                 dataColumnSidecarGossipChannel,
                 dutyMetrics,
-                P2PConfig.DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED));
+                P2PConfig.DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED),
+            executionPayloadFactory,
+            executionPayloadPublisher);
   }
 
   @TestTemplate

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import java.util.List;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public interface ExecutionPayloadFactory {
+
+  ExecutionPayloadFactory NOOP =
+      new ExecutionPayloadFactory() {
+        @Override
+        public SafeFuture<ExecutionPayloadEnvelope> createUnsignedExecutionPayload(
+            final UInt64 builderIndex, final BeaconBlockAndState blockAndState) {
+          return new SafeFuture<>();
+        }
+
+        @Override
+        public List<DataColumnSidecar> createDataColumnSidecars(
+            final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+          return List.of();
+        }
+      };
+
+  SafeFuture<ExecutionPayloadEnvelope> createUnsignedExecutionPayload(
+      UInt64 builderIndex, BeaconBlockAndState blockAndState);
+
+  List<DataColumnSidecar> createDataColumnSidecars(
+      SignedExecutionPayloadEnvelope signedExecutionPayload);
+}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactory.java
@@ -28,7 +28,7 @@ public interface ExecutionPayloadFactory {
         @Override
         public SafeFuture<ExecutionPayloadEnvelope> createUnsignedExecutionPayload(
             final UInt64 builderIndex, final BeaconBlockAndState blockAndState) {
-          return new SafeFuture<>();
+          return SafeFuture.completedFuture(null);
         }
 
         @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloas.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import java.util.List;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+// TODO-GLOAS: https://github.com/Consensys/teku/issues/10008
+public class ExecutionPayloadFactoryGloas implements ExecutionPayloadFactory {
+
+  public ExecutionPayloadFactoryGloas() {}
+
+  @Override
+  public SafeFuture<ExecutionPayloadEnvelope> createUnsignedExecutionPayload(
+      final UInt64 builderIndex, final BeaconBlockAndState blockAndState) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public List<DataColumnSidecar> createDataColumnSidecars(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -830,7 +830,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+  public SafeFuture<Void> publishSignedExecutionPayloadBid(
       final SignedExecutionPayloadBid signedExecutionPayloadBid) {
     throw new UnsupportedOperationException("This method is not implemented by the Beacon Node");
   }
@@ -858,7 +858,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
                     "Unable to produce execution payload for slot {} and block {} because parent has optimistically validated payload",
                     slot,
                     blockAndState.getRoot().toUnprefixedHexString());
-                throw new NodeSyncingException();
+                return NodeSyncingException.failedFuture();
               }
               return executionPayloadFactory
                   .createUnsignedExecutionPayload(builderIndex, blockAndState)
@@ -867,9 +867,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayload(
+  public SafeFuture<Void> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
-    return executionPayloadPublisher.sendSignedExecutionPayload(signedExecutionPayload);
+    return executionPayloadPublisher.publishSignedExecutionPayload(signedExecutionPayload);
   }
 
   private Optional<SubmitDataError> fromInternalValidationResult(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
@@ -72,9 +73,14 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -105,6 +111,7 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.coordinator.duties.AttesterDutiesGenerator;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.publisher.BlockPublisher;
+import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisher;
 
 public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChannel {
 
@@ -143,6 +150,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   private final SyncCommitteeContributionPool syncCommitteeContributionPool;
   private final ProposersDataManager proposersDataManager;
   private final BlockPublisher blockPublisher;
+  private final ExecutionPayloadFactory executionPayloadFactory;
+  private final ExecutionPayloadPublisher executionPayloadPublisher;
 
   private final AttesterDutiesGenerator attesterDutiesGenerator;
 
@@ -167,7 +176,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
       final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager,
       final BlockProductionAndPublishingPerformanceFactory
           blockProductionAndPublishingPerformanceFactory,
-      final BlockPublisher blockPublisher) {
+      final BlockPublisher blockPublisher,
+      final ExecutionPayloadFactory executionPayloadFactory,
+      final ExecutionPayloadPublisher executionPayloadPublisher) {
     this.blockProductionAndPublishingPerformanceFactory =
         blockProductionAndPublishingPerformanceFactory;
     this.chainDataProvider = chainDataProvider;
@@ -189,6 +200,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     this.syncCommitteeSubscriptionManager = syncCommitteeSubscriptionManager;
     this.proposersDataManager = proposersDataManager;
     this.blockPublisher = blockPublisher;
+    this.executionPayloadFactory = executionPayloadFactory;
+    this.executionPayloadPublisher = executionPayloadPublisher;
     this.attesterDutiesGenerator = new AttesterDutiesGenerator(spec);
   }
 
@@ -797,6 +810,68 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
         validatorIndices, epoch, chainDataProvider.getCurrentEpoch());
   }
 
+  @Override
+  public SafeFuture<Optional<List<BeaconCommitteeSelectionProof>>> getBeaconCommitteeSelectionProof(
+      final List<BeaconCommitteeSelectionProof> requests) {
+    throw new UnsupportedOperationException("This method is not implemented by the Beacon Node");
+  }
+
+  @Override
+  public SafeFuture<Optional<List<SyncCommitteeSelectionProof>>> getSyncCommitteeSelectionProof(
+      final List<SyncCommitteeSelectionProof> requests) {
+    throw new UnsupportedOperationException("This method is not implemented by the Beacon Node");
+  }
+
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9997 (not required for devnet-0)
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
+      final UInt64 slot, final UInt64 builderIndex) {
+    throw new UnsupportedOperationException("This method is not implemented by the Beacon Node");
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+      final SignedExecutionPayloadBid signedExecutionPayloadBid) {
+    throw new UnsupportedOperationException("This method is not implemented by the Beacon Node");
+  }
+
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
+      final UInt64 slot, final UInt64 builderIndex) {
+    if (isSyncActive()) {
+      return NodeSyncingException.failedFuture();
+    }
+    return combinedChainDataClient
+        .getBlockAndStateInEffectAtSlot(slot)
+        .thenCompose(
+            maybeBlockAndState -> {
+              if (maybeBlockAndState.isEmpty()) {
+                return CompletableFuture.completedFuture(Optional.empty());
+              }
+              final BeaconBlockAndState blockAndState = maybeBlockAndState.get();
+              LOG.info(
+                  "Producing unsigned execution payload for slot {} and block {}",
+                  slot,
+                  blockAndState.getRoot());
+              if (combinedChainDataClient.isOptimisticBlock(blockAndState.getParentRoot())) {
+                LOG.warn(
+                    "Unable to produce execution payload for slot {} and block {} because parent has optimistically validated payload",
+                    slot,
+                    blockAndState.getRoot().toUnprefixedHexString());
+                throw new NodeSyncingException();
+              }
+              return executionPayloadFactory
+                  .createUnsignedExecutionPayload(builderIndex, blockAndState)
+                  .thenApply(Optional::of);
+            });
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    return executionPayloadPublisher.sendSignedExecutionPayload(signedExecutionPayload);
+  }
+
   private Optional<SubmitDataError> fromInternalValidationResult(
       final InternalValidationResult internalValidationResult, final int resultIndex) {
     if (!internalValidationResult.isReject()) {
@@ -933,18 +1008,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
                     .getRoot()
                     .equals(signedBlockContainer.getRoot()))
         .orElse(false);
-  }
-
-  @Override
-  public SafeFuture<Optional<List<BeaconCommitteeSelectionProof>>> getBeaconCommitteeSelectionProof(
-      final List<BeaconCommitteeSelectionProof> requests) {
-    throw new UnsupportedOperationException("This method is not implemented by the Beacon Node");
-  }
-
-  @Override
-  public SafeFuture<Optional<List<SyncCommitteeSelectionProof>>> getSyncCommitteeSelectionProof(
-      final List<SyncCommitteeSelectionProof> requests) {
-    throw new UnsupportedOperationException("This method is not implemented by the Beacon Node");
   }
 
   private record BlockProductionPreparationContext(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisher.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator.publisher;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+/** Used to publish execution payload and data column sidecars */
+public interface ExecutionPayloadPublisher {
+
+  ExecutionPayloadPublisher NOOP =
+      new ExecutionPayloadPublisher() {
+        @Override
+        public SafeFuture<Void> sendSignedExecutionPayload(
+            final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+          return SafeFuture.COMPLETE;
+        }
+      };
+
+  SafeFuture<Void> sendSignedExecutionPayload(
+      SignedExecutionPayloadEnvelope signedExecutionPayload);
+}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisher.java
@@ -22,12 +22,12 @@ public interface ExecutionPayloadPublisher {
   ExecutionPayloadPublisher NOOP =
       new ExecutionPayloadPublisher() {
         @Override
-        public SafeFuture<Void> sendSignedExecutionPayload(
+        public SafeFuture<Void> publishSignedExecutionPayload(
             final SignedExecutionPayloadEnvelope signedExecutionPayload) {
           return SafeFuture.COMPLETE;
         }
       };
 
-  SafeFuture<Void> sendSignedExecutionPayload(
+  SafeFuture<Void> publishSignedExecutionPayload(
       SignedExecutionPayloadEnvelope signedExecutionPayload);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisherGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisherGloas.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 public class ExecutionPayloadPublisherGloas implements ExecutionPayloadPublisher {
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayload(
+  public SafeFuture<Void> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     throw new UnsupportedOperationException("Not yet implemented");
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisherGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisherGloas.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator.publisher;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+// TODO-GLOAS: https://github.com/Consensys/teku/issues/10008
+public class ExecutionPayloadPublisherGloas implements ExecutionPayloadPublisher {
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -1322,17 +1322,17 @@ class ValidatorApiHandlerTest {
   }
 
   @Test
-  public void sendSignedExecutionPayload_shouldPublish() {
+  public void publishSignedExecutionPayload_shouldPublish() {
     final SignedExecutionPayloadEnvelope signedExecutionPayload =
         dataStructureUtil.randomSignedExecutionPayloadEnvelope(5);
-    when(executionPayloadPublisher.sendSignedExecutionPayload(eq(signedExecutionPayload)))
+    when(executionPayloadPublisher.publishSignedExecutionPayload(eq(signedExecutionPayload)))
         .thenReturn(SafeFuture.COMPLETE);
     final SafeFuture<Void> result =
-        validatorApiHandler.sendSignedExecutionPayload(signedExecutionPayload);
+        validatorApiHandler.publishSignedExecutionPayload(signedExecutionPayload);
 
     assertThat(result).isCompleted();
 
-    verify(executionPayloadPublisher).sendSignedExecutionPayload(signedExecutionPayload);
+    verify(executionPayloadPublisher).publishSignedExecutionPayload(signedExecutionPayload);
   }
 
   private boolean validatorIsLive(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -86,10 +86,13 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -119,6 +122,7 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.publisher.BlockPublisher;
+import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisher;
 
 class ValidatorApiHandlerTest {
 
@@ -142,6 +146,11 @@ class ValidatorApiHandlerTest {
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
+  private final ExecutionPayloadFactory executionPayloadFactory =
+      mock(ExecutionPayloadFactory.class);
+  private final ExecutionPayloadPublisher executionPayloadPublisher =
+      mock(ExecutionPayloadPublisher.class);
+
   private final SyncCommitteeMessagePool syncCommitteeMessagePool =
       mock(SyncCommitteeMessagePool.class);
   private final SyncCommitteeContributionPool syncCommitteeContributionPool =
@@ -162,7 +171,7 @@ class ValidatorApiHandlerTest {
 
   @BeforeEach
   public void setUp() {
-    this.spec = TestSpecFactory.createMinimalAltair();
+    this.spec = TestSpecFactory.createMinimalGloas();
     this.epochStartSlot = spec.computeStartSlotAtEpoch(EPOCH);
     this.previousEpochStartSlot = spec.computeStartSlotAtEpoch(PREVIOUS_EPOCH);
     this.dataStructureUtil = new DataStructureUtil(spec);
@@ -189,7 +198,9 @@ class ValidatorApiHandlerTest {
             syncCommitteeContributionPool,
             syncCommitteeSubscriptionManager,
             blockProductionPerformanceFactory,
-            blockPublisher);
+            blockPublisher,
+            executionPayloadFactory,
+            executionPayloadPublisher);
 
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(forkChoiceTrigger.prepareForBlockProduction(any(), any())).thenReturn(SafeFuture.COMPLETE);
@@ -441,7 +452,10 @@ class ValidatorApiHandlerTest {
             syncCommitteeContributionPool,
             syncCommitteeSubscriptionManager,
             blockProductionPerformanceFactory,
-            blockPublisher);
+            blockPublisher,
+            executionPayloadFactory,
+            executionPayloadPublisher);
+    dataStructureUtil = new DataStructureUtil(spec);
     // Best state is still in Phase0
     final BeaconState state =
         dataStructureUtil.stateBuilderPhase0().slot(previousEpochStartSlot.minus(1)).build();
@@ -853,31 +867,6 @@ class ValidatorApiHandlerTest {
 
   @Test
   void sendSignedAttestations_shouldSaveConvertedAttestationFromSingleAttestation() {
-    spec = TestSpecFactory.createMinimalElectra();
-    dataStructureUtil = new DataStructureUtil(spec);
-    validatorApiHandler =
-        new ValidatorApiHandler(
-            chainDataProvider,
-            nodeDataProvider,
-            networkDataProvider,
-            chainDataClient,
-            syncStateProvider,
-            blockFactory,
-            attestationPool,
-            attestationManager,
-            attestationTopicSubscriptions,
-            activeValidatorTracker,
-            dutyMetrics,
-            performanceTracker,
-            spec,
-            forkChoiceTrigger,
-            proposersDataManager,
-            syncCommitteeMessagePool,
-            syncCommitteeContributionPool,
-            syncCommitteeSubscriptionManager,
-            blockProductionPerformanceFactory,
-            blockPublisher);
-
     final Attestation attestation = dataStructureUtil.randomSingleAttestation();
     final Attestation convertedAttestation = dataStructureUtil.randomAttestation();
     doAnswer(
@@ -1283,6 +1272,67 @@ class ValidatorApiHandlerTest {
     verify(performanceTracker).saveProducedAttestation(attestation);
     verify(dutyMetrics).onAttestationPublished(attestation.getData().getSlot());
     assertThat(result).isCompletedWithValue(emptyList());
+  }
+
+  @Test
+  public void createUnsignedExecutionPayload_shouldFailWhenNodeIsSyncing() {
+    nodeIsSyncing();
+    final SafeFuture<Optional<ExecutionPayloadEnvelope>> result =
+        validatorApiHandler.createUnsignedExecutionPayload(
+            ONE, dataStructureUtil.randomBuilderIndex());
+
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
+  }
+
+  @Test
+  public void createUnsignedExecutionPayload_shouldFailWhenParentBlockIsOptimistic() {
+    final UInt64 newSlot = UInt64.valueOf(25);
+    final BeaconBlockAndState blockAndState = dataStructureUtil.randomBlockAndState(newSlot);
+    when(chainDataClient.getBlockAndStateInEffectAtSlot(eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blockAndState)));
+    when(chainDataClient.isOptimisticBlock(blockAndState.getParentRoot())).thenReturn(true);
+
+    final SafeFuture<Optional<ExecutionPayloadEnvelope>> result =
+        validatorApiHandler.createUnsignedExecutionPayload(
+            newSlot, dataStructureUtil.randomBuilderIndex());
+
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
+    verifyNoInteractions(blockFactory);
+  }
+
+  @Test
+  public void createUnsignedExecutionPayload_shouldCreateExecutionPayload() {
+    final UInt64 newSlot = UInt64.valueOf(25);
+    final BeaconBlockAndState blockAndState = dataStructureUtil.randomBlockAndState(newSlot);
+    final UInt64 builderIndex = UInt64.valueOf(42);
+    final ExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomExecutionPayloadEnvelope(newSlot);
+
+    when(chainDataClient.getBlockAndStateInEffectAtSlot(eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blockAndState)));
+    when(executionPayloadFactory.createUnsignedExecutionPayload(builderIndex, blockAndState))
+        .thenReturn(SafeFuture.completedFuture(executionPayload));
+
+    SafeFuture<Optional<ExecutionPayloadEnvelope>> result =
+        validatorApiHandler.createUnsignedExecutionPayload(newSlot, builderIndex);
+
+    assertThat(result).isCompletedWithValue(Optional.of(executionPayload));
+  }
+
+  @Test
+  public void sendSignedExecutionPayload_shouldPublish() {
+    final SignedExecutionPayloadEnvelope signedExecutionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(5);
+    when(executionPayloadPublisher.sendSignedExecutionPayload(eq(signedExecutionPayload)))
+        .thenReturn(SafeFuture.COMPLETE);
+    final SafeFuture<Void> result =
+        validatorApiHandler.sendSignedExecutionPayload(signedExecutionPayload);
+
+    assertThat(result).isCompleted();
+
+    verify(executionPayloadPublisher).sendSignedExecutionPayload(signedExecutionPayload);
   }
 
   private boolean validatorIsLive(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPayment.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPayment.java
@@ -41,8 +41,8 @@ public class BuilderPendingPayment
     return getField1();
   }
 
-  public BuilderPendingPayment copyWithNewWeight(final UInt64 newWeight) {
-    return new BuilderPendingPayment(getSchema(), newWeight, getWithdrawal());
+  public BuilderPendingPayment copyWithNewWeight(final UInt64 weight) {
+    return new BuilderPendingPayment(getSchema(), weight, getWithdrawal());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
@@ -29,22 +29,18 @@ import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessor
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
 
 public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
-  private final SpecConfigFulu configFulu;
-  private final MiscHelpersFulu miscHelpersFulu;
 
   public BeaconStateAccessorsFulu(
       final SpecConfig config,
       final PredicatesElectra predicatesElectra,
       final MiscHelpersFulu miscHelpers) {
     super(SpecConfigFulu.required(config), predicatesElectra, miscHelpers);
-    configFulu = config.toVersionFulu().orElseThrow();
-    this.miscHelpersFulu = miscHelpers;
   }
 
   @Override
   protected void validateStateCanCalculateProposerIndexAtSlot(
       final BeaconState state, final UInt64 requestedSlot) {
-    final UInt64 epoch = miscHelpersFulu.computeEpochAtSlot(requestedSlot);
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);
     final UInt64 stateEpoch = getCurrentEpoch(state);
     checkArgument(
         epoch.equals(stateEpoch) || stateEpoch.increment().equals(epoch),
@@ -58,7 +54,7 @@ public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
   @Override
   public int getBeaconProposerIndex(final BeaconState state, final UInt64 requestedSlot) {
     validateStateCanCalculateProposerIndexAtSlot(state, requestedSlot);
-    final int lookaheadIndex = requestedSlot.mod(configFulu.getSlotsPerEpoch()).intValue();
+    final int lookaheadIndex = requestedSlot.mod(config.getSlotsPerEpoch()).intValue();
     return BeaconStateFulu.required(state)
         .getProposerLookahead()
         .get(lookaheadIndex)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -35,7 +35,7 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
 
   @Override
   public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
-    // TODO(GLOAS): in ePBS, data availability is delayed until the processing of the execution
+    // TODO-GLOAS: in ePBS, data availability is delayed until the processing of the execution
     // payload.
     // We may have a dedicated availability checker for the execution stage.
     // If it will be the case, this will remain a NOOP

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -245,7 +245,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "qXEUxa5aZZ9BlZLtLjYfCMDgMF4UNxHLYlSDaVLRjUmsvrDQAL1UzqetNhMbZP6BCgUFHTlnNpYFngCrmfrt6f5QSdRc0UvhTvRUG52MAEtCaTqwbhLI4iYv3+AbIPNz"));
+                "hVEMaMnqdD2ZaaqvczX5KDZltt+oVPldTj6R+R/c2/cHjZgj1OwNbfJGOuhS7VuZAxw4B6eVbLBj+OvrUs95tpQZNEvKln3QU8zWNZw271pRW1FzYn62HP2jx1rZguNU"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadEnvelope(envelope, fork);
     asyncRunner.executeQueuedActions();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -145,6 +145,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -3093,6 +3094,10 @@ public final class DataStructureUtil {
   }
 
   public ExecutionPayloadEnvelope randomExecutionPayloadEnvelope() {
+    return randomExecutionPayloadEnvelope(randomSlot());
+  }
+
+  public ExecutionPayloadEnvelope randomExecutionPayloadEnvelope(final UInt64 slot) {
     return getGloasSchemaDefinitions()
         .getExecutionPayloadEnvelopeSchema()
         .create(
@@ -3100,9 +3105,15 @@ public final class DataStructureUtil {
             randomExecutionRequests(),
             randomBuilderIndex(),
             randomBytes32(),
-            randomSlot(),
+            slot,
             randomBlobKzgCommitments(),
             randomBytes32());
+  }
+
+  public SignedExecutionPayloadEnvelope randomSignedExecutionPayloadEnvelope(final long slot) {
+    return getGloasSchemaDefinitions()
+        .getSignedExecutionPayloadEnvelopeSchema()
+        .create(randomExecutionPayloadEnvelope(UInt64.valueOf(slot)), randomSignature());
   }
 
   public ExecutionProof randomExecutionProof() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -266,6 +266,8 @@ import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
 import tech.pegasys.teku.validator.coordinator.Eth1DataProvider;
 import tech.pegasys.teku.validator.coordinator.Eth1VotingPeriod;
+import tech.pegasys.teku.validator.coordinator.ExecutionPayloadFactory;
+import tech.pegasys.teku.validator.coordinator.ExecutionPayloadFactoryGloas;
 import tech.pegasys.teku.validator.coordinator.FutureBlockProductionPreparationTrigger;
 import tech.pegasys.teku.validator.coordinator.GraffitiBuilder;
 import tech.pegasys.teku.validator.coordinator.MilestoneBasedBlockFactory;
@@ -278,6 +280,8 @@ import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.SyncCommitteePerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.ValidatorPerformanceMetrics;
 import tech.pegasys.teku.validator.coordinator.publisher.BlockPublisher;
+import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisher;
+import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisherGloas;
 import tech.pegasys.teku.validator.coordinator.publisher.MilestoneBasedBlockPublisher;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityCalculator;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityValidator;
@@ -1466,6 +1470,17 @@ public class BeaconChainController extends Service implements BeaconChainControl
             dutyMetrics,
             beaconConfig.p2pConfig().isGossipBlobsAfterBlockEnabled());
 
+    final ExecutionPayloadFactory executionPayloadFactory;
+    final ExecutionPayloadPublisher executionPayloadPublisher;
+
+    if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      executionPayloadFactory = new ExecutionPayloadFactoryGloas();
+      executionPayloadPublisher = new ExecutionPayloadPublisherGloas();
+    } else {
+      executionPayloadFactory = ExecutionPayloadFactory.NOOP;
+      executionPayloadPublisher = ExecutionPayloadPublisher.NOOP;
+    }
+
     this.validatorApiHandler =
         new ValidatorApiHandler(
             new ChainDataProvider(
@@ -1492,7 +1507,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
             syncCommitteeContributionPool,
             syncCommitteeSubscriptionManager,
             blockProductionPerformanceFactory,
-            blockPublisher);
+            blockPublisher,
+            executionPayloadFactory,
+            executionPayloadPublisher);
     eventChannels
         .subscribe(SlotEventsChannel.class, activeValidatorTracker)
         .subscribe(ExecutionClientEventsChannel.class, executionClientVersionProvider)

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+/**
+ * <a
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md#builders-attributions">Builders
+ * attributions</a>
+ */
+public interface BuilderApiChannel {
+
+  SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
+      UInt64 slot, UInt64 builderIndex);
+
+  SafeFuture<Void> sendSignedExecutionPayloadBid(
+      SignedExecutionPayloadBid signedExecutionPayloadBid);
+
+  SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
+      UInt64 slot, UInt64 builderIndex);
+
+  SafeFuture<Void> sendSignedExecutionPayload(
+      SignedExecutionPayloadEnvelope signedExecutionPayload);
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
@@ -31,12 +31,12 @@ public interface BuilderApiChannel {
   SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
       UInt64 slot, UInt64 builderIndex);
 
-  SafeFuture<Void> sendSignedExecutionPayloadBid(
+  SafeFuture<Void> publishSignedExecutionPayloadBid(
       SignedExecutionPayloadBid signedExecutionPayloadBid);
 
   SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
       UInt64 slot, UInt64 builderIndex);
 
-  SafeFuture<Void> sendSignedExecutionPayload(
+  SafeFuture<Void> publishSignedExecutionPayload(
       SignedExecutionPayloadEnvelope signedExecutionPayload);
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -210,7 +210,7 @@ public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface
         }
 
         @Override
-        public SafeFuture<Void> sendSignedExecutionPayloadBid(
+        public SafeFuture<Void> publishSignedExecutionPayloadBid(
             final SignedExecutionPayloadBid signedExecutionPayloadBid) {
           return SafeFuture.COMPLETE;
         }
@@ -222,7 +222,7 @@ public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface
         }
 
         @Override
-        public SafeFuture<Void> sendSignedExecutionPayload(
+        public SafeFuture<Void> publishSignedExecutionPayload(
             final SignedExecutionPayloadEnvelope signedExecutionPayload) {
           return SafeFuture.COMPLETE;
         }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -37,6 +37,10 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -49,7 +53,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 
-public interface ValidatorApiChannel extends ChannelInterface {
+public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface {
   ValidatorApiChannel NO_OP =
       new ValidatorApiChannel() {
         @Override
@@ -197,6 +201,30 @@ public interface ValidatorApiChannel extends ChannelInterface {
         public SafeFuture<Optional<List<SyncCommitteeSelectionProof>>>
             getSyncCommitteeSelectionProof(final List<SyncCommitteeSelectionProof> requests) {
           return SafeFuture.completedFuture(Optional.of(requests));
+        }
+
+        @Override
+        public SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
+            final UInt64 slot, final UInt64 builderIndex) {
+          return SafeFuture.completedFuture(Optional.empty());
+        }
+
+        @Override
+        public SafeFuture<Void> sendSignedExecutionPayloadBid(
+            final SignedExecutionPayloadBid signedExecutionPayloadBid) {
+          return SafeFuture.COMPLETE;
+        }
+
+        @Override
+        public SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
+            final UInt64 slot, final UInt64 builderIndex) {
+          return SafeFuture.completedFuture(Optional.empty());
+        }
+
+        @Override
+        public SafeFuture<Void> sendSignedExecutionPayload(
+            final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+          return SafeFuture.COMPLETE;
         }
       };
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
@@ -46,7 +46,7 @@ public class BeaconNodeRequestLabels {
   public static final String CREATE_UNSIGNED_EXECUTION_PAYLOAD_BID_METHOD =
       "create_unsigned_execution_payload_bid";
   public static final String PUBLISH_EXECUTION_PAYLOAD_BID_METHOD = "publish_execution_payload_bid";
-  public static final String GET_UNSIGNED_EXECUTION_PAYLOAD_METHOD =
-      "get_unsigned_execution_payload";
+  public static final String CREATE_UNSIGNED_EXECUTION_PAYLOAD_METHOD =
+      "create_unsigned_execution_payload";
   public static final String PUBLISH_EXECUTION_PAYLOAD_METHOD = "publish_execution_payload";
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
@@ -42,4 +42,11 @@ public class BeaconNodeRequestLabels {
   public static final String GET_VALIDATORS_LIVENESS = "get_validators_liveness";
   public static final String BEACON_COMMITTEE_SELECTIONS = "beacon_committee_selections";
   public static final String SYNC_COMMITTEE_SELECTIONS = "sync_committee_selections";
+  // Builder namespace
+  public static final String CREATE_UNSIGNED_EXECUTION_PAYLOAD_BID_METHOD =
+      "create_unsigned_execution_payload_bid";
+  public static final String PUBLISH_EXECUTION_PAYLOAD_BID_METHOD = "publish_execution_payload_bid";
+  public static final String GET_UNSIGNED_EXECUTION_PAYLOAD_METHOD =
+      "get_unsigned_execution_payload";
+  public static final String PUBLISH_EXECUTION_PAYLOAD_METHOD = "publish_execution_payload";
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -292,10 +292,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+  public SafeFuture<Void> publishSignedExecutionPayloadBid(
       final SignedExecutionPayloadBid signedExecutionPayloadBid) {
     return countDataRequest(
-        delegate.sendSignedExecutionPayloadBid(signedExecutionPayloadBid),
+        delegate.publishSignedExecutionPayloadBid(signedExecutionPayloadBid),
         BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_BID_METHOD);
   }
 
@@ -308,10 +308,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayload(
+  public SafeFuture<Void> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return countDataRequest(
-        delegate.sendSignedExecutionPayload(signedExecutionPayload),
+        delegate.publishSignedExecutionPayload(signedExecutionPayload),
         BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_METHOD);
   }
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -304,7 +304,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot, final UInt64 builderIndex) {
     return countOptionalDataRequest(
         delegate.createUnsignedExecutionPayload(slot, builderIndex),
-        BeaconNodeRequestLabels.GET_UNSIGNED_EXECUTION_PAYLOAD_METHOD);
+        BeaconNodeRequestLabels.CREATE_UNSIGNED_EXECUTION_PAYLOAD_METHOD);
   }
 
   @Override

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -46,6 +46,10 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -266,7 +270,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<List<BeaconCommitteeSelectionProof>>> getBeaconCommitteeSelectionProof(
       final List<BeaconCommitteeSelectionProof> requests) {
-    return countDataRequest(
+    return countOptionalDataRequest(
         delegate.getBeaconCommitteeSelectionProof(requests),
         BeaconNodeRequestLabels.BEACON_COMMITTEE_SELECTIONS);
   }
@@ -274,9 +278,41 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<List<SyncCommitteeSelectionProof>>> getSyncCommitteeSelectionProof(
       final List<SyncCommitteeSelectionProof> requests) {
-    return countDataRequest(
+    return countOptionalDataRequest(
         delegate.getSyncCommitteeSelectionProof(requests),
         BeaconNodeRequestLabels.SYNC_COMMITTEE_SELECTIONS);
+  }
+
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return countOptionalDataRequest(
+        delegate.createUnsignedExecutionPayloadBid(slot, builderIndex),
+        BeaconNodeRequestLabels.CREATE_UNSIGNED_EXECUTION_PAYLOAD_BID_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+      final SignedExecutionPayloadBid signedExecutionPayloadBid) {
+    return countDataRequest(
+        delegate.sendSignedExecutionPayloadBid(signedExecutionPayloadBid),
+        BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_BID_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return countOptionalDataRequest(
+        delegate.createUnsignedExecutionPayload(slot, builderIndex),
+        BeaconNodeRequestLabels.GET_UNSIGNED_EXECUTION_PAYLOAD_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    return countDataRequest(
+        delegate.sendSignedExecutionPayload(signedExecutionPayload),
+        BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_METHOD);
   }
 
   private <T> SafeFuture<T> countDataRequest(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -356,8 +356,8 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   /**
-   * TODO-GLOAS: we need logic similar to {@link #blindedBlockCreatorCache} to call only the beacon
-   * node which created the bid
+   * TODO-GLOAS: https://github.com/Consensys/teku/issues/10008 we need logic similar to {@link
+   * #blindedBlockCreatorCache} to call only the beacon node which created the bid
    */
   @Override
   public SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -348,10 +348,10 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+  public SafeFuture<Void> publishSignedExecutionPayloadBid(
       final SignedExecutionPayloadBid signedExecutionPayloadBid) {
     return relayRequest(
-        apiChannel -> apiChannel.sendSignedExecutionPayloadBid(signedExecutionPayloadBid),
+        apiChannel -> apiChannel.publishSignedExecutionPayloadBid(signedExecutionPayloadBid),
         BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_BID_METHOD);
   }
 
@@ -368,10 +368,10 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayload(
+  public SafeFuture<Void> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return relayRequest(
-        apiChannel -> apiChannel.sendSignedExecutionPayload(signedExecutionPayload),
+        apiChannel -> apiChannel.publishSignedExecutionPayload(signedExecutionPayload),
         BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_METHOD);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -364,7 +364,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot, final UInt64 builderIndex) {
     return tryRequestUntilSuccess(
         apiChannel -> apiChannel.createUnsignedExecutionPayload(slot, builderIndex),
-        BeaconNodeRequestLabels.GET_UNSIGNED_EXECUTION_PAYLOAD_METHOD);
+        BeaconNodeRequestLabels.CREATE_UNSIGNED_EXECUTION_PAYLOAD_METHOD);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -49,6 +49,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -333,6 +337,42 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
     return relayRequest(
         apiChannel -> apiChannel.getSyncCommitteeSelectionProof(requests),
         BeaconNodeRequestLabels.SYNC_COMMITTEE_SELECTIONS);
+  }
+
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.createUnsignedExecutionPayloadBid(slot, builderIndex),
+        BeaconNodeRequestLabels.CREATE_UNSIGNED_EXECUTION_PAYLOAD_BID_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+      final SignedExecutionPayloadBid signedExecutionPayloadBid) {
+    return relayRequest(
+        apiChannel -> apiChannel.sendSignedExecutionPayloadBid(signedExecutionPayloadBid),
+        BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_BID_METHOD);
+  }
+
+  /**
+   * TODO-GLOAS: we need logic similar to {@link #blindedBlockCreatorCache} to call only the beacon
+   * node which created the bid
+   */
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.createUnsignedExecutionPayload(slot, builderIndex),
+        BeaconNodeRequestLabels.GET_UNSIGNED_EXECUTION_PAYLOAD_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    return relayRequest(
+        apiChannel -> apiChannel.sendSignedExecutionPayload(signedExecutionPayload),
+        BeaconNodeRequestLabels.PUBLISH_EXECUTION_PAYLOAD_METHOD);
   }
 
   private <T> SafeFuture<T> relayRequest(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -53,6 +53,10 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
@@ -332,6 +336,31 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   public SafeFuture<Optional<List<SyncCommitteeSelectionProof>>> getSyncCommitteeSelectionProof(
       final List<SyncCommitteeSelectionProof> requests) {
     return sendRequest(() -> typeDefClient.getSyncCommitteeSelectionProof(requests));
+  }
+
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9997 (not required for devnet-0)
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+      final SignedExecutionPayloadBid signedExecutionPayloadBid) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+  }
+
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
   }
 
   private SafeFuture<Void> sendRequest(final ExceptionThrowingRunnable requestExecutor) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -346,7 +346,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+  public SafeFuture<Void> publishSignedExecutionPayloadBid(
       final SignedExecutionPayloadBid signedExecutionPayloadBid) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
   }
@@ -358,7 +358,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayload(
+  public SafeFuture<Void> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -36,6 +36,10 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -238,5 +242,37 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   public SafeFuture<Optional<List<SyncCommitteeSelectionProof>>> getSyncCommitteeSelectionProof(
       final List<SyncCommitteeSelectionProof> requests) {
     return dutiesProviderChannel.getSyncCommitteeSelectionProof(requests);
+  }
+
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return blockHandlerChannel
+        .orElse(dutiesProviderChannel)
+        .createUnsignedExecutionPayloadBid(slot, builderIndex);
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+      final SignedExecutionPayloadBid signedExecutionPayloadBid) {
+    return blockHandlerChannel
+        .orElse(dutiesProviderChannel)
+        .sendSignedExecutionPayloadBid(signedExecutionPayloadBid);
+  }
+
+  @Override
+  public SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
+      final UInt64 slot, final UInt64 builderIndex) {
+    return blockHandlerChannel
+        .orElse(dutiesProviderChannel)
+        .createUnsignedExecutionPayload(slot, builderIndex);
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    return blockHandlerChannel
+        .orElse(dutiesProviderChannel)
+        .sendSignedExecutionPayload(signedExecutionPayload);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -253,11 +253,11 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayloadBid(
+  public SafeFuture<Void> publishSignedExecutionPayloadBid(
       final SignedExecutionPayloadBid signedExecutionPayloadBid) {
     return blockHandlerChannel
         .orElse(dutiesProviderChannel)
-        .sendSignedExecutionPayloadBid(signedExecutionPayloadBid);
+        .publishSignedExecutionPayloadBid(signedExecutionPayloadBid);
   }
 
   @Override
@@ -269,10 +269,10 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> sendSignedExecutionPayload(
+  public SafeFuture<Void> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return blockHandlerChannel
         .orElse(dutiesProviderChannel)
-        .sendSignedExecutionPayload(signedExecutionPayload);
+        .publishSignedExecutionPayload(signedExecutionPayload);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
- Introduce `BuilderApiChannel` which is used to communicate the builder coming from the VC to the BN. Currently, remote VC implementation is not implemented and not required.
- Not implemented versions of `ExecutionPayloadFactory` and `ExecutionPayloadPublisher` (will be done later)
- Added a sample implementation for the two methods which will be used in devnet-0 in the `ValidatorApiHandler`
- `SafeFuture<Void>` is TBD. Can easily change later, but for simplicity using that as a return for the publishing methods.

## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/10008

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add builder API and execution payload create/publish flow (Gloas), wiring through validator channels, controller, metrics, and tests with stub implementations.
> 
> - **Validator API**:
>   - Introduce `BuilderApiChannel` with ePBS (Gloas) methods: `createUnsignedExecutionPayloadBid`, `publishSignedExecutionPayloadBid`, `createUnsignedExecutionPayload`, `publishSignedExecutionPayload`.
>   - Extend `ValidatorApiChannel` to include builder methods; add metric labels and counting for them.
>   - Implement in `ValidatorApiHandler`: produce unsigned execution payload via `ExecutionPayloadFactory` (with parent-optimistic/sync checks) and publish via `ExecutionPayloadPublisher`; bid methods remain unimplemented.
>   - Wire through sentry/failover/remote channels; remote returns unsupported for new endpoints.
> - **Execution payload plumbing**:
>   - Add `ExecutionPayloadFactory` and `ExecutionPayloadPublisher` interfaces (+ `*Gloas` stubs) and inject via `BeaconChainController` (enabled only when `GLOAS` is supported; otherwise NOOP).
> - **Tests & utilities**:
>   - Update/extend tests for new builder APIs (`ValidatorApiHandlerTest` adds creation/publish tests; integration test wiring).
>   - `DataStructureUtil`: helpers for `ExecutionPayloadEnvelope(slot)` and signed variant; adjust LocalSigner expected signature.
> - **Spec helpers & minor fixes**:
>   - `BeaconStateAccessorsFulu`: use shared helpers/config; `BuilderPendingPayment.copyWithNewWeight` param rename; minor TODO/format tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ded0691cc159c26132ea8160843a853f3c8f6149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->