### PR TITLE
changed error logger to fix null messages

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 
@@ -341,12 +342,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          final String message = getMessageFromException(error);
-          if (message.equals(UNKNOWN_ERROR)) {
-            logger.error(message, error);
-          } else {
-            logger.error(message);
-          }
+          logWithCause(logger, Level.ERROR, error);
           return null;
         });
   }
@@ -360,12 +356,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          final String message = getMessageFromException(error);
-          if (message.equals(UNKNOWN_ERROR)) {
-            logger.warn(message, error);
-          } else {
-            logger.warn(message);
-          }
+          logWithCause(logger, Level.WARN, error);
           return null;
         });
   }
@@ -379,12 +370,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          final String message = getMessageFromException(error);
-          if (message.equals(UNKNOWN_ERROR)) {
-            logger.info(message, error);
-          } else {
-            logger.info(message);
-          }
+          logWithCause(logger, Level.INFO, error);
           return null;
         });
   }
@@ -398,12 +384,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          final String message = getMessageFromException(error);
-          if (message.equals(UNKNOWN_ERROR)) {
-            logger.debug(message, error);
-          } else {
-            logger.debug(message);
-          }
+          logWithCause(logger, Level.DEBUG, error);
           return null;
         });
   }
@@ -417,14 +398,18 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          final String message = getMessageFromException(error);
-          if (message.equals(UNKNOWN_ERROR)) {
-            logger.trace(message, error);
-          } else {
-            logger.trace(message);
-          }
+          logWithCause(logger, Level.TRACE, error);
           return null;
         });
+  }
+
+  private void logWithCause(final Logger logger, final Level level, final Throwable error) {
+    final String message = getMessageFromException(error);
+    if (message.equals(UNKNOWN_ERROR)) {
+      logger.log(level, message, error);
+    } else {
+      logger.log(level, message);
+    }
   }
 
   public SafeFuture<Void> ignoreCancelException() {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -321,6 +321,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     if (error == null) {
       return UNKNOWN_ERROR;
     }
+    final Throwable rootCause = Throwables.getRootCause(error);
+    if (rootCause.getMessage() == null) {
+      return error.getMessage() != null ? error.getMessage() : UNKNOWN_ERROR;
+    }
     return Throwables.getRootCause(error).getMessage();
   }
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -321,11 +321,15 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     if (error == null) {
       return UNKNOWN_ERROR;
     }
-    final Throwable rootCause = Throwables.getRootCause(error);
-    if (rootCause.getMessage() == null) {
-      return error.getMessage() != null ? error.getMessage() : UNKNOWN_ERROR;
+    try {
+      final Throwable rootCause = Throwables.getRootCause(error);
+      if (rootCause.getMessage() == null) {
+        return error.getMessage() != null ? error.getMessage() : UNKNOWN_ERROR;
+      }
+      return Throwables.getRootCause(error).getMessage();
+    } catch (final IllegalArgumentException exception) {
+      return UNKNOWN_ERROR;
     }
-    return Throwables.getRootCause(error).getMessage();
   }
 
   /**
@@ -337,7 +341,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          logger.error(getMessageFromException(error));
+          final String message = getMessageFromException(error);
+          if (message.equals(UNKNOWN_ERROR)) {
+            logger.error(message, error);
+          } else {
+            logger.error(message);
+          }
           return null;
         });
   }
@@ -351,7 +360,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          logger.warn(getMessageFromException(error));
+          final String message = getMessageFromException(error);
+          if (message.equals(UNKNOWN_ERROR)) {
+            logger.warn(message, error);
+          } else {
+            logger.warn(message);
+          }
           return null;
         });
   }
@@ -365,7 +379,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          logger.info(getMessageFromException(error));
+          final String message = getMessageFromException(error);
+          if (message.equals(UNKNOWN_ERROR)) {
+            logger.info(message, error);
+          } else {
+            logger.info(message);
+          }
           return null;
         });
   }
@@ -379,7 +398,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          logger.debug(getMessageFromException(error));
+          final String message = getMessageFromException(error);
+          if (message.equals(UNKNOWN_ERROR)) {
+            logger.debug(message, error);
+          } else {
+            logger.debug(message);
+          }
           return null;
         });
   }
@@ -393,7 +417,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final CompletionStage<?> completionStage = this;
     completionStage.exceptionally(
         error -> {
-          logger.trace(getMessageFromException(error));
+          final String message = getMessageFromException(error);
+          if (message.equals(UNKNOWN_ERROR)) {
+            logger.trace(message, error);
+          } else {
+            logger.trace(message);
+          }
           return null;
         });
   }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -108,6 +108,23 @@ public class SafeFutureTest {
   }
 
   @Test
+  public void shouldThrowableIfMessageWasUnknown() {
+    try (LogCaptor logCaptor = LogCaptor.forClass(SafeFutureTest.class)) {
+      final SafeFuture<Void> future = new SafeFuture<>();
+      future.finishError(LOG);
+
+      final Throwable throwable = new IllegalArgumentException("UNKNOWN ERROR");
+      try {
+        future.completeExceptionally(throwable);
+      } catch (final Exception e) {
+        LOG.info("exception");
+      }
+      assertThat(logCaptor.getErrorLogs().getFirst()).contains("UNKNOWN ERROR");
+      assertThat(logCaptor.getThrowable(0)).contains(throwable);
+    }
+  }
+
+  @Test
   public void shouldLogMessageAtWarnLevel() {
     try (LogCaptor logCaptor = LogCaptor.forClass(SafeFutureTest.class)) {
       final SafeFuture<Void> future = new SafeFuture<>();


### PR DESCRIPTION

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves SafeFuture logging to handle null/invalid exception messages and logs the throwable when the message is UNKNOWN ERROR; adds corresponding test.
> 
> - **Async `SafeFuture`**:
>   - Harden `getMessageFromException` to handle null root-cause messages and `IllegalArgumentException` from `getRootCause`, falling back to original error or `"UNKNOWN ERROR"`.
>   - Add `logWithCause` to include the throwable when the message is `"UNKNOWN ERROR"`; update `finishError/Warn/Info/Debug/Trace` to use it.
> - **Tests**:
>   - Add test to verify the throwable is logged when the message is `"UNKNOWN ERROR"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b42cb7d28384a565861da35bd009a43123a7bbea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->