### PR TITLE
Create `ExecutionPayloadDuty`

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -67,7 +67,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
     return operationSelector.createBlobSidecarsSelector().apply(blockContainer);
   }
 
-  protected SafeFuture<BlockContainer> createBlockContents(final BeaconBlock block) {
+  private SafeFuture<BlockContainer> createBlockContents(final BeaconBlock block) {
     // The execution BlobsBundle has been cached as part of the block creation
     return operationSelector
         .createBlobsBundleSelector()

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloas.java
@@ -13,50 +13,18 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
-
 import com.google.common.base.Preconditions;
 import java.util.Optional;
-import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.SlotCaches;
 
 // Gloas is more similar to BlockFactoryPhase0 than BlockFactoryFulu
 public class BlockFactoryGloas extends BlockFactoryPhase0 {
 
   public BlockFactoryGloas(final Spec spec, final BlockOperationSelectorFactory operationSelector) {
     super(spec, operationSelector);
-  }
-
-  @Override
-  protected BlockContainerAndMetaData beaconBlockAndStateToBlockContainerAndMetaData(
-      final BeaconBlockAndState blockAndState) {
-    final SlotCaches slotCaches = BeaconStateCache.getSlotCaches(blockAndState.getState());
-    final BeaconBlock block = blockAndState.getBlock();
-    final UInt256 blockExecutionValue = slotCaches.getBlockExecutionValue();
-    return new BlockContainerAndMetaData(
-        block,
-        spec.atSlot(blockAndState.getSlot()).getMilestone(),
-        blockExecutionValue.isZero()
-            // use value from the bid for the execution_payload_value field if not set in the cache
-            // (TBD)
-            ? GWEI_TO_WEI.multiply(
-                block
-                    .getBody()
-                    .getOptionalSignedExecutionPayloadBid()
-                    .orElseThrow()
-                    .getMessage()
-                    .getValue()
-                    .longValue())
-            : blockExecutionValue,
-        GWEI_TO_WEI.multiply(slotCaches.getBlockProposerRewards().longValue()));
   }
 
   // blocks in ePBS are all unblinded

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -79,10 +79,10 @@ public class BlockFactoryPhase0 implements BlockFactory {
                 requestedBuilderBoostFactor,
                 blockProductionPerformance),
             blockProductionPerformance)
-        .thenApply(this::beaconBlockAndStateToBlockContainerAndMetaData);
+        .thenApply(this::blockAndStateToBlockContainerAndMetaData);
   }
 
-  protected BlockContainerAndMetaData beaconBlockAndStateToBlockContainerAndMetaData(
+  private BlockContainerAndMetaData blockAndStateToBlockContainerAndMetaData(
       final BeaconBlockAndState blockAndState) {
     final SlotCaches slotCaches = BeaconStateCache.getSlotCaches(blockAndState.getState());
     return new BlockContainerAndMetaData(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -282,16 +282,6 @@ public abstract class AbstractBlockFactoryTest {
     }
 
     if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
-      // set the execution value to the value from the bid
-      blockExecutionValue =
-          GWEI_TO_WEI.multiply(
-              block
-                  .getBody()
-                  .getOptionalSignedExecutionPayloadBid()
-                  .orElseThrow()
-                  .getMessage()
-                  .getValue()
-                  .longValue());
       assertThat(block.getBody().getOptionalSignedExecutionPayloadBid())
           .hasValueSatisfying(
               signedBid -> assertThat(signedBid.getMessage()).isEqualTo(executionPayloadBid));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
@@ -13,7 +13,10 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
 import java.util.Optional;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -49,13 +52,22 @@ public interface ExecutionPayloadSummary {
 
   Bytes getExtraData();
 
-  Bytes32 getPayloadHash();
-
   boolean isDefaultPayload();
 
   Optional<Bytes32> getOptionalWithdrawalsRoot();
 
   default String toLogString() {
     return LogFormatter.formatBlock(getBlockNumber(), getBlockHash());
+  }
+
+  default UInt64 computeGasPercentage(final Logger logger) {
+    try {
+      return getGasLimit().isGreaterThan(0L)
+          ? getGasUsed().times(100).dividedBy(getGasLimit())
+          : ZERO;
+    } catch (final ArithmeticException ex) {
+      logger.debug("Failed to compute gas percentage", ex);
+      return UInt64.ZERO;
+    }
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBellatrix.java
@@ -188,11 +188,6 @@ public class ExecutionPayloadBellatrix
   }
 
   @Override
-  public Bytes32 getPayloadHash() {
-    return hashTreeRoot();
-  }
-
-  @Override
   public SszList<Transaction> getTransactions() {
     return getField13();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBellatrix.java
@@ -190,11 +190,6 @@ public class ExecutionPayloadHeaderBellatrix
   }
 
   @Override
-  public Bytes32 getPayloadHash() {
-    return hashTreeRoot();
-  }
-
-  @Override
   public boolean isHeaderOfDefaultPayload() {
     return equals(getSchema().getHeaderOfDefaultPayload());
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadCapellaImpl.java
@@ -191,11 +191,6 @@ public class ExecutionPayloadCapellaImpl
   }
 
   @Override
-  public Bytes32 getPayloadHash() {
-    return hashTreeRoot();
-  }
-
-  @Override
   public SszList<Transaction> getTransactions() {
     return getField13();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderCapellaImpl.java
@@ -192,11 +192,6 @@ public class ExecutionPayloadHeaderCapellaImpl
   }
 
   @Override
-  public Bytes32 getPayloadHash() {
-    return hashTreeRoot();
-  }
-
-  @Override
   public Bytes32 getWithdrawalsRoot() {
     return getField14().get();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadDenebImpl.java
@@ -200,11 +200,6 @@ public class ExecutionPayloadDenebImpl
   }
 
   @Override
-  public Bytes32 getPayloadHash() {
-    return hashTreeRoot();
-  }
-
-  @Override
   public SszList<Transaction> getTransactions() {
     return getField13();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderDenebImpl.java
@@ -200,11 +200,6 @@ public class ExecutionPayloadHeaderDenebImpl
   }
 
   @Override
-  public Bytes32 getPayloadHash() {
-    return hashTreeRoot();
-  }
-
-  @Override
   public Bytes32 getWithdrawalsRoot() {
     return getField14().get();
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1248,9 +1248,9 @@ public final class DataStructureUtil {
   }
 
   public BlockContainerAndMetaData randomBlockContainerAndMetaData(
-      final BlockContainer blockContents, final UInt64 slotNum) {
+      final BlockContainer blockContainer, final UInt64 slotNum) {
     return new BlockContainerAndMetaData(
-        blockContents, spec.atSlot(slotNum).getMilestone(), randomUInt256(), randomUInt256());
+        blockContainer, spec.atSlot(slotNum).getMilestone(), randomUInt256(), randomUInt256());
   }
 
   public BeaconBlock randomBlindedBeaconBlock(final UInt64 slot) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -32,6 +32,7 @@ public class ValidatorLogger {
       new ValidatorLogger(LoggingConfigurator.VALIDATOR_LOGGER_NAME);
   public static final int LONGEST_TYPE_LENGTH = "sync_contribution".length();
   private static final String PREFIX = "Validator   *** ";
+  private static final String BUILDER_PREFIX = "Builder     *** ";
 
   @SuppressWarnings("PrivateStaticFinalLoggers")
   private final Logger log;
@@ -311,5 +312,30 @@ public class ValidatorLogger {
             "%sSlashing protection last updated more than %s epochs ago for validators: %s",
             PREFIX, deltaEpochs, formatValidators(maybeKey));
     log.warn(ColorConsolePrinter.print(infoString, Color.YELLOW));
+  }
+
+  public void logExecutionPayloadDuty(
+      final UInt64 slot, final UInt64 builderIndex, final Bytes32 blockRoot, final String suffix) {
+    final String paddedType = Strings.padEnd("execution_payload", LONGEST_TYPE_LENGTH, ' ');
+    log.info(
+        ColorConsolePrinter.print(
+            String.format(
+                "%sPublished %s  Slot: %s, Builder: %s, Block Root: %s, %s",
+                BUILDER_PREFIX,
+                paddedType,
+                slot,
+                builderIndex,
+                LogFormatter.formatHashRoot(blockRoot),
+                suffix),
+            ColorConsolePrinter.Color.PURPLE));
+  }
+
+  public void executionPayloadDutyFailed(
+      final UInt64 slot, final UInt64 builderIndex, final Throwable error) {
+    final String errorString =
+        String.format(
+            "%sFailed to produce execution_payload  Slot: %s Builder: %s",
+            BUILDER_PREFIX, slot, builderIndex);
+    log.error(ColorConsolePrinter.print(errorString, ColorConsolePrinter.Color.RED), error);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import static tech.pegasys.teku.infrastructure.exceptions.ExitConstants.FATAL_EXIT_CODE;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import java.net.http.HttpClient;
 import java.nio.file.Path;
@@ -39,7 +40,6 @@ import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.SyncDataAccessor;
 import tech.pegasys.teku.infrastructure.io.SystemSignalListener;
-import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.restapi.RestApi;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -66,6 +66,8 @@ import tech.pegasys.teku.validator.client.duties.ValidatorDutyMetrics;
 import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
 import tech.pegasys.teku.validator.client.duties.attestations.AttestationDutyFactory;
 import tech.pegasys.teku.validator.client.duties.attestations.AttestationProductionDuty;
+import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadBidEventsChannel;
+import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadDuty;
 import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTracker;
 import tech.pegasys.teku.validator.client.duties.synccommittee.SyncCommitteeScheduledDuties;
 import tech.pegasys.teku.validator.client.loader.HttpClientExternalSignerFactory;
@@ -430,7 +432,7 @@ public class ValidatorClientService extends Service {
                 SyncDataAccessor.create(slashingProtectionPath), slashingProtectionPath);
     final SlashingProtectionLogger slashingProtectionLogger =
         new SlashingProtectionLogger(
-            slashingProtector, config.getSpec(), asyncRunner, ValidatorLogger.VALIDATOR_LOGGER);
+            slashingProtector, config.getSpec(), asyncRunner, VALIDATOR_LOGGER);
     final Supplier<HttpClient> externalSignerHttpClientFactory =
         HttpClientExternalSignerFactory.create(config.getValidatorConfig());
     return ValidatorLoader.create(
@@ -469,7 +471,12 @@ public class ValidatorClientService extends Service {
     final ValidatorDutyMetrics validatorDutyMetrics = ValidatorDutyMetrics.create(metricsSystem);
     final BlockDutyFactory blockDutyFactory =
         new BlockDutyFactory(
-            forkProvider, validatorApiChannel, blockContainerSigner, spec, validatorDutyMetrics);
+            forkProvider,
+            validatorApiChannel,
+            blockContainerSigner,
+            spec,
+            validatorDutyMetrics,
+            eventChannels.getPublisher(ExecutionPayloadBidEventsChannel.class));
     final boolean dvtSelectionsEndpointEnabled =
         config.getValidatorConfig().isDvtSelectionsEndpointEnabled();
     final AttestationDutyFactory attestationDutyFactory =
@@ -566,6 +573,13 @@ public class ValidatorClientService extends Service {
           });
       validatorRegistrator.ifPresent(validatorTimingChannels::add);
     }
+
+    if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      final ExecutionPayloadDuty executionPayloadDuty =
+          new ExecutionPayloadDuty(spec, asyncRunner, validatorApiChannel, VALIDATOR_LOGGER);
+      eventChannels.subscribe(ExecutionPayloadBidEventsChannel.class, executionPayloadDuty);
+    }
+
     addValidatorCountMetric(metricsSystem, validators);
     final ValidatorStatusLogger validatorStatusLogger = new ValidatorStatusLogger(validators);
     validatorStatusProvider.subscribeValidatorStatusesUpdates(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
+import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadBidEventsChannel;
 import tech.pegasys.teku.validator.client.signer.BlockContainerSigner;
 
 public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> {
@@ -27,18 +28,21 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
   private final BlockContainerSigner blockContainerSigner;
   private final Spec spec;
   private final ValidatorDutyMetrics validatorDutyMetrics;
+  private final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher;
 
   public BlockDutyFactory(
       final ForkProvider forkProvider,
       final ValidatorApiChannel validatorApiChannel,
       final BlockContainerSigner blockContainerSigner,
       final Spec spec,
-      final ValidatorDutyMetrics validatorDutyMetrics) {
+      final ValidatorDutyMetrics validatorDutyMetrics,
+      final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher) {
     this.forkProvider = forkProvider;
     this.validatorApiChannel = validatorApiChannel;
     this.blockContainerSigner = blockContainerSigner;
     this.spec = spec;
     this.validatorDutyMetrics = validatorDutyMetrics;
+    this.executionPayloadBidEventsChannelPublisher = executionPayloadBidEventsChannelPublisher;
   }
 
   @Override
@@ -50,7 +54,8 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
         validatorApiChannel,
         blockContainerSigner,
         spec,
-        validatorDutyMetrics);
+        validatorDutyMetrics,
+        executionPayloadBidEventsChannelPublisher);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.validator.client.duties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
@@ -34,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
+import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadBidEventsChannel;
 import tech.pegasys.teku.validator.client.signer.BlockContainerSigner;
 
 public class BlockProductionDuty implements Duty {
@@ -54,6 +55,7 @@ public class BlockProductionDuty implements Duty {
   private final BlockContainerSigner blockContainerSigner;
   private final Spec spec;
   private final ValidatorDutyMetrics validatorDutyMetrics;
+  private final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher;
 
   public BlockProductionDuty(
       final Validator validator,
@@ -62,7 +64,8 @@ public class BlockProductionDuty implements Duty {
       final ValidatorApiChannel validatorApiChannel,
       final BlockContainerSigner blockContainerSigner,
       final Spec spec,
-      final ValidatorDutyMetrics validatorDutyMetrics) {
+      final ValidatorDutyMetrics validatorDutyMetrics,
+      final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher) {
     this.validator = validator;
     this.slot = slot;
     this.forkProvider = forkProvider;
@@ -70,6 +73,7 @@ public class BlockProductionDuty implements Duty {
     this.blockContainerSigner = blockContainerSigner;
     this.spec = spec;
     this.validatorDutyMetrics = validatorDutyMetrics;
+    this.executionPayloadBidEventsChannelPublisher = executionPayloadBidEventsChannelPublisher;
   }
 
   @Override
@@ -99,7 +103,9 @@ public class BlockProductionDuty implements Duty {
         .thenCompose(
             signedBlockContainer ->
                 validatorDutyMetrics.record(
-                    () -> sendBlock(signedBlockContainer), this, ValidatorDutyMetricsSteps.SEND))
+                    () -> sendBlock(signedBlockContainer, forkInfo),
+                    this,
+                    ValidatorDutyMetricsSteps.SEND))
         .exceptionally(
             error -> {
               LOG.debug(
@@ -148,15 +154,22 @@ public class BlockProductionDuty implements Duty {
     return blockContainerSigner.sign(blockContainer, validator, forkInfo);
   }
 
-  private SafeFuture<DutyResult> sendBlock(final SignedBlockContainer signedBlockContainer) {
+  private SafeFuture<DutyResult> sendBlock(
+      final SignedBlockContainer signedBlockContainer, final ForkInfo forkInfo) {
     return validatorApiChannel
         .sendSignedBlock(signedBlockContainer, BroadcastValidationLevel.GOSSIP)
         .thenApply(
             result -> {
               if (result.isPublished()) {
+                final BeaconBlockBody blockBody =
+                    signedBlockContainer.getSignedBlock().getMessage().getBody();
+                blockBody
+                    .getOptionalSignedExecutionPayloadBid()
+                    .ifPresent(
+                        signedBid ->
+                            notifyExecutionPayloadBidEventsSubscribers(signedBid, forkInfo));
                 return DutyResult.success(
-                    signedBlockContainer.getRoot(),
-                    getBlockSummary(signedBlockContainer.getSignedBlock().getMessage().getBody()));
+                    signedBlockContainer.getRoot(), getBlockSummary(blockBody));
               }
               return DutyResult.forError(
                   validator.getPublicKey(),
@@ -193,20 +206,10 @@ public class BlockProductionDuty implements Duty {
 
   private String getExecutionSummaryFromExecutionPayloadSummary(
       final ExecutionPayloadSummary summary) {
-    UInt64 gasPercentage;
-    try {
-      gasPercentage =
-          summary.getGasLimit().isGreaterThan(0L)
-              ? summary.getGasUsed().times(100).dividedBy(summary.getGasLimit())
-              : ZERO;
-    } catch (final ArithmeticException e) {
-      gasPercentage = UInt64.ZERO;
-      LOG.debug("Failed to compute percentage", e);
-    }
     return String.format(
         "%s (%s%%) gas, EL block: %s (%s)",
         summary.getGasUsed(),
-        gasPercentage,
+        summary.computeGasPercentage(LOG),
         summary.getBlockHash().toUnprefixedHexString(),
         summary.getBlockNumber());
   }
@@ -217,6 +220,15 @@ public class BlockProductionDuty implements Duty {
         bid.getBuilderIndex(),
         bid.getGasLimit(),
         LogFormatter.formatAbbreviatedHashRoot(bid.getBlockHash()));
+  }
+
+  private void notifyExecutionPayloadBidEventsSubscribers(
+      final SignedExecutionPayloadBid signedBid, final ForkInfo forkInfo) {
+    // G2_POINT_AT_INFINITY signature indicates a self-built bid
+    if (signedBid.getSignature().isInfinity()) {
+      executionPayloadBidEventsChannelPublisher.onSelfBuiltBidIncludedInBlock(
+          validator, forkInfo, signedBid.getMessage());
+    }
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadBidEventsChannel.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadBidEventsChannel.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.execution;
+
+import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.validator.client.Validator;
+
+/** Used to notify subscribers for events related to bids included in blocks */
+public interface ExecutionPayloadBidEventsChannel extends VoidReturningChannelInterface {
+
+  /** Block proposed by {@code validator} is using a self-built bid */
+  void onSelfBuiltBidIncludedInBlock(
+      Validator validator, ForkInfo forkInfo, ExecutionPayloadBid bid);
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.execution;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.Validator;
+import tech.pegasys.teku.validator.client.duties.Duty;
+
+/**
+ * This duty doesn't implement the {@link Duty} interface, because it is run adhoc and triggered by
+ * bid events coming from {@link ExecutionPayloadBidEventsChannel}
+ */
+public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
+
+  // we need some time for the block to be disseminated across the network before performing the
+  // execution payload duty
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/10018
+  @VisibleForTesting
+  static final Duration EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID = Duration.ofMillis(500);
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+  private final AsyncRunner asyncRunner;
+  private final ValidatorApiChannel validatorApiChannel;
+  private final ValidatorLogger validatorLogger;
+
+  public ExecutionPayloadDuty(
+      final Spec spec,
+      final AsyncRunner asyncRunner,
+      final ValidatorApiChannel validatorApiChannel,
+      final ValidatorLogger validatorLogger) {
+    this.spec = spec;
+    this.asyncRunner = asyncRunner;
+    this.validatorApiChannel = validatorApiChannel;
+    this.validatorLogger = validatorLogger;
+  }
+
+  @Override
+  public void onSelfBuiltBidIncludedInBlock(
+      final Validator validator, final ForkInfo forkInfo, final ExecutionPayloadBid bid) {
+    asyncRunner
+        .runAfterDelay(
+            () ->
+                performExecutionPayloadDuty(
+                    validator, forkInfo, bid.getSlot(), bid.getBuilderIndex()),
+            EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID)
+        .finishStackTrace();
+  }
+
+  private void performExecutionPayloadDuty(
+      final Validator validator,
+      final ForkInfo forkInfo,
+      final UInt64 slot,
+      final UInt64 builderIndex) {
+    validatorApiChannel
+        .createUnsignedExecutionPayload(slot, builderIndex)
+        .thenApply(this::validateExecutionPayload)
+        .thenCompose(
+            executionPayload -> signExecutionPayload(validator, executionPayload, forkInfo))
+        .thenCompose(this::publishSignedExecutionPayload)
+        .finish(error -> validatorLogger.executionPayloadDutyFailed(slot, builderIndex, error));
+  }
+
+  private ExecutionPayloadEnvelope validateExecutionPayload(
+      final Optional<ExecutionPayloadEnvelope> maybeExecutionPayload) {
+    return maybeExecutionPayload.orElseThrow(
+        () ->
+            new IllegalStateException(
+                "Node was not syncing but could not create execution payload"));
+  }
+
+  private SafeFuture<SignedExecutionPayloadEnvelope> signExecutionPayload(
+      final Validator validator,
+      final ExecutionPayloadEnvelope executionPayload,
+      final ForkInfo forkInfo) {
+    return validator
+        .getSigner()
+        .signExecutionPayloadEnvelope(executionPayload, forkInfo)
+        .thenApply(
+            signature ->
+                SchemaDefinitionsGloas.required(
+                        spec.atSlot(executionPayload.getSlot()).getSchemaDefinitions())
+                    .getSignedExecutionPayloadEnvelopeSchema()
+                    .create(executionPayload, signature));
+  }
+
+  private SafeFuture<Void> publishSignedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    return validatorApiChannel
+        .publishSignedExecutionPayload(signedExecutionPayload)
+        .thenRun(
+            () -> {
+              final ExecutionPayloadEnvelope executionPayload = signedExecutionPayload.getMessage();
+              validatorLogger.logExecutionPayloadDuty(
+                  executionPayload.getSlot(),
+                  executionPayload.getBuilderIndex(),
+                  executionPayload.getBeaconBlockRoot(),
+                  getExecutionSummary(executionPayload));
+            });
+  }
+
+  private String getExecutionSummary(final ExecutionPayloadEnvelope executionPayload) {
+    final ExecutionPayload payload = executionPayload.getPayload();
+    return String.format(
+        "Blobs: %d, %s (%s%%) gas, EL block: %s (%s)",
+        executionPayload.getBlobKzgCommitments().size(),
+        payload.getGasUsed(),
+        payload.computeGasPercentage(LOG),
+        payload.getBlockHash().toUnprefixedHexString(),
+        payload.getBlockNumber());
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -57,11 +57,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsDeneb;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
@@ -69,6 +71,7 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.ForkProvider;
 import tech.pegasys.teku.validator.client.Validator;
+import tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadBidEventsChannel;
 import tech.pegasys.teku.validator.client.signer.BlockContainerSigner;
 import tech.pegasys.teku.validator.client.signer.MilestoneBasedBlockContainerSigner;
 
@@ -94,6 +97,8 @@ class BlockProductionDutyTest {
       new MilestoneBasedBlockContainerSigner(spec);
   private final ValidatorDutyMetrics validatorDutyMetrics =
       spy(ValidatorDutyMetrics.create(new StubMetricsSystem()));
+  private final ExecutionPayloadBidEventsChannel executionPayloadBidEventsChannelPublisher =
+      mock(ExecutionPayloadBidEventsChannel.class);
   private BlockProductionDuty duty;
 
   @BeforeEach
@@ -106,22 +111,14 @@ class BlockProductionDutyTest {
             validatorApiChannel,
             blockContainerSigner,
             spec,
-            validatorDutyMetrics);
+            validatorDutyMetrics,
+            executionPayloadBidEventsChannelPublisher);
     when(forkProvider.getForkInfo(any())).thenReturn(completedFuture(fork));
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void shouldCreateAndPublishBlock(final boolean isBlindedBlocksEnabled) {
-    duty =
-        new BlockProductionDuty(
-            validator,
-            CAPELLA_SLOT,
-            forkProvider,
-            validatorApiChannel,
-            blockContainerSigner,
-            spec,
-            validatorDutyMetrics);
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
     final BlockContainerAndMetaData blockContainerAndMetaData;
@@ -168,15 +165,7 @@ class BlockProductionDutyTest {
 
   @Test
   public void forDeneb_shouldCreateAndPublishBlockContents() {
-    duty =
-        new BlockProductionDuty(
-            validator,
-            denebSlot,
-            forkProvider,
-            validatorApiChannel,
-            blockContainerSigner,
-            spec,
-            validatorDutyMetrics);
+    duty = createBlockProductionDutyForDeneb();
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
@@ -256,15 +245,7 @@ class BlockProductionDutyTest {
 
   @Test
   public void forDeneb_shouldCreateAndPublishBlindedBlock() {
-    duty =
-        new BlockProductionDuty(
-            validator,
-            denebSlot,
-            forkProvider,
-            validatorApiChannel,
-            blockContainerSigner,
-            spec,
-            validatorDutyMetrics);
+    duty = createBlockProductionDutyForDeneb();
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
@@ -319,15 +300,7 @@ class BlockProductionDutyTest {
 
   @Test
   public void forDeneb_shouldFailWhenNoKzgProofs() {
-    duty =
-        new BlockProductionDuty(
-            validator,
-            denebSlot,
-            forkProvider,
-            validatorApiChannel,
-            blockContainerSigner,
-            spec,
-            validatorDutyMetrics);
+    duty = createBlockProductionDutyForDeneb();
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
@@ -362,15 +335,7 @@ class BlockProductionDutyTest {
 
   @Test
   public void forDeneb_shouldFailWhenNoBlobs() {
-    duty =
-        new BlockProductionDuty(
-            validator,
-            denebSlot,
-            forkProvider,
-            validatorApiChannel,
-            blockContainerSigner,
-            spec,
-            validatorDutyMetrics);
+    duty = createBlockProductionDutyForDeneb();
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
@@ -505,15 +470,6 @@ class BlockProductionDutyTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void shouldUseBlockV3ToCreateAndPublishBlock(final boolean isBlindedBlocksEnabled) {
-    duty =
-        new BlockProductionDuty(
-            validator,
-            CAPELLA_SLOT,
-            forkProvider,
-            validatorApiChannel,
-            blockContainerSigner,
-            spec,
-            validatorDutyMetrics);
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
     final BlockContainerAndMetaData blockContainerAndMetaData;
@@ -570,7 +526,8 @@ class BlockProductionDutyTest {
             validatorApiChannel,
             blockContainerSigner,
             spec,
-            validatorDutyMetrics);
+            validatorDutyMetrics,
+            executionPayloadBidEventsChannelPublisher);
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
@@ -649,6 +606,60 @@ class BlockProductionDutyTest {
         .record(any(), any(BlockProductionDuty.class), eq(ValidatorDutyMetricsSteps.SEND));
   }
 
+  @Test
+  public void forGloas_shouldCreateAndPublishBlockAndNotifyBidEventsSubscribersWhenSelfBuiltBid() {
+    final UInt64 slot = UInt64.valueOf(42);
+    final Spec spec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final BlockContainerSigner blockContainerSigner = new MilestoneBasedBlockContainerSigner(spec);
+    duty =
+        new BlockProductionDuty(
+            validator,
+            UInt64.valueOf(42),
+            forkProvider,
+            validatorApiChannel,
+            blockContainerSigner,
+            spec,
+            validatorDutyMetrics,
+            executionPayloadBidEventsChannelPublisher);
+
+    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
+    final BLSSignature blockSignature = dataStructureUtil.randomSignature();
+
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+    final BeaconBlockBody blockBody =
+        dataStructureUtil.randomBeaconBlockBody(
+            builder ->
+                builder.signedExecutionPayloadBid(
+                    SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
+                        .getSignedExecutionPayloadBidSchema()
+                        .create(
+                            // mimicking self-built bid
+                            bid, BLSSignature.infinity())));
+
+    final BlockContainerAndMetaData blockContainerAndMetaData =
+        dataStructureUtil.randomBlockContainerAndMetaData(
+            dataStructureUtil.randomBeaconBlock(slot, blockBody), slot);
+
+    final BeaconBlock unsignedBlock = blockContainerAndMetaData.blockContainer().getBlock();
+
+    when(signer.createRandaoReveal(spec.computeEpochAtSlot(slot), fork))
+        .thenReturn(completedFuture(randaoReveal));
+    when(validatorApiChannel.createUnsignedBlock(
+            slot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+        .thenReturn(completedFuture(Optional.of(blockContainerAndMetaData)));
+    when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
+    final SignedBeaconBlock signedBlock =
+        dataStructureUtil.signedBlock(unsignedBlock, blockSignature);
+    when(validatorApiChannel.sendSignedBlock(signedBlock, BroadcastValidationLevel.GOSSIP))
+        .thenReturn(completedFuture(SendSignedBlockResult.success(signedBlock.getRoot())));
+
+    performAndReportDuty(slot);
+
+    verify(executionPayloadBidEventsChannelPublisher)
+        .onSelfBuiltBidIncludedInBlock(validator, fork, bid);
+  }
+
   public void assertDutyFails(final RuntimeException error) {
     assertDutyFails(error, CAPELLA_SLOT);
   }
@@ -666,6 +677,18 @@ class BlockProductionDutyTest {
     assertThat(expectedError.getCause()).isEqualTo(actualError.getCause());
     assertThat(expectedError.getMessage()).isEqualTo(actualError.getMessage());
     verifyNoMoreInteractions(validatorLogger);
+  }
+
+  private BlockProductionDuty createBlockProductionDutyForDeneb() {
+    return new BlockProductionDuty(
+        validator,
+        denebSlot,
+        forkProvider,
+        validatorApiChannel,
+        blockContainerSigner,
+        spec,
+        validatorDutyMetrics,
+        executionPayloadBidEventsChannelPublisher);
   }
 
   private void performAndReportDuty() {
@@ -757,11 +780,6 @@ class BlockProductionDutyTest {
 
     @Override
     public Bytes getExtraData() {
-      return null;
-    }
-
-    @Override
-    public Bytes32 getPayloadHash() {
       return null;
     }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.execution;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.validator.client.duties.execution.ExecutionPayloadDuty.EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.Validator;
+
+class ExecutionPayloadDutyTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private final Signer signer = mock(Signer.class);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
+
+  private final Validator validator =
+      new Validator(
+          dataStructureUtil.randomPublicKey(),
+          signer,
+          new FileBackedGraffitiProvider(
+              Optional.of(dataStructureUtil.randomBytes32()), Optional.empty()));
+  private final ForkInfo fork = dataStructureUtil.randomForkInfo();
+
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+
+  private ExecutionPayloadDuty duty;
+
+  @BeforeEach
+  public void setUp() {
+    duty = new ExecutionPayloadDuty(spec, asyncRunner, validatorApiChannel, validatorLogger);
+  }
+
+  @Test
+  public void performsDuty_onSelfBuiltBidIncludedInBlock() {
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+
+    final SignedExecutionPayloadEnvelope signedExecutionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(42);
+
+    when(validatorApiChannel.createUnsignedExecutionPayload(bid.getSlot(), bid.getBuilderIndex()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(signedExecutionPayload.getMessage())));
+    when(signer.signExecutionPayloadEnvelope(signedExecutionPayload.getMessage(), fork))
+        .thenReturn(SafeFuture.completedFuture(signedExecutionPayload.getSignature()));
+    when(validatorApiChannel.publishSignedExecutionPayload(any())).thenReturn(SafeFuture.COMPLETE);
+
+    duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
+
+    // delayed
+    asyncRunner.executeDueActions();
+
+    verifyNoInteractions(validatorApiChannel, validatorLogger);
+
+    timeProvider.advanceTimeBy(EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID);
+
+    // should execute now
+    asyncRunner.executeDueActions();
+
+    verify(validatorApiChannel).publishSignedExecutionPayload(signedExecutionPayload);
+    verify(validatorLogger)
+        .logExecutionPayloadDuty(
+            eq(signedExecutionPayload.getMessage().getSlot()),
+            eq(signedExecutionPayload.getMessage().getBuilderIndex()),
+            eq(signedExecutionPayload.getMessage().getBeaconBlockRoot()),
+            any());
+  }
+
+  @Test
+  public void dutyFailureLogsAnError() {
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+
+    final IllegalStateException exception = new IllegalStateException("oopsy");
+    when(validatorApiChannel.createUnsignedExecutionPayload(bid.getSlot(), bid.getBuilderIndex()))
+        .thenReturn(SafeFuture.failedFuture(exception));
+
+    duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
+
+    timeProvider.advanceTimeBy(EXECUTION_PAYLOAD_DUTY_DELAY_FOR_SELF_BUILT_BID);
+    asyncRunner.executeDueActions();
+
+    verify(validatorLogger)
+        .executionPayloadDutyFailed(
+            eq(bid.getSlot()),
+            eq(bid.getBuilderIndex()),
+            argThat(throwable -> throwable.getCause().equals(exception)));
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Introduce new `ExecutionPayloadDuty` which is run adhoc and react to bid events
- Modify `BlockProductionDuty` to emit a bid event if self-built bid is added to the block
- Set `execution_block_value` in `setExecutionPayloadBid` similar to `setExecutionData` (simplifies the test)
- Remove `Bytes32 getPayloadHash();` from ExecutionPayloadSummary (not used anywhere)

That's how the logging looks (local interop):
<img width="2290" height="900" alt="image" src="https://github.com/user-attachments/assets/a8706dba-5531-4414-8cf1-65c5fcc7bea5" />


## Fixed Issue(s)
fixes #10008 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an ad-hoc ExecutionPayloadDuty triggered by self-built bid events, wires it into the validator client with new logging, updates block production to emit these events, refactors execution bid handling, and removes the unused payload-hash API.
> 
> - **Validator Client (Gloas)**:
>   - Add `ExecutionPayloadDuty` that subscribes to `ExecutionPayloadBidEventsChannel` and publishes signed execution payloads after a short delay.
>   - Wire up the duty in `ValidatorClientService`; add event publisher to `BlockDutyFactory` and emit events from `BlockProductionDuty` when a self-built bid is included.
>   - Enhance logging via `ValidatorLogger` with execution payload duty messages.
> - **Block production / EL integration**:
>   - Rework `setExecutionPayloadBid` in `BlockOperationSelectorFactory` to use `ExecutionPayloadResult`, set the signed bid, and cache `executionPayloadValue` in parallel.
>   - Compute gas percentage via `ExecutionPayloadSummary.computeGasPercentage` and remove `getPayloadHash()` from summary and payload/header implementations.
> - **Misc**:
>   - Minor visibility/rename cleanups in `BlockFactoryDeneb` and `BlockFactoryPhase0`.
>   - Tests: add `ExecutionPayloadDutyTest`; update `BlockProductionDutyTest` and `AbstractBlockFactoryTest`; small util adjustments in `DataStructureUtil`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c82d9db58a2563b6e43cabdfb2c5b9b9a6e288f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->