### PR TITLE
Update ref tests to v1.6.0-beta.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,10 +331,10 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.6.0-beta.0"
+def refTestVersion = nightly ? "nightly" : "v1.6.0-beta.1"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
-def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'
+def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'
 def slashingProtectionInterchangeRefTestBaseUrl = 'https://github.com/eth-clients/slashing-protection-interchange-tests/archive/refs/tags'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -23,10 +23,8 @@ import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DEN
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
-import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -181,12 +179,6 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       final TestDefinition testDefinition,
       final BeaconState preState)
       throws Exception {
-    // TODO-GLOAS: https://github.com/ethereum/consensus-specs/issues/4545
-    if (testDefinition.getFork().equals(TestFork.GLOAS)
-        && operation.equals(Operation.EXECUTION_PAYLOAD)
-        && !Files.exists(testDefinition.getTestDirectory().resolve("signed_envelope.ssz_snappy"))) {
-      return;
-    }
     final boolean isOperationValid =
         testDefinition.getTestDirectory().resolve(EXPECTED_STATE_FILE).toFile().exists();
     if (isOperationValid) {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -23,8 +23,10 @@ import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DEN
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
+import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -179,6 +181,12 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       final TestDefinition testDefinition,
       final BeaconState preState)
       throws Exception {
+    // TODO-GLOAS: https://github.com/ethereum/consensus-specs/issues/4545
+    if (testDefinition.getFork().equals(TestFork.GLOAS)
+        && operation.equals(Operation.EXECUTION_PAYLOAD)
+        && !Files.exists(testDefinition.getTestDirectory().resolve("signed_envelope.ssz_snappy"))) {
+      return;
+    }
     final boolean isOperationValid =
         testDefinition.getTestDirectory().resolve(EXPECTED_STATE_FILE).toFile().exists();
     if (isOperationValid) {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
@@ -29,6 +29,7 @@ public class SszGenericTests {
           .put("ssz_generic/containers", new SszGenericContainerTestExecutor())
           .put("ssz_generic/progressive_bitlist", TestExecutor.IGNORE_TESTS)
           .put("ssz_generic/progressive_containers", TestExecutor.IGNORE_TESTS)
+          .put("ssz_generic/compatible_unions", TestExecutor.IGNORE_TESTS)
           .put("ssz_generic/uints", new SszGenericUIntTestExecutor())
           .build();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/DataColumnSidecarBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/DataColumnSidecarBuilder.java
@@ -36,9 +36,9 @@ public interface DataColumnSidecarBuilder {
 
   DataColumnSidecarBuilder kzgCommitmentsInclusionProof(List<Bytes32> kzgCommitmentsInclusionProof);
 
-  DataColumnSidecarBuilder beaconBlockRoot(Bytes32 beaconBlockRoot);
-
   DataColumnSidecarBuilder slot(UInt64 slot);
+
+  DataColumnSidecarBuilder beaconBlockRoot(Bytes32 beaconBlockRoot);
 
   DataColumnSidecar build();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/DataColumnSidecarSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/DataColumnSidecarSchema.java
@@ -30,6 +30,7 @@ public interface DataColumnSidecarSchema<T extends DataColumnSidecar>
   SszFieldName FIELD_KZG_PROOFS = () -> "kzg_proofs";
   SszFieldName FIELD_SIGNED_BLOCK_HEADER = () -> "signed_block_header";
   SszFieldName FIELD_KZG_COMMITMENTS_INCLUSION_PROOF = () -> "kzg_commitments_inclusion_proof";
+  SszFieldName FIELD_SLOT = () -> "slot";
   SszFieldName FIELD_BEACON_BLOCK_ROOT = () -> "beacon_block_root";
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarBuilderFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarBuilderFulu.java
@@ -80,13 +80,13 @@ public class DataColumnSidecarBuilderFulu implements DataColumnSidecarBuilder {
   }
 
   @Override
-  public DataColumnSidecarBuilder beaconBlockRoot(final Bytes32 beaconBlockRoot) {
+  public DataColumnSidecarBuilder slot(final UInt64 slot) {
     // NO-OP for Fulu
     return this;
   }
 
   @Override
-  public DataColumnSidecarBuilder slot(final UInt64 slot) {
+  public DataColumnSidecarBuilder beaconBlockRoot(final Bytes32 beaconBlockRoot) {
     // NO-OP for Fulu
     return this;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarBuilderGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarBuilderGloas.java
@@ -27,6 +27,7 @@ public class DataColumnSidecarBuilderGloas extends DataColumnSidecarBuilderFulu 
 
   private DataColumnSidecarSchemaGloas schema;
 
+  protected UInt64 slot;
   protected Bytes32 beaconBlockRoot;
 
   public DataColumnSidecarBuilderGloas schema(final DataColumnSidecarSchemaGloas schema) {
@@ -49,14 +50,14 @@ public class DataColumnSidecarBuilderGloas extends DataColumnSidecarBuilderFulu 
   }
 
   @Override
-  public DataColumnSidecarBuilder beaconBlockRoot(final Bytes32 beaconBlockRoot) {
-    this.beaconBlockRoot = beaconBlockRoot;
+  public DataColumnSidecarBuilder slot(final UInt64 slot) {
+    this.slot = slot;
     return this;
   }
 
   @Override
-  public DataColumnSidecarBuilder slot(final UInt64 slot) {
-    // TODO-GLOAS: https://github.com/ethereum/consensus-specs/pull/4645
+  public DataColumnSidecarBuilder beaconBlockRoot(final Bytes32 beaconBlockRoot) {
+    this.beaconBlockRoot = beaconBlockRoot;
     return this;
   }
 
@@ -64,7 +65,7 @@ public class DataColumnSidecarBuilderGloas extends DataColumnSidecarBuilderFulu 
   public DataColumnSidecar build() {
     validate();
     return new DataColumnSidecarGloas(
-        schema, index, column, kzgCommitments, kzgProofs, beaconBlockRoot);
+        schema, index, column, kzgCommitments, kzgProofs, slot, beaconBlockRoot);
   }
 
   @Override
@@ -74,6 +75,7 @@ public class DataColumnSidecarBuilderGloas extends DataColumnSidecarBuilderFulu 
     checkNotNull(column, "column must be specified");
     checkNotNull(kzgCommitments, "kzgCommitments must be specified");
     checkNotNull(kzgProofs, "kzgProofs must be specified");
+    checkNotNull(slot, "slot must be specified");
     checkNotNull(beaconBlockRoot, "beaconBlockRoot must be specified");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarGloas.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.datastructures.blobs.versions.gloas;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container5;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container6;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -28,12 +28,13 @@ import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 
 public class DataColumnSidecarGloas
-    extends Container5<
+    extends Container6<
         DataColumnSidecarGloas,
         SszUInt64,
         DataColumn,
         SszList<SszKZGCommitment>,
         SszList<SszKZGProof>,
+        SszUInt64,
         SszBytes32>
     implements DataColumnSidecar {
 
@@ -47,6 +48,7 @@ public class DataColumnSidecarGloas
       final DataColumn column,
       final SszList<SszKZGCommitment> kzgCommitments,
       final SszList<SszKZGProof> kzgProofs,
+      final UInt64 slot,
       final Bytes32 beaconBlockRoot) {
     super(
         schema,
@@ -54,6 +56,7 @@ public class DataColumnSidecarGloas
         column,
         kzgCommitments,
         kzgProofs,
+        SszUInt64.of(slot),
         SszBytes32.of(beaconBlockRoot));
   }
 
@@ -77,15 +80,14 @@ public class DataColumnSidecarGloas
     return getField3();
   }
 
-  // TODO-GLOAS: https://github.com/ethereum/consensus-specs/pull/4645
   @Override
   public UInt64 getSlot() {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return getField4().get();
   }
 
   @Override
   public Bytes32 getBeaconBlockRoot() {
-    return getField4().get();
+    return getField5().get();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarSchemaGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarSchemaGloas.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.spec.datastructures.blobs.versions.gloas;
 
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema5;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema6;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -33,12 +33,13 @@ import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProofSchema;
 
 public class DataColumnSidecarSchemaGloas
-    extends ContainerSchema5<
+    extends ContainerSchema6<
         DataColumnSidecarGloas,
         SszUInt64,
         DataColumn,
         SszList<SszKZGCommitment>,
         SszList<SszKZGProof>,
+        SszUInt64,
         SszBytes32>
     implements DataColumnSidecarSchema<DataColumnSidecarGloas> {
 
@@ -56,6 +57,7 @@ public class DataColumnSidecarSchemaGloas
             FIELD_KZG_PROOFS,
             SszListSchema.create(
                 SszKZGProofSchema.INSTANCE, specConfig.getMaxBlobCommitmentsPerBlock())),
+        namedSchema(FIELD_SLOT, SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema(FIELD_BEACON_BLOCK_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
@@ -159,7 +159,7 @@ public class BlockRewardCalculatorUtil {
         .map(
             attestation ->
                 blockProcessor
-                    .calculateAttestationProcessingResult(
+                    .processAttestation(
                         mutableBeaconStateAltair, attestation, indexedAttestationProvider)
                     .proposerReward())
         .filter(Optional::isPresent)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -136,14 +136,14 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       final IndexedAttestationProvider indexedAttestationProvider) {
     final MutableBeaconStateAltair state = MutableBeaconStateAltair.required(genericState);
     final AttestationProcessingResult result =
-        calculateAttestationProcessingResult(state, attestation, indexedAttestationProvider);
+        processAttestation(state, attestation, indexedAttestationProvider);
     consumeAttestationProcessingResult(attestation.getData(), result, genericState);
   }
 
   public record AttestationProcessingResult(
       Optional<UInt64> proposerReward, int builderPaymentIndex, UInt64 builderPaymentWeightDelta) {}
 
-  public AttestationProcessingResult calculateAttestationProcessingResult(
+  public AttestationProcessingResult processAttestation(
       final MutableBeaconStateAltair state,
       final Attestation attestation,
       final IndexedAttestationProvider indexedAttestationProvider) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -155,19 +155,15 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
 
     // Update epoch participation flags
     final SszMutableList<SszByte> epochParticipation;
-    final int builderPaymentIndex;
-
     final boolean forCurrentEpoch =
         data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state));
     if (forCurrentEpoch) {
       epochParticipation = state.getCurrentEpochParticipation();
-      builderPaymentIndex =
-          specConfig.getSlotsPerEpoch()
-              + data.getSlot().mod(specConfig.getSlotsPerEpoch()).intValue();
     } else {
       epochParticipation = state.getPreviousEpochParticipation();
-      builderPaymentIndex = data.getSlot().mod(specConfig.getSlotsPerEpoch()).intValue();
     }
+    final int builderPaymentIndex = getBuilderPaymentIndex(forCurrentEpoch, data);
+
     // track the weight for pending builder payment
     UInt64 builderPaymentWeightDelta = UInt64.ZERO;
 
@@ -223,6 +219,11 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
 
     return new AttestationProcessingResult(
         proposerReward, builderPaymentIndex, builderPaymentWeightDelta);
+  }
+
+  protected int getBuilderPaymentIndex(final boolean forCurrentEpoch, final AttestationData data) {
+    // NO-OP
+    return 0;
   }
 
   protected UInt64 updateBuilderPaymentWeight(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -272,26 +272,6 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
   }
 
   @Override
-  protected void consumeAttestationProcessingResult(
-      final AttestationData data,
-      final AttestationProcessingResult result,
-      final MutableBeaconState state) {
-    super.consumeAttestationProcessingResult(data, result, state);
-    // update builder payment weight
-    final UInt64 weightDelta = result.builderPaymentWeightDelta();
-    if (!weightDelta.isZero()) {
-      final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
-      final BuilderPendingPayment payment =
-          stateGloas.getBuilderPendingPayments().get(result.builderPaymentIndex());
-      stateGloas
-          .getBuilderPendingPayments()
-          .set(
-              result.builderPaymentIndex(),
-              payment.copyWithNewWeight(payment.getWeight().plus(weightDelta)));
-    }
-  }
-
-  @Override
   protected int getBuilderPaymentIndex(final boolean forCurrentEpoch, final AttestationData data) {
     if (forCurrentEpoch) {
       return specConfig.getSlotsPerEpoch()
@@ -319,6 +299,26 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
           state.getValidators().get(attestingIndex).getEffectiveBalance());
     } else {
       return builderPaymentWeightDelta;
+    }
+  }
+
+  @Override
+  protected void consumeAttestationProcessingResult(
+      final AttestationData data,
+      final AttestationProcessingResult result,
+      final MutableBeaconState state) {
+    super.consumeAttestationProcessingResult(data, result, state);
+    // update builder payment weight
+    final UInt64 weightDelta = result.builderPaymentWeightDelta();
+    if (!weightDelta.isZero()) {
+      final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
+      final BuilderPendingPayment payment =
+          stateGloas.getBuilderPendingPayments().get(result.builderPaymentIndex());
+      stateGloas
+          .getBuilderPendingPayments()
+          .set(
+              result.builderPaymentIndex(),
+              payment.copyWithNewWeight(payment.getWeight().plus(weightDelta)));
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -38,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
@@ -210,24 +212,30 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       throw new BlockProcessingException("Bid is not for the right parent block");
     }
 
-    // Record the pending payment
-    final BuilderPendingPayment pendingPayment =
-        schemaDefinitionsGloas
-            .getBuilderPendingPaymentSchema()
-            .create(
-                UInt64.ZERO,
-                schemaDefinitionsGloas
-                    .getBuilderPendingWithdrawalSchema()
-                    .create(bid.getFeeRecipient(), amount, builderIndex, UInt64.ZERO));
+    // Record the pending payment if there is some payment
+    if (amount.isGreaterThan(UInt64.ZERO)) {
+      final BuilderPendingPayment pendingPayment =
+          schemaDefinitionsGloas
+              .getBuilderPendingPaymentSchema()
+              .create(
+                  UInt64.ZERO,
+                  schemaDefinitionsGloas
+                      .getBuilderPendingWithdrawalSchema()
+                      .create(
+                          bid.getFeeRecipient(),
+                          amount,
+                          builderIndex,
+                          SpecConfig.FAR_FUTURE_EPOCH));
 
-    stateGloas
-        .getBuilderPendingPayments()
-        .set(
-            bid.getSlot()
-                .mod(specConfig.getSlotsPerEpoch())
-                .plus(specConfig.getSlotsPerEpoch())
-                .intValue(),
-            pendingPayment);
+      stateGloas
+          .getBuilderPendingPayments()
+          .set(
+              bid.getSlot()
+                  .mod(specConfig.getSlotsPerEpoch())
+                  .plus(specConfig.getSlotsPerEpoch())
+                  .intValue(),
+              pendingPayment);
+    }
 
     // Cache the execution payload bid
     stateGloas.setLatestExecutionPayloadBid(bid);
@@ -273,22 +281,15 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     final UInt64 weightDelta = attestationProcessingResult.builderPaymentWeightDelta();
     if (!weightDelta.isZero()) {
       final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
-      final int builderPaymentIndex;
-      if (attestationProcessingResult.currentEpochTarget()) {
-        builderPaymentIndex =
-            specConfig.getSlotsPerEpoch()
-                + data.getSlot().mod(specConfig.getSlotsPerEpoch()).intValue();
-      } else {
-        builderPaymentIndex = data.getSlot().mod(specConfig.getSlotsPerEpoch()).intValue();
-      }
-      final BuilderPendingPayment currentPendingPayment =
-          stateGloas.getBuilderPendingPayments().get(builderPaymentIndex);
+      final BuilderPendingPayment payment =
+          stateGloas
+              .getBuilderPendingPayments()
+              .get(attestationProcessingResult.builderPaymentIndex());
       stateGloas
           .getBuilderPendingPayments()
           .set(
-              builderPaymentIndex,
-              currentPendingPayment.copyWithNewWeight(
-                  currentPendingPayment.getWeight().plus(weightDelta)));
+              attestationProcessingResult.builderPaymentIndex(),
+              payment.copyWithNewWeight(payment.getWeight().plus(weightDelta)));
     }
   }
 
@@ -296,11 +297,16 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
   // This ensures each validator contributes exactly once per slot
   @Override
   protected UInt64 updateBuilderPaymentWeight(
+      final int builderPaymentIndex,
       final UInt64 builderPaymentWeightDelta,
       final AttestationData data,
       final int attestingIndex,
       final BeaconState state) {
-    if (beaconStateAccessorsGloas.isAttestationSameSlot(state, data)) {
+    final BuilderPendingPayment payment =
+        BeaconStateGloas.required(state).getBuilderPendingPayments().get(builderPaymentIndex);
+    if (beaconStateAccessorsGloas.isAttestationSameSlot(state, data)
+        // only add to the payment quorum if the payment is not trivial
+        && payment.getWithdrawal().getAmount().isGreaterThan(UInt64.ZERO)) {
       return builderPaymentWeightDelta.plus(
           state.getValidators().get(attestingIndex).getEffectiveBalance());
     } else {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -274,21 +274,19 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
   @Override
   protected void consumeAttestationProcessingResult(
       final AttestationData data,
-      final AttestationProcessingResult attestationProcessingResult,
+      final AttestationProcessingResult result,
       final MutableBeaconState state) {
-    super.consumeAttestationProcessingResult(data, attestationProcessingResult, state);
+    super.consumeAttestationProcessingResult(data, result, state);
     // update builder payment weight
-    final UInt64 weightDelta = attestationProcessingResult.builderPaymentWeightDelta();
+    final UInt64 weightDelta = result.builderPaymentWeightDelta();
     if (!weightDelta.isZero()) {
       final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
       final BuilderPendingPayment payment =
-          stateGloas
-              .getBuilderPendingPayments()
-              .get(attestationProcessingResult.builderPaymentIndex());
+          stateGloas.getBuilderPendingPayments().get(result.builderPaymentIndex());
       stateGloas
           .getBuilderPendingPayments()
           .set(
-              attestationProcessingResult.builderPaymentIndex(),
+              result.builderPaymentIndex(),
               payment.copyWithNewWeight(payment.getWeight().plus(weightDelta)));
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -293,6 +293,16 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     }
   }
 
+  @Override
+  protected int getBuilderPaymentIndex(final boolean forCurrentEpoch, final AttestationData data) {
+    if (forCurrentEpoch) {
+      return specConfig.getSlotsPerEpoch()
+          + data.getSlot().mod(specConfig.getSlotsPerEpoch()).intValue();
+    } else {
+      return data.getSlot().mod(specConfig.getSlotsPerEpoch()).intValue();
+    }
+  }
+
   // Add weight for same-slot attestations when any new flag is set
   // This ensures each validator contributes exactly once per slot
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -105,15 +105,17 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
         } else {
           withdrawableBalance = UInt64.ZERO;
         }
-        withdrawals.add(
-            schemaDefinitions
-                .getWithdrawalSchema()
-                .create(
-                    withdrawalIndex,
-                    builderIndex,
-                    withdrawal.getFeeRecipient(),
-                    withdrawableBalance));
-        withdrawalIndex = withdrawalIndex.increment();
+        if (withdrawableBalance.isGreaterThan(UInt64.ZERO)) {
+          withdrawals.add(
+              schemaDefinitions
+                  .getWithdrawalSchema()
+                  .create(
+                      withdrawalIndex,
+                      builderIndex,
+                      withdrawal.getFeeRecipient(),
+                      withdrawableBalance));
+          withdrawalIndex = withdrawalIndex.increment();
+        }
       }
       processedBuilderWithdrawalsCount++;
     }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
@@ -95,7 +95,7 @@ public class BlockRewardCalculatorUtilTest {
     when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
         .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
     when(blockProcessorAltair.calculateAttestationProcessingResult(any(), any(), any()))
-        .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), false, UInt64.ZERO));
+        .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), 0, UInt64.ZERO));
     final BeaconState preState = data.randomBeaconState();
     final BeaconBlock block =
         data.blockBuilder(preState.getSlot().increment().longValue())
@@ -114,7 +114,7 @@ public class BlockRewardCalculatorUtilTest {
     when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
         .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
     when(blockProcessorAltair.calculateAttestationProcessingResult(any(), any(), any()))
-        .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), false, UInt64.ZERO));
+        .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), 0, UInt64.ZERO));
     final BeaconState preState = data.randomBeaconState();
     final BeaconBlock block =
         data.blockBuilder(preState.getSlot().increment().longValue())

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
@@ -94,7 +94,7 @@ public class BlockRewardCalculatorUtilTest {
     // reward equals the number of attestations
     when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
         .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
-    when(blockProcessorAltair.calculateAttestationProcessingResult(any(), any(), any()))
+    when(blockProcessorAltair.processAttestation(any(), any(), any()))
         .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), 0, UInt64.ZERO));
     final BeaconState preState = data.randomBeaconState();
     final BeaconBlock block =
@@ -105,15 +105,14 @@ public class BlockRewardCalculatorUtilTest {
     final BlockRewardData reward =
         calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
     assertThat(reward.attestations()).isEqualTo(10L);
-    verify(blockProcessorAltair, times(10))
-        .calculateAttestationProcessingResult(any(), any(), any());
+    verify(blockProcessorAltair, times(10)).processAttestation(any(), any(), any());
   }
 
   @Test
   void getBlockRewardData_shouldOutputRewardData() {
     when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
         .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
-    when(blockProcessorAltair.calculateAttestationProcessingResult(any(), any(), any()))
+    when(blockProcessorAltair.processAttestation(any(), any(), any()))
         .thenReturn(new AttestationProcessingResult(Optional.of(UInt64.ONE), 0, UInt64.ZERO));
     final BeaconState preState = data.randomBeaconState();
     final BeaconBlock block =
@@ -135,8 +134,7 @@ public class BlockRewardCalculatorUtilTest {
                 140L,
                 3 * SINGLE_SLASHING_REWARD,
                 2 * SINGLE_SLASHING_REWARD));
-    verify(blockProcessorAltair, times(10))
-        .calculateAttestationProcessingResult(any(), any(), any());
+    verify(blockProcessorAltair, times(10)).processAttestation(any(), any(), any());
   }
 
   @Test

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerCSV.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerCSV.java
@@ -317,7 +317,7 @@ public class AggregatingAttestationPoolProfilerCSV implements AggregatingAttesta
         attestation ->
             rewards.add(
                 blockProcessor
-                    .calculateAttestationProcessingResult(
+                    .processAttestation(
                         mutableBeaconStateAltair, attestation, indexedAttestationProvider)
                     .proposerReward()));
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerLog.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/utils/AggregatingAttestationPoolProfilerLog.java
@@ -136,7 +136,7 @@ public class AggregatingAttestationPoolProfilerLog implements AggregatingAttesta
         attestation ->
             rewards.add(
                 blockProcessor
-                    .calculateAttestationProcessingResult(
+                    .processAttestation(
                         mutableBeaconStateAltair, attestation, indexedAttestationProvider)
                     .proposerReward()));
 

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
@@ -220,8 +220,6 @@ public abstract class AbstractRpcMethodIntegrationTest {
 
   protected static Stream<Arguments> generateSpecTransitionWithCombinationParams() {
     return SpecMilestone.getAllMilestonesFrom(SpecMilestone.ALTAIR).stream()
-        // TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-        .filter(specMilestone -> !specMilestone.equals(SpecMilestone.GLOAS))
         .flatMap(
             milestone -> {
               final SpecMilestone prevMilestone = milestone.getPreviousMilestone();
@@ -235,8 +233,6 @@ public abstract class AbstractRpcMethodIntegrationTest {
 
   protected static Stream<Arguments> generateSpecTransition() {
     return SpecMilestone.getAllMilestonesFrom(SpecMilestone.ALTAIR).stream()
-        // TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-        .filter(specMilestone -> !specMilestone.equals(SpecMilestone.GLOAS))
         .map(milestone -> Arguments.of(milestone.getPreviousMilestone(), milestone));
   }
 

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -262,8 +262,17 @@ public class BeaconBlocksByRootIntegrationTest extends AbstractRpcMethodIntegrat
       assertThat(res).isCompletedExceptionally();
       assertThatThrownBy(res::get)
           .hasCauseInstanceOf(RpcException.class)
-          .hasRootCauseInstanceOf(DeserializationFailedException.class)
-          .hasMessageContaining("Failed to deserialize payload");
+          .satisfiesAnyOf(
+              ex ->
+                  assertThat(ex.getCause())
+                      .isInstanceOf(DeserializationFailedException.class)
+                      .hasMessageContaining("Failed to deserialize payload"),
+              ex ->
+                  assertThat(ex.getCause())
+                      // happens when fields are removed and the ssz length bound of the next fork
+                      // is less than the current one
+                      .isInstanceOf(RpcException.LengthOutOfBoundsException.class)
+                      .hasMessageContaining("Chunk length is not within bounds for expected type"));
     }
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -71,10 +71,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
-// TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-@TestSpecContext(
-    milestone = {FULU, GLOAS},
-    ignoredMilestones = GLOAS)
+@TestSpecContext(milestone = {FULU, GLOAS})
 public class DataColumnSidecarsByRootMessageHandlerTest {
 
   private final UInt64 genesisTime = UInt64.valueOf(1982239L);

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.6.0-beta.0
+version: v1.6.0-beta.1
 style: full
 
 specrefs:
@@ -52,6 +52,8 @@ specrefs:
       - LightClientFinalityUpdate
       - LightClientHeader#capella
       - LightClientOptimisticUpdate
+      - LightClientBootstrap#capella
+      - LightClientUpdate#capella
 
       # Not implemented: gloas
       - ForkChoiceNode#gloas
@@ -224,6 +226,7 @@ specrefs:
       - process_slashings#altair
       - process_sync_committee_contributions#altair
       - set_or_append_list#altair
+      - compute_merkle_proof#altair
 
       # Not implemented: bellatrix
       - get_execution_payload#bellatrix
@@ -332,6 +335,6 @@ specrefs:
       - upgrade_to_gloas#gloas
       - validate_merge_block#gloas
       - validate_on_attestation#gloas
-      - verify_data_column_sidecar_inclusion_proof#gloas
+      - verify_data_column_sidecar#gloas
       - verify_execution_payload_bid_signature#gloas
       - verify_execution_payload_envelope_signature#gloas

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -43,15 +43,6 @@
     BUILDER_PAYMENT_THRESHOLD_NUMERATOR: uint64 = 6
     </spec>
 
-- name: BUILDER_PENDING_WITHDRAWALS_LIMIT
-  sources:
-    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
-      search: "BUILDER_PENDING_WITHDRAWALS_LIMIT:"
-  spec: |
-    <spec constant_var="BUILDER_PENDING_WITHDRAWALS_LIMIT" fork="gloas" hash="a71d297e">
-    BUILDER_PENDING_WITHDRAWALS_LIMIT: uint64 = 2**20
-    </spec>
-
 - name: BUILDER_WITHDRAWAL_PREFIX
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -762,12 +762,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarSchemaGloas.java
   spec: |
-    <spec container="DataColumnSidecar" fork="gloas" hash="240a2d70">
+    <spec container="DataColumnSidecar" fork="gloas" hash="8028928b">
     class DataColumnSidecar(Container):
         index: ColumnIndex
         column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        # [Modified in Gloas:EIP7732]
+        # Removed `signed_block_header`
+        # [Modified in Gloas:EIP7732]
+        # Removed `kzg_commitments_inclusion_proof`
+        # [New in Gloas:EIP7732]
+        slot: Slot
+        # [New in Gloas:EIP7732]
         beacon_block_root: Root
     </spec>
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -688,9 +688,24 @@
     - file: infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSPublicKey.java
       search: public static BLSPublicKey aggregate(
   spec: |
-    <spec fn="eth_aggregate_pubkeys" fork="altair" hash="977edbdb">
+    <spec fn="eth_aggregate_pubkeys" fork="altair" hash="bfb5ddd0">
     def eth_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
-        return bls.AggregatePKs(pubkeys)
+        """
+        Return the aggregate public key for the public keys in ``pubkeys``.
+
+        Note: the ``+`` operation should be interpreted as elliptic curve point addition, which takes as input
+        elliptic curve points that must be decoded from the input ``BLSPubkey``s.
+        This implementation is for demonstrative purposes only and ignores encoding/decoding concerns.
+        Refer to the BLS signature draft standard for more information.
+        """
+        assert len(pubkeys) > 0
+        # Ensure that the given inputs are valid pubkeys
+        assert all(bls.KeyValidate(pubkey) for pubkey in pubkeys)
+
+        result = copy(pubkeys[0])
+        for pubkey in pubkeys[1:]:
+            result += pubkey
+        return result
     </spec>
 
 - name: eth_fast_aggregate_verify
@@ -2970,12 +2985,12 @@
     - file: ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
       search: public boolean isWithinWeakSubjectivityPeriod(
   spec: |
-    <spec fn="is_within_weak_subjectivity_period" fork="phase0" hash="f8a94089">
+    <spec fn="is_within_weak_subjectivity_period" fork="phase0" hash="aef08e82">
     def is_within_weak_subjectivity_period(
         store: Store, ws_state: BeaconState, ws_checkpoint: Checkpoint
     ) -> bool:
         # Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
-        assert ws_state.latest_block_header.state_root == ws_checkpoint.root
+        assert get_block_root(ws_state, ws_checkpoint.epoch) == ws_checkpoint.root
         assert compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch
 
         ws_period = compute_weak_subjectivity_period(ws_state)
@@ -5775,7 +5790,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public boolean verifyDataColumnSidecar(
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="fulu" hash="509c0986">
+    <spec fn="verify_data_column_sidecar" fork="fulu" hash="1517491f">
     def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
         """
         Verify if the data column sidecar is valid.
@@ -5786,6 +5801,11 @@
 
         # A sidecar for zero blobs is invalid
         if len(sidecar.kzg_commitments) == 0:
+            return False
+
+        # Check that the sidecar respects the blob limit
+        epoch = compute_epoch_at_slot(sidecar.signed_block_header.message.slot)
+        if len(sidecar.kzg_commitments) > get_blob_parameters(epoch).max_blobs_per_block:
             return False
 
         # The column length must be equal to the number of commitments/proofs

--- a/specrefs/presets.yml
+++ b/specrefs/presets.yml
@@ -7,6 +7,15 @@
     BASE_REWARD_FACTOR: uint64 = 64
     </spec>
 
+- name: BUILDER_PENDING_WITHDRAWALS_LIMIT
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
+      search: "BUILDER_PENDING_WITHDRAWALS_LIMIT:"
+  spec: |
+    <spec preset_var="BUILDER_PENDING_WITHDRAWALS_LIMIT" fork="gloas" hash="40b31377">
+    BUILDER_PENDING_WITHDRAWALS_LIMIT: uint64 = 1048576
+    </spec>
+
 - name: BYTES_PER_LOGS_BLOOM
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/releases/tag/v1.6.0-beta.1

Also changed the url as per:
https://discordapp.com/channels/595666850260713488/598292067260825641/1430532954584776795

## Fixed Issue(s)
related to #9833

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps reference/spec versions to v1.6.0-beta.1 and updates Gloas data structures, attestation/reward processing, withdrawals, and networking/tests to match latest consensus changes.
> 
> - **Spec/Test Vectors**:
>   - Update ref tests to `v1.6.0-beta.1` and base URL; bump specrefs version and entries (constants, containers, functions, presets).
>   - Add SSZ generic test skip for `ssz_generic/compatible_unions`.
> - **Blobs/DataColumnSidecar (Gloas)**:
>   - Change `DataColumnSidecarGloas` schema from 5→6 fields; add `slot` and move `beacon_block_root`; builder/schema updated accordingly.
> - **Block Processing/Rewards**:
>   - Rename attestation API to `.processAttestation(...)` returning `proposerReward`, `builderPaymentIndex`, and `builderPaymentWeightDelta`; propagate across calculators and profilers.
>   - Gloas: compute builder payment index via helper; update weight only for non-trivial payments; record pending payments only when `amount > 0` and set `withdrawable_epoch` to `FAR_FUTURE_EPOCH`.
>   - Withdrawals (Gloas): only emit non-zero withdrawals.
> - **Networking/Tests**:
>   - Re-enable Gloas in tests and handle additional SSZ errors (`LengthOutOfBoundsException`) across ByRange/ByRoot tests.
>   - Update DataColumnSidecarsByRoot handler test to run on Fulu and Gloas.
>   - Adjust unit tests to new attestation processing API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e1db7a02034e4bd2b15d485ac18e368a58a126. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->