### PR TITLE
Add BlobSelectorFactory and its initialization

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerWithChainDataProviderTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerWithChainDataProviderTest.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
+import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
 import tech.pegasys.teku.storage.client.BlobSidecarReconstructionProvider;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -79,6 +80,7 @@ public class AbstractMigratedBeaconHandlerWithChainDataProviderTest
             recentChainData,
             combinedChainDataClient,
             new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec)),
-            mock(BlobSidecarReconstructionProvider.class));
+            mock(BlobSidecarReconstructionProvider.class),
+            mock(BlobReconstructionProvider.class));
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
+import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
 import tech.pegasys.teku.storage.client.BlobSidecarReconstructionProvider;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -119,6 +120,7 @@ public class DataProvider {
     private boolean isLivenessTrackingEnabled = true;
     private IntSupplier rejectedExecutionSupplier;
     private BlobSidecarReconstructionProvider blobSidecarReconstructionProvider;
+    private BlobReconstructionProvider blobReconstructionProvider;
     private DataColumnSidecarManager dataColumnSidecarManager;
 
     public Builder recentChainData(final RecentChainData recentChainData) {
@@ -227,6 +229,12 @@ public class DataProvider {
       return this;
     }
 
+    public Builder blobReconstructionProvider(
+        final BlobReconstructionProvider blobReconstructionProvider) {
+      this.blobReconstructionProvider = blobReconstructionProvider;
+      return this;
+    }
+
     public Builder dataColumnSidecarManager(
         final DataColumnSidecarManager dataColumnSidecarManager) {
       this.dataColumnSidecarManager = dataColumnSidecarManager;
@@ -259,7 +267,8 @@ public class DataProvider {
               recentChainData,
               combinedChainDataClient,
               rewardCalculator,
-              blobSidecarReconstructionProvider);
+              blobSidecarReconstructionProvider,
+              blobReconstructionProvider);
       final SyncDataProvider syncDataProvider =
           new SyncDataProvider(syncService, rejectedExecutionSupplier);
       final ValidatorDataProvider validatorDataProvider =

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSelector.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blobselector;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.metadata.BlobsAndMetaData;
+
+public interface BlobSelector {
+  SafeFuture<Optional<BlobsAndMetaData>> getBlobs(List<Bytes32> versionedHashes);
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSelectorFactory.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blobselector;
+
+import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.AbstractSelectorFactory;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZGCommitment;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
+import tech.pegasys.teku.spec.datastructures.metadata.BlobsAndMetaData;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
+import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
+import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class BlobSelectorFactory extends AbstractSelectorFactory<BlobSelector> {
+  private final Spec spec;
+  private final BlobReconstructionProvider blobReconstructionProvider;
+  private final Function<KZGCommitment, Bytes32> commitmentToVersionedHash;
+
+  public BlobSelectorFactory(
+      final Spec spec,
+      final CombinedChainDataClient client,
+      final BlobReconstructionProvider blobReconstructionProvider) {
+    super(client);
+    this.spec = spec;
+    this.blobReconstructionProvider = blobReconstructionProvider;
+    this.commitmentToVersionedHash =
+        kzgCommitment -> {
+          final MiscHelpersDeneb miscHelpersDeneb =
+              MiscHelpersDeneb.required(spec.forMilestone(SpecMilestone.DENEB).miscHelpers());
+          return miscHelpersDeneb.kzgCommitmentToVersionedHash(kzgCommitment).get();
+        };
+  }
+
+  @Override
+  public BlobSelector blockRootSelector(final Bytes32 blockRoot) {
+    return versionedHashes -> {
+      return client
+          .getBlockByBlockRoot(blockRoot)
+          .thenCompose(maybeSignedBlock -> fetchBlobsFromBlock(maybeSignedBlock, versionedHashes));
+    };
+  }
+
+  @Override
+  public BlobSelector headSelector() {
+    return versionedHashes ->
+        client
+            .getChainHead()
+            .map(
+                chainHead ->
+                    chainHead
+                        .getBlock()
+                        .thenCompose(
+                            maybeSignedBlock ->
+                                fetchBlobsFromBlock(maybeSignedBlock, versionedHashes)))
+            .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  @Override
+  public BlobSelector finalizedSelector() {
+    return versionedHashes -> fetchBlobsFromBlock(client.getFinalizedBlock(), versionedHashes);
+  }
+
+  @Override
+  public BlobSelector genesisSelector() {
+    return versionedHashes ->
+        client
+            .getBlockAtSlotExact(GENESIS_SLOT)
+            .thenCompose(
+                maybeSignedBlock -> fetchBlobsFromBlock(maybeSignedBlock, versionedHashes));
+  }
+
+  @Override
+  public BlobSelector slotSelector(final UInt64 slot) {
+    return versionedHashes ->
+        client
+            .getChainHead()
+            .map(
+                chainHead ->
+                    client
+                        .getBlockAtSlotExact(slot, chainHead.getRoot())
+                        .thenCompose(
+                            maybeSignedBlock ->
+                                fetchBlobsFromBlock(maybeSignedBlock, versionedHashes)))
+            .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  private SafeFuture<Optional<BlobsAndMetaData>> fetchBlobsFromBlock(
+      final Optional<SignedBeaconBlock> maybeSignedBlock, final List<Bytes32> versionedHashes) {
+    final Optional<ChainHead> maybeChainHead = client.getChainHead();
+    if (maybeSignedBlock.isEmpty() || maybeChainHead.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.empty());
+    }
+    final Collection<SlotAndBlockRootAndBlobIndex> identifiers =
+        toBlobIdentifiers(versionedHashes, maybeSignedBlock);
+    final ChainHead chainHead = maybeChainHead.get();
+    final BeaconBlock block = maybeSignedBlock.get().getMessage();
+    final boolean isCanonical =
+        client.isCanonicalBlock(block.getSlot(), block.getRoot(), chainHead.getRoot());
+    final boolean isOptimistic =
+        chainHead.isOptimistic() || client.isOptimisticBlock(block.getRoot());
+    final boolean isFinalized = client.isFinalized(block.getSlot());
+    if (identifiers.isEmpty()) {
+      return SafeFuture.completedFuture(
+          addMetaData(
+              Optional.of(List.of()), block.getSlot(), isOptimistic, isCanonical, isFinalized));
+    } else {
+      final SafeFuture<List<Blob>> blobsFuture;
+      if (spec.atSlot(block.getSlot()).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
+        blobsFuture =
+            blobReconstructionProvider.reconstructBlobs(
+                block.getSlotAndBlockRoot(),
+                identifiers.stream().map(SlotAndBlockRootAndBlobIndex::getBlobIndex).toList(),
+                isCanonical);
+      } else {
+        blobsFuture =
+            client
+                .getBlobSidecars(
+                    block.getSlotAndBlockRoot(),
+                    identifiers.stream().map(SlotAndBlockRootAndBlobIndex::getBlobIndex).toList())
+                .thenApply(
+                    blobSidecars -> blobSidecars.stream().map(BlobSidecar::getBlob).toList());
+      }
+      return blobsFuture.thenApply(
+          blobs ->
+              addMetaData(
+                  Optional.of(blobs), block.getSlot(), isOptimistic, isCanonical, isFinalized));
+    }
+  }
+
+  @VisibleForTesting
+  Map<Bytes32, SlotAndBlockRootAndBlobIndex> blockToVersionedHashBlobs(
+      final Optional<SignedBeaconBlock> block) {
+    if (block.isEmpty()
+        || spec.atSlot(block.get().getSlot()).getMilestone().isLessThan(SpecMilestone.DENEB)) {
+      return Collections.emptyMap();
+    }
+
+    final SszList<SszKZGCommitment> blobKzgCommitments =
+        BeaconBlockBodyDeneb.required(block.get().getMessage().getBody()).getBlobKzgCommitments();
+    return IntStream.range(0, blobKzgCommitments.size())
+        .mapToObj(index -> Pair.of(index, blobKzgCommitments.get(index)))
+        .collect(
+            Collectors.toConcurrentMap(
+                commitmentPair ->
+                    commitmentToVersionedHash.apply(commitmentPair.getValue().getKZGCommitment()),
+                commitmentPair ->
+                    new SlotAndBlockRootAndBlobIndex(
+                        block.get().getSlot(),
+                        block.get().getRoot(),
+                        UInt64.valueOf(commitmentPair.getKey())),
+                // we often have duplicates in testnets
+                (existing, replacement) -> replacement));
+  }
+
+  @VisibleForTesting
+  Collection<SlotAndBlockRootAndBlobIndex> toBlobIdentifiers(
+      final List<Bytes32> versionedHashes, final Optional<SignedBeaconBlock> block) {
+    final Map<Bytes32, SlotAndBlockRootAndBlobIndex> blockToVersionedHashBlobs =
+        blockToVersionedHashBlobs(block);
+    if (blockToVersionedHashBlobs.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    if (versionedHashes.isEmpty()) {
+      return blockToVersionedHashBlobs.values();
+    }
+
+    return versionedHashes.stream()
+        .map(key -> Optional.ofNullable(blockToVersionedHashBlobs.get(key)))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+  }
+
+  private Optional<BlobsAndMetaData> addMetaData(
+      final Optional<List<Blob>> maybeBlobList,
+      final UInt64 blockSlot,
+      final boolean executionOptimistic,
+      final boolean canonical,
+      final boolean finalized) {
+    return maybeBlobList.map(
+        blobList ->
+            new BlobsAndMetaData(
+                blobList,
+                spec.atSlot(blockSlot).getMilestone(),
+                executionOptimistic,
+                canonical,
+                finalized));
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
+import tech.pegasys.teku.api.blobselector.BlobSelectorFactory;
 import tech.pegasys.teku.api.blobselector.BlobSidecarSelectorFactory;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.datacolumnselector.DataColumnSidecarSelectorFactory;
@@ -40,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.BeaconStateBuilderAltair;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
 import tech.pegasys.teku.storage.client.BlobSidecarReconstructionProvider;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -59,6 +61,7 @@ public abstract class AbstractChainDataProviderTest {
   protected CombinedChainDataClient combinedChainDataClient;
   protected BlockSelectorFactory blockSelectorFactory;
   protected BlobSidecarSelectorFactory blobSidecarSelectorFactory;
+  protected BlobSelectorFactory blobSelectorFactory;
   protected DataColumnSidecarSelectorFactory dataColumnSidecarSelectorFactory;
   protected StateSelectorFactory stateSelectorFactory;
   protected BeaconState beaconStateInternal;
@@ -69,6 +72,8 @@ public abstract class AbstractChainDataProviderTest {
       mock(CombinedChainDataClient.class);
   protected final BlobSidecarReconstructionProvider mockBlobSidecarReconstructionProvider =
       mock(BlobSidecarReconstructionProvider.class);
+  protected final BlobReconstructionProvider mockBlobReconstructionProvider =
+      mock(BlobReconstructionProvider.class);
 
   protected abstract Spec getSpec();
 
@@ -112,6 +117,10 @@ public abstract class AbstractChainDataProviderTest {
         spy(
             new BlobSidecarSelectorFactory(
                 spec, mockCombinedChainDataClient, mockBlobSidecarReconstructionProvider));
+    this.blobSelectorFactory =
+        spy(
+            new BlobSelectorFactory(
+                spec, mockCombinedChainDataClient, mockBlobReconstructionProvider));
     this.dataColumnSidecarSelectorFactory =
         spy(new DataColumnSidecarSelectorFactory(spec, mockCombinedChainDataClient));
     final ChainDataProvider provider =
@@ -122,6 +131,7 @@ public abstract class AbstractChainDataProviderTest {
             blockSelectorFactory,
             stateSelectorFactory,
             blobSidecarSelectorFactory,
+            blobSelectorFactory,
             dataColumnSidecarSelectorFactory,
             rewardCalculatorMock);
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -110,7 +110,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final List<ProtoNodeData> chainHeads = provider.getChainHeads();
     assertThat(chainHeads)
         .containsExactly(
@@ -134,7 +135,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             null,
             mockCombinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(false);
     assertThatThrownBy(provider::getGenesisTime).isInstanceOf(ChainDataUnavailableException.class);
   }
@@ -148,7 +150,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     final UInt64 result = provider.getGenesisTime();
     assertEquals(genesis, result);
@@ -162,7 +165,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             null,
             mockCombinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(false);
     assertThatThrownBy(provider::getGenesisData).isInstanceOf(ChainDataUnavailableException.class);
   }
@@ -179,7 +183,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     final GenesisData result = provider.getGenesisData();
     assertThat(result)
@@ -195,7 +200,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final SignedBeaconBlock block =
         storageSystem.getChainHead().getSignedBeaconBlock().orElseThrow();
     BlockAndMetaData result = provider.getBlockAndMetaData("head").get().orElseThrow();
@@ -212,7 +218,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final SignedBeaconBlock block =
         storageSystem.getChainHead().getSignedBeaconBlock().orElseThrow();
     BlockHeadersResponse results =
@@ -228,7 +235,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final UInt64 slot = combinedChainDataClient.getCurrentSlot();
     BlockHeadersResponse results =
         safeJoin(provider.getBlockHeaders(Optional.empty(), Optional.of(slot)));
@@ -243,7 +251,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     final UInt64 headSlot = recentChainData.getHeadSlot();
     storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
@@ -264,7 +273,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     List<Integer> indices =
         provider.getFilteredValidatorList(internalState, List.of("1", "33"), emptySet()).stream()
             .map(v -> v.getIndex().intValue())
@@ -281,7 +291,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final Bytes48 key = internalState.getValidators().get(12).getPubkeyBytes();
     final String missingKey = data.randomPublicKey().toString();
     List<Bytes48> pubkeys =
@@ -303,7 +314,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     assertThat(
             provider.getFilteredValidatorList(
@@ -324,7 +336,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThat(
             provider
                 .getStateCommittees(
@@ -345,7 +358,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     assertThat(
             provider
@@ -364,7 +378,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     assertThat(
             provider
@@ -610,7 +625,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final BeaconState internalState = data.randomBeaconState();
 
     BeaconBlockHeader expectedBlockHeader = BeaconBlockHeader.fromState(internalState);
@@ -631,7 +647,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final BeaconState internalState = data.randomBeaconState(1024);
     assertThat(provider.getValidatorBalancesFromState(internalState, emptyList())).hasSize(1024);
 
@@ -649,7 +666,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final BeaconState internalState = data.randomBeaconState(8);
     final Validator validator = internalState.getValidators().get(0);
     final StateValidatorIdentity identity =
@@ -673,7 +691,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final Optional<ObjectAndMetaData<Bytes32>> response = provider.getBlockRoot("head").get();
     assertThat(response).isPresent();
     assertThat(response.get().getData()).isEqualTo(bestBlock.getRoot());
@@ -687,7 +706,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     ChainBuilder chainBuilder = storageSystem.chainBuilder();
 
     ChainBuilder.BlockOptions blockOptions = ChainBuilder.BlockOptions.create();
@@ -730,7 +750,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData1,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     when(recentChainData1.getCurrentEpoch()).thenReturn(Optional.empty());
     assertThatThrownBy(() -> provider.getValidatorInclusionAtEpoch(data.randomEpoch()))
         .isInstanceOf(ServiceUnavailableException.class);
@@ -744,7 +765,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThatThrownBy(() -> provider.getValidatorInclusionAtEpoch(UInt64.valueOf(3)))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> provider.getValidatorInclusionAtEpoch(UInt64.valueOf(4)))
@@ -761,7 +783,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final Optional<StateAndMetaData> maybeState =
         Optional.of(
             new StateAndMetaData(
@@ -780,7 +803,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final Optional<StateAndMetaData> maybeState =
         Optional.of(
             new StateAndMetaData(
@@ -797,7 +821,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertDoesNotThrow(
         () -> provider.checkMinimumMilestone(Optional.empty(), SpecMilestone.ELECTRA, "badbeef"));
   }
@@ -811,7 +836,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             mockCombinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     // expect to see the last slot of epoch requested, so 3 * 8 - 1 (23)
     when(mockCombinedChainDataClient.getChainHead())
         .thenReturn(combinedChainDataClient.getChainHead());
@@ -830,7 +856,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     Optional<Bytes32> finalizedBlockRoot = provider.getFinalizedBlockRoot(UInt64.valueOf(24)).get();
     assertThat(finalizedBlockRoot).isPresent();
   }
@@ -844,7 +871,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     Optional<Bytes32> finalizedBlockRoot = provider.getFinalizedBlockRoot(UInt64.valueOf(1)).get();
     assertThat(finalizedBlockRoot).isEmpty();
   }
@@ -1116,7 +1144,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThat(provider.getRandaoAtEpochFromState(state, Optional.of(epoch)))
         .isEqualTo(maybeRandao);
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTestPhase0.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTestPhase0.java
@@ -85,7 +85,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final List<ProtoNodeData> chainHeads = provider.getChainHeads();
     assertThat(chainHeads)
         .containsExactly(
@@ -109,7 +110,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             null,
             mockCombinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(false);
     assertThatThrownBy(provider::getGenesisTime).isInstanceOf(ChainDataUnavailableException.class);
   }
@@ -123,7 +125,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     final UInt64 result = provider.getGenesisTime();
     assertEquals(genesis, result);
@@ -137,7 +140,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             null,
             mockCombinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     when(mockCombinedChainDataClient.isStoreAvailable()).thenReturn(false);
     assertThatThrownBy(provider::getGenesisData).isInstanceOf(ChainDataUnavailableException.class);
   }
@@ -154,7 +158,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     final GenesisData result = provider.getGenesisData();
     assertThat(result)
@@ -170,7 +175,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final SignedBeaconBlock block =
         storageSystem.getChainHead().getSignedBeaconBlock().orElseThrow();
     BlockAndMetaData result = provider.getBlockAndMetaData("head").get().orElseThrow();
@@ -187,7 +193,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final SignedBeaconBlock block =
         storageSystem.getChainHead().getSignedBeaconBlock().orElseThrow();
     BlockHeadersResponse results =
@@ -203,7 +210,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final UInt64 slot = combinedChainDataClient.getCurrentSlot();
     BlockHeadersResponse results =
         safeJoin(provider.getBlockHeaders(Optional.empty(), Optional.of(slot)));
@@ -218,7 +226,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     final UInt64 headSlot = recentChainData.getHeadSlot();
     storageSystem.chainUpdater().advanceChain(headSlot.plus(1));
@@ -239,7 +248,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     List<Integer> indices =
         provider.getFilteredValidatorList(internalState, List.of("1", "33"), emptySet()).stream()
             .map(v -> v.getIndex().intValue())
@@ -256,7 +266,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final Bytes48 key = internalState.getValidators().get(12).getPubkeyBytes();
     final String missingKey = data.randomPublicKey().toString();
     List<Bytes48> pubkeys =
@@ -278,7 +289,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     assertThat(
             provider.getFilteredValidatorList(
@@ -299,7 +311,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThat(
             provider
                 .getStateCommittees(
@@ -320,7 +333,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     assertThat(
             provider
@@ -339,7 +353,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
 
     assertThat(
             provider
@@ -360,7 +375,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final BeaconState internalState = data.randomBeaconState();
     when(mockCombinedChainDataClient.getBestState())
         .thenReturn(Optional.of(completedFuture(internalState)));
@@ -380,7 +396,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec)),
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final SafeFuture<Optional<SyncCommitteeRewardData>> future =
         provider.getSyncCommitteeRewardsFromBlockId("head", Set.of());
     assertThat(future).isCompletedExceptionally();
@@ -399,7 +416,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final BeaconState internalState = data.randomBeaconState();
 
     BeaconBlockHeader expectedBlockHeader = BeaconBlockHeader.fromState(internalState);
@@ -420,7 +438,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final BeaconState internalState = data.randomBeaconState(1024);
     assertThat(provider.getValidatorBalancesFromState(internalState, emptyList())).hasSize(1024);
 
@@ -438,7 +457,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     final Optional<ObjectAndMetaData<Bytes32>> response = provider.getBlockRoot("head").get();
     assertThat(response).isPresent();
     assertThat(response.get().getData()).isEqualTo(bestBlock.getRoot());
@@ -452,7 +472,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     ChainBuilder chainBuilder = storageSystem.chainBuilder();
 
     ChainBuilder.BlockOptions blockOptions = ChainBuilder.BlockOptions.create();
@@ -486,7 +507,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThat(provider.stateParameterMaySupportAltair("genesis")).isFalse();
   }
 
@@ -499,7 +521,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData1,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     when(recentChainData1.getCurrentEpoch()).thenReturn(Optional.empty());
     assertThatThrownBy(() -> provider.getValidatorInclusionAtEpoch(data.randomEpoch()))
         .isInstanceOf(ServiceUnavailableException.class);
@@ -513,7 +536,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThatThrownBy(() -> provider.getValidatorInclusionAtEpoch(UInt64.valueOf(3)))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> provider.getValidatorInclusionAtEpoch(UInt64.valueOf(4)))
@@ -531,7 +555,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             mockCombinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     // expect to see the last slot of epoch requested, so 3 * 8 - 1 (23)
     when(mockCombinedChainDataClient.getChainHead())
         .thenReturn(combinedChainDataClient.getChainHead());
@@ -550,7 +575,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     Optional<Bytes32> finalizedBlockRoot = provider.getFinalizedBlockRoot(UInt64.valueOf(24)).get();
     assertThat(finalizedBlockRoot).isPresent();
   }
@@ -564,7 +590,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     Optional<Bytes32> finalizedBlockRoot = provider.getFinalizedBlockRoot(UInt64.valueOf(1)).get();
     assertThat(finalizedBlockRoot).isEmpty();
   }
@@ -577,7 +604,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThatThrownBy(
             () ->
                 chainDataProvider.getExpectedWithdrawalsFromState(
@@ -598,7 +626,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
             recentChainData,
             combinedChainDataClient,
             rewardCalculatorMock,
-            mockBlobSidecarReconstructionProvider);
+            mockBlobSidecarReconstructionProvider,
+            mockBlobReconstructionProvider);
     assertThat(provider.getRandaoAtEpochFromState(state, Optional.of(epoch)))
         .isEqualTo(maybeRandao);
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSelectorFactoryTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blobselector;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
+import tech.pegasys.teku.spec.datastructures.metadata.BlobsAndMetaData;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
+import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+// TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
+@TestSpecContext(allMilestones = true, ignoredMilestones = SpecMilestone.GLOAS)
+public class BlobSelectorFactoryTest {
+
+  private final CombinedChainDataClient client = mock(CombinedChainDataClient.class);
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private List<Bytes32> versionedHashes = Collections.emptyList();
+  private final List<UInt64> indices = List.of(UInt64.ZERO);
+  private final SignedBlockAndState blockAndState =
+      dataStructureUtil.randomSignedBlockAndState(100);
+  private final SignedBeaconBlock block = blockAndState.getBlock();
+  private final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecars(1);
+  private final List<Blob> blobs = blobSidecars.stream().map(BlobSidecar::getBlob).toList();
+  private final BlobReconstructionProvider blobReconstructionProvider =
+      mock(BlobReconstructionProvider.class);
+  private final BlobSelectorFactory blobSelectorFactory =
+      new BlobSelectorFactory(spec, client, blobReconstructionProvider);
+
+  @BeforeEach
+  public void setup() {
+    final MiscHelpersDeneb miscHelpersDeneb =
+        MiscHelpersDeneb.required(spec.forMilestone(SpecMilestone.DENEB).miscHelpers());
+    final BeaconBlockBodyDeneb beaconBlockBody =
+        BeaconBlockBodyDeneb.required(block.getMessage().getBody());
+    this.versionedHashes =
+        List.of(
+            miscHelpersDeneb
+                .kzgCommitmentToVersionedHash(
+                    beaconBlockBody.getBlobKzgCommitments().get(0).getKZGCommitment())
+                .get());
+    when(client.isCanonicalBlock(any(), any(), any())).thenReturn(true);
+    when(client.isOptimisticBlock(any())).thenReturn(false);
+    when(client.isFinalized(any())).thenReturn(true);
+  }
+
+  @Test
+  public void headSelector_shouldGetHeadBlobs() throws ExecutionException, InterruptedException {
+    when(client.getChainHead()).thenReturn(Optional.of(ChainHead.create(blockAndState)));
+    when(client.getBlobSidecars(blockAndState.getSlotAndBlockRoot(), indices))
+        .thenReturn(SafeFuture.completedFuture(blobSidecars));
+
+    final Optional<BlobsAndMetaData> result =
+        blobSelectorFactory.headSelector().getBlobs(versionedHashes).get();
+    assertThat(result.get().getData()).isEqualTo(blobs);
+  }
+
+  @Test
+  public void finalizedSelector_shouldGetFinalizedBlobs()
+      throws ExecutionException, InterruptedException {
+    // chainHead is required for optimistic/canonical checks
+    when(client.getChainHead())
+        .thenReturn(Optional.of(ChainHead.create(dataStructureUtil.randomBlockAndState(123))));
+    when(client.getFinalizedBlock()).thenReturn(Optional.of(block));
+    when(client.getBlobSidecars(block.getSlotAndBlockRoot(), indices))
+        .thenReturn(SafeFuture.completedFuture(blobSidecars));
+
+    final Optional<BlobsAndMetaData> result =
+        blobSelectorFactory.finalizedSelector().getBlobs(versionedHashes).get();
+    assertThat(result.get().getData()).isEqualTo(blobs);
+  }
+
+  @Test
+  public void genesisSelector_shouldGetGenesisBlobs()
+      throws ExecutionException, InterruptedException {
+    // chainHead is required for optimistic/canonical checks
+    when(client.getChainHead())
+        .thenReturn(Optional.of(ChainHead.create(dataStructureUtil.randomBlockAndState(123))));
+    when(client.getBlockAtSlotExact(UInt64.ZERO))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(client.getBlobSidecars(block.getSlotAndBlockRoot(), indices))
+        .thenReturn(SafeFuture.completedFuture(blobSidecars));
+
+    final Optional<BlobsAndMetaData> result =
+        blobSelectorFactory.genesisSelector().getBlobs(versionedHashes).get();
+    assertThat(result.get().getData()).isEqualTo(blobs);
+  }
+
+  @Test
+  public void blockRootSelector_shouldGetBlobs() throws ExecutionException, InterruptedException {
+    // chainHead is required for optimistic/canonical checks
+    when(client.getChainHead())
+        .thenReturn(Optional.of(ChainHead.create(dataStructureUtil.randomBlockAndState(123))));
+    when(client.getBlockByBlockRoot(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(client.getBlobSidecars(block.getSlotAndBlockRoot(), indices))
+        .thenReturn(SafeFuture.completedFuture(blobSidecars));
+
+    final Optional<BlobsAndMetaData> result =
+        blobSelectorFactory.blockRootSelector(block.getRoot()).getBlobs(versionedHashes).get();
+    assertThat(result.get().getData()).isEqualTo(blobs);
+  }
+
+  @Test
+  public void slotSelector_shouldGetBlobs() throws ExecutionException, InterruptedException {
+    // chainHead is required for optimistic/canonical checks
+    final ChainHead chainHead = ChainHead.create(dataStructureUtil.randomBlockAndState(123));
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.getBlockAtSlotExact(block.getSlot(), chainHead.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(client.getBlobSidecars(block.getSlotAndBlockRoot(), indices))
+        .thenReturn(SafeFuture.completedFuture(blobSidecars));
+
+    final Optional<BlobsAndMetaData> result =
+        blobSelectorFactory.slotSelector(block.getSlot()).getBlobs(versionedHashes).get();
+    assertThat(result.get().getData()).isEqualTo(blobs);
+  }
+
+  @Test
+  public void createSelectorForBlockId_shouldThrowBadRequestException() {
+    assertThrows(
+        BadRequestException.class, () -> blobSelectorFactory.createSelectorForBlockId("a"));
+  }
+
+  @Test
+  public void stateRootSelector_shouldThrowUnsupportedOperationException() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> blobSelectorFactory.stateRootSelector(dataStructureUtil.randomBytes32()));
+  }
+
+  @Test
+  public void createSelectorForBlockId_shouldThrowBadRequestExceptionOnJustifiedKeyword() {
+    assertThrows(
+        BadRequestException.class, () -> blobSelectorFactory.createSelectorForBlockId("justified"));
+  }
+
+  @Test
+  public void justifiedSelector_shouldThrowUnsupportedOperationException() {
+    assertThrows(UnsupportedOperationException.class, blobSelectorFactory::justifiedSelector);
+  }
+
+  @Test
+  public void shouldNotLookForBlobSidecarsWhenNoKzgCommitments()
+      throws ExecutionException, InterruptedException {
+    // chainHead is required for optimistic/canonical checks
+    when(client.getChainHead())
+        .thenReturn(Optional.of(ChainHead.create(dataStructureUtil.randomBlockAndState(123))));
+
+    final SignedBeaconBlock blockWithEmptyCommitments =
+        dataStructureUtil.randomSignedBeaconBlockWithEmptyCommitments();
+    when(client.getBlockByBlockRoot(blockWithEmptyCommitments.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blockWithEmptyCommitments)));
+
+    final Optional<BlobsAndMetaData> result =
+        blobSelectorFactory
+            .blockRootSelector(blockWithEmptyCommitments.getRoot())
+            .getBlobs(versionedHashes)
+            .get();
+    verify(client, never()).getBlobSidecars(any(SlotAndBlockRoot.class), anyList());
+    assertThat(result).isPresent();
+    assertThat(result.get().getData()).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldLookForBlobSidecarsOnlyAfterDeneb(
+      final TestSpecInvocationContextProvider.SpecContext ctx)
+      throws ExecutionException, InterruptedException {
+    final BlobSelectorFactory blobSelectorFactory =
+        new BlobSelectorFactory(ctx.getSpec(), client, blobReconstructionProvider);
+    // chainHead is required for optimistic/canonical checks
+    final ChainHead chainHead = ChainHead.create(dataStructureUtil.randomBlockAndState(123));
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+
+    when(client.getBlockAtSlotExact(block.getSlot(), chainHead.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(client.getBlobSidecars(any(SlotAndBlockRoot.class), anyList()))
+        .thenReturn(SafeFuture.completedFuture(List.of(dataStructureUtil.randomBlobSidecar())));
+    when(blobReconstructionProvider.reconstructBlobs(any(), anyList(), anyBoolean()))
+        .thenReturn(SafeFuture.completedFuture(List.of()));
+    blobSelectorFactory.slotSelector(block.getSlot()).getBlobs(versionedHashes).get();
+    if (ctx.getSpec().isMilestoneSupported(SpecMilestone.FULU)) {
+      verify(blobReconstructionProvider)
+          .reconstructBlobs(any(SlotAndBlockRoot.class), anyList(), anyBoolean());
+      verify(client, never()).getBlobSidecars(any(SlotAndBlockRoot.class), anyList());
+    } else if (ctx.getSpec().isMilestoneSupported(SpecMilestone.DENEB)) {
+      verify(client).getBlobSidecars(any(SlotAndBlockRoot.class), anyList());
+    } else {
+      verify(client, never()).getBlobSidecars(any(SlotAndBlockRoot.class), anyList());
+    }
+  }
+
+  @TestTemplate
+  public void blockToVersionedHashBlobs_AllMilestones(
+      final TestSpecInvocationContextProvider.SpecContext ctx) {
+
+    final DataStructureUtil dataStructureUtil1 = new DataStructureUtil(ctx.getSpec());
+    final SignedBeaconBlock signedBeaconBlock = dataStructureUtil1.randomSignedBeaconBlock();
+    final BlobSelectorFactory blobSelectorFactory =
+        new BlobSelectorFactory(ctx.getSpec(), client, blobReconstructionProvider);
+    final Map<Bytes32, SlotAndBlockRootAndBlobIndex> blockToVersionedHashBlobs =
+        blobSelectorFactory.blockToVersionedHashBlobs(Optional.of(signedBeaconBlock));
+    if (ctx.getSpec().isMilestoneSupported(SpecMilestone.DENEB)) {
+      assertThat(blockToVersionedHashBlobs.values())
+          .containsExactlyInAnyOrderElementsOf(
+              IntStream.range(
+                      0,
+                      signedBeaconBlock
+                          .getMessage()
+                          .getBody()
+                          .getOptionalBlobKzgCommitments()
+                          .map(SszList::size)
+                          .orElse(0))
+                  .mapToObj(
+                      index ->
+                          new SlotAndBlockRootAndBlobIndex(
+                              signedBeaconBlock.getSlot(),
+                              signedBeaconBlock.getRoot(),
+                              UInt64.valueOf(index)))
+                  .collect(Collectors.toSet()));
+    } else {
+      assertThat(blockToVersionedHashBlobs).isEmpty();
+    }
+  }
+
+  @Test
+  public void blockToVersionedHashBlobs_NoBlock() {
+    final Map<Bytes32, SlotAndBlockRootAndBlobIndex> blockToVersionedHashBlobs =
+        blobSelectorFactory.blockToVersionedHashBlobs(Optional.empty());
+    assertThat(blockToVersionedHashBlobs).isEmpty();
+  }
+
+  @TestTemplate
+  public void toBlobIdentifiers_EmptyVersionedHashesAllMilestones(
+      final TestSpecInvocationContextProvider.SpecContext ctx) {
+
+    final DataStructureUtil dataStructureUtil1 = new DataStructureUtil(ctx.getSpec());
+    final SignedBeaconBlock signedBeaconBlock = dataStructureUtil1.randomSignedBeaconBlock();
+    final BlobSelectorFactory blobSelectorFactory =
+        new BlobSelectorFactory(ctx.getSpec(), client, blobReconstructionProvider);
+    final Collection<SlotAndBlockRootAndBlobIndex> blobIdentifiers =
+        blobSelectorFactory.toBlobIdentifiers(List.of(), Optional.of(signedBeaconBlock));
+    if (ctx.getSpec().isMilestoneSupported(SpecMilestone.DENEB)) {
+      assertThat(blobIdentifiers)
+          .containsExactlyInAnyOrderElementsOf(
+              IntStream.range(
+                      0,
+                      signedBeaconBlock
+                          .getMessage()
+                          .getBody()
+                          .getOptionalBlobKzgCommitments()
+                          .map(SszList::size)
+                          .orElse(0))
+                  .mapToObj(
+                      index ->
+                          new SlotAndBlockRootAndBlobIndex(
+                              signedBeaconBlock.getSlot(),
+                              signedBeaconBlock.getRoot(),
+                              UInt64.valueOf(index)))
+                  .collect(Collectors.toSet()));
+    } else {
+      assertThat(blobIdentifiers).isEmpty();
+    }
+  }
+
+  @TestTemplate
+  public void toBlobIdentifiers_VersionedHashFilterAllMilestones(
+      final TestSpecInvocationContextProvider.SpecContext ctx) {
+    assumeThat(ctx.getSpec().isMilestoneSupported(SpecMilestone.DENEB)).isTrue();
+
+    final DataStructureUtil dataStructureUtil1 = new DataStructureUtil(ctx.getSpec());
+    final SignedBeaconBlock signedBeaconBlock = dataStructureUtil1.randomSignedBeaconBlock();
+    final BlobSelectorFactory blobSelectorFactory =
+        new BlobSelectorFactory(ctx.getSpec(), client, blobReconstructionProvider);
+    final Map<Bytes32, SlotAndBlockRootAndBlobIndex> blockToVersionedHashBlobs =
+        blobSelectorFactory.blockToVersionedHashBlobs(Optional.of(signedBeaconBlock));
+    final Map.Entry<Bytes32, SlotAndBlockRootAndBlobIndex> first =
+        blockToVersionedHashBlobs.entrySet().stream().findFirst().get();
+    final Collection<SlotAndBlockRootAndBlobIndex> blobIdentifiers =
+        blobSelectorFactory.toBlobIdentifiers(
+            List.of(first.getKey()), Optional.of(signedBeaconBlock));
+
+    assertThat(blobIdentifiers).containsExactly(first.getValue());
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/BlobsAndMetaData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/BlobsAndMetaData.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.metadata;
+
+import java.util.List;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
+
+public class BlobsAndMetaData extends ObjectAndMetaData<List<Blob>> {
+
+  public BlobsAndMetaData(
+      final List<Blob> data,
+      final SpecMilestone milestone,
+      final boolean executionOptimistic,
+      final boolean canonical,
+      final boolean finalized) {
+    super(data, milestone, executionOptimistic, canonical, finalized);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/types/VersionedHash.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/types/VersionedHash.java
@@ -53,6 +53,10 @@ public class VersionedHash {
     return value;
   }
 
+  public Bytes32 get() {
+    return Bytes32.wrap(Bytes.concatenate(version, value));
+  }
+
   public String toHexString() {
     return Bytes.wrap(version, value).toHexString();
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -44,7 +44,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.api.RewardCalculator;
@@ -246,6 +245,7 @@ import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.api.ThrottlingStorageQueryChannel;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
+import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
 import tech.pegasys.teku.storage.client.BlobSidecarReconstructionProvider;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -392,6 +392,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected Path debugDataDirectory;
   protected volatile UInt256 nodeId;
   protected volatile BlobSidecarReconstructionProvider blobSidecarReconstructionProvider;
+  protected volatile BlobReconstructionProvider blobReconstructionProvider;
   protected volatile ValidatorApiHandler validatorApiHandler;
 
   public BeaconChainController(
@@ -667,6 +668,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     initSlashingEventsSubscriptions();
     initPerformanceTracker();
     initBlobSidecarReconstructionProvider();
+    initBlobReconstructionProvider();
     initDataProvider();
     initValidatorApiHandler();
     initRestAPI();
@@ -1202,6 +1204,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
         new BlobSidecarReconstructionProvider(combinedChainDataClient, spec);
   }
 
+  protected void initBlobReconstructionProvider() {
+    LOG.debug("BeaconChainController.initBlobReconstructionProvider()");
+    this.blobReconstructionProvider = new BlobReconstructionProvider(combinedChainDataClient, spec);
+  }
+
   protected void initDataProvider() {
     dataProvider =
         DataProvider.builder()
@@ -1210,6 +1217,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .combinedChainDataClient(combinedChainDataClient)
             .rewardCalculator(rewardCalculator)
             .blobSidecarReconstructionProvider(blobSidecarReconstructionProvider)
+            .blobReconstructionProvider(blobReconstructionProvider)
             .p2pNetwork(p2pNetwork)
             .syncService(syncService)
             .validatorApiChannel(
@@ -1483,12 +1491,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
     this.validatorApiHandler =
         new ValidatorApiHandler(
-            new ChainDataProvider(
-                spec,
-                recentChainData,
-                combinedChainDataClient,
-                rewardCalculator,
-                blobSidecarReconstructionProvider),
+            dataProvider.getChainDataProvider(),
             dataProvider.getNodeDataProvider(),
             dataProvider.getNetworkDataProvider(),
             combinedChainDataClient,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Part of #9978 fixing #9835
We have `BlobSidecarSelector` but `GetBlobSidecars` API will be deprecated + the logic differs too much to reuse anything. So I decided to create separate selector. When `GetBlobSidecars` is removed from the API spec, we will just delete everything around it.
Also I've reused `ChainDataProvider` in `BeaconChainController` init flow. I don't understand why we had 2 instances. No need for it. It didin't cost anything, but it's better to be organized.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce blob selection by versioned hashes with `BlobSelector/Factory` and `getBlobs`, plumbed via `BlobReconstructionProvider` through `ChainDataProvider`, `DataProvider`, and `BeaconChainController`, with tests added/updated.
> 
> - **API/Selectors**:
>   - Add `BlobSelector` and `BlobSelectorFactory` to fetch blobs by versioned hash; selects from `BlobReconstructionProvider` (≥ Fulu) or `BlobSidecars` (Deneb).
>   - Add `getBlobs(blockId, versionedHashes)` to `ChainDataProvider`; inject new `BlobSelectorFactory`.
>   - Introduce `BlobsAndMetaData` response type.
>   - Extend `VersionedHash` with `get()`.
> - **Wiring/Construction**:
>   - Extend `ChainDataProvider` constructors to accept both `BlobSidecarReconstructionProvider` and `BlobReconstructionProvider`.
>   - Update `DataProvider.Builder` and `BeaconChainController` to initialize and pass `BlobReconstructionProvider`; reuse `dataProvider.getChainDataProvider()` in `ValidatorApiHandler`.
> - **Tests**:
>   - Add `BlobSelectorFactoryTest` covering selection paths and milestone behavior.
>   - Update chain data provider tests to pass new dependencies and validate unchanged behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a313a4c9a11f5bba81b7f34c1c50982d52112dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->