### PR TITLE
[Failovers] Execution payload only created by the node which created the bid

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockGLOAS.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockGLOAS.json
@@ -332,13 +332,13 @@
       ],
       "signed_execution_payload_bid": {
         "message": {
-          "parent_block_hash": "0x9a4e1443f05120d1c5ff9428f324f1eb6c313fc86e943fec09794b98025d0baa",
-          "parent_block_root": "0xf9f3f64210cc7c298f4e990115d157ed8b403aa2fe7f0b8feefe9c814641a05f",
-          "block_hash": "0x0c15f142b0175c6e8491002de9596cba91433934b44834491c80e04920a257ea",
-          "fee_recipient": "0xd3b10243d034be9fa5c8caaa6ebf2e537e3a3c7e",
-          "gas_limit": "4826964785459200112",
-          "builder_index": "2970787",
-          "slot": "12932064024",
+          "parent_block_hash": "0x0c15f142b0175c6e8491002de9596cba91433934b44834491c80e04920a257ea",
+          "parent_block_root": "0xd3b10243d034be9fa5c8caaa6ebf2e537e3a3c7e91eeb91a93fc15f1917f314a",
+          "block_hash": "0xe6d2fc4270809de49a0b32d641484320853d3b1047b7e2d4c07d59b96ce0e8d4",
+          "fee_recipient": "0x4678df4290faf93c645a36af63f4a921a44c36ea",
+          "gas_limit": "4817049881864128048",
+          "builder_index": "740284",
+          "slot": "1310451960",
           "value": "4822007335809147728",
           "blob_kzg_commitments_root": "0x3357e542f0ae1af86f17cf83906b95549e49375821da85bd778267dad563c6ff"
         },

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SlotAndBuilderIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SlotAndBuilderIndex.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.epbs;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public record SlotAndBuilderIndex(UInt64 slot, UInt64 builderIndex) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.SlotAndBuilderIndex;
 
 public class ExecutionPayloadBid
     extends Container9<
@@ -99,6 +100,10 @@ public class ExecutionPayloadBid
 
   public Bytes32 getBlobKzgCommitmentsRoot() {
     return getField8().get();
+  }
+
+  public SlotAndBuilderIndex getSlotAndBuilderIndex() {
+    return new SlotAndBuilderIndex(getSlot(), getBuilderIndex());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
@@ -228,7 +228,6 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
         .set(paymentIndex, schemaDefinitions.getBuilderPendingPaymentSchema().getDefault());
 
     // Cache the execution payload hash
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/9936
     final BitSet newExecutionPayloadAvailability =
         stateGloas.getExecutionPayloadAvailability().getAsBitSet();
     final int indexToModify =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -225,7 +225,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "in3xXac/5V1v0YQ8pnMUivujVivWnn7SZchrxYzmZLUUQgNpZJ8NU7ef07CpyDU1CGoxZJatDVNE4TQOMl7lWDPdwxu2RmSL2BF66KdVNRAkCuXLy9KSlPpy5t4ld9eE"));
+                "pToYn303XI2b3xhMp9gnkHdWYTISbpMUYns6iy3BL+n5YBt/zrsS6I1tAJ67Aw0sBhc2NIyt2BH8va1gc9pMhFTUwM068fTEHiGBy9rlOv2xMsKwkH01Jjz0ukS7bgDw"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadBid(bid, fork);
     asyncRunner.executeQueuedActions();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -227,7 +227,7 @@ public class BlockProposalTestUtil {
                 builder.executionRequests(dataStructureUtil.randomExecutionRequests());
               }
               // TODO-GLOAS: potentially better stubbing of bid and payload attestations
-              // https://github.com/Consensys/teku/issues/9959
+              // https://github.com/Consensys/teku/issues/10071
               if (builder.supportsSignedExecutionPayloadBid()) {
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -3089,6 +3089,11 @@ public final class DataStructureUtil {
   }
 
   public ExecutionPayloadBid randomExecutionPayloadBid() {
+    return randomExecutionPayloadBid(randomSlot(), randomBuilderIndex());
+  }
+
+  public ExecutionPayloadBid randomExecutionPayloadBid(
+      final UInt64 slot, final UInt64 builderIndex) {
     return getGloasSchemaDefinitions()
         .getExecutionPayloadBidSchema()
         .create(
@@ -3097,8 +3102,8 @@ public final class DataStructureUtil {
             randomBytes32(),
             randomEth1Address(),
             randomUInt64(),
-            randomBuilderIndex(),
-            randomSlot(),
+            builderIndex,
+            slot,
             randomUInt64(),
             randomBytes32());
   }

--- a/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockGLOAS.json
+++ b/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockGLOAS.json
@@ -1,5 +1,5 @@
 {
-  "version":"capella",
+  "version":"gloas",
   "execution_payload_blinded":false,
   "execution_payload_value":"12345",
   "consensus_block_value":"123000000000",
@@ -261,13 +261,13 @@
       } ],
       "signed_execution_payload_bid" : {
         "message" : {
-          "parent_block_hash" : "0x9a4e1443f05120d1c5ff9428f324f1eb6c313fc86e943fec09794b98025d0baa",
-          "parent_block_root" : "0xf9f3f64210cc7c298f4e990115d157ed8b403aa2fe7f0b8feefe9c814641a05f",
-          "block_hash" : "0x0c15f142b0175c6e8491002de9596cba91433934b44834491c80e04920a257ea",
-          "fee_recipient" : "0xd3b10243d034be9fa5c8caaa6ebf2e537e3a3c7e",
-          "gas_limit" : "4826964785459200112",
-          "builder_index" : "2970787",
-          "slot" : "12932064024",
+          "parent_block_hash" : "0x0c15f142b0175c6e8491002de9596cba91433934b44834491c80e04920a257ea",
+          "parent_block_root" : "0xd3b10243d034be9fa5c8caaa6ebf2e537e3a3c7e91eeb91a93fc15f1917f314a",
+          "block_hash" : "0xe6d2fc4270809de49a0b32d641484320853d3b1047b7e2d4c07d59b96ce0e8d4",
+          "fee_recipient" : "0x4678df4290faf93c645a36af63f4a921a44c36ea",
+          "gas_limit" : "4817049881864128048",
+          "builder_index" : "740284",
+          "slot" : "1310451960",
           "value" : "4822007335809147728",
           "blob_kzg_commitments_root" : "0x3357e542f0ae1af86f17cf83906b95549e49375821da85bd778267dad563c6ff"
         },

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -345,7 +345,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   public SafeFuture<Optional<ExecutionPayloadBid>> createUnsignedExecutionPayloadBid(
       final UInt64 slot, final UInt64 builderIndex) {
     return tryRequestUntilSuccess(
-C        apiChannel ->
+        apiChannel ->
             apiChannel
                 .createUnsignedExecutionPayloadBid(slot, builderIndex)
                 .thenPeek(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -353,7 +353,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
                     bid -> {
                       if (!failoverDelegates.isEmpty() && bid.isPresent()) {
                         executionPayloadBidCreatorCache.put(
-                            new SlotAndBuilderIndex(slot, builderIndex), apiChannel);
+                            bid.get().getSlotAndBuilderIndex(), apiChannel);
                       }
                     }),
         BeaconNodeRequestLabels.CREATE_UNSIGNED_EXECUTION_PAYLOAD_BID_METHOD);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -629,7 +629,7 @@ class FailoverValidatorApiHandlerTest {
     final UInt64 slot = UInt64.ONE;
     final UInt64 builderIndex = dataStructureUtil.randomBuilderIndex();
 
-    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid(slot, builderIndex);
 
     final ValidatorApiChannelRequest<Optional<ExecutionPayloadBid>> bidCreationRequest =
         apiChannel -> apiChannel.createUnsignedExecutionPayloadBid(slot, builderIndex);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -87,7 +87,7 @@ import tech.pegasys.teku.validator.remote.FailoverValidatorApiHandler.ValidatorA
 
 class FailoverValidatorApiHandlerTest {
 
-  private static final Spec SPEC = TestSpecFactory.createMinimalGloas();
+  private static final Spec SPEC = TestSpecFactory.createMinimalBellatrix();
   private static final DataStructureUtil DATA_STRUCTURE_UTIL = new DataStructureUtil(SPEC);
 
   private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
@@ -623,10 +623,13 @@ class FailoverValidatorApiHandlerTest {
 
   @Test
   public void executionPayloadIsCreatedByTheBeaconNodeWhichCreatedTheBid() {
-    final UInt64 slot = UInt64.ONE;
-    final UInt64 builderIndex = DATA_STRUCTURE_UTIL.randomBuilderIndex();
+    final Spec spec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
-    final ExecutionPayloadBid bid = DATA_STRUCTURE_UTIL.randomExecutionPayloadBid();
+    final UInt64 slot = UInt64.ONE;
+    final UInt64 builderIndex = dataStructureUtil.randomBuilderIndex();
+
+    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
 
     final ValidatorApiChannelRequest<Optional<ExecutionPayloadBid>> bidCreationRequest =
         apiChannel -> apiChannel.createUnsignedExecutionPayloadBid(slot, builderIndex);
@@ -636,7 +639,7 @@ class FailoverValidatorApiHandlerTest {
 
     SafeFutureAssert.assertThatSafeFuture(bidCreationRequest.run(failoverApiHandler)).isCompleted();
     final ExecutionPayloadEnvelope executionPayloadEnvelope =
-        DATA_STRUCTURE_UTIL.randomExecutionPayloadEnvelope(slot);
+        dataStructureUtil.randomExecutionPayloadEnvelope(slot);
 
     final ValidatorApiChannelRequest<Optional<ExecutionPayloadEnvelope>>
         executionPayloadCreationRequest =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Only create execution payload by the node which created the bid. Also removed reference to one of the Gloas issues, which I closed, because I had a bit of a dig into `SszBitVector` and saw that there were comments about immutability and don't think it's worth the time given `.getAsBitSet` is performant enough.

## Fixed Issue(s)
related to #9959

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Execution payload creation now routes only to the beacon node that created the bid via a SlotAndBuilderIndex cache, with supporting utility, tests, and fixtures updates.
> 
> - **Failover logic (validator/remote)**:
>   - Add per-bid cache `Map<SlotAndBuilderIndex, ValidatorApiChannel>` in `FailoverValidatorApiHandler`.
>   - On `createUnsignedExecutionPayloadBid`, store the creating channel keyed by `slot` and `builderIndex`.
>   - On `createUnsignedExecutionPayload`, route exclusively to the cached channel; otherwise fall back to normal failover.
>   - Log when routing exclusively to bid-origin node.
> - **Data structures (spec)**:
>   - New `record` `tech/pegasys/teku/spec/datastructures/epbs/SlotAndBuilderIndex`.
>   - `ExecutionPayloadBid` adds `getSlotAndBuilderIndex()` helper.
> - **Processor/Util tweaks**:
>   - Minor cleanup in `ExecutionPayloadProcessorGloas` (remove stale TODO).
>   - `DataStructureUtil`: add overload `randomExecutionPayloadBid(UInt64 slot, UInt64 builderIndex)` and use it.
> - **Tests**:
>   - Add test ensuring execution payload is created only by the node that created the bid in `FailoverValidatorApiHandlerTest`.
>   - Update `LocalSignerTest` expected signature for `ExecutionPayloadBid`.
>   - Adjust `BlockProposalTestUtil` comment link.
> - **Fixtures**:
>   - Update GLOAS JSON fixtures and example values (e.g., `version: "gloas"`, bid fields) in `newBlockGLOAS.json` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b2bc3ade7b72567cb43c61d41b2dd3defc89658. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->