### PR TITLE
fix: incorrect import path for `SszKZGCommitment` and minor Javadoc cleanup

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
-import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.spec.datastructures.types.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
@@ -47,7 +47,7 @@ class StubBlobSidecarManager implements BlobSidecarManager {
     this.kzg = kzg;
   }
 
-  /** Prepare the blobs and proofs for a block provided by the reference test * */
+  /** Prepare the blobs and proofs for a block provided by the reference test. */
   public void prepareBlobsAndProofsForBlock(
       final SignedBeaconBlock block, final List<Blob> blobs, final List<KZGProof> proofs) {
     blobsAndProofsByBlockRoot.put(block.getRoot(), new BlobsAndProofs(blobs, proofs));


### PR DESCRIPTION
## PR Description

this pull request fixes a compilation issue in `StubBlobSidecarManager.java` caused by an incorrect import path for `SszKZGCommitment`.
the package name was mistakenly written as `tech.pegasys.teku.spec.datastructures.type`, which does not exist.
it has been corrected to the proper package `tech.pegasys.teku.spec.datastructures.types`.

additionally, a minor Javadoc formatting issue was fixed in the `prepareBlobsAndProofsForBlock` method to comply with Teku’s documentation conventions.

**Summary of changes:**

* fixed import path:
  `tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment` → `tech.pegasys.teku.spec.datastructures.types.SszKZGCommitment`
* cleaned up Javadoc comment formatting (removed extra `*`, added period).

**impact:**

* restores successful compilation of reference test utilities.
* no functional changes or runtime impact.

---

## Documentation

* [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

---

## Changelog

* [x] I thought about adding a changelog entry, and added one if I deemed necessary.
  *(No changelog entry required — internal compilation fix only.)*
