### PR TITLE
Reduce datacolumn prunning log level

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/log/gossip/DasGossipBatchLogger.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/log/gossip/DasGossipBatchLogger.java
@@ -208,6 +208,12 @@ public class DasGossipBatchLogger implements DasGossipLogger {
   public synchronized void onReceive(
       final DataColumnSidecar sidecar, final InternalValidationResult validationResult) {
     if (needToLogEvent(validationResult.isReject())) {
+      LOG.debug(
+          "DataColumnSidecar rejected: {}, commitments: {}, proofs: {}, reason: {}",
+          sidecar.toLogString(),
+          sidecar.getKzgCommitments(),
+          sidecar.getKzgProofs(),
+          validationResult.getDescription().orElse("<no reason>"));
       events.add(
           new ReceiveEvent(timeProvider.getTimeInMillis().longValue(), sidecar, validationResult));
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPruner.java
@@ -117,7 +117,7 @@ public class DataColumnSidecarPruner extends Service {
     pruningActiveLabelledGauge.set(1, pruningMetricsType);
     final long start = System.currentTimeMillis();
     final UInt64 minCustodySlot = calculatePruneSlot();
-    LOG.info("Pruning data column sidecars before slot {}", minCustodySlot);
+    LOG.debug("Pruning data column sidecars before slot {}", minCustodySlot);
     database.pruneAllSidecars(minCustodySlot.minusMinZero(1), pruneLimit);
 
     pruningTimingsLabelledGauge.set(System.currentTimeMillis() - start, pruningMetricsType);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reduce pruner log to debug and add debug logging of rejected DataColumnSidecars with commitments, proofs, and reason.
> 
> - **Logging**:
>   - **DasGossipBatchLogger**: On receive of rejected `DataColumnSidecar`, add debug log with `sidecar.toLogString()`, `getKzgCommitments()`, `getKzgProofs()`, and rejection reason.
>   - **DataColumnSidecarPruner**: Change pruning announcement from `info` to `debug` for "Pruning data column sidecars before slot ...".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0f515f9de43ecb27c330e411382f14c24df46ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->