### PR TITLE
Fix typos

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1189,10 +1189,10 @@ public class KvStoreDatabase implements Database {
             streamNonCanonicalDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive)) {
 
       if (pruneDataColumnSidecars(pruneLimit, prunableIdentifiers, false)) {
-        LOG.debug("Pruned reached the limit of {} data column sidecars", pruneLimit);
+        LOG.debug("Data column sidecars pruning reached the limit of {}", pruneLimit);
       }
       if (pruneDataColumnSidecars(pruneLimit, prunableNonCanonicalIdentifiers, true)) {
-        LOG.debug("Pruned reached the limit of {} non canonical data column sidecars", pruneLimit);
+        LOG.debug("Non canonical data column sidecars pruning reached the limit of {}", pruneLimit);
       }
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1192,7 +1192,7 @@ public class KvStoreDatabase implements Database {
         LOG.debug("Data column sidecars pruning reached the limit of {}", pruneLimit);
       }
       if (pruneDataColumnSidecars(pruneLimit, prunableNonCanonicalIdentifiers, true)) {
-        LOG.debug("Non canonical data column sidecars pruning reached the limit of {}", pruneLimit);
+        LOG.debug("Non-canonical data column sidecars pruning reached the limit of {}", pruneLimit);
       }
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -401,7 +401,6 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   @Override
   public void close() throws Exception {
     hotDao.close();
-    hotDao.close();
     finalizedDao.close();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix a couple of typos

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes duplicate `hotDao.close()` call and tweaks debug messages for data column sidecar pruning limits.
> 
> - **Storage**:
>   - `KvStoreCombinedDaoAdapter`: Remove duplicate `hotDao.close()` in `close()` to prevent double-close.
>   - `KvStoreDatabase`: Refine debug log messages when sidecar pruning hits the limit for canonical and non-canonical entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2b81f86a80a323a2ba4be60cb249368862424d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->