### PR TITLE
Update ref tests to v1.6.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Breaking Changes
 
 ### Additions and Improvements
- - Implemented `/eth/v1/beacon/states/{state_id}/proposer_lookahead` which is accessible from fulu.
+ - 🚀 Added mainnet configuration for the FULU fork 🦓 due at epoch 411392, December 3, 2025, 09:49:11pm UTC
+ - Implemented `/eth/v1/beacon/states/{state_id}/proposer_lookahead` which will be accessible after the Fulu fork.
 
 ### Bug Fixes

--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.6.0-beta.1"
+def refTestVersion = nightly ? "nightly" : "v1.6.0-beta.2"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -23,10 +23,8 @@ import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DEN
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
-import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -181,12 +179,6 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       final TestDefinition testDefinition,
       final BeaconState preState)
       throws Exception {
-    // TODO-GLOAS: https://github.com/ethereum/consensus-specs/issues/4545
-    if (testDefinition.getFork().equals(TestFork.GLOAS)
-        && operation.equals(Operation.EXECUTION_PAYLOAD)
-        && !Files.exists(testDefinition.getTestDirectory().resolve("signed_envelope.ssz_snappy"))) {
-      return;
-    }
     final boolean isOperationValid =
         testDefinition.getTestDirectory().resolve(EXPECTED_STATE_FILE).toFile().exists();
     if (isOperationValid) {

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -63,9 +63,8 @@ public class ReferenceTestFinder {
               }
 
               // TODO-GLOAS: Short circuit to limit what tests we run for Gloas while it is under
-              // development
-              // This is temporary and should be removed once we are up-to-date with Gloas specs
-              // (see https://github.com/Consensys/teku-internal/issues/221)
+              // development. This is temporary and should be removed once we are up-to-date with
+              // Gloas specs (see https://github.com/Consensys/teku-internal/issues/221)
               if (fork.equals(TestFork.GLOAS)) {
                 return Stream.of(
                         new BlsTestFinder(),
@@ -73,10 +72,8 @@ public class ReferenceTestFinder {
                         new SszTestFinder("ssz_generic"),
                         new SszTestFinder("ssz_static"),
                         new ShufflingTestFinder(),
-                        new PyspecTestFinder(List.of(), List.of("fork_choice/"))
-                        // merkle proof tests are not applicable in Gloas, these will be removed in
-                        // the next reference tests release
-                        )
+                        new PyspecTestFinder(List.of(), List.of("fork_choice/")),
+                        new MerkleProofTestFinder())
                     .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
               }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -154,15 +154,15 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
             state, data, state.getSlot().minus(data.getSlot()));
 
     // Update epoch participation flags
-    final SszMutableList<SszByte> epochParticipation;
-    final boolean forCurrentEpoch =
+    final boolean currentEpochTarget =
         data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state));
-    if (forCurrentEpoch) {
+    final SszMutableList<SszByte> epochParticipation;
+    if (currentEpochTarget) {
       epochParticipation = state.getCurrentEpochParticipation();
     } else {
       epochParticipation = state.getPreviousEpochParticipation();
     }
-    final int builderPaymentIndex = getBuilderPaymentIndex(forCurrentEpoch, data);
+    final int builderPaymentIndex = getBuilderPaymentIndex(currentEpochTarget, data);
 
     // track the weight for pending builder payment
     UInt64 builderPaymentWeightDelta = UInt64.ZERO;
@@ -195,7 +195,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
             .getProgressiveTotalBalances()
             .onAttestation(
                 state.getValidators().get(index),
-                forCurrentEpoch,
+                currentEpochTarget,
                 miscHelpersAltair.hasFlag(newParticipationFlags, TIMELY_SOURCE_FLAG_INDEX),
                 miscHelpersAltair.hasFlag(newParticipationFlags, TIMELY_TARGET_FLAG_INDEX),
                 miscHelpersAltair.hasFlag(newParticipationFlags, TIMELY_HEAD_FLAG_INDEX));
@@ -221,7 +221,8 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
         proposerReward, builderPaymentIndex, builderPaymentWeightDelta);
   }
 
-  protected int getBuilderPaymentIndex(final boolean forCurrentEpoch, final AttestationData data) {
+  protected int getBuilderPaymentIndex(
+      final boolean currentEpochTarget, final AttestationData data) {
     // NO-OP
     return 0;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -181,6 +181,7 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
 
   @Override
   public void processWithdrawals(final MutableBeaconState state) {
+    // Get information about the expected withdrawals
     final ExpectedWithdrawals expectedWithdrawals = getExpectedWithdrawals(state);
     processWithdrawalsUnchecked(
         state,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -181,7 +181,6 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
 
   @Override
   public void processWithdrawals(final MutableBeaconState state) {
-    // Get information about the expected withdrawals
     final ExpectedWithdrawals expectedWithdrawals = getExpectedWithdrawals(state);
     processWithdrawalsUnchecked(
         state,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -272,8 +272,9 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
   }
 
   @Override
-  protected int getBuilderPaymentIndex(final boolean forCurrentEpoch, final AttestationData data) {
-    if (forCurrentEpoch) {
+  protected int getBuilderPaymentIndex(
+      final boolean currentEpochTarget, final AttestationData data) {
+    if (currentEpochTarget) {
       return specConfig.getSlotsPerEpoch()
           + data.getSlot().mod(specConfig.getSlotsPerEpoch()).intValue();
     } else {
@@ -281,8 +282,8 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     }
   }
 
-  // Add weight for same-slot attestations when any new flag is set
-  // This ensures each validator contributes exactly once per slot
+  // Add weight for same-slot attestations when any new flag is set.
+  // This ensures each validator contributes exactly once per slot.
   @Override
   protected UInt64 updateBuilderPaymentWeight(
       final int builderPaymentIndex,
@@ -358,8 +359,8 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       throws BlockProcessingException {
     // process_payload_attestation
     for (final PayloadAttestation payloadAttestation : payloadAttestations) {
-      // Check that the attestation is for the parent beacon block
       final PayloadAttestationData data = payloadAttestation.getData();
+      // Check that the attestation is for the parent beacon block
       if (!data.getBeaconBlockRoot().equals(state.getLatestBlockHeader().getParentRoot())) {
         throw new BlockProcessingException("Attestation is NOT for the parent beacon block");
       }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.forktransition;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
@@ -92,10 +93,9 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                       .ofBits(IntStream.range(0, specConfig.getSlotsPerHistoricalRoot()).toArray());
               state.setExecutionPayloadAvailability(executionPayloadAvailability);
               final List<BuilderPendingPayment> builderPendingPayments =
-                  IntStream.range(0, 2 * specConfig.getSlotsPerEpoch())
-                      .mapToObj(
-                          __ -> schemaDefinitions.getBuilderPendingPaymentSchema().getDefault())
-                      .toList();
+                  Collections.nCopies(
+                      2 * specConfig.getSlotsPerEpoch(),
+                      schemaDefinitions.getBuilderPendingPaymentSchema().getDefault());
               state.setBuilderPendingPayments(
                   schemaDefinitions
                       .getBuilderPendingPaymentsSchema()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
@@ -49,9 +49,9 @@ public class PredicatesGloas extends PredicatesElectra {
   /**
    * is_parent_block_full
    *
-   * <p>This function returns true if the last committed payload bid was fulfilled with a payload,
-   * this can only happen when both beacon block and payload were present. This function must be
-   * called on a beacon state before processing the execution payload bid in the block.
+   * <p>*Note*: This function returns true if the last committed payload bid was fulfilled with a
+   * payload, which can only happen when both beacon block and payload were present. This function
+   * must be called on a beacon state before processing the execution payload bid in the block.
    */
   public boolean isParentBlockFull(final BeaconState state) {
     return BeaconStateGloas.required(state)
@@ -60,12 +60,12 @@ public class PredicatesGloas extends PredicatesElectra {
         .equals(BeaconStateGloas.required(state).getLatestBlockHash());
   }
 
-  public boolean hasBuilderWithdrawalCredential(final Validator validator) {
-    return isBuilderWithdrawalCredential(validator.getWithdrawalCredentials());
-  }
-
   public boolean isBuilderWithdrawalCredential(final Bytes32 withdrawalCredentials) {
     return withdrawalCredentials.get(0) == BUILDER_WITHDRAWAL_BYTE;
+  }
+
+  public boolean hasBuilderWithdrawalCredential(final Validator validator) {
+    return isBuilderWithdrawalCredential(validator.getWithdrawalCredentials());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch;
 
 import com.google.common.collect.Iterables;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -89,9 +91,10 @@ public class EpochProcessorGloas extends EpochProcessorFulu {
               }
             });
     final List<BuilderPendingPayment> oldPayments =
-        builderPendingPayments
-            .asList()
-            .subList(specConfig.getSlotsPerEpoch(), builderPendingPayments.size());
+        new ArrayList<>(
+            builderPendingPayments
+                .asList()
+                .subList(specConfig.getSlotsPerEpoch(), builderPendingPayments.size()));
     final List<BuilderPendingPayment> newPayments =
         Collections.nCopies(
             specConfig.getSlotsPerEpoch(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch;
 
 import com.google.common.collect.Iterables;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
@@ -13,7 +13,8 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch;
 
-import java.util.ArrayList;
+import com.google.common.collect.Iterables;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableVector;
@@ -70,36 +71,31 @@ public class EpochProcessorGloas extends EpochProcessorFulu {
     final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
     final SszMutableVector<BuilderPendingPayment> builderPendingPayments =
         stateGloas.getBuilderPendingPayments();
-    builderPendingPayments
-        .asList()
-        .subList(0, specConfig.getSlotsPerEpoch())
+    IntStream.range(0, specConfig.getSlotsPerEpoch())
         .forEach(
-            payment -> {
+            i -> {
+              final BuilderPendingPayment payment = builderPendingPayments.get(i);
               if (payment.getWeight().isGreaterThan(quorum)) {
+                final UInt64 amount = payment.getWithdrawal().getAmount();
                 final UInt64 exitQueueEpoch =
                     BeaconStateMutatorsElectra.required(beaconStateMutators)
-                        .computeExitEpochAndUpdateChurn(
-                            stateGloas, payment.getWithdrawal().getAmount());
+                        .computeExitEpochAndUpdateChurn(stateGloas, amount);
+                final UInt64 withdrawableEpoch =
+                    exitQueueEpoch.plus(specConfig.getMinValidatorWithdrawabilityDelay());
                 stateGloas
                     .getBuilderPendingWithdrawals()
                     .append(
-                        payment
-                            .getWithdrawal()
-                            .copyWithNewWithdrawableEpoch(
-                                exitQueueEpoch.plus(
-                                    specConfig.getMinValidatorWithdrawabilityDelay())));
+                        payment.getWithdrawal().copyWithNewWithdrawableEpoch(withdrawableEpoch));
               }
             });
-    final List<BuilderPendingPayment> updatedBuilderPendingPayments =
-        new ArrayList<>(
-            builderPendingPayments
-                .asList()
-                .subList(specConfig.getSlotsPerEpoch(), builderPendingPayments.size()));
-    final BuilderPendingPayment emptyPayment =
-        builderPendingPayments.getSchema().getElementSchema().getDefault();
-    updatedBuilderPendingPayments.addAll(
-        IntStream.range(0, specConfig.getSlotsPerEpoch()).mapToObj(__ -> emptyPayment).toList());
-    stateGloas.setBuilderPendingPayments(
-        builderPendingPayments.getSchema().createFromElements(updatedBuilderPendingPayments));
+    final List<BuilderPendingPayment> oldPayments =
+        builderPendingPayments
+            .asList()
+            .subList(specConfig.getSlotsPerEpoch(), builderPendingPayments.size());
+    final List<BuilderPendingPayment> newPayments =
+        Collections.nCopies(
+            specConfig.getSlotsPerEpoch(),
+            builderPendingPayments.getSchema().getElementSchema().getDefault());
+    builderPendingPayments.setAll(Iterables.concat(oldPayments, newPayments));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -42,8 +42,8 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
   /**
    * is_valid_indexed_payload_attestation
    *
-   * <p>Check if ``indexed_payload_attestation`` is not empty, has sorted and unique indices and has
-   * a valid aggregate signature.
+   * <p>Check if ``indexed_payload_attestation`` is non-empty, has sorted indices, and has a valid
+   * aggregate signature.
    */
   public boolean isValidIndexedPayloadAttestation(
       final BeaconState state, final IndexedPayloadAttestation indexedPayloadAttestation) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -50,6 +50,7 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
 
   @Override
   public void processWithdrawals(final MutableBeaconState state) {
+    // Return early if the parent block is empty
     if (!predicatesGloas.isParentBlockFull(state)) {
       return;
     }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -140,7 +140,7 @@ public class BlockProposalTestUtil {
                 builder.executionRequests(dataStructureUtil.randomExecutionRequests());
               }
               // TODO-GLOAS: potentially better stubbing of bid and payload attestations
-              // https://github.com/Consensys/teku/issues/9959
+              // https://github.com/Consensys/teku/issues/10071
               if (builder.supportsSignedExecutionPayloadBid()) {
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.6.0-beta.1
+version: v1.6.0-beta.2
 style: full
 
 specrefs:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -844,26 +844,30 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public List<Integer> getAttestationParticipationFlagIndices(
   spec: |
-    <spec fn="get_attestation_participation_flag_indices" fork="altair" hash="c13f596c">
+    <spec fn="get_attestation_participation_flag_indices" fork="altair" hash="d697ae39">
     def get_attestation_participation_flag_indices(
         state: BeaconState, data: AttestationData, inclusion_delay: uint64
     ) -> Sequence[int]:
         """
         Return the flag indices that are satisfied by an attestation.
         """
+        # Matching source
         if data.target.epoch == get_current_epoch(state):
             justified_checkpoint = state.current_justified_checkpoint
         else:
             justified_checkpoint = state.previous_justified_checkpoint
-
-        # Matching roots
         is_matching_source = data.source == justified_checkpoint
-        is_matching_target = is_matching_source and data.target.root == get_block_root(
-            state, data.target.epoch
-        )
-        is_matching_head = is_matching_target and data.beacon_block_root == get_block_root_at_slot(
-            state, data.slot
-        )
+
+        # Matching target
+        target_root = get_block_root(state, data.target.epoch)
+        target_root_matches = data.target.root == target_root
+        is_matching_target = is_matching_source and target_root_matches
+
+        # Matching head
+        head_root = get_block_root_at_slot(state, data.slot)
+        head_root_matches = data.beacon_block_root == head_root
+        is_matching_head = is_matching_target and head_root_matches
+
         assert is_matching_source
 
         participation_flag_indices = []
@@ -884,26 +888,30 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
       search: protected boolean shouldSetTargetTimelinessFlag(
   spec: |
-    <spec fn="get_attestation_participation_flag_indices" fork="deneb" hash="55cbe933">
+    <spec fn="get_attestation_participation_flag_indices" fork="deneb" hash="7b46fd38">
     def get_attestation_participation_flag_indices(
         state: BeaconState, data: AttestationData, inclusion_delay: uint64
     ) -> Sequence[int]:
         """
         Return the flag indices that are satisfied by an attestation.
         """
+        # Matching source
         if data.target.epoch == get_current_epoch(state):
             justified_checkpoint = state.current_justified_checkpoint
         else:
             justified_checkpoint = state.previous_justified_checkpoint
-
-        # Matching roots
         is_matching_source = data.source == justified_checkpoint
-        is_matching_target = is_matching_source and data.target.root == get_block_root(
-            state, data.target.epoch
-        )
-        is_matching_head = is_matching_target and data.beacon_block_root == get_block_root_at_slot(
-            state, data.slot
-        )
+
+        # Matching target
+        target_root = get_block_root(state, data.target.epoch)
+        target_root_matches = data.target.root == target_root
+        is_matching_target = is_matching_source and target_root_matches
+
+        # Matching head
+        head_root = get_block_root_at_slot(state, data.slot)
+        head_root_matches = data.beacon_block_root == head_root
+        is_matching_head = is_matching_target and head_root_matches
+
         assert is_matching_source
 
         participation_flag_indices = []
@@ -4069,7 +4077,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDeneb.java
       search: public void validateExecutionPayload(
   spec: |
-    <spec fn="process_execution_payload" fork="deneb" hash="b88cf7ed">
+    <spec fn="process_execution_payload" fork="deneb" hash="5e93d3cd">
     def process_execution_payload(
         state: BeaconState, body: BeaconBlockBody, execution_engine: ExecutionEngine
     ) -> None:
@@ -4081,20 +4089,23 @@
         assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
         # Verify timestamp
         assert payload.timestamp == compute_time_at_slot(state, state.slot)
-
-        # [New in Deneb:EIP4844] Verify commitments are under limit
+        # [New in Deneb:EIP4844]
+        # Verify commitments are under limit
         assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
 
-        # Verify the execution payload is valid
-        # [Modified in Deneb:EIP4844] Pass `versioned_hashes` to Execution Engine
-        # [Modified in Deneb:EIP4788] Pass `parent_beacon_block_root` to Execution Engine
+        # [New in Deneb:EIP4844]
+        # Compute list of versioned hashes
         versioned_hashes = [
             kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
         ]
+
+        # Verify the execution payload is valid
         assert execution_engine.verify_and_notify_new_payload(
             NewPayloadRequest(
                 execution_payload=payload,
+                # [New in Deneb:EIP4844]
                 versioned_hashes=versioned_hashes,
+                # [New in Deneb:EIP4788]
                 parent_beacon_block_root=state.latest_block_header.parent_root,
             )
         )
@@ -4127,7 +4138,7 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/block/BlockProcessorFulu.java
   spec: |
-    <spec fn="process_execution_payload" fork="fulu" hash="9a872dd6">
+    <spec fn="process_execution_payload" fork="fulu" hash="adc1f5c6">
     def process_execution_payload(
         state: BeaconState, body: BeaconBlockBody, execution_engine: ExecutionEngine
     ) -> None:
@@ -4145,10 +4156,13 @@
             len(body.blob_kzg_commitments)
             <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
         )
-        # Verify the execution payload is valid
+
+        # Compute list of versioned hashes
         versioned_hashes = [
             kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
         ]
+
+        # Verify the execution payload is valid
         assert execution_engine.verify_and_notify_new_payload(
             NewPayloadRequest(
                 execution_payload=payload,
@@ -4157,6 +4171,7 @@
                 execution_requests=body.execution_requests,
             )
         )
+
         # Cache execution payload header
         state.latest_execution_payload_header = ExecutionPayloadHeader(
             parent_hash=payload.parent_hash,
@@ -4734,16 +4749,40 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
       search: public void processSyncAggregate(
   spec: |
-    <spec fn="process_sync_aggregate" fork="altair" hash="d9a71877">
+    <spec fn="process_sync_aggregate" fork="altair" hash="5f7c046f">
     def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) -> None:
         # Verify sync committee aggregate signature signing over the previous slot block root
         committee_pubkeys = state.current_sync_committee.pubkeys
-        participant_pubkeys = [
-            pubkey for pubkey, bit in zip(committee_pubkeys, sync_aggregate.sync_committee_bits) if bit
-        ]
+        committee_bits = sync_aggregate.sync_committee_bits
+        if sum(committee_bits) == SYNC_COMMITTEE_SIZE:
+            # All members participated - use precomputed aggregate key
+            participant_pubkeys = [state.current_sync_committee.aggregate_pubkey]
+        elif sum(committee_bits) > SYNC_COMMITTEE_SIZE // 2:
+            # More than half participated - subtract non-participant keys.
+            # First determine nonparticipating members
+            non_participant_pubkeys = [
+                pubkey for pubkey, bit in zip(committee_pubkeys, committee_bits) if not bit
+            ]
+            # Compute aggregate of non-participants
+            non_participant_aggregate = eth_aggregate_pubkeys(non_participant_pubkeys)
+            # Subtract non-participants from the full aggregate
+            # This is equivalent to: aggregate_pubkey + (-non_participant_aggregate)
+            participant_pubkey = bls.add(
+                bls.bytes48_to_G1(state.current_sync_committee.aggregate_pubkey),
+                bls.neg(bls.bytes48_to_G1(non_participant_aggregate)),
+            )
+            participant_pubkeys = [BLSPubkey(bls.G1_to_bytes48(participant_pubkey))]
+        else:
+            # Less than half participated - aggregate participant keys
+            participant_pubkeys = [
+                pubkey
+                for pubkey, bit in zip(committee_pubkeys, sync_aggregate.sync_committee_bits)
+                if bit
+            ]
         previous_slot = max(state.slot, Slot(1)) - Slot(1)
         domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
         signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
+        # Note: eth_fast_aggregate_verify works with a singleton list containing an aggregated key
         assert eth_fast_aggregate_verify(
             participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature
         )
@@ -4924,7 +4963,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="electra" hash="bb094f95">
+    <spec fn="process_withdrawals" fork="electra" hash="dd99a91f">
     def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
         # [Modified in Electra:EIP7251]
         expected_withdrawals, processed_partial_withdrawals_count = get_expected_withdrawals(state)
@@ -4934,7 +4973,8 @@
         for withdrawal in expected_withdrawals:
             decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
 
-        # [New in Electra:EIP7251] Update pending partial withdrawals
+        # [New in Electra:EIP7251]
+        # Update pending partial withdrawals
         state.pending_partial_withdrawals = state.pending_partial_withdrawals[
             processed_partial_withdrawals_count:
         ]

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
@@ -23,8 +23,8 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 
 /**
  * <a
- * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md#builders-attributions">Builders
- * attributions</a>
+ * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md#builder-activities">Builder
+ * activities</a>
  */
 public interface BuilderApiChannel {
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
https://github.com/ethereum/consensus-specs/releases/tag/v1.6.0-beta.2

Mainly cleaned up Gloas to make it very similar to the specs in terms of naming + refactor of the `get_attestation_participation_flag_indices` (mostly naming again)

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates to consensus-specs v1.6.0-beta.2, refactors attestation/ builder-payment logic for Gloas, expands test coverage, and adds Fulu mainnet config entry.
> 
> - **Specs & Tests**:
>   - Bump reference tests to `v1.6.0-beta.2` (`build.gradle`, `specrefs/.ethspecify.yml`).
>   - Refresh spec mappings in `specrefs/functions.yml`.
> - **Gloas Alignment**:
>   - Refactor Altair/Gloas attestation participation logic: clearer source/target/head checks and `computeIsMatchingHead` signature; rename `forCurrentEpoch` → `currentEpochTarget` (`BlockProcessorAltair`, `BeaconStateAccessorsAltair`, `BeaconStateAccessorsGloas`, `BlockProcessorGloas`).
>   - Builder payments: clarify quorum calc, index selection, same-slot weight updates, and pending payments rotation using `setAll`/`Iterables` (`BeaconStateAccessorsGloas`, `BlockProcessorGloas`, `EpochProcessorGloas`).
>   - Fork upgrade initializes `builder_pending_payments` via `Collections.nCopies` and sets new Gloas fields (`GloasStateUpgrade`).
>   - Minor logic/comment tweaks for payload attestations and withdrawals (`BlockProcessorGloas`, `WithdrawalsHelpersGloas`).
> - **Reference Tests**:
>   - Remove skip for missing Gloas envelope in operation tests; include `MerkleProofTestFinder` for `GLOAS` (`OperationsTestExecutor`, `ReferenceTestFinder`).
> - **Changelog**:
>   - Add mainnet configuration for the `FULU` fork; note `/eth/v1/beacon/states/{state_id}/proposer_lookahead` availability (`CHANGELOG.md`).
> - **Misc**:
>   - Update links/comments (e.g., `BuilderApiChannel`, `BlockProposalTestUtil`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a8bbb334802905e3c96532815519d85ed007792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->