### PR TITLE
Small fixes pre-release

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -64,7 +64,7 @@ dependencyManagement {
       entry 'oshi-core-java11'
     }
 
-    dependencySet(group: 'io.netty', version: '4.2.5.Final') {
+    dependencySet(group: 'io.netty', version: '4.2.7.Final') {
       entry 'netty-handler'
       entry 'netty-codec-http'
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.eth2.peers;
 
 import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
@@ -65,7 +64,7 @@ public class Eth2PeerFactory {
     this.peerRequestLimit = peerRequestLimit;
     this.discoveryNodeIdExtractor = discoveryNodeIdExtractor;
     this.dataColumnSidecarSignatureValidator =
-        new DataColumnSidecarSignatureValidator(spec, chainDataClient, BLSSignatureVerifier.SIMPLE);
+        new DataColumnSidecarSignatureValidator(spec, chainDataClient);
   }
 
   public Eth2Peer create(final Peer peer, final BeaconChainMethods rpcMethods) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/DataColumnSidecarSignatureValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/DataColumnSidecarSignatureValidatorTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.peers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.ForkSchedule;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
@@ -44,6 +46,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class DataColumnSidecarSignatureValidatorTest {
   private final Spec spec = Mockito.mock(Spec.class);
+  private final SpecConfig specConfig = mock(SpecConfig.class);
   private final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createMinimalFulu());
 
@@ -68,7 +71,7 @@ public class DataColumnSidecarSignatureValidatorTest {
           .build();
 
   private final DataColumnSidecarSignatureValidator validator =
-      new DataColumnSidecarSignatureValidator(spec, chainDataClient, signatureVerifier);
+      new DataColumnSidecarSignatureValidator(spec, chainDataClient);
 
   @BeforeEach
   void setUp() {
@@ -87,6 +90,8 @@ public class DataColumnSidecarSignatureValidatorTest {
     when(spec.computeSigningRoot(signedBeaconBlockHeader.getMessage(), domain))
         .thenReturn(signingRoot);
 
+    when(spec.getSpecConfig(any())).thenReturn(specConfig);
+    when(specConfig.getBLSSignatureVerifier()).thenReturn(signatureVerifier);
     // valid by default
     when(signatureVerifier.verify(
             proposerPubKey, signingRoot, signedBeaconBlockHeader.getSignature()))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Route data column sidecar signature checks through epoch-specific `Spec` config and update Netty to `4.2.7.Final`.
> 
> - **Networking/eth2**:
>   - `DataColumnSidecarSignatureValidator`:
>     - Remove explicit `BLSSignatureVerifier` dependency/constructor param; fetch via `spec.getSpecConfig(epoch).getBLSSignatureVerifier()`.
>   - `Eth2PeerFactory`:
>     - Update instantiation to use new `DataColumnSidecarSignatureValidator(spec, chainDataClient)`.
>   - Tests (`DataColumnSidecarSignatureValidatorTest`):
>     - Mock `SpecConfig` and verifier retrieval; adjust setup and constructor usage; add argument matcher.
> - **Build**:
>   - Bump `io.netty` from `4.2.5.Final` to `4.2.7.Final`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e860fd1917837e0578124e93f444ec44e848df5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->