### PR TITLE
Use `specConfig.getBLSSignatureVerifier()` instead of `BLSSignatureVerifier.SIMPLE`

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -145,7 +145,8 @@ public abstract class AttestationUtil {
 
   public AttestationProcessingResult isValidIndexedAttestation(
       final Fork fork, final BeaconState state, final ValidatableAttestation attestation) {
-    return isValidIndexedAttestation(fork, state, attestation, BLSSignatureVerifier.SIMPLE);
+    return isValidIndexedAttestation(
+        fork, state, attestation, specConfig.getBLSSignatureVerifier());
   }
 
   public AttestationProcessingResult isValidIndexedAttestation(
@@ -215,7 +216,8 @@ public abstract class AttestationUtil {
    */
   public AttestationProcessingResult isValidIndexedAttestation(
       final Fork fork, final BeaconState state, final IndexedAttestation indexedAttestation) {
-    return isValidIndexedAttestation(fork, state, indexedAttestation, BLSSignatureVerifier.SIMPLE);
+    return isValidIndexedAttestation(
+        fork, state, indexedAttestation, specConfig.getBLSSignatureVerifier());
   }
 
   public AttestationProcessingResult isValidIndexedAttestation(


### PR DESCRIPTION
## PR Description

This is a follow up fix to #9805 and  #10012  PRs, which uses `specConfig.getBLSSignatureVerifier()` when validating Attestations and AttesterSlashings.

@lucassaldanha @rolfyone 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches attestation validation to use `specConfig.getBLSSignatureVerifier()` instead of `BLSSignatureVerifier.SIMPLE` for indexed attestations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c05ea68079eb9cd560380953fd639cc7e63b8052. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->