### PR TITLE
Revert override `validateStateCanCalculateProposerIndexAtSlot` for Fulu

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -226,6 +226,19 @@ public abstract class BeaconStateAccessors {
             });
   }
 
+  protected void validateStateCanCalculateProposerIndexAtSlot(
+      final BeaconState state, final UInt64 requestedSlot) {
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);
+    final UInt64 stateEpoch = getCurrentEpoch(state);
+    checkArgument(
+        epoch.equals(stateEpoch),
+        "get_beacon_proposer_index is only used for requesting a slot in the current epoch. Requested slot %s (in epoch %s), state slot %s (in epoch %s)",
+        requestedSlot,
+        epoch,
+        state.getSlot(),
+        stateEpoch);
+  }
+
   public UInt64 getFinalityDelay(final BeaconState state) {
     return getPreviousEpoch(state).minus(state.getFinalizedCheckpoint().getEpoch());
   }
@@ -236,19 +249,6 @@ public abstract class BeaconStateAccessors {
 
   public boolean isInactivityLeak(final BeaconState state) {
     return isInactivityLeak(getFinalityDelay(state));
-  }
-
-  protected void validateStateCanCalculateProposerIndexAtSlot(
-      final BeaconState state, final UInt64 requestedSlot) {
-    final UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);
-    final UInt64 stateEpoch = getCurrentEpoch(state);
-    checkArgument(
-        epoch.equals(stateEpoch),
-        "Cannot calculate proposer index for a slot outside the current epoch. Requested slot %s (in epoch %s), state slot %s (in epoch %s)",
-        requestedSlot,
-        epoch,
-        state.getSlot(),
-        stateEpoch);
   }
 
   public Bytes32 getBlockRootAtSlot(final BeaconState state, final UInt64 slot)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
@@ -38,20 +38,6 @@ public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
   }
 
   @Override
-  protected void validateStateCanCalculateProposerIndexAtSlot(
-      final BeaconState state, final UInt64 requestedSlot) {
-    final UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);
-    final UInt64 stateEpoch = getCurrentEpoch(state);
-    checkArgument(
-        epoch.equals(stateEpoch) || stateEpoch.increment().equals(epoch),
-        "Cannot compute proposer index, as the state supplied is out of range of the requested slot. Requested slot %s (in epoch %s), state slot %s (in epoch %s)",
-        requestedSlot,
-        epoch,
-        state.getSlot(),
-        stateEpoch);
-  }
-
-  @Override
   public int getBeaconProposerIndex(final BeaconState state, final UInt64 requestedSlot) {
     validateStateCanCalculateProposerIndexAtSlot(state, requestedSlot);
     final int lookaheadIndex = requestedSlot.mod(config.getSlotsPerEpoch()).intValue();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Revert #10000 since the previous validation still applies to the Fulu implementation

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts Fulu’s relaxed proposer-index validation to only allow the current epoch, updates error message, and adjusts tests accordingly.
> 
> - **Spec helpers**:
>   - **Validation**: Remove Fulu override of `validateStateCanCalculateProposerIndexAtSlot`; `getBeaconProposerIndex` now validates slots are in the current epoch only via base `BeaconStateAccessors`.
>   - **Error message**: Update validation message to reference `get_beacon_proposer_index` usage for current-epoch requests.
> - **Tests (Fulu)**:
>   - Rename and update tests: drop next-epoch success case; add parameterized assertions that non-current-epoch slots throw with the new message; minor cleanup in genesis test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e99fbd04900225cee6999d63ba45fb356971635f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->