### PR TITLE
Make column sidecars db logging lighter when debug is disabled

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -91,6 +91,10 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
     private long maxAddedSlot = 0;
 
     private void logOnNewSidecar(final DataColumnSidecar sidecar) {
+      if (!LOG.isDebugEnabled()) {
+        return;
+      }
+
       final int currentAddCounter = addCounter.incrementAndGet();
       final int slot = sidecar.getSlot().intValue();
       final long prevMaxAddedSlot;
@@ -127,6 +131,10 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
 
     private SafeFuture<Void> logNewFirstCustodyIncompleteSlot(
         final Optional<UInt64> maybeCurrentSlot, final UInt64 newSlot) {
+      if (!LOG.isDebugEnabled()) {
+        return SafeFuture.COMPLETE;
+      }
+
       if (maybeCurrentSlot.isEmpty() || !maybeCurrentSlot.get().equals(newSlot)) {
         return getColumnIdentifiers(newSlot)
             .thenCompose(
@@ -156,6 +164,10 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
 
     private void logNewFirstSamplerIncompleteSlot(
         final Optional<UInt64> maybeCurrentSlot, final UInt64 newSlot) {
+      if (!LOG.isDebugEnabled()) {
+        return;
+      }
+
       if (maybeCurrentSlot.isEmpty() || !maybeCurrentSlot.get().equals(newSlot)) {
         LOG.debug(
             "DataColumnSidecarDB: setFirstSamplerIncompleteSlot {} ~> {}",


### PR DESCRIPTION


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids unnecessary work by early-returning in DetailLogger methods when debug logging is off.
> 
> - **Statetransition backend**:
>   - `DataColumnSidecarDBImpl.DetailLogger`:
>     - Add `LOG.isDebugEnabled()` guards with early returns in `logOnNewSidecar`, `logNewFirstCustodyIncompleteSlot` (returns `SafeFuture.COMPLETE`), and `logNewFirstSamplerIncompleteSlot`.
>     - Reduces overhead by skipping computations and async work when debug logging is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1418429cb39b7868c8f25a9d3abf58ab13d6945a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->