### PR TITLE
Fork choice compliance test integration

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -109,12 +109,12 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor("basic_is_parent_root"))
           .put("fork_choice/deposit_with_reorg", new ForkChoiceTestExecutor())
           // Fork choice generated test types
-          .put("fork_choice_generated/block_weight_test", new ForkChoiceTestExecutor())
-          .put("fork_choice_generated/block_tree_test", new ForkChoiceTestExecutor())
-          .put("fork_choice_generated/attester_slashing_test", new ForkChoiceTestExecutor())
-          .put("fork_choice_generated/invalid_message_test", new ForkChoiceTestExecutor())
-          .put("fork_choice_generated/block_cover_test", new ForkChoiceTestExecutor())
-          .put("fork_choice_generated/shuffling_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_compliance/block_weight_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_compliance/block_tree_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_compliance/attester_slashing_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_compliance/invalid_message_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_compliance/block_cover_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_compliance/shuffling_test", new ForkChoiceTestExecutor())
           .build();
 
   private final List<?> testsToSkip;

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -17,9 +17,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
+import static tech.pegasys.teku.reference.BlsSetting.IGNORED;
+import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +45,7 @@ import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGProof;
+import tech.pegasys.teku.reference.BlsSetting;
 import tech.pegasys.teku.reference.KzgRetriever;
 import tech.pegasys.teku.reference.TestDataUtils;
 import tech.pegasys.teku.reference.TestExecutor;
@@ -53,12 +59,15 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
@@ -99,6 +108,13 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/should_override_forkchoice_update", new ForkChoiceTestExecutor())
           .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor("basic_is_parent_root"))
           .put("fork_choice/deposit_with_reorg", new ForkChoiceTestExecutor())
+          // Fork choice generated test types
+          .put("fork_choice_generated/block_weight_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_generated/block_tree_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_generated/attester_slashing_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_generated/invalid_message_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_generated/block_cover_test", new ForkChoiceTestExecutor())
+          .put("fork_choice_generated/shuffling_test", new ForkChoiceTestExecutor())
           .build();
 
   private final List<?> testsToSkip;
@@ -114,9 +130,10 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           "Test " + testDefinition.getDisplayName() + " has been ignored");
     }
 
-    // Note: The fork choice spec says there may be settings in a meta.yaml file but currently no
-    // tests actually have one, so we currently don't bother trying to load it.
-    final Spec spec = testDefinition.getSpec();
+    // Load `meta.yaml` and read the BLS setting
+    final ForkChoiceMetaData metaData = getMetaData(testDefinition);
+    final boolean blsDisabled = metaData.getBlsSetting() == IGNORED;
+    final Spec spec = testDefinition.getSpec(!blsDisabled);
     final BeaconState anchorState =
         TestDataUtils.loadStateFromSsz(testDefinition, "anchor_state" + SSZ_SNAPPY_EXTENSION);
     final SignedBeaconBlock anchorBlock = loadAnchorBlock(testDefinition);
@@ -307,14 +324,20 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final ForkChoice forkChoice,
       final Map<String, Object> step) {
     final String attestationName = get(step, "attestation");
+    final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
     final Attestation attestation =
         TestDataUtils.loadSsz(
             testDefinition,
             attestationName + SSZ_SNAPPY_EXTENSION,
             testDefinition.getSpec().getGenesisSchemaDefinitions().getAttestationSchema());
     final Spec spec = testDefinition.getSpec();
-    assertThat(forkChoice.onAttestation(ValidatableAttestation.from(spec, attestation)))
-        .isCompleted();
+    final SafeFuture<AttestationProcessingResult> result =
+        forkChoice.onAttestation(ValidatableAttestation.from(spec, attestation));
+    assertThat(result).isCompleted();
+    AttestationProcessingResult processingResult = safeJoin(result);
+    assertThat(processingResult.isSuccessful())
+        .withFailMessage(processingResult.getInvalidReason())
+        .isEqualTo(valid);
   }
 
   private void applyAttesterSlashing(
@@ -537,6 +560,32 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             assertThat(expectedValidatorIsConnected).isTrue();
           }
 
+          case "viable_for_head_roots_and_weights" -> {
+            final List<Map<String, Object>> viableHeadRootsAndWeightsData = get(checks, checkType);
+            final Map<Bytes32, UInt64> viableHeadRootsAndWeights =
+                viableHeadRootsAndWeightsData.stream()
+                    .collect(
+                        Collectors.toMap(
+                            entry -> Bytes32.fromHexString((String) entry.get("root")),
+                            entry -> UInt64.valueOf(entry.get("weight").toString())));
+            final Map<Bytes32, UInt64> chainHeadRootsAndWeights =
+                recentChainData
+                    .getForkChoiceStrategy()
+                    .map(ReadOnlyForkChoiceStrategy::getChainHeads)
+                    .orElse(Collections.emptyList())
+                    .stream()
+                    .collect(Collectors.toMap(ProtoNodeData::getRoot, ProtoNodeData::getWeight));
+
+            assertThat(chainHeadRootsAndWeights.keySet())
+                .containsAll(viableHeadRootsAndWeights.keySet());
+
+            for (Bytes32 root : viableHeadRootsAndWeights.keySet()) {
+              UInt64 weight = viableHeadRootsAndWeights.get(root);
+              UInt64 actualWeight = chainHeadRootsAndWeights.get(root);
+              assertThat(actualWeight).describedAs("block %s's weight", root).isEqualTo(weight);
+            }
+          }
+
           default ->
               throw new UnsupportedOperationException("Unsupported check type: " + checkType);
         }
@@ -587,5 +636,35 @@ public class ForkChoiceTestExecutor implements TestExecutor {
   private static Optional<Bytes32> getOptionallyBytes32(
       final Map<String, Object> yamlData, final String key) {
     return ForkChoiceTestExecutor.<String>getOptionally(yamlData, key).map(Bytes32::fromHexString);
+  }
+
+  private static ForkChoiceMetaData getMetaData(final TestDefinition testDefinition)
+      throws IOException {
+    final ForkChoiceMetaData metaData;
+    final Path metaPath = testDefinition.getTestDirectory().resolve("meta.yaml");
+    if (metaPath.toFile().exists()) {
+      metaData = loadYaml(testDefinition, "meta.yaml", ForkChoiceMetaData.class);
+    } else {
+      metaData = ForkChoiceMetaData.DEFAULT;
+    }
+
+    return metaData;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class ForkChoiceMetaData {
+    static final ForkChoiceMetaData DEFAULT = new ForkChoiceMetaData(0);
+
+    private ForkChoiceMetaData(
+        @JsonProperty(value = "bls_setting", required = false, defaultValue = "0")
+            final int blsSetting) {
+      this.blsSetting = blsSetting;
+    }
+
+    private final int blsSetting;
+
+    public BlsSetting getBlsSetting() {
+      return BlsSetting.forCode(blsSetting);
+    }
   }
 }


### PR DESCRIPTION
## PR Description

This PR integrates non-production code changes needed to run fork choice compliance tests.

@lucassaldanha 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds fork choice compliance test types, reads `meta.yaml` to control BLS, validates attestations against `valid` flag, and checks viable head roots/weights.
> 
> - **Fork choice reference tests**:
>   - **Test types**: Add `fork_choice_compliance/*` suites (`block_weight_test`, `block_tree_test`, `attester_slashing_test`, `invalid_message_test`, `block_cover_test`, `shuffling_test`).
>   - **Meta config**: Load `meta.yaml` (`bls_setting`) via `ForkChoiceMetaData`; pass `getSpec(!blsDisabled)` to toggle BLS.
>   - **Attestation handling**: Evaluate `onAttestation` result and assert success based on `valid` flag using `AttestationProcessingResult`.
>   - **New checks**: Support `viable_for_head_roots_and_weights` to assert chain head roots and weights via `ReadOnlyForkChoiceStrategy`/`ProtoNodeData`.
>   - **Helpers**: Add YAML loader and `ForkChoiceMetaData` class for parsing `bls_setting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4599bb74cfafea80206782ba072a4b47c9dcedf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->