### PR TITLE
GHA updated workflows - to remove the noise in the main PR view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,16 +290,16 @@ jobs:
       src_root: "src/property-test/java"
       runner: "gha-runner-scale-set-ubuntu-22.04-amd64-xl"
 
-  # propertyTestsReport:
-  #   runs-on: ubuntu-24.04
-  #   needs: propertyTests
-  #   if: always()
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - uses: ./.github/actions/collate-junit-reports
-  #       if: always()        
-  #       with:
-  #         stage_key: property
+  propertyTestsReport:
+    runs-on: ubuntu-24.04
+    needs: propertyTests
+    if: always()
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/collate-junit-reports
+        if: always()        
+        with:
+          stage_key: property
 
   acceptanceTests:
     needs: assemble
@@ -314,16 +314,16 @@ jobs:
       src_root: "src/acceptance-test/java"
       runner: "ubuntu-latest-128"
 
-  # acceptanceTestsReport:
-  #   runs-on: ubuntu-24.04
-  #   needs: acceptanceTests
-  #   if: always()
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - uses: ./.github/actions/collate-junit-reports
-  #       if: always()        
-  #       with:
-  #         stage_key: acceptance
+  acceptanceTestsReport:
+    runs-on: ubuntu-24.04
+    needs: acceptanceTests
+    if: always()
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/collate-junit-reports
+        if: always()        
+        with:
+          stage_key: acceptance
 
   # referenceTestsPrep:
   #   needs: assemble

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,29 +253,29 @@ jobs:
         with:
           stage_key: unit
 
-  # integrationTests:
-  #   needs: assemble
-  #   runs-on: ubuntu-latest-128
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v5
-  #       with:
-  #         submodules: 'recursive'
-  #     - name: Prepare
-  #       uses: ./.github/actions/prepare
-  #     - name: Download assemble-output
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: assemble-output
-  #         path: ${{ github.workspace }}   
-  #     - name: Integration Tests
-  #       run: |
-  #         ./gradlew integrationTest
-  #     - name: Test results 
-  #       uses: ./.github/actions/collate-test-results
-  #       if: always()        
-  #       with:
-  #         stage_key: 'integration'
+  integrationTests:
+    needs: assemble
+    runs-on: ubuntu-latest-128
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Download assemble-output
+        uses: actions/download-artifact@v4
+        with:
+          name: assemble-output
+          path: ${{ github.workspace }}   
+      - name: Integration Tests
+        run: |
+          ./gradlew integrationTest
+      - name: Test results 
+        uses: ./.github/actions/collate-test-results
+        if: always()        
+        with:
+          stage_key: 'integration'
 
   propertyTests:
     needs: assemble
@@ -325,189 +325,186 @@ jobs:
         with:
           stage_key: acceptance
 
-  # referenceTestsPrep:
-  #   needs: assemble
-  #   runs-on: ubuntu-24.04
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v5
-  #       with:
-  #         submodules: 'recursive'
-  #     - name: Prepare
-  #       uses: ./.github/actions/prepare
-  #     - name: Download assemble-output
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         github-token: ${{ github.token }}
-  #         repository: ${{ github.repository }}
-  #         run-id: ${{ github.run_id }}
-  #         name: assemble-output
-  #         merge-multiple: true
-  #         path: ${{ github.workspace }}          
-  #     - uses: actions/cache/restore@v4
-  #       with:
-  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-  #         key: reftests-${{ hashFiles('build.gradle') }}
-  #     - shell: bash
-  #       run: |
-  #         tree ./eth-reference-tests/            
-  #     - name: FetchReferenceTests
-  #       shell: bash
-  #       run: |
-  #         if [ ! -d "eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/tests" ]
-  #         then
-  #           ./gradlew --no-daemon expandRefTests
-  #         fi
-  #     - name: CompileReferenceTests
-  #       shell: bash
-  #       run: |
-  #         ./gradlew --no-daemon --parallel compileReferenceTestJava
-  #     - name: Caching reference tests 
-  #       uses: actions/cache/save@v4
-  #       with:
-  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-  #         key: reftests-${{ hashFiles('build.gradle') }}
-  #     - name: Upload reftests
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: reftests
-  #         path: |
-  #           ./eth-reference-tests/
-  #         retention-days: 1
-  #         include-hidden-files: 'true'
+  referenceTestsPrep:
+    needs: assemble
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Download assemble-output
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          name: assemble-output
+          merge-multiple: true
+          path: ${{ github.workspace }}          
+      - uses: actions/cache/restore@v4
+        with:
+          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+          key: reftests-${{ hashFiles('build.gradle') }}
+      - shell: bash
+        run: |
+          tree ./eth-reference-tests/            
+      - name: FetchReferenceTests
+        shell: bash
+        run: |
+          if [ ! -d "eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/tests" ]
+          then
+            ./gradlew --no-daemon expandRefTests
+          fi
+      - name: CompileReferenceTests
+        shell: bash
+        run: |
+          ./gradlew --no-daemon --parallel compileReferenceTestJava
+      - name: Caching reference tests 
+        uses: actions/cache/save@v4
+        with:
+          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+          key: reftests-${{ hashFiles('build.gradle') }}
+      - name: Upload reftests
+        uses: actions/upload-artifact@v4
+        with:
+          name: reftests
+          path: |
+            ./eth-reference-tests/
+          retention-days: 1
+          include-hidden-files: 'true'
 
-  # referenceTests:
-  #   needs: referenceTestsPrep
-  #   runs-on: "gha-runner-scale-set-ubuntu-22.04-amd64-xxl"
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       shard: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]   # parallel shards
-  #       total: [32]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v5
-  #       with:
-  #         submodules: 'recursive'
-  #     - name: Prepare
-  #       uses: ./.github/actions/prepare
-  #     - name: Download assemble-output
-  #       uses: actions/download-artifact@v5
-  #       with:
-  #         github-token: ${{ github.token }}
-  #         repository: ${{ github.repository }}
-  #         run-id: ${{ github.run_id }}
-  #         name: assemble-output
-  #         merge-multiple: true
-  #         path: ${{ github.workspace }}
-  #     - uses: actions/cache/restore@v4
-  #       with:
-  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-  #         key: reftests-${{ hashFiles('build.gradle') }}          
-  #     - name: Download reftests
-  #       uses: actions/download-artifact@v5
-  #       with:
-  #         github-token: ${{ github.token }}
-  #         repository: ${{ github.repository }}
-  #         run-id: ${{ github.run_id }}
-  #         name: reftests
-  #         merge-multiple: true 
-  #         path: ./eth-reference-tests
-  #     - name: Login to dockerhub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USER_RO }}
-  #         password: ${{ secrets.DOCKER_PASSWORD_RO }}
-  #     - uses: actions/cache/restore@v4
-  #       with:
-  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-  #         key: reftests-${{ hashFiles('build.gradle') }}
-  #     - name: Compute shard ${{ matrix.shard }} of ${{ matrix.total }} for ReferenceTests
-  #       id: shard
-  #       shell: bash
-  #       run: |
-  #         SRC_PATTERN="*/src/referenceTest/generated_tests/*Test.java"
-  #         SRC_ROOT="src/referenceTest/generated_tests"
+  referenceTests:
+    needs: referenceTestsPrep
+    runs-on: "gha-runner-scale-set-ubuntu-22.04-amd64-xxl"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0,1,2,3,4,5,6,7]   # parallel shards
+        total: [8]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Download assemble-output
+        uses: actions/download-artifact@v5
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          name: assemble-output
+          merge-multiple: true
+          path: ${{ github.workspace }}
+      - uses: actions/cache/restore@v4
+        with:
+          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+          key: reftests-${{ hashFiles('build.gradle') }}          
+      - name: Download reftests
+        uses: actions/download-artifact@v5
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          name: reftests
+          merge-multiple: true 
+          path: ./eth-reference-tests
+      - name: Login to dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER_RO }}
+          password: ${{ secrets.DOCKER_PASSWORD_RO }}
+      - uses: actions/cache/restore@v4
+        with:
+          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+          key: reftests-${{ hashFiles('build.gradle') }}
+      - name: Compute shard ${{ matrix.shard }} of ${{ matrix.total }} for ReferenceTests
+        id: shard
+        shell: bash
+        run: |
+          SRC_PATTERN="*/src/referenceTest/generated_tests/*Test.java"
+          SRC_ROOT="src/referenceTest/generated_tests"
+          # 1) Collect test classes by pattern = FQNs
+          CLASSNAMES=$(find . -type f -name "*.java" -path "$SRC_PATTERN" \
+            | sed "s@.*/$SRC_ROOT/@@" \
+            | sed 's@/@.@g' \
+            | sed 's/.\{5\}$//')
+          # 2) Modulo split
+          CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
+            | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
 
-  #         # 1) Collect test classes by pattern = FQNs
-  #         CLASSNAMES=$(find . -type f -name "*.java" -path "$SRC_PATTERN" \
-  #           | sed "s@.*/$SRC_ROOT/@@" \
-  #           | sed 's@/@.@g' \
-  #           | sed 's/.\{5\}$//')
+          if [ -z "$CLASSES_FOR_SHARD" ]; then
+            echo "args=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # 3) Build --tests args
+          GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
+          echo "Prepared arguments for Gradle (ReferenceTests): $GRADLE_ARGS"
+          echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
+      - name: Run ReferenceTests (shard)
+        if: steps.shard.outputs.args != ''
+        run: |
+          ./gradlew --no-daemon --parallel --info \
+            -x generateReferenceTestClasses \
+            -x processReferenceTestResources \
+            -x cleanReferenceTestClasses \
+            referenceTest ${{ inputs.gradle_args }} ${{ steps.shard.outputs.args }}
+      - name: Upload JUnit XML + HTML for ReferenceTests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reference-reports-${{ matrix.shard }}
+          path: |
+            **/build/test-results/**/TEST-*.xml
+            **/build/reports/tests/**
+          if-no-files-found: ignore
+          retention-days: 1
 
-  #         # 2) Modulo split
-  #         CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
-  #           | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
+  referenceTestsReport:
+    runs-on: ubuntu-24.04
+    needs: referenceTests
+    if: always()
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/collate-junit-reports
+        if: always()
+        with:
+          stage_key: reference
 
-  #         if [ -z "$CLASSES_FOR_SHARD" ]; then
-  #           echo "args=" >> "$GITHUB_OUTPUT"
-  #           exit 0
-  #         fi
+  # DockerTags
+  # everything is a standard develop-jdk24/21; but you also add develop to develop-jdk21
+  # develop = develop-jdk21
+  # develop-jdk24
+  # publishDockerJDK21:
+  #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+  #   needs: [assemble]
+  #   uses: ./.github/workflows/publish-docker.yml
+  #   with:
+  #     assemble_run_id: ${{ github.run_id }}
+  #     jdk_version: jdk21
+  #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
+  #   secrets: inherit
+  #
+  # publishDockerJDK24:
+  #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+  #   needs: [assemble]
+  #   uses: ./.github/workflows/publish-docker.yml
+  #   with:
+  #     assemble_run_id: ${{ github.run_id }}
+  #     jdk_version: jdk24
+  #   secrets: inherit
 
-  #         # 3) Build --tests args
-  #         GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
-  #         echo "Prepared arguments for Gradle (ReferenceTests): $GRADLE_ARGS"
-  #         echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
-  #     - name: Run ReferenceTests (shard)
-  #       if: steps.shard.outputs.args != ''
-  #       run: |
-  #         ./gradlew --no-daemon --parallel --info \
-  #           -x generateReferenceTestClasses \
-  #           -x processReferenceTestResources \
-  #           -x cleanReferenceTestClasses \
-  #           referenceTest ${{ inputs.gradle_args }} ${{ steps.shard.outputs.args }}
-  #     - name: Upload JUnit XML + HTML for ReferenceTests
-  #       if: always()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: reference-reports-${{ matrix.shard }}
-  #         path: |
-  #           **/build/test-results/**/TEST-*.xml
-  #           **/build/reports/tests/**
-  #         if-no-files-found: ignore
-  #         retention-days: 1
-
-  # referenceTestsReport:
-  #   runs-on: ubuntu-24.04
-  #   needs: referenceTests
-  #   if: always()
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - uses: ./.github/actions/collate-junit-reports
-  #       if: always()
-  #       with:
-  #         stage_key: reference
-
-  # # DockerTags
-  # # everything is a standard develop-jdk24/21; but you also add develop to develop-jdk21
-  # # develop = develop-jdk21
-  # # develop-jdk24
-  # # publishDockerJDK21:
-  # #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-  # #   needs: [assemble]
-  # #   uses: ./.github/workflows/publish-docker.yml
-  # #   with:
-  # #     assemble_run_id: ${{ github.run_id }}
-  # #     jdk_version: jdk21
-  # #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
-  # #   secrets: inherit
-  # #
-  # # publishDockerJDK24:
-  # #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-  # #   needs: [assemble]
-  # #   uses: ./.github/workflows/publish-docker.yml
-  # #   with:
-  # #     assemble_run_id: ${{ github.run_id }}
-  # #     jdk_version: jdk24
-  # #   secrets: inherit
-
-  # # Release Distribution
-  # # publishRelease:
-  # #   if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-  # #   needs: [assemble]
-  # #   uses: ./.github/workflows/publish-release.yml
-  # #   with:
-  # #     assemble_run_id: ${{ github.run_id }}
-  # #     publish_version: ${{ needs.assemble.outputs.publish-version }}
-  # #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
-  # #   secrets: inherit
+  # Release Distribution
+  # publishRelease:
+  #   if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+  #   needs: [assemble]
+  #   uses: ./.github/workflows/publish-release.yml
+  #   with:
+  #     assemble_run_id: ${{ github.run_id }}
+  #     publish_version: ${{ needs.assemble.outputs.publish-version }}
+  #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
+  #   secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
 
   spotless:
     runs-on: ubuntu-24.04
-    environment: dev
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -65,7 +64,6 @@ jobs:
 
   moduleChecks:
     runs-on: ubuntu-24.04
-    environment: dev
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -80,7 +78,6 @@ jobs:
   windowsBuild:
     needs: [spotless, moduleChecks ]
     runs-on: windows-2022
-    environment: dev
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -110,7 +107,6 @@ jobs:
 
   assemble:
     runs-on: ubuntu-24.04
-    environment: dev
     outputs:
       workflow-run-id: ${{ steps.workflowdetails.outputs.run_id }}
       publish-version: ${{ steps.projectDetails.outputs.publish-version }}
@@ -157,7 +153,6 @@ jobs:
   extractAPISpec:
     needs: assemble
     runs-on: ubuntu-24.04
-    environment: dev
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -206,7 +201,6 @@ jobs:
   #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
   #   needs: extractAPISpec
   #   runs-on: ubuntu-24.04
-  #   environment: dev
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v5
@@ -259,30 +253,29 @@ jobs:
         with:
           stage_key: unit
 
-  integrationTests:
-    needs: assemble
-    runs-on: ubuntu-latest-128
-    environment: dev
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          submodules: 'recursive'
-      - name: Prepare
-        uses: ./.github/actions/prepare
-      - name: Download assemble-output
-        uses: actions/download-artifact@v4
-        with:
-          name: assemble-output
-          path: ${{ github.workspace }}   
-      - name: Integration Tests
-        run: |
-          ./gradlew integrationTest
-      - name: Test results 
-        uses: ./.github/actions/collate-test-results
-        if: always()        
-        with:
-          stage_key: 'integration'
+  # integrationTests:
+  #   needs: assemble
+  #   runs-on: ubuntu-latest-128
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v5
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: Prepare
+  #       uses: ./.github/actions/prepare
+  #     - name: Download assemble-output
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: assemble-output
+  #         path: ${{ github.workspace }}   
+  #     - name: Integration Tests
+  #       run: |
+  #         ./gradlew integrationTest
+  #     - name: Test results 
+  #       uses: ./.github/actions/collate-test-results
+  #       if: always()        
+  #       with:
+  #         stage_key: 'integration'
 
   propertyTests:
     needs: assemble
@@ -297,16 +290,16 @@ jobs:
       src_root: "src/property-test/java"
       runner: "gha-runner-scale-set-ubuntu-22.04-amd64-xl"
 
-  propertyTestsReport:
-    runs-on: ubuntu-24.04
-    needs: propertyTests
-    if: always()
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/collate-junit-reports
-        if: always()        
-        with:
-          stage_key: property
+  # propertyTestsReport:
+  #   runs-on: ubuntu-24.04
+  #   needs: propertyTests
+  #   if: always()
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - uses: ./.github/actions/collate-junit-reports
+  #       if: always()        
+  #       with:
+  #         stage_key: property
 
   acceptanceTests:
     needs: assemble
@@ -321,202 +314,200 @@ jobs:
       src_root: "src/acceptance-test/java"
       runner: "ubuntu-latest-128"
 
-  acceptanceTestsReport:
-    runs-on: ubuntu-24.04
-    needs: acceptanceTests
-    if: always()
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/collate-junit-reports
-        if: always()        
-        with:
-          stage_key: acceptance
+  # acceptanceTestsReport:
+  #   runs-on: ubuntu-24.04
+  #   needs: acceptanceTests
+  #   if: always()
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - uses: ./.github/actions/collate-junit-reports
+  #       if: always()        
+  #       with:
+  #         stage_key: acceptance
 
-  referenceTestsPrep:
-    needs: assemble
-    runs-on: ubuntu-24.04
-    environment: dev
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          submodules: 'recursive'
-      - name: Prepare
-        uses: ./.github/actions/prepare
-      - name: Download assemble-output
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          name: assemble-output
-          merge-multiple: true
-          path: ${{ github.workspace }}          
-      - uses: actions/cache/restore@v4
-        with:
-          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}
-      - shell: bash
-        run: |
-          tree ./eth-reference-tests/            
-      - name: FetchReferenceTests
-        shell: bash
-        run: |
-          if [ ! -d "eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/tests" ]
-          then
-            ./gradlew --no-daemon expandRefTests
-          fi
-      - name: CompileReferenceTests
-        shell: bash
-        run: |
-          ./gradlew --no-daemon --parallel compileReferenceTestJava
-      - name: Caching reference tests 
-        uses: actions/cache/save@v4
-        with:
-          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}
-      - name: Upload reftests
-        uses: actions/upload-artifact@v4
-        with:
-          name: reftests
-          path: |
-            ./eth-reference-tests/
-          retention-days: 1
-          include-hidden-files: 'true'
+  # referenceTestsPrep:
+  #   needs: assemble
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v5
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: Prepare
+  #       uses: ./.github/actions/prepare
+  #     - name: Download assemble-output
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         github-token: ${{ github.token }}
+  #         repository: ${{ github.repository }}
+  #         run-id: ${{ github.run_id }}
+  #         name: assemble-output
+  #         merge-multiple: true
+  #         path: ${{ github.workspace }}          
+  #     - uses: actions/cache/restore@v4
+  #       with:
+  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+  #         key: reftests-${{ hashFiles('build.gradle') }}
+  #     - shell: bash
+  #       run: |
+  #         tree ./eth-reference-tests/            
+  #     - name: FetchReferenceTests
+  #       shell: bash
+  #       run: |
+  #         if [ ! -d "eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/tests" ]
+  #         then
+  #           ./gradlew --no-daemon expandRefTests
+  #         fi
+  #     - name: CompileReferenceTests
+  #       shell: bash
+  #       run: |
+  #         ./gradlew --no-daemon --parallel compileReferenceTestJava
+  #     - name: Caching reference tests 
+  #       uses: actions/cache/save@v4
+  #       with:
+  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+  #         key: reftests-${{ hashFiles('build.gradle') }}
+  #     - name: Upload reftests
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: reftests
+  #         path: |
+  #           ./eth-reference-tests/
+  #         retention-days: 1
+  #         include-hidden-files: 'true'
 
-  referenceTests:
-    needs: referenceTestsPrep
-    runs-on: "gha-runner-scale-set-ubuntu-22.04-amd64-xxl"
-    environment: dev
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]   # parallel shards
-        total: [32]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          submodules: 'recursive'
-      - name: Prepare
-        uses: ./.github/actions/prepare
-      - name: Download assemble-output
-        uses: actions/download-artifact@v5
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          name: assemble-output
-          merge-multiple: true
-          path: ${{ github.workspace }}
-      - uses: actions/cache/restore@v4
-        with:
-          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}          
-      - name: Download reftests
-        uses: actions/download-artifact@v5
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          name: reftests
-          merge-multiple: true 
-          path: ./eth-reference-tests
-      - name: Login to dockerhub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER_RO }}
-          password: ${{ secrets.DOCKER_PASSWORD_RO }}
-      - uses: actions/cache/restore@v4
-        with:
-          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}
-      - name: Compute shard ${{ matrix.shard }} of ${{ matrix.total }} for ReferenceTests
-        id: shard
-        shell: bash
-        run: |
-          SRC_PATTERN="*/src/referenceTest/generated_tests/*Test.java"
-          SRC_ROOT="src/referenceTest/generated_tests"
+  # referenceTests:
+  #   needs: referenceTestsPrep
+  #   runs-on: "gha-runner-scale-set-ubuntu-22.04-amd64-xxl"
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       shard: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]   # parallel shards
+  #       total: [32]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v5
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: Prepare
+  #       uses: ./.github/actions/prepare
+  #     - name: Download assemble-output
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         github-token: ${{ github.token }}
+  #         repository: ${{ github.repository }}
+  #         run-id: ${{ github.run_id }}
+  #         name: assemble-output
+  #         merge-multiple: true
+  #         path: ${{ github.workspace }}
+  #     - uses: actions/cache/restore@v4
+  #       with:
+  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+  #         key: reftests-${{ hashFiles('build.gradle') }}          
+  #     - name: Download reftests
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         github-token: ${{ github.token }}
+  #         repository: ${{ github.repository }}
+  #         run-id: ${{ github.run_id }}
+  #         name: reftests
+  #         merge-multiple: true 
+  #         path: ./eth-reference-tests
+  #     - name: Login to dockerhub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USER_RO }}
+  #         password: ${{ secrets.DOCKER_PASSWORD_RO }}
+  #     - uses: actions/cache/restore@v4
+  #       with:
+  #         path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+  #         key: reftests-${{ hashFiles('build.gradle') }}
+  #     - name: Compute shard ${{ matrix.shard }} of ${{ matrix.total }} for ReferenceTests
+  #       id: shard
+  #       shell: bash
+  #       run: |
+  #         SRC_PATTERN="*/src/referenceTest/generated_tests/*Test.java"
+  #         SRC_ROOT="src/referenceTest/generated_tests"
 
-          # 1) Collect test classes by pattern = FQNs
-          CLASSNAMES=$(find . -type f -name "*.java" -path "$SRC_PATTERN" \
-            | sed "s@.*/$SRC_ROOT/@@" \
-            | sed 's@/@.@g' \
-            | sed 's/.\{5\}$//')
+  #         # 1) Collect test classes by pattern = FQNs
+  #         CLASSNAMES=$(find . -type f -name "*.java" -path "$SRC_PATTERN" \
+  #           | sed "s@.*/$SRC_ROOT/@@" \
+  #           | sed 's@/@.@g' \
+  #           | sed 's/.\{5\}$//')
 
-          # 2) Modulo split
-          CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
-            | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
+  #         # 2) Modulo split
+  #         CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
+  #           | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
 
-          if [ -z "$CLASSES_FOR_SHARD" ]; then
-            echo "args=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+  #         if [ -z "$CLASSES_FOR_SHARD" ]; then
+  #           echo "args=" >> "$GITHUB_OUTPUT"
+  #           exit 0
+  #         fi
 
-          # 3) Build --tests args
-          GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
-          echo "Prepared arguments for Gradle (ReferenceTests): $GRADLE_ARGS"
-          echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
-      - name: Run ReferenceTests (shard)
-        if: steps.shard.outputs.args != ''
-        run: |
-          ./gradlew --no-daemon --parallel --info \
-            -x generateReferenceTestClasses \
-            -x processReferenceTestResources \
-            -x cleanReferenceTestClasses \
-            referenceTest ${{ inputs.gradle_args }} ${{ steps.shard.outputs.args }}
-      - name: Upload JUnit XML + HTML for ReferenceTests
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: reference-reports-${{ matrix.shard }}
-          path: |
-            **/build/test-results/**/TEST-*.xml
-            **/build/reports/tests/**
-          if-no-files-found: ignore
-          retention-days: 1
+  #         # 3) Build --tests args
+  #         GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
+  #         echo "Prepared arguments for Gradle (ReferenceTests): $GRADLE_ARGS"
+  #         echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
+  #     - name: Run ReferenceTests (shard)
+  #       if: steps.shard.outputs.args != ''
+  #       run: |
+  #         ./gradlew --no-daemon --parallel --info \
+  #           -x generateReferenceTestClasses \
+  #           -x processReferenceTestResources \
+  #           -x cleanReferenceTestClasses \
+  #           referenceTest ${{ inputs.gradle_args }} ${{ steps.shard.outputs.args }}
+  #     - name: Upload JUnit XML + HTML for ReferenceTests
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: reference-reports-${{ matrix.shard }}
+  #         path: |
+  #           **/build/test-results/**/TEST-*.xml
+  #           **/build/reports/tests/**
+  #         if-no-files-found: ignore
+  #         retention-days: 1
 
-  referenceTestsReport:
-    runs-on: ubuntu-24.04
-    needs: referenceTests
-    if: always()
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/collate-junit-reports
-        if: always()
-        with:
-          stage_key: reference
+  # referenceTestsReport:
+  #   runs-on: ubuntu-24.04
+  #   needs: referenceTests
+  #   if: always()
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - uses: ./.github/actions/collate-junit-reports
+  #       if: always()
+  #       with:
+  #         stage_key: reference
 
-  # DockerTags
-  # everything is a standard develop-jdk24/21; but you also add develop to develop-jdk21
-  # develop = develop-jdk21
-  # develop-jdk24
-  # publishDockerJDK21:
-  #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-  #   needs: [assemble]
-  #   uses: ./.github/workflows/publish-docker.yml
-  #   with:
-  #     assemble_run_id: ${{ github.run_id }}
-  #     jdk_version: jdk21
-  #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
-  #   secrets: inherit
-  #
-  # publishDockerJDK24:
-  #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-  #   needs: [assemble]
-  #   uses: ./.github/workflows/publish-docker.yml
-  #   with:
-  #     assemble_run_id: ${{ github.run_id }}
-  #     jdk_version: jdk24
-  #   secrets: inherit
+  # # DockerTags
+  # # everything is a standard develop-jdk24/21; but you also add develop to develop-jdk21
+  # # develop = develop-jdk21
+  # # develop-jdk24
+  # # publishDockerJDK21:
+  # #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+  # #   needs: [assemble]
+  # #   uses: ./.github/workflows/publish-docker.yml
+  # #   with:
+  # #     assemble_run_id: ${{ github.run_id }}
+  # #     jdk_version: jdk21
+  # #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
+  # #   secrets: inherit
+  # #
+  # # publishDockerJDK24:
+  # #   #if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+  # #   needs: [assemble]
+  # #   uses: ./.github/workflows/publish-docker.yml
+  # #   with:
+  # #     assemble_run_id: ${{ github.run_id }}
+  # #     jdk_version: jdk24
+  # #   secrets: inherit
 
-  # Release Distribution
-  # publishRelease:
-  #   if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-  #   needs: [assemble]
-  #   uses: ./.github/workflows/publish-release.yml
-  #   with:
-  #     assemble_run_id: ${{ github.run_id }}
-  #     publish_version: ${{ needs.assemble.outputs.publish-version }}
-  #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
-  #   secrets: inherit
+  # # Release Distribution
+  # # publishRelease:
+  # #   if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+  # #   needs: [assemble]
+  # #   uses: ./.github/workflows/publish-release.yml
+  # #   with:
+  # #     assemble_run_id: ${{ github.run_id }}
+  # #     publish_version: ${{ needs.assemble.outputs.publish-version }}
+  # #     include_hash_in_docker: ${{ github.event_name == 'workflow_dispatch' && inputs.include_hash_in_docker || 'false' }}
+  # #   secrets: inherit

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -87,50 +87,43 @@ jobs:
             | sed 's@/@.@g' \
             | sed 's/.\{5\}$//' \
             | sort )
-
-          # # 2) Modulo split
-          # CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
-          #   | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
-
-          # if [ -z "$CLASSES_FOR_SHARD" ]; then
-          #   echo "args=" >> "$GITHUB_OUTPUT"
-          #   exit 0
-          # fi
-
-          # # 3) Build --tests args
-          # GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
-          # echo "Prepared arguments for Gradle (${{ inputs.stage_name }}): $GRADLE_ARGS"
-          # echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
-
-          TOTAL=$(echo "$CLASSNAMES" | wc -l)
-          PER_SHARD=$(( (TOTAL + TOTAL_SHARDS - 1) / TOTAL_SHARDS ))
-          START=$(( SHARD_INDEX * PER_SHARD + 1 ))
-          END=$(( START + PER_SHARD - 1 ))
-
-          echo "Total test classes: $TOTAL"
-          echo "Classes per shard: $PER_SHARD"
-          echo "Running lines $START to $END"
-
-          CLASSES_FOR_SHARD=$(echo "$CLASSNAMES" | sed -n "${START},${END}p")
-
+          # 2) Modulo split i.e (NR-1) % shards == shard
+          CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
+            | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
           if [ -z "$CLASSES_FOR_SHARD" ]; then
-            echo "⚠️ No classes for this shard."
+            echo "args=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # 3) Build --tests args
+          GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
+          echo "Prepared arguments for Gradle (${{ inputs.stage_name }}): $GRADLE_ARGS"
+          echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
 
-          echo "Running acceptance tests for classes:"
-          echo "$CLASSES_FOR_SHARD"
+          # 2) Contiguous Range Split
+          # TOTAL=$(echo "$CLASSNAMES" | wc -l)
+          # PER_SHARD=$(( (TOTAL + TOTAL_SHARDS - 1) / TOTAL_SHARDS ))
+          # START=$(( SHARD_INDEX * PER_SHARD + 1 ))
+          # END=$(( START + PER_SHARD - 1 ))
+          # echo "Total test classes: $TOTAL"
+          # echo "Classes per shard: $PER_SHARD"
+          # echo "Running lines $START to $END"
+          # CLASSES_FOR_SHARD=$(echo "$CLASSNAMES" | sed -n "${START},${END}p")
+          # if [ -z "$CLASSES_FOR_SHARD" ]; then
+          #   echo "⚠️ No classes for this shard."
+          #   exit 0
+          # fi
+          # echo "Running acceptance tests for classes:"
+          # echo "$CLASSES_FOR_SHARD"
+          # # Format Gradle arguments like CircleCI’s `GRADLE_ARGS`
+          # GRADLE_ARGS=$(echo "$CLASSES_FOR_SHARD" | awk '{print "--tests",$1}')
+          # echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
+          # # Run Gradle acceptance tests for this shard
+          # # ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} $GRADLE_ARGS
 
-          # 2. Format Gradle arguments like CircleCI’s `GRADLE_ARGS`
-          GRADLE_ARGS=$(echo "$CLASSES_FOR_SHARD" | awk '{print "--tests",$1}')
-
-          # 3. Run Gradle acceptance tests for this shard
-          ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} $GRADLE_ARGS
-
-      # - name: Run ${{ inputs.stage_name }} (shard)
-      #   if: steps.shard.outputs.args != ''
-      #   run: |
-      #     ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} ${{ steps.shard.outputs.args }}
+      - name: Run ${{ inputs.stage_name }} (shard)
+        if: steps.shard.outputs.args != ''
+        run: |
+          ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} ${{ steps.shard.outputs.args }}
 
       - name: Upload JUnit XML + HTML for ${{ inputs.stage_name }}
         if: always()

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -35,12 +35,11 @@ permissions:
 jobs:
   matrix-tests-template:
     runs-on: ${{ inputs.runner }}
-    environment: dev
     strategy:
       fail-fast: false
       matrix:
-        shard: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]   # parallel shards
-        total: [32]
+        shard: [0,1,2,3,4,5,6,7]   # parallel shards
+        total: [8]
 
     steps:
       - name: Checkout
@@ -66,14 +65,16 @@ jobs:
       - name: Login to dockerhub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER_RW }}
-          password: ${{ secrets.DOCKER_PASSWORD_RW }}
+          username: ${{ secrets.DOCKER_USER_RO }}
+          password: ${{ secrets.DOCKER_PASSWORD_RO }}
 
-      # TODO: remove this step
-      - shell: bash
-        run: |
-          sudo apt-get update && sudo apt-get install -y tree
-          tree .          
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
       - name: Compute shard ${{ matrix.shard }} of ${{ matrix.total }} for ${{ inputs.stage_name }}
         id: shard
@@ -84,26 +85,52 @@ jobs:
           CLASSNAMES=$(find . -type f -name "*.java" -path "$SRC_PATTERN" \
             | sed "s@.*/${{ inputs.src_root }}/@@" \
             | sed 's@/@.@g' \
-            | sed 's/.\{5\}$//')
+            | sed 's/.\{5\}$//' \
+            | sort )
 
-          # 2) Modulo split
-          CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
-            | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
+          # # 2) Modulo split
+          # CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
+          #   | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')
+
+          # if [ -z "$CLASSES_FOR_SHARD" ]; then
+          #   echo "args=" >> "$GITHUB_OUTPUT"
+          #   exit 0
+          # fi
+
+          # # 3) Build --tests args
+          # GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
+          # echo "Prepared arguments for Gradle (${{ inputs.stage_name }}): $GRADLE_ARGS"
+          # echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
+
+          TOTAL=$(echo "$CLASSNAMES" | wc -l)
+          PER_SHARD=$(( (TOTAL + TOTAL_SHARDS - 1) / TOTAL_SHARDS ))
+          START=$(( SHARD_INDEX * PER_SHARD + 1 ))
+          END=$(( START + PER_SHARD - 1 ))
+
+          echo "Total test classes: $TOTAL"
+          echo "Classes per shard: $PER_SHARD"
+          echo "Running lines $START to $END"
+
+          CLASSES_FOR_SHARD=$(echo "$CLASSNAMES" | sed -n "${START},${END}p")
 
           if [ -z "$CLASSES_FOR_SHARD" ]; then
-            echo "args=" >> "$GITHUB_OUTPUT"
+            echo "⚠️ No classes for this shard."
             exit 0
           fi
 
-          # 3) Build --tests args
-          GRADLE_ARGS=$(printf "%s\n" "$CLASSES_FOR_SHARD" | awk '{printf "--tests %s ", $0}')
-          echo "Prepared arguments for Gradle (${{ inputs.stage_name }}): $GRADLE_ARGS"
-          echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
+          echo "Running acceptance tests for classes:"
+          echo "$CLASSES_FOR_SHARD"
 
-      - name: Run ${{ inputs.stage_name }} (shard)
-        if: steps.shard.outputs.args != ''
-        run: |
-          ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} ${{ steps.shard.outputs.args }}
+          # 2. Format Gradle arguments like CircleCI’s `GRADLE_ARGS`
+          GRADLE_ARGS=$(echo "$CLASSES_FOR_SHARD" | awk '{print "--tests",$1}')
+
+          # 3. Run Gradle acceptance tests for this shard
+          ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} $GRADLE_ARGS
+
+      # - name: Run ${{ inputs.stage_name }} (shard)
+      #   if: steps.shard.outputs.args != ''
+      #   run: |
+      #     ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} ${{ steps.shard.outputs.args }}
 
       - name: Upload JUnit XML + HTML for ${{ inputs.stage_name }}
         if: always()
@@ -115,4 +142,4 @@ jobs:
             **/build/reports/tests/**
           if-no-files-found: ignore
           retention-days: 1
-          
+      

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -99,27 +99,6 @@ jobs:
           echo "Prepared arguments for Gradle (${{ inputs.stage_name }}): $GRADLE_ARGS"
           echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
 
-          # 2) Contiguous Range Split
-          # TOTAL=$(echo "$CLASSNAMES" | wc -l)
-          # PER_SHARD=$(( (TOTAL + TOTAL_SHARDS - 1) / TOTAL_SHARDS ))
-          # START=$(( SHARD_INDEX * PER_SHARD + 1 ))
-          # END=$(( START + PER_SHARD - 1 ))
-          # echo "Total test classes: $TOTAL"
-          # echo "Classes per shard: $PER_SHARD"
-          # echo "Running lines $START to $END"
-          # CLASSES_FOR_SHARD=$(echo "$CLASSNAMES" | sed -n "${START},${END}p")
-          # if [ -z "$CLASSES_FOR_SHARD" ]; then
-          #   echo "⚠️ No classes for this shard."
-          #   exit 0
-          # fi
-          # echo "Running acceptance tests for classes:"
-          # echo "$CLASSES_FOR_SHARD"
-          # # Format Gradle arguments like CircleCI’s `GRADLE_ARGS`
-          # GRADLE_ARGS=$(echo "$CLASSES_FOR_SHARD" | awk '{print "--tests",$1}')
-          # echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
-          # # Run Gradle acceptance tests for this shard
-          # # ./gradlew --no-daemon --parallel --info ${{ inputs.gradle_task }} $GRADLE_ARGS
-
       - name: Run ${{ inputs.stage_name }} (shard)
         if: steps.shard.outputs.args != ''
         run: |


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
GHA updated workflows - to remove the noise in the main PR view


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cuts test matrix shards from 32 to 8, adds Gradle caching, switches Docker creds to read-only, and removes extraneous env/settings and debug steps.
> 
> - **GitHub Actions**:
>   - **Matrix Tests Template (`.github/workflows/matrix-tests-template.yml`)**:
>     - Reduce shards from `32` to `8` (`matrix.shard`/`total`).
>     - Add Gradle cache step for `~/.gradle` caches and wrapper.
>     - Switch DockerHub login to read-only secrets (`DOCKER_USER_RO`/`DOCKER_PASSWORD_RO`).
>     - Remove temporary debug step installing `tree`.
>     - Stabilize sharding by sorting collected class names and clarifying modulo-split comment.
>   - **CI Workflow (`.github/workflows/ci.yml`)**:
>     - Reference tests: reduce shards from `32` to `8`.
>     - Remove `environment: dev` settings from multiple jobs.
>     - Minor cleanup in reference test sharding script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70df6e6c18ed6dc00793f19671f09d291f6f5359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->