### PR TITLE
Make RPC fetch delay logic reusable

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -613,7 +613,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
     }
     // delay RPC fetching
     final SafeFuture<Void> rpcFetchDelay =
-        asyncRunner.getDelayedFuture(rpcFetchDelayProvider.calulate(slotAndBlockRoot.getSlot()));
+        asyncRunner.getDelayedFuture(rpcFetchDelayProvider.calculate(slotAndBlockRoot.getSlot()));
 
     asyncRunner
         .runAsync(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -15,12 +15,10 @@ package tech.pegasys.teku.statetransition.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getRootCauseMessage;
-import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.statetransition.blobs.RemoteOrigin.LOCAL_EL;
 import static tech.pegasys.teku.statetransition.blobs.RemoteOrigin.LOCAL_PROPOSAL;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,7 +42,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
-import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -92,17 +89,11 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
   static final String GAUGE_BLOB_SIDECARS_LABEL = "blob_sidecars";
   static final String GAUGE_BLOB_SIDECARS_TRACKERS_LABEL = "blob_sidecars_trackers";
 
-  // RPC fetching delay timings
-  static final long MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS = 1500L;
-  static final UInt64 MIN_WAIT_MILLIS = UInt64.valueOf(500);
-  static final UInt64 TARGET_WAIT_MILLIS = UInt64.valueOf(1000);
-
   private final SettableLabelledGauge sizeGauge;
   private final LabelledMetric<Counter> poolStatsCounters;
   private final Map<Bytes32, BlockBlobSidecarsTracker> blockBlobSidecarsTrackers = new HashMap<>();
   private final NavigableSet<SlotAndBlockRoot> orderedBlobSidecarsTrackers = new TreeSet<>();
   private final Spec spec;
-  private final TimeProvider timeProvider;
   private final AsyncRunner asyncRunner;
   private final RecentChainData recentChainData;
   private final ExecutionLayerChannel executionLayer;
@@ -129,29 +120,31 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
 
   private final BlockImportChannel blockImportChannel;
 
+  private final RPCFetchDelayProvider rpcFetchDelayProvider;
+
   BlockBlobSidecarsTrackersPoolImpl(
       final BlockImportChannel blockImportChannel,
       final SettableLabelledGauge sizeGauge,
       final LabelledMetric<Counter> poolStatsCounters,
       final Spec spec,
-      final TimeProvider timeProvider,
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
       final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher,
+      final RPCFetchDelayProvider rpcFetchDelayProvider,
       final UInt64 historicalSlotTolerance,
       final UInt64 futureSlotTolerance,
       final int maxTrackers) {
     super(spec, futureSlotTolerance, historicalSlotTolerance);
     this.blockImportChannel = blockImportChannel;
     this.spec = spec;
-    this.timeProvider = timeProvider;
     this.asyncRunner = asyncRunner;
     this.recentChainData = recentChainData;
     this.executionLayer = executionLayer;
     this.gossipValidatorSupplier = gossipValidatorSupplier;
     this.blobSidecarGossipPublisher = blobSidecarGossipPublisher;
+    this.rpcFetchDelayProvider = rpcFetchDelayProvider;
     this.maxTrackers = maxTrackers;
     this.sizeGauge = sizeGauge;
     this.poolStatsCounters = poolStatsCounters;
@@ -166,12 +159,12 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
       final SettableLabelledGauge sizeGauge,
       final LabelledMetric<Counter> poolStatsCounters,
       final Spec spec,
-      final TimeProvider timeProvider,
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
       final ExecutionLayerChannel executionLayer,
       final Supplier<BlobSidecarGossipValidator> gossipValidatorSupplier,
       final Function<BlobSidecar, SafeFuture<Void>> blobSidecarGossipPublisher,
+      final RPCFetchDelayProvider rpcFetchDelayProvider,
       final UInt64 historicalSlotTolerance,
       final UInt64 futureSlotTolerance,
       final int maxTrackers,
@@ -179,12 +172,12 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
     super(spec, futureSlotTolerance, historicalSlotTolerance);
     this.blockImportChannel = blockImportChannel;
     this.spec = spec;
-    this.timeProvider = timeProvider;
     this.asyncRunner = asyncRunner;
     this.recentChainData = recentChainData;
     this.executionLayer = executionLayer;
     this.gossipValidatorSupplier = gossipValidatorSupplier;
     this.blobSidecarGossipPublisher = blobSidecarGossipPublisher;
+    this.rpcFetchDelayProvider = rpcFetchDelayProvider;
     this.maxTrackers = maxTrackers;
     this.sizeGauge = sizeGauge;
     this.poolStatsCounters = poolStatsCounters;
@@ -620,7 +613,7 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
     }
     // delay RPC fetching
     final SafeFuture<Void> rpcFetchDelay =
-        asyncRunner.getDelayedFuture(calculateRpcFetchDelay(slotAndBlockRoot));
+        asyncRunner.getDelayedFuture(rpcFetchDelayProvider.calulate(slotAndBlockRoot.getSlot()));
 
     asyncRunner
         .runAsync(
@@ -632,37 +625,6 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
                     .thenRun(() -> fetchMissingBlockOrBlobsFromRPC(slotAndBlockRoot))
                     .handleException(this::logBlockOrBlobsRPCFailure))
         .finishStackTrace();
-  }
-
-  @VisibleForTesting
-  Duration calculateRpcFetchDelay(final SlotAndBlockRoot slotAndBlockRoot) {
-    final UInt64 slot = slotAndBlockRoot.getSlot();
-
-    if (slot.isLessThan(getCurrentSlot())) {
-      // old slot
-      return Duration.ZERO;
-    }
-
-    final UInt64 nowMillis = timeProvider.getTimeInMillis();
-    final UInt64 slotStartTimeMillis = secondsToMillis(recentChainData.computeTimeAtSlot(slot));
-    final UInt64 attestationDueMillis =
-        slotStartTimeMillis.plus(spec.getAttestationDueMillis(slot));
-
-    if (nowMillis.isGreaterThanOrEqualTo(attestationDueMillis)) {
-      // late block, we already produced attestations on previous head,
-      // so let's wait our target delay before trying to fetch
-      return Duration.ofMillis(TARGET_WAIT_MILLIS.intValue());
-    }
-
-    final UInt64 upperLimitRelativeToAttDue =
-        attestationDueMillis.minus(MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS);
-
-    final UInt64 targetMillis = nowMillis.plus(TARGET_WAIT_MILLIS);
-
-    final UInt64 finalTime =
-        targetMillis.min(upperLimitRelativeToAttDue).max(nowMillis.plus(MIN_WAIT_MILLIS));
-
-    return Duration.ofMillis(finalTime.minus(nowMillis).intValue());
   }
 
   private synchronized SafeFuture<Void> fetchMissingBlobsFromLocalEL(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -13,6 +13,10 @@
 
 package tech.pegasys.teku.statetransition.util;
 
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MIN_WAIT_MILLIS;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_TARGET_WAIT_MILLIS;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Collections;
@@ -53,11 +57,6 @@ public class PoolFactory {
   private static final int EL_RECOVERY_TASKS_LIMIT = 10;
   private static final Duration EL_BLOBS_FETCHING_DELAY = Duration.ofMillis(500);
   private static final int EL_BLOBS_FETCHING_MAX_RETRIES = 3;
-
-  // RPC fetching delay timings
-  static final long MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS = 1500L;
-  static final UInt64 MIN_WAIT_MILLIS = UInt64.valueOf(500);
-  static final UInt64 TARGET_WAIT_MILLIS = UInt64.valueOf(1000);
 
   private final SettableLabelledGauge pendingPoolsSizeGauge;
   private final SettableLabelledGauge blockBlobSidecarsTrackersPoolSizeGauge;
@@ -199,22 +198,29 @@ public class PoolFactory {
         executionLayer,
         gossipValidatorSupplier,
         blobSidecarGossipPublisher,
-        createPoolForBlockBlobSidecarsTrackers(spec, timeProvider, recentChainData),
+        createRPCFetchDelayProvider(
+            spec,
+            timeProvider,
+            recentChainData,
+            CurrentSlotProvider.create(spec, recentChainData.getStore())),
         historicalBlockTolerance,
         futureBlockTolerance,
         maxTrackers);
   }
 
-  private RPCFetchDelayProvider createPoolForBlockBlobSidecarsTrackers(
-      final Spec spec, final TimeProvider timeProvider, final RecentChainData recentChainData) {
+  public static RPCFetchDelayProvider createRPCFetchDelayProvider(
+      final Spec spec,
+      final TimeProvider timeProvider,
+      final RecentChainData recentChainData,
+      final CurrentSlotProvider currentSlotProvider) {
     return RPCFetchDelayProvider.create(
         spec,
         timeProvider,
         recentChainData,
-        CurrentSlotProvider.create(spec, recentChainData.getStore()),
-        MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
-        MIN_WAIT_MILLIS,
-        TARGET_WAIT_MILLIS);
+        currentSlotProvider,
+        DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
+        DEFAULT_MIN_WAIT_MILLIS,
+        DEFAULT_TARGET_WAIT_MILLIS);
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PoolFactory.java
@@ -188,6 +188,17 @@ public class PoolFactory {
       final UInt64 historicalBlockTolerance,
       final UInt64 futureBlockTolerance,
       final int maxTrackers) {
+
+    final RPCFetchDelayProvider rpcFetchDelayProvider =
+        RPCFetchDelayProvider.create(
+            spec,
+            timeProvider,
+            recentChainData,
+            CurrentSlotProvider.create(spec, recentChainData.getStore()),
+            DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
+            DEFAULT_MIN_WAIT_MILLIS,
+            DEFAULT_TARGET_WAIT_MILLIS);
+
     return new BlockBlobSidecarsTrackersPoolImpl(
         blockImportChannel,
         blockBlobSidecarsTrackersPoolSizeGauge,
@@ -198,29 +209,10 @@ public class PoolFactory {
         executionLayer,
         gossipValidatorSupplier,
         blobSidecarGossipPublisher,
-        createRPCFetchDelayProvider(
-            spec,
-            timeProvider,
-            recentChainData,
-            CurrentSlotProvider.create(spec, recentChainData.getStore())),
+        rpcFetchDelayProvider,
         historicalBlockTolerance,
         futureBlockTolerance,
         maxTrackers);
-  }
-
-  public static RPCFetchDelayProvider createRPCFetchDelayProvider(
-      final Spec spec,
-      final TimeProvider timeProvider,
-      final RecentChainData recentChainData,
-      final CurrentSlotProvider currentSlotProvider) {
-    return RPCFetchDelayProvider.create(
-        spec,
-        timeProvider,
-        recentChainData,
-        currentSlotProvider,
-        DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
-        DEFAULT_MIN_WAIT_MILLIS,
-        DEFAULT_TARGET_WAIT_MILLIS);
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProvider.java
@@ -62,5 +62,5 @@ public interface RPCFetchDelayProvider {
     };
   }
 
-  Duration calulate(UInt64 slot);
+  Duration calculate(UInt64 slot);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.util;
+
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
+
+import java.time.Duration;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+@FunctionalInterface
+public interface RPCFetchDelayProvider {
+  static RPCFetchDelayProvider create(
+      final Spec spec,
+      final TimeProvider timeProvider,
+      final RecentChainData recentChainData,
+      final CurrentSlotProvider currentSlotProvider,
+      final long maxWaitRelativeToAttDueMillis,
+      final UInt64 minWaitMillis,
+      final UInt64 targetWaitMillis) {
+
+    return (slot) -> {
+      if (slot.isLessThan(currentSlotProvider.getCurrentSlot())) {
+        // old slot
+        return Duration.ZERO;
+      }
+
+      final UInt64 nowMillis = timeProvider.getTimeInMillis();
+      final UInt64 slotStartTimeMillis = secondsToMillis(recentChainData.computeTimeAtSlot(slot));
+      final UInt64 attestationDueMillis =
+          slotStartTimeMillis.plus(spec.getAttestationDueMillis(slot));
+
+      if (nowMillis.isGreaterThanOrEqualTo(attestationDueMillis)) {
+        // late block, we already produced attestations on previous head,
+        // so let's wait our target delay before trying to fetch
+        return Duration.ofMillis(targetWaitMillis.intValue());
+      }
+
+      final UInt64 upperLimitRelativeToAttDue =
+          attestationDueMillis.minus(maxWaitRelativeToAttDueMillis);
+
+      final UInt64 targetMillis = nowMillis.plus(targetWaitMillis);
+
+      final UInt64 finalTime =
+          targetMillis.min(upperLimitRelativeToAttDue).max(nowMillis.plus(minWaitMillis));
+
+      return Duration.ofMillis(finalTime.minus(nowMillis).intValue());
+    };
+  }
+
+  Duration calulate(UInt64 slot);
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProvider.java
@@ -24,6 +24,13 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 @FunctionalInterface
 public interface RPCFetchDelayProvider {
+  // RPC fetching delay timings
+  long DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS = 1500L;
+  UInt64 DEFAULT_MIN_WAIT_MILLIS = UInt64.valueOf(500);
+  UInt64 DEFAULT_TARGET_WAIT_MILLIS = UInt64.valueOf(1000);
+
+  RPCFetchDelayProvider NO_DELAY = slot -> Duration.ZERO;
+
   static RPCFetchDelayProvider create(
       final Spec spec,
       final TimeProvider timeProvider,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -127,7 +127,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     when(executionLayer.engineGetBlobAndProofs(any(), eq(currentSlot)))
         .thenReturn(SafeFuture.completedFuture(List.of()));
     when(blobSidecarPublisher.apply(any())).thenReturn(SafeFuture.COMPLETE);
-    when(rpcFetchDelayProvider.calulate(any())).thenReturn(Duration.ZERO);
+    when(rpcFetchDelayProvider.calculate(any())).thenReturn(Duration.ZERO);
     setSlot(currentSlot);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImplTest.java
@@ -25,7 +25,6 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 import static tech.pegasys.teku.statetransition.util.BlockBlobSidecarsTrackersPoolImpl.GAUGE_BLOB_SIDECARS_LABEL;
 import static tech.pegasys.teku.statetransition.util.BlockBlobSidecarsTrackersPoolImpl.GAUGE_BLOB_SIDECARS_TRACKERS_LABEL;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -84,8 +83,6 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
   private final BlobSidecarGossipValidator blobSidecarGossipValidator =
       mock(BlobSidecarGossipValidator.class);
 
-  private final RPCFetchDelayProvider rpcFetchDelayProvider = mock(RPCFetchDelayProvider.class);
-
   private final BlockImportChannel blockImportChannel = mock(BlockImportChannel.class);
   private final int maxItems = 15;
 
@@ -111,7 +108,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
                 executionLayer,
                 () -> blobSidecarGossipValidator,
                 blobSidecarPublisher,
-                rpcFetchDelayProvider,
+                RPCFetchDelayProvider.NO_DELAY,
                 historicalTolerance,
                 futureTolerance,
                 maxItems,
@@ -127,7 +124,6 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
     when(executionLayer.engineGetBlobAndProofs(any(), eq(currentSlot)))
         .thenReturn(SafeFuture.completedFuture(List.of()));
     when(blobSidecarPublisher.apply(any())).thenReturn(SafeFuture.COMPLETE);
-    when(rpcFetchDelayProvider.calculate(any())).thenReturn(Duration.ZERO);
     setSlot(currentSlot);
   }
 
@@ -1205,7 +1201,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
                 executionLayer,
                 () -> blobSidecarGossipValidator,
                 blobSidecarPublisher,
-                rpcFetchDelayProvider,
+                RPCFetchDelayProvider.NO_DELAY,
                 historicalTolerance,
                 futureTolerance,
                 maxItems,
@@ -1232,7 +1228,7 @@ public class BlockBlobSidecarsTrackersPoolImplTest {
                 executionLayer,
                 () -> blobSidecarGossipValidator,
                 blobSidecarPublisher,
-                rpcFetchDelayProvider,
+                RPCFetchDelayProvider.NO_DELAY,
                 historicalTolerance,
                 futureTolerance,
                 maxItems,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
@@ -16,9 +16,9 @@ package tech.pegasys.teku.statetransition.util;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.statetransition.util.PoolFactory.MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS;
-import static tech.pegasys.teku.statetransition.util.PoolFactory.MIN_WAIT_MILLIS;
-import static tech.pegasys.teku.statetransition.util.PoolFactory.TARGET_WAIT_MILLIS;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MIN_WAIT_MILLIS;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_TARGET_WAIT_MILLIS;
 
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,9 +44,9 @@ public class RPCFetchDelayProviderTest {
           timeProvider,
           recentChainData,
           currentSlotProvider,
-          MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
-          MIN_WAIT_MILLIS,
-          TARGET_WAIT_MILLIS);
+          DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
+          DEFAULT_MIN_WAIT_MILLIS,
+          DEFAULT_TARGET_WAIT_MILLIS);
 
   @BeforeEach
   public void setUp() {
@@ -65,7 +65,7 @@ public class RPCFetchDelayProviderTest {
     final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
     // we can wait the full target
-    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(DEFAULT_TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
@@ -81,7 +81,7 @@ public class RPCFetchDelayProviderTest {
     final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
     // we can wait the full target
-    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(MIN_WAIT_MILLIS.longValue()));
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(DEFAULT_MIN_WAIT_MILLIS.longValue()));
   }
 
   @Test
@@ -96,7 +96,7 @@ public class RPCFetchDelayProviderTest {
     final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
     // we can wait the full target
-    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(DEFAULT_TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
@@ -112,9 +112,9 @@ public class RPCFetchDelayProviderTest {
     final UInt64 blockArrivalTimeMillis =
         startSlotInMillis
             .plus(4_000)
-            .minus(MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS)
+            .minus(DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS)
             .plus(millisecondsIntoAttDueLimit)
-            .minus(TARGET_WAIT_MILLIS);
+            .minus(DEFAULT_TARGET_WAIT_MILLIS);
 
     timeProvider.advanceTimeByMillis(blockArrivalTimeMillis.longValue());
 
@@ -125,7 +125,10 @@ public class RPCFetchDelayProviderTest {
     assertThat(fetchDelay)
         .isEqualTo(
             Duration.ofMillis(
-                TARGET_WAIT_MILLIS.minus(millisecondsIntoAttDueLimit).minus(1).longValue()));
+                DEFAULT_TARGET_WAIT_MILLIS
+                    .minus(millisecondsIntoAttDueLimit)
+                    .minus(1)
+                    .longValue()));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.util;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.statetransition.util.PoolFactory.MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS;
+import static tech.pegasys.teku.statetransition.util.PoolFactory.MIN_WAIT_MILLIS;
+import static tech.pegasys.teku.statetransition.util.PoolFactory.TARGET_WAIT_MILLIS;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class RPCFetchDelayProviderTest {
+  private final Spec spec = TestSpecFactory.createMainnetDeneb();
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final CurrentSlotProvider currentSlotProvider = mock(CurrentSlotProvider.class);
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+
+  private final UInt64 currentSlot = UInt64.valueOf(10);
+
+  private final RPCFetchDelayProvider rpcFetchDelayProvider =
+      RPCFetchDelayProvider.create(
+          spec,
+          timeProvider,
+          recentChainData,
+          currentSlotProvider,
+          MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
+          MIN_WAIT_MILLIS,
+          TARGET_WAIT_MILLIS);
+
+  @BeforeEach
+  public void setUp() {
+    when(currentSlotProvider.getCurrentSlot()).thenReturn(currentSlot);
+  }
+
+  @Test
+  void shouldRespectTargetWhenBlockIsEarly() {
+    final UInt64 startSlotInSeconds = UInt64.valueOf(10);
+
+    when(recentChainData.computeTimeAtSlot(currentSlot)).thenReturn(startSlotInSeconds);
+
+    // blocks arrives at slot start
+    timeProvider.advanceTimeBySeconds(startSlotInSeconds.longValue());
+
+    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+
+    // we can wait the full target
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
+  }
+
+  @Test
+  void calculateBlockFetchDelay_shouldRespectMinimumWhenRpcIsLate() {
+    final UInt64 startSlotInSeconds = UInt64.valueOf(10);
+    final UInt64 startSlotInMillis = startSlotInSeconds.times(1_000);
+
+    when(recentChainData.computeTimeAtSlot(currentSlot)).thenReturn(startSlotInSeconds);
+
+    // blocks arrives 200ms before attestation due
+    timeProvider.advanceTimeByMillis(startSlotInMillis.plus(3_800).longValue());
+
+    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+
+    // we can wait the full target
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(MIN_WAIT_MILLIS.longValue()));
+  }
+
+  @Test
+  void calculateBlockFetchDelay_shouldRespectTargetWhenRpcIsVeryLate() {
+    final UInt64 startSlotInSeconds = UInt64.valueOf(10);
+
+    when(recentChainData.computeTimeAtSlot(currentSlot)).thenReturn(startSlotInSeconds);
+
+    // blocks arrives 1s after attestation due
+    timeProvider.advanceTimeBySeconds(startSlotInSeconds.plus(5).longValue());
+
+    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+
+    // we can wait the full target
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
+  }
+
+  @Test
+  void calculateRpcFetchDelay_shouldRespectAttestationDueLimit() {
+    final UInt64 startSlotInSeconds = UInt64.valueOf(10);
+    final UInt64 startSlotInMillis = startSlotInSeconds.times(1_000);
+
+    when(recentChainData.computeTimeAtSlot(currentSlot)).thenReturn(startSlotInSeconds);
+
+    final UInt64 millisecondsIntoAttDueLimit = UInt64.valueOf(200);
+
+    // block arrival is 200ms over the max wait relative to the attestation due
+    final UInt64 blockArrivalTimeMillis =
+        startSlotInMillis
+            .plus(4_000)
+            .minus(MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS)
+            .plus(millisecondsIntoAttDueLimit)
+            .minus(TARGET_WAIT_MILLIS);
+
+    timeProvider.advanceTimeByMillis(blockArrivalTimeMillis.longValue());
+
+    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+
+    // we can only wait 200ms less than target
+    // note the extra 1ms is from the difference of 1/3 slot time vs the 3333 basis points
+    assertThat(fetchDelay)
+        .isEqualTo(
+            Duration.ofMillis(
+                TARGET_WAIT_MILLIS.minus(millisecondsIntoAttDueLimit).minus(1).longValue()));
+  }
+
+  @Test
+  void calculateRpcFetchDelay_shouldReturnZeroIfSlotIsOld() {
+    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot.decrement());
+
+    assertThat(fetchDelay).isEqualTo(Duration.ZERO);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
@@ -59,7 +59,7 @@ public class RPCFetchDelayProviderTest {
 
     when(recentChainData.computeTimeAtSlot(currentSlot)).thenReturn(startSlotInSeconds);
 
-    // blocks arrives at slot start
+    // first block\dataSidecar arrives at slot start
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.longValue());
 
     final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
@@ -75,12 +75,12 @@ public class RPCFetchDelayProviderTest {
 
     when(recentChainData.computeTimeAtSlot(currentSlot)).thenReturn(startSlotInSeconds);
 
-    // blocks arrives 200ms before attestation due
+    // first block\dataSidecar arrives 200ms before attestation due
     timeProvider.advanceTimeByMillis(startSlotInMillis.plus(3_800).longValue());
 
     final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
-    // we can wait the full target
+    // we can't wait less than min
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(DEFAULT_MIN_WAIT_MILLIS.longValue()));
   }
 
@@ -90,7 +90,7 @@ public class RPCFetchDelayProviderTest {
 
     when(recentChainData.computeTimeAtSlot(currentSlot)).thenReturn(startSlotInSeconds);
 
-    // blocks arrives 1s after attestation due
+    // first block\dataSidecar arrives 1s after attestation due
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.plus(5).longValue());
 
     final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
@@ -108,7 +108,7 @@ public class RPCFetchDelayProviderTest {
 
     final UInt64 millisecondsIntoAttDueLimit = UInt64.valueOf(200);
 
-    // block arrival is 200ms over the max wait relative to the attestation due
+    // first block\dataSidecar arrival is 200ms over the max wait relative to the attestation due
     final UInt64 blockArrivalTimeMillis =
         startSlotInMillis
             .plus(4_000)

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/RPCFetchDelayProviderTest.java
@@ -62,7 +62,7 @@ public class RPCFetchDelayProviderTest {
     // blocks arrives at slot start
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.longValue());
 
-    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+    final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
@@ -78,7 +78,7 @@ public class RPCFetchDelayProviderTest {
     // blocks arrives 200ms before attestation due
     timeProvider.advanceTimeByMillis(startSlotInMillis.plus(3_800).longValue());
 
-    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+    final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(MIN_WAIT_MILLIS.longValue()));
@@ -93,7 +93,7 @@ public class RPCFetchDelayProviderTest {
     // blocks arrives 1s after attestation due
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.plus(5).longValue());
 
-    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+    final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
     // we can wait the full target
     assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
@@ -118,7 +118,7 @@ public class RPCFetchDelayProviderTest {
 
     timeProvider.advanceTimeByMillis(blockArrivalTimeMillis.longValue());
 
-    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot);
+    final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot);
 
     // we can only wait 200ms less than target
     // note the extra 1ms is from the difference of 1/3 slot time vs the 3333 basis points
@@ -130,7 +130,7 @@ public class RPCFetchDelayProviderTest {
 
   @Test
   void calculateRpcFetchDelay_shouldReturnZeroIfSlotIsOld() {
-    final Duration fetchDelay = rpcFetchDelayProvider.calulate(currentSlot.decrement());
+    final Duration fetchDelay = rpcFetchDelayProvider.calculate(currentSlot.decrement());
 
     assertThat(fetchDelay).isEqualTo(Duration.ZERO);
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -774,7 +774,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
     }
   }
 
-
   @VisibleForTesting
   boolean isMilestoneScheduledOrActive(final SpecMilestone milestone) {
     return spec.isMilestoneSupported(milestone)


### PR DESCRIPTION
Move the RPC fetch delay calculation outside `BlockBlobSidecarsTrackersPoolImpl` to be later reused in DAS Sampler.

relater to #9976

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Externalizes RPC fetch delay logic into `RPCFetchDelayProvider` and integrates it with `BlockBlobSidecarsTrackersPoolImpl` via `PoolFactory`, with corresponding test updates.
> 
> - **Util**:
>   - Introduce `RPCFetchDelayProvider` with `create(...)`, `NO_DELAY`, and default timing constants; exposes `Duration calculate(UInt64 slot)`.
> - **Blob Sidecars Trackers Pool** (`BlockBlobSidecarsTrackersPoolImpl`):
>   - Remove internal delay constants and `TimeProvider` dependency; add `RPCFetchDelayProvider` field/ctor param.
>   - Use `rpcFetchDelayProvider.calculate(slot)` in `onFirstSeen` to delay RPC fetching.
> - **Factory Wiring** (`PoolFactory`):
>   - Construct `RPCFetchDelayProvider` using `spec`, `timeProvider`, `recentChainData`, and `CurrentSlotProvider` with default timings.
>   - Pass the provider into new pool constructors (including test-only factory).
> - **Tests**:
>   - Add `RPCFetchDelayProviderTest` covering delay calculation scenarios.
>   - Update `BlockBlobSidecarsTrackersPoolImplTest` to mock/use `RPCFetchDelayProvider` and adjusted async/time stubs; remove in-class delay calc tests; adapt delayed action assertions.
> - **Misc**:
>   - Minor cleanup in `BeaconChainController` (no functional change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c2a22f453133da3680cc897ec8709dd6edb6d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->