### PR TITLE
fix issue of login before docker manifest publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,6 +487,7 @@ jobs:
       - run:
           name: Create and publish docker manifest
           command: |
+            docker login --username "${DOCKER_USER_RW}" --password "${DOCKER_PASSWORD_RW}"
             ./gradlew --no-daemon --parallel -PincludeCommitHashInDockerTag=<< pipeline.parameters.include_commit_hash_in_docker_tag >> manifestDocker
       - notify
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
fix issue of login before docker manifest publish

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Docker Hub login to the `manifestDocker` job so the docker manifest can be created and published.
> 
> - **CI (CircleCI)**:
>   - In `.circleci/config.yml`, update `jobs.manifestDocker` to run `docker login` with `${DOCKER_USER_RW}`/`${DOCKER_PASSWORD_RW}` before invoking `gradlew manifestDocker`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 837de529f9d5ecf755022169a908d5300b211053. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->