### PR TITLE
implemented rest api proposer_lookahead for fulu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 ### Breaking Changes
 
 ### Additions and Improvements
+ - Implemented `/eth/v1/beacon/states/{state_id}/proposer_lookahead` which is accessible from fulu.
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_proposer_lookahead.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_proposer_lookahead.json
@@ -1,0 +1,101 @@
+{
+  "get" : {
+    "tags" : [ "Beacon" ],
+    "operationId" : "getPendingProposerLookahead",
+    "summary" : "Get proposer look ahead from state",
+    "description" : "Returns proposer lookahead for state with given 'stateId'. Should return 400 if the state retrieved is prior to Fulu.",
+    "parameters" : [ {
+      "name" : "state_id",
+      "required" : true,
+      "in" : "path",
+      "schema" : {
+        "type" : "string",
+        "description" : "State identifier. Can be one of: \"head\" (canonical head in node's view), \"genesis\", \"finalized\", \"justified\", &lt;slot&gt;, &lt;hex encoded stateRoot with 0x prefix&gt;.",
+        "example" : "head"
+      }
+    } ],
+    "responses" : {
+      "200" : {
+        "description" : "Request successful",
+        "headers" : {
+          "Eth-Consensus-Version" : {
+            "description" : "Required in response so client can deserialize returned json or ssz data more effectively.",
+            "required" : true,
+            "schema" : {
+              "type" : "string",
+              "enum" : [ "phase0", "altair", "bellatrix", "capella", "deneb", "electra", "fulu", "gloas" ],
+              "example" : "phase0"
+            }
+          }
+        },
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/GetProposerLookaheadResponse"
+            }
+          },
+          "application/octet-stream" : {
+            "schema" : {
+              "type" : "string",
+              "format" : "binary"
+            }
+          }
+        }
+      },
+      "404" : {
+        "description" : "Not found",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "415" : {
+        "description" : "Unsupported media type",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "503" : {
+        "description" : "Service unavailable",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "204" : {
+        "description" : "Data is unavailable because the chain has not yet reached genesis",
+        "content" : { }
+      },
+      "400" : {
+        "description" : "The request could not be processed, check the response for more information.",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Internal server error",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_proposer_lookahead.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_proposer_lookahead.json
@@ -1,7 +1,7 @@
 {
   "get" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "getPendingProposerLookahead",
+    "operationId" : "getStateProposerLookahead",
     "summary" : "Get proposer look ahead from state",
     "description" : "Returns proposer lookahead for state with given 'stateId'. Should return 400 if the state retrieved is prior to Fulu.",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetProposerLookaheadResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetProposerLookaheadResponse.json
@@ -1,0 +1,26 @@
+{
+  "title" : "GetProposerLookaheadResponse",
+  "type" : "object",
+  "required" : [ "version", "execution_optimistic", "finalized", "data" ],
+  "properties" : {
+    "version" : {
+      "type" : "string",
+      "enum" : [ "phase0", "altair", "bellatrix", "capella", "deneb", "electra", "fulu", "gloas" ]
+    },
+    "execution_optimistic" : {
+      "type" : "boolean"
+    },
+    "finalized" : {
+      "type" : "boolean"
+    },
+    "data" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "unsigned 64 bit integer",
+        "example" : "1",
+        "format" : "uint64"
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateFork;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStatePendingConsolidations;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStatePendingDeposits;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStatePendingPartialWithdrawals;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateProposerLookahead;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateRandao;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateRoot;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateSyncCommittees;
@@ -261,6 +262,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             .endpoint(new GetStatePendingConsolidations(dataProvider, schemaCache))
             .endpoint(new GetStatePendingDeposits(dataProvider, schemaCache))
             .endpoint(new GetStatePendingPartialWithdrawals(dataProvider, schemaCache))
+            .endpoint(new GetStateProposerLookahead(dataProvider, schemaCache))
             .endpoint(new GetDepositSnapshot(eth1DataProvider))
             // Event Handler
             .endpoint(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookahead.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookahead.java
@@ -55,7 +55,7 @@ public class GetStateProposerLookahead extends RestApiEndpoint {
       final ChainDataProvider provider, final SchemaDefinitionCache schemaDefinitionCache) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getPendingProposerLookahead")
+            .operationId("getStateProposerLookahead")
             .summary("Get proposer look ahead from state")
             .description(
                 "Returns proposer lookahead for state with given 'stateId'. Should return 400 if the state retrieved is prior to Fulu.")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookahead.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookahead.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_STATE_ID;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.ETH_CONSENSUS_HEADER_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.sszResponseType;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.FINALIZED;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64VectorSchema;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
+
+public class GetStateProposerLookahead extends RestApiEndpoint {
+  public static final String ROUTE = "/eth/v1/beacon/states/{state_id}/proposer_lookahead";
+
+  private final ChainDataProvider chainDataProvider;
+
+  public GetStateProposerLookahead(
+      final DataProvider dataProvider, final SchemaDefinitionCache schemaDefinitionCache) {
+    this(dataProvider.getChainDataProvider(), schemaDefinitionCache);
+  }
+
+  GetStateProposerLookahead(
+      final ChainDataProvider provider, final SchemaDefinitionCache schemaDefinitionCache) {
+    super(
+        EndpointMetadata.get(ROUTE)
+            .operationId("getPendingProposerLookahead")
+            .summary("Get proposer look ahead from state")
+            .description(
+                "Returns proposer lookahead for state with given 'stateId'. Should return 400 if the state retrieved is prior to Fulu.")
+            .pathParam(PARAMETER_STATE_ID)
+            .tags(TAG_BEACON)
+            .response(
+                SC_OK,
+                "Request successful",
+                getResponseType(schemaDefinitionCache),
+                sszResponseType(),
+                ETH_CONSENSUS_HEADER_TYPE)
+            .withNotFoundResponse()
+            .withUnsupportedMediaTypeResponse()
+            .withChainDataResponses()
+            .build());
+    this.chainDataProvider = provider;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static SerializableTypeDefinition<ObjectAndMetaData<SszUInt64Vector>> getResponseType(
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    final SchemaDefinitionsFulu definitions =
+        schemaDefinitionCache.getSchemaDefinition(SpecMilestone.FULU).toVersionFulu().orElseThrow();
+    final SszUInt64VectorSchema<SszUInt64Vector> schema =
+        (SszUInt64VectorSchema<SszUInt64Vector>) definitions.getProposerLookaheadSchema();
+    return SerializableTypeDefinition.<ObjectAndMetaData<SszUInt64Vector>>object()
+        .name("GetProposerLookaheadResponse")
+        .withField("version", MILESTONE_TYPE, ObjectAndMetaData::getMilestone)
+        .withField(EXECUTION_OPTIMISTIC, BOOLEAN_TYPE, ObjectAndMetaData::isExecutionOptimistic)
+        .withField(FINALIZED, BOOLEAN_TYPE, ObjectAndMetaData::isFinalized)
+        .withField("data", schema.getJsonTypeDefinition(), ObjectAndMetaData::getData)
+        .build();
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    final SafeFuture<Optional<ObjectAndMetaData<SszUInt64Vector>>> future =
+        chainDataProvider.getStateProposerLookahead(request.getPathParameter(PARAMETER_STATE_ID));
+
+    request.respondAsync(
+        future.thenApply(
+            maybeData ->
+                maybeData
+                    .map(
+                        objectAndMetadata -> {
+                          request.header(
+                              HEADER_CONSENSUS_VERSION,
+                              objectAndMetadata.getMilestone().lowerCaseName());
+                          return AsyncApiResponse.respondOk(objectAndMetadata);
+                        })
+                    .orElseGet(AsyncApiResponse::respondNotFound)));
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookaheadTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookaheadTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_UNSUPPORTED_MEDIA_TYPE;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseStringFromMetadata;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
+
+public class GetStateProposerLookaheadTest
+    extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
+
+  @BeforeEach
+  public void setup() {
+
+    final GetStateProposerLookahead proposerLookahead =
+        new GetStateProposerLookahead(chainDataProvider, schemaDefinitionCache);
+    initialise(SpecMilestone.FULU);
+    genesis();
+    setHandler(proposerLookahead);
+    request.setPathParameter("state_id", "head");
+  }
+
+  @Test
+  void metadata_shouldHandle400() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_BAD_REQUEST);
+  }
+
+  @Test
+  void metadata_shouldHandle404() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_NOT_FOUND);
+  }
+
+  @Test
+  void metadata_shouldHandle415() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_UNSUPPORTED_MEDIA_TYPE);
+  }
+
+  @Test
+  void metadata_shouldHandle500() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void metadata_shouldHandle503() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void metadata_shouldHandle200() throws IOException {
+    final BeaconStateFulu state = BeaconStateFulu.required(dataStructureUtil.randomBeaconState(32));
+    final ObjectAndMetaData<SszUInt64Vector> responseData =
+        new ObjectAndMetaData<>(
+            state.getProposerLookahead(), SpecMilestone.FULU, false, true, false);
+    final String resource =
+        Resources.toString(
+            Resources.getResource(
+                GetStateProposerLookaheadTest.class, "stateProposerLookahead.json"),
+            UTF_8);
+    final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
+    assertThat(data).isEqualTo(resource);
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookaheadTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateProposerLookaheadTest.java
@@ -21,12 +21,14 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_UNSUPPORTED_MEDIA_TYPE;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseSszFromMetadata;
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseStringFromMetadata;
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.io.Resources;
 import java.io.IOException;
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
@@ -87,5 +89,15 @@ public class GetStateProposerLookaheadTest
             UTF_8);
     final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
     assertThat(data).isEqualTo(resource);
+  }
+
+  @Test
+  void metadata_shouldHandle200OctetStream() throws IOException {
+    final BeaconStateFulu state = BeaconStateFulu.required(dataStructureUtil.randomBeaconState(32));
+    final ObjectAndMetaData<SszUInt64Vector> responseData =
+        new ObjectAndMetaData<>(
+            state.getProposerLookahead(), SpecMilestone.FULU, false, true, false);
+    final byte[] data = getResponseSszFromMetadata(handler, SC_OK, responseData);
+    assertThat(Bytes.of(data)).isEqualTo(state.getProposerLookahead().sszSerialize());
   }
 }

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/stateProposerLookahead.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/stateProposerLookahead.json
@@ -1,0 +1,1 @@
+{"version":"fulu","execution_optimistic":false,"finalized":false,"data":["28","28","28","28","28","28","28","28","28","28","29","29","29","29","29","29"]}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -824,7 +824,7 @@ public class ChainDataProvider {
 
   Optional<ObjectAndMetaData<SszUInt64Vector>> getProposerLookahead(
       final Optional<StateAndMetaData> maybeStateAndMetadata) {
-    checkMinimumMilestone(maybeStateAndMetadata, SpecMilestone.FULU, "validator ids");
+    checkMinimumMilestone(maybeStateAndMetadata, SpecMilestone.FULU, "proposer lookahead");
 
     return maybeStateAndMetadata.map(
         stateAndMetaData -> {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -811,6 +812,31 @@ public class ChainDataProvider {
         .createSelectorForStateId(stateIdParam)
         .getState()
         .thenApply(this::getPendingPartialWithdrawals);
+  }
+
+  public SafeFuture<Optional<ObjectAndMetaData<SszUInt64Vector>>> getStateProposerLookahead(
+      final String stateIdParam) {
+    return stateSelectorFactory
+        .createSelectorForStateId(stateIdParam)
+        .getState()
+        .thenApply(this::getProposerLookahead);
+  }
+
+  Optional<ObjectAndMetaData<SszUInt64Vector>> getProposerLookahead(
+      final Optional<StateAndMetaData> maybeStateAndMetadata) {
+    checkMinimumMilestone(maybeStateAndMetadata, SpecMilestone.FULU, "validator ids");
+
+    return maybeStateAndMetadata.map(
+        stateAndMetaData -> {
+          final SszUInt64Vector proposerLookahead =
+              stateAndMetaData.getData().toVersionFulu().orElseThrow().getProposerLookahead();
+          return new ObjectAndMetaData<>(
+              proposerLookahead,
+              stateAndMetaData.getMilestone(),
+              stateAndMetaData.isExecutionOptimistic(),
+              stateAndMetaData.isCanonical(),
+              stateAndMetaData.isFinalized());
+        });
   }
 
   public SafeFuture<Optional<ObjectAndMetaData<SszList<PendingConsolidation>>>>


### PR DESCRIPTION
Gives access to the state attribute included in fulu.

fixes #10076

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Fulu-only GET endpoint to fetch proposer lookahead from state, wired into REST API with OpenAPI schema and comprehensive tests.
> 
> - **REST API (Beacon v1)**:
>   - Add `GetStateProposerLookahead` handler exposing `GET /eth/v1/beacon/states/{state_id}/proposer_lookahead` (JSON/SSZ), sets `Eth-Consensus-Version` header.
>   - Wire endpoint in `JsonTypeDefinitionBeaconRestApi`.
> - **Data Provider**:
>   - Add `ChainDataProvider#getStateProposerLookahead` and `getProposerLookahead`, enforcing `FULU` minimum milestone and returning `SszUInt64Vector` with metadata.
> - **OpenAPI/Schema**:
>   - New path spec `_eth_v1_beacon_states_{state_id}_proposer_lookahead.json` and response schema `GetProposerLookaheadResponse.json`.
> - **Tests**:
>   - Add handler tests validating 200 (JSON/SSZ) and error responses.
>   - Add `ChainDataProviderTest` cases for success, empty input, and pre-Fulu rejection.
> - **Changelog**:
>   - Note the new `proposer_lookahead` endpoint under additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b73f02396cfc55dabaa0b74d8d753f753b0fb6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->