### PR TITLE
Upgrade to stable v1.6.0 reference tests release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.6.0-beta.2"
+def refTestVersion = nightly ? "nightly" : "v1.6.0"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.6.0-beta.2
+version: v1.6.0
 style: full
 
 specrefs:

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -121,8 +121,16 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BLOB_SCHEDULE:"
   spec: |
-    <spec config_var="BLOB_SCHEDULE" fork="fulu" hash="f3f1064a">
+    <spec config_var="BLOB_SCHEDULE" fork="fulu" hash="07879110">
     BLOB_SCHEDULE: tuple[frozendict[str, Any], ...] = (
+        frozendict({
+            "EPOCH": 412672,
+            "MAX_BLOBS_PER_BLOCK": 15,
+        }),
+        frozendict({
+            "EPOCH": 419072,
+            "MAX_BLOBS_PER_BLOCK": 21,
+        }),
     )
     </spec>
 
@@ -276,8 +284,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "FULU_FORK_EPOCH:"
   spec: |
-    <spec config_var="FULU_FORK_EPOCH" fork="fulu" hash="673334be">
-    FULU_FORK_EPOCH: Epoch = 18446744073709551615
+    <spec config_var="FULU_FORK_EPOCH" fork="fulu" hash="af10fa3c">
+    FULU_FORK_EPOCH: Epoch = 411392
     </spec>
 
 - name: FULU_FORK_VERSION


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/releases/tag/v1.6.0

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches reference tests to stable v1.6.0 and updates specrefs/configs for Fulu fork epoch and blob schedule.
> 
> - **Build**:
>   - Set `refTestVersion` to `v1.6.0` in `build.gradle` (from `v1.6.0-beta.2`).
> - **Spec refs**:
>   - Update `.ethspecify.yml` `version` to `v1.6.0`.
>   - **Configs** (`specrefs/configs.yml`):
>     - Set `FULU_FORK_EPOCH` to `411392` (was `UINT64_MAX`).
>     - Update `BLOB_SCHEDULE` with epochs `412672` → `MAX_BLOBS_PER_BLOCK=15` and `419072` → `MAX_BLOBS_PER_BLOCK=21`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c0abec32a747a4583fa0475c6ffc1dd55c223b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->