### PR TITLE
Change logging of custody count persistence

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -107,7 +107,6 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     final Optional<Integer> maybeCustodyCount =
         combinedChainDataClient.getCustodyGroupCount().map(UInt64::intValue);
     if (maybeCustodyCount.isEmpty() || maybeCustodyCount.get() < initCustodyGroupCount) {
-      LOG.info("Persisting initial custody group count to {}", initCustodyGroupCount);
       updateCustodyGroupCount(initCustodyGroupCount, maybeCustodyCount);
     } else {
       LOG.info("Using custody group count {} from store", maybeCustodyCount.get());
@@ -245,10 +244,10 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   private void updateCustodyGroupCount(
       final int newCustodyGroupCount, final Optional<Integer> maybeCustodyGroupCount) {
     if (maybeCustodyGroupCount.isEmpty() || maybeCustodyGroupCount.get() < newCustodyGroupCount) {
-      LOG.debug(
-          "Custody group count updated from {} to {}.",
-          maybeCustodyGroupCount.map(Object::toString).orElse("<not set>"),
-          newCustodyGroupCount);
+      LOG.info(
+          "Persisting custody group count of {} (old value: {}).",
+          newCustodyGroupCount,
+          maybeCustodyGroupCount.map(Object::toString).orElse("<not set>"));
       combinedChainDataClient.updateCustodyGroupCount(newCustodyGroupCount);
     }
     final int oldValue = custodyGroupCount.getAndSet(newCustodyGroupCount);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Issues with current logging:
- "Custody group count updated from" - not clear that it's updated in DB
- On validator node we have set 4 from n/a and after that update from 4 to 8+ is missed from info logging

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts CustodyGroupCountManagerImpl logs to clearly indicate when custody group counts are persisted, promoting key message to info level and removing a redundant initial log.
> 
> - **Statetransition (`CustodyGroupCountManagerImpl`)**:
>   - Promote and reword persistence log: replace debug "Custody group count updated from ..." with info "Persisting custody group count of ... (old value: ...)" when writing to the store.
>   - Remove initial info log "Persisting initial custody group count to ..."; rely on the unified persistence log in `updateCustodyGroupCount`.
>   - Retain existing info log for using stored count: "Using custody group count ... from store".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c13a77fd8329a7f1bbce43c515a9797fcb333c58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->