### PR TITLE
Added batchSignatureVerifier NOOP option for tests

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -14,12 +14,15 @@
 package tech.pegasys.teku.ethtests.finder;
 
 import java.nio.file.Path;
+import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.TestSpecConfig;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifierImpl;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
 public class TestDefinition {
@@ -84,9 +87,18 @@ public class TestDefinition {
         };
     final BLSSignatureVerifier blsSignatureVerifier =
         blsSignatureVerificationEnabled ? BLSSignatureVerifier.SIMPLE : BLSSignatureVerifier.NO_OP;
+    final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier =
+        blsSignatureVerificationEnabled
+            ? () -> BatchSignatureVerifier.NO_OP
+            : BatchSignatureVerifierImpl::new;
     spec =
         TestSpecFactory.create(
-            milestone, network, builder -> builder.blsSignatureVerifier(blsSignatureVerifier));
+            milestone,
+            network,
+            builder ->
+                builder
+                    .blsSignatureVerifier(blsSignatureVerifier)
+                    .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier));
   }
 
   public String getTestType() {

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -89,8 +89,8 @@ public class TestDefinition {
         blsSignatureVerificationEnabled ? BLSSignatureVerifier.SIMPLE : BLSSignatureVerifier.NO_OP;
     final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier =
         blsSignatureVerificationEnabled
-            ? () -> BatchSignatureVerifier.NO_OP
-            : BatchSignatureVerifierImpl::new;
+            ? BatchSignatureVerifierImpl::new
+            : () -> BatchSignatureVerifier.NO_OP;
     spec =
         TestSpecFactory.create(
             milestone,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
 
 public class DelegatingSpecConfig implements SpecConfig {
   protected final SpecConfig specConfig;
@@ -476,5 +477,10 @@ public class DelegatingSpecConfig implements SpecConfig {
   @Override
   public BLSSignatureVerifier getBLSSignatureVerifier() {
     return specConfig.getBLSSignatureVerifier();
+  }
+
+  @Override
+  public BatchSignatureVerifier createBatchSignatureVerifier() {
+    return specConfig.createBatchSignatureVerifier();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
 
 public interface SpecConfig extends NetworkingSpecConfig {
   // Non-configurable constants
@@ -232,4 +233,6 @@ public interface SpecConfig extends NetworkingSpecConfig {
   SpecMilestone getMilestone();
 
   BLSSignatureVerifier getBLSSignatureVerifier();
+
+  BatchSignatureVerifier createBatchSignatureVerifier();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.config;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
@@ -23,6 +24,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.constants.WithdrawalPrefixes;
 import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
 
 public class SpecConfigPhase0 implements SpecConfig {
   private final Map<String, Object> rawConfig;
@@ -125,6 +127,7 @@ public class SpecConfigPhase0 implements SpecConfig {
   private final UInt64 maxPerEpochActivationExitChurnLimit;
 
   private final BLSSignatureVerifier blsSignatureVerifier;
+  private final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier;
 
   // altair fork
   private final Bytes4 altairForkVersion;
@@ -225,6 +228,7 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int aggregateDueBps,
       final int proposerReorgCutoffBps,
       final BLSSignatureVerifier blsSignatureVerifier,
+      final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier,
       final Bytes4 altairForkVersion,
       final UInt64 altairForkEpoch,
       final Bytes4 bellatrixForkVersion,
@@ -324,6 +328,7 @@ public class SpecConfigPhase0 implements SpecConfig {
     this.gloasForkVersion = gloasForkVersion;
     this.gloasForkEpoch = gloasForkEpoch;
     this.blsSignatureVerifier = blsSignatureVerifier;
+    this.batchSignatureVerifierSupplier = batchSignatureVerifierSupplier;
   }
 
   @Override
@@ -774,6 +779,11 @@ public class SpecConfigPhase0 implements SpecConfig {
   @Override
   public BLSSignatureVerifier getBLSSignatureVerifier() {
     return blsSignatureVerifier;
+  }
+
+  @Override
+  public BatchSignatureVerifier createBatchSignatureVerifier() {
+    return batchSignatureVerifierSupplier.get();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
@@ -35,6 +36,8 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAndParent;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.config.SpecConfigPhase0;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifierImpl;
 
 @SuppressWarnings({"UnusedReturnValue", "unused"})
 public class SpecConfigBuilder {
@@ -161,6 +164,8 @@ public class SpecConfigBuilder {
   private UInt64 gloasForkEpoch = FAR_FUTURE_EPOCH;
 
   private BLSSignatureVerifier blsSignatureVerifier = BLSSignatureVerifier.SIMPLE;
+  private Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier =
+      BatchSignatureVerifierImpl::new;
 
   private UInt64 maxPerEpochActivationExitChurnLimit = UInt64.valueOf(256000000000L);
   private final BuilderChain<SpecConfig, SpecConfigGloas> builderChain =
@@ -299,6 +304,7 @@ public class SpecConfigBuilder {
                 aggregateDueBps,
                 proposerReorgCutoffBps,
                 blsSignatureVerifier,
+                batchSignatureVerifierSupplier,
                 altairForkVersion,
                 altairForkEpoch,
                 bellatrixForkVersion,
@@ -966,6 +972,12 @@ public class SpecConfigBuilder {
 
   public SpecConfigBuilder blsSignatureVerifier(final BLSSignatureVerifier blsSignatureVerifier) {
     this.blsSignatureVerifier = blsSignatureVerifier;
+    return this;
+  }
+
+  public SpecConfigBuilder batchSignatureVerifierSupplier(
+      final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier) {
+    this.batchSignatureVerifierSupplier = batchSignatureVerifierSupplier;
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -134,7 +134,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       final IndexedAttestationCache indexedAttestationCache,
       final Optional<? extends OptimisticExecutionPayloadExecutor> payloadExecutor)
       throws StateTransitionException {
-    final BatchSignatureVerifier signatureVerifier = new BatchSignatureVerifier();
+    final BatchSignatureVerifier signatureVerifier = specConfig.createBatchSignatureVerifier();
     final BeaconState result =
         processAndValidateBlock(
             signedBlock,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifier.java
@@ -13,96 +13,44 @@
 
 package tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
-import tech.pegasys.teku.bls.BatchSemiAggregate;
 
-/**
- * Implementation which doesn't perform any actual validations on {@link #verify(List, Bytes,
- * BLSSignature)} call but just collects signatures which are then validated in a batched optimized
- * way with {@link #batchVerify()} call.
- *
- * <p>Every instance of this class is disposable, i.e. it is intended for just a single batch and a
- * single {@link #batchVerify()} call.
- *
- * <p>This is thread-safe class.
- */
-public class BatchSignatureVerifier implements BLSSignatureVerifier {
+public interface BatchSignatureVerifier extends BLSSignatureVerifier {
 
-  private static class Job {
-    final int idx;
-    final List<BLSPublicKey> publicKeys;
-    final Bytes message;
-    final BLSSignature signature;
+  BatchSignatureVerifier NO_OP =
+      new BatchSignatureVerifier() {
+        @Override
+        public boolean verify(
+            final List<BLSPublicKey> publicKeys,
+            final Bytes message,
+            final BLSSignature signature) {
+          return true;
+        }
 
-    public Job(
-        final int idx,
-        final List<BLSPublicKey> publicKeys,
-        final Bytes message,
-        final BLSSignature signature) {
-      this.idx = idx;
-      this.publicKeys = publicKeys;
-      this.message = message;
-      this.signature = signature;
-    }
-  }
+        @Override
+        public boolean verify(
+            final List<List<BLSPublicKey>> publicKeys,
+            final List<Bytes> messages,
+            final List<BLSSignature> signatures) {
+          return true;
+        }
 
-  @VisibleForTesting final List<Job> toVerify = new ArrayList<>();
-  private boolean complete = false;
+        @Override
+        public boolean batchVerify() {
+          return true;
+        }
+      };
 
   @Override
-  public synchronized boolean verify(
-      final List<BLSPublicKey> publicKeys, final Bytes message, final BLSSignature signature) {
-    if (complete) {
-      throw new IllegalStateException("Reuse of disposable instance");
-    }
-
-    checkArgument(!publicKeys.isEmpty(), "No public keys supplied for verify");
-    toVerify.add(new Job(toVerify.size(), publicKeys, message, signature));
-    return true;
-  }
+  boolean verify(List<BLSPublicKey> publicKeys, Bytes message, BLSSignature signature);
 
   @Override
-  public boolean verify(
-      final List<List<BLSPublicKey>> publicKeys,
-      final List<Bytes> messages,
-      final List<BLSSignature> signatures) {
-    for (int i = 0; i < publicKeys.size(); i++) {
-      if (!verify(publicKeys.get(i), messages.get(i), signatures.get(i))) {
-        return false;
-      }
-    }
-    return true;
-  }
+  boolean verify(
+      List<List<BLSPublicKey>> publicKeys, List<Bytes> messages, List<BLSSignature> signatures);
 
-  /**
-   * Performs verification of all the signatures collected with one or more calls to {@link
-   * #verify(List, Bytes, BLSSignature)}
-   *
-   * <p>After this method completes the instance should be disposed and any subsequent calls to this
-   * instance methods would fail with exception
-   */
-  public synchronized boolean batchVerify() {
-    if (complete) {
-      throw new IllegalStateException("Reuse of disposable instance");
-    }
-    List<BatchSemiAggregate> batchSemiAggregates =
-        toVerify.stream()
-            .parallel()
-            .map(job -> BLS.prepareBatchVerify(job.idx, job.publicKeys, job.message, job.signature))
-            .toList();
-    complete = true;
-    if (batchSemiAggregates.isEmpty()) {
-      return true;
-    }
-    return BLS.completeBatchVerify(batchSemiAggregates);
-  }
+  boolean batchVerify();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifierImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifierImpl.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.bls.BatchSemiAggregate;
+
+/**
+ * Implementation which doesn't perform any actual validations on {@link #verify(List, Bytes,
+ * BLSSignature)} call but just collects signatures which are then validated in a batched optimized
+ * way with {@link #batchVerify()} call.
+ *
+ * <p>Every instance of this class is disposable, i.e. it is intended for just a single batch and a
+ * single {@link #batchVerify()} call.
+ *
+ * <p>This is thread-safe class.
+ */
+public class BatchSignatureVerifierImpl implements BatchSignatureVerifier {
+
+  private record Job(
+      int idx, List<BLSPublicKey> publicKeys, Bytes message, BLSSignature signature) {}
+
+  @VisibleForTesting final List<Job> toVerify = new ArrayList<>();
+  private boolean complete = false;
+
+  @Override
+  public synchronized boolean verify(
+      final List<BLSPublicKey> publicKeys, final Bytes message, final BLSSignature signature) {
+    if (complete) {
+      throw new IllegalStateException("Reuse of disposable instance");
+    }
+
+    checkArgument(!publicKeys.isEmpty(), "No public keys supplied for verify");
+    toVerify.add(new Job(toVerify.size(), publicKeys, message, signature));
+    return true;
+  }
+
+  @Override
+  public boolean verify(
+      final List<List<BLSPublicKey>> publicKeys,
+      final List<Bytes> messages,
+      final List<BLSSignature> signatures) {
+    for (int i = 0; i < publicKeys.size(); i++) {
+      if (!verify(publicKeys.get(i), messages.get(i), signatures.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Performs verification of all the signatures collected with one or more calls to {@link
+   * #verify(List, Bytes, BLSSignature)}
+   *
+   * <p>After this method completes the instance should be disposed and any subsequent calls to this
+   * instance methods would fail with exception
+   */
+  @Override
+  public synchronized boolean batchVerify() {
+    if (complete) {
+      throw new IllegalStateException("Reuse of disposable instance");
+    }
+    List<BatchSemiAggregate> batchSemiAggregates =
+        toVerify.stream()
+            .parallel()
+            .map(job -> BLS.prepareBatchVerify(job.idx, job.publicKeys, job.message, job.signature))
+            .toList();
+    complete = true;
+    if (batchSemiAggregates.isEmpty()) {
+      return true;
+    }
+    return BLS.completeBatchVerify(batchSemiAggregates);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifierTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifierTest.java
@@ -34,7 +34,7 @@ public class BatchSignatureVerifierTest {
 
   @Test
   public void shouldRaiseExceptionIfNoValidPublicKeys() {
-    BatchSignatureVerifier verifier = new BatchSignatureVerifier();
+    BatchSignatureVerifier verifier = new BatchSignatureVerifierImpl();
 
     verifier.verify(
         List.of(BLSPublicKey.empty()),
@@ -46,7 +46,7 @@ public class BatchSignatureVerifierTest {
 
   @Test
   public void shouldRaiseExceptionIfNoSuppliedPublicKeys() {
-    BatchSignatureVerifier verifier = new BatchSignatureVerifier();
+    BatchSignatureVerifier verifier = new BatchSignatureVerifierImpl();
 
     assertThatThrownBy(
             () ->
@@ -59,7 +59,7 @@ public class BatchSignatureVerifierTest {
 
   @Test
   public void testParallel() throws Exception {
-    BatchSignatureVerifier verifier = new BatchSignatureVerifier();
+    BatchSignatureVerifierImpl verifier = new BatchSignatureVerifierImpl();
 
     BLSPublicKey publicKey = BLSTestUtil.randomPublicKey(42);
     Bytes message = Bytes.wrap("Hello, world!".getBytes(UTF_8));
@@ -96,7 +96,7 @@ public class BatchSignatureVerifierTest {
 
   @Test
   void shouldBeValidWhenNothingVerified() {
-    final BatchSignatureVerifier verifier = new BatchSignatureVerifier();
+    final BatchSignatureVerifier verifier = new BatchSignatureVerifierImpl();
     assertThat(verifier.batchVerify()).isTrue();
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.Extension;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifierImpl;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -98,6 +101,7 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
   }
 
   public static class SpecContext {
+
     private final String displayName;
     private final Spec spec;
     private final DataStructureUtil dataStructureUtil;
@@ -118,11 +122,18 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
       } else {
         final BLSSignatureVerifier blsSignatureVerifier =
             signatureVerifierNoop ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE;
+        final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier =
+            signatureVerifierNoop
+                ? () -> BatchSignatureVerifier.NO_OP
+                : BatchSignatureVerifierImpl::new;
         this.spec =
             TestSpecFactory.create(
                 specMilestone,
                 network,
-                builder -> builder.blsSignatureVerifier(blsSignatureVerifier));
+                builder ->
+                    builder
+                        .blsSignatureVerifier(blsSignatureVerifier)
+                        .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier));
         this.dataStructureUtil = new DataStructureUtil(spec);
         this.schemaDefinitions = spec.forMilestone(specMilestone).getSchemaDefinitions();
       }
@@ -201,6 +212,7 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
   }
 
   public static class SpecContextParameterResolver<T> implements ParameterResolver {
+
     T data;
 
     public SpecContextParameterResolver(final T data) {


### PR DESCRIPTION
## PR Description
Add a new method to `SpecConfig` to create a new instance of `BatchSignatureVerifier`, called `createBatchSignatureVerifier()`.

The reasoning behind it is that it will always create a new instance of `BatchSignatureVerifier` via its supplier. But adds the option of changing the supplier on `SpecConfigBuilder`.

For `TestDefinition` and `TestSpecInvocationContextProvider`, when the flag `signatureVerifierNoop` is true, we set the supplier to return an instance of `BatchSignatureVerifier.NO_OP`.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a supplier-based BatchSignatureVerifier (with NO_OP option) and wires it through SpecConfig/Builder and block processing; refactors verifier into interface + implementation and updates tests.
> 
> - **Spec/Config**:
>   - Add `SpecConfig#createBatchSignatureVerifier()` and plumb a `Supplier<BatchSignatureVerifier>` via `SpecConfigPhase0` and `SpecConfigBuilder` (defaulting to `BatchSignatureVerifierImpl`).
>   - `DelegatingSpecConfig` delegates `createBatchSignatureVerifier()`.
> - **Logic**:
>   - `AbstractBlockProcessor` now uses `specConfig.createBatchSignatureVerifier()` for per-block batch verification.
>   - Extract `BatchSignatureVerifier` to interface with `NO_OP`; add concrete `BatchSignatureVerifierImpl`.
> - **Tests/Fixtures**:
>   - Update tests to use `BatchSignatureVerifierImpl` and new API.
>   - `TestDefinition` and `TestSpecInvocationContextProvider` can inject `NO_OP` via the supplier when signature verification is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3835a120984dd3696f73fe9c8fd63b9d1242f0db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->