### PR TITLE
Remove netty-codec-smtp dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -997,6 +997,11 @@ subprojects {
       exclude(group: "org.apache.logging.log4j", module: "log4j-slf4j-impl")
       exclude(group: "org.apache.logging.log4j", module: "log4j-slf4j2-impl")
     }
+
+    // exclude until we update Besu dependencies (https://github.com/Consensys/teku/issues/10060)
+    configureEach {
+      exclude(group: "io.netty", module: "netty-codec-smtp")
+    }
   }
 
   def jarName = project.name


### PR DESCRIPTION
## PR Description

We have a transitive dependency that has been flagged in a recent CVE (https://avd.aquasec.com/nvd/cve-2025-59419). Although it does not directly affect Teku, we want to get rid of it to avoid any warnings on build scans.

With this solution, we are basically pulling this dependency from any other possible transitive pull.

## Fixed Issue(s)
related to #10060 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a global Gradle exclusion for `io.netty:netty-codec-smtp` across all configurations.
> 
> - **Build/Gradle**:
>   - **Dependency exclusion**: In `build.gradle`, applies `configureEach { exclude(group: "io.netty", module: "netty-codec-smtp") }` under `configurations` to remove the transitive `io.netty:netty-codec-smtp` module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c5aaca788d017e2959d8d129be0c029f4a8f868. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->