### PR TITLE
Apply RPC fetch delay to fulu

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -13,16 +13,17 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -33,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecarRetriever;
+import tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChannel {
@@ -46,20 +48,24 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
   private final CustodyGroupCountManager custodyGroupCountManager;
   private final Map<Bytes32, DataColumnSamplingTracker> recentlySampledColumnsByRoot =
       new ConcurrentHashMap<>();
+
+  private final AsyncRunner asyncRunner;
   private final RecentChainData recentChainData;
+  private final RPCFetchDelayProvider rpcFetchDelayProvider;
 
   public DasSamplerBasic(
       final Spec spec,
+      final AsyncRunner asyncRunner,
       final CurrentSlotProvider currentSlotProvider,
+      final RPCFetchDelayProvider rpcFetchDelayProvider,
       final DataColumnSidecarCustody custody,
       final DataColumnSidecarRetriever retriever,
       final CustodyGroupCountManager custodyGroupCountManager,
       final RecentChainData recentChainData) {
     this.currentSlotProvider = currentSlotProvider;
-    checkNotNull(spec);
-    checkNotNull(custody);
-    checkNotNull(retriever);
+    this.rpcFetchDelayProvider = rpcFetchDelayProvider;
     this.spec = spec;
+    this.asyncRunner = asyncRunner;
     this.custody = custody;
     this.retriever = retriever;
     this.custodyGroupCountManager = custodyGroupCountManager;
@@ -71,6 +77,11 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
     return recentlySampledColumnsByRoot;
   }
 
+  /**
+   * When syncing or backfilling always make sure to call this method with known DataColumn *before*
+   * calling {@link DasSamplerBasic#checkDataAvailability(UInt64, Bytes32)} so that RPC fetch won't
+   * be executed on those columns.
+   */
   @Override
   public void onAlreadyKnownDataColumn(
       final DataColumnSlotAndIdentifier columnId, final RemoteOrigin remoteOrigin) {
@@ -91,6 +102,31 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
 
     final DataColumnSamplingTracker tracker = getOrCreateTracker(slot, blockRoot);
 
+    if (tracker.rpcFetchScheduled().compareAndSet(false, true)) {
+      fetchMissingColumnsViaRPC(slot, blockRoot, tracker);
+    }
+
+    return tracker.completionFuture();
+  }
+
+  private void onFirstSeen(
+      final UInt64 slot, final Bytes32 blockRoot, final DataColumnSamplingTracker tracker) {
+    final Duration delay = rpcFetchDelayProvider.calculate(slot);
+    if (delay.isZero()) {
+      // in case of immediate RPC fetch, let's postpone the actual fetch when checkDataAvailability
+      // is called.
+      // this is needed because 0 delay means we are syncing\backfilling this slot, so we want to
+      // wait eventual known columns to be added via onAlreadyKnownDataColumn before fetching.
+      return;
+    }
+    tracker.rpcFetchScheduled().set(true);
+    asyncRunner
+        .getDelayedFuture(delay)
+        .always(() -> fetchMissingColumnsViaRPC(slot, blockRoot, tracker));
+  }
+
+  private void fetchMissingColumnsViaRPC(
+      final UInt64 slot, final Bytes32 blockRoot, final DataColumnSamplingTracker tracker) {
     final List<DataColumnSlotAndIdentifier> missingColumns = tracker.getMissingColumnIdentifiers();
     LOG.debug(
         "checkDataAvailability(): missing columns for slot {} root {}: {}",
@@ -121,14 +157,23 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
               }
             })
         .finishError(LOG);
-
-    return tracker.completionFuture();
   }
 
   private DataColumnSamplingTracker getOrCreateTracker(final UInt64 slot, final Bytes32 blockRoot) {
-    return recentlySampledColumnsByRoot.computeIfAbsent(
-        blockRoot,
-        k -> DataColumnSamplingTracker.create(slot, blockRoot, custodyGroupCountManager));
+    final AtomicBoolean firstSeen = new AtomicBoolean(false);
+    final DataColumnSamplingTracker tracker =
+        recentlySampledColumnsByRoot.computeIfAbsent(
+            blockRoot,
+            k -> {
+              firstSeen.set(true);
+              return DataColumnSamplingTracker.create(slot, blockRoot, custodyGroupCountManager);
+            });
+
+    if (firstSeen.get()) {
+      onFirstSeen(slot, blockRoot, tracker);
+    }
+
+    return tracker;
   }
 
   private SafeFuture<DataColumnSidecar> retrieveColumnWithSamplingAndCustody(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.datacolumns;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -29,6 +30,7 @@ record DataColumnSamplingTracker(
     Bytes32 blockRoot,
     List<UInt64> samplingRequirement,
     Set<UInt64> missingColumns,
+    AtomicBoolean rpcFetchScheduled,
     SafeFuture<List<UInt64>> completionFuture) {
   private static final Logger LOG = LogManager.getLogger();
 
@@ -40,7 +42,12 @@ record DataColumnSamplingTracker(
     final Set<UInt64> missingColumns = ConcurrentHashMap.newKeySet(samplingRequirement.size());
     missingColumns.addAll(samplingRequirement);
     return new DataColumnSamplingTracker(
-        slot, blockRoot, samplingRequirement, missingColumns, new SafeFuture<>());
+        slot,
+        blockRoot,
+        samplingRequirement,
+        missingColumns,
+        new AtomicBoolean(false),
+        new SafeFuture<>());
   }
 
   boolean add(final DataColumnSlotAndIdentifier columnIdentifier, final RemoteOrigin origin) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -261,6 +261,7 @@ public class DasSamplerBasicTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
   void checkDataAvailability_shouldRPCFetchImmediatelyIfNotPreviouslyScheduled() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(dataStructureUtil.randomSlot(), dataStructureUtil.randomBytes32());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,6 +32,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -43,12 +46,17 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler.SamplingEligibilityStatus;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecarRetriever;
+import tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class DasSamplerBasicTest {
   private static final Spec SPEC = TestSpecFactory.createMinimalFulu();
   private static final List<UInt64> SAMPLING_INDICES =
       List.of(UInt64.valueOf(5), UInt64.ZERO, UInt64.valueOf(2));
+
+  private final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(0);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(stubTimeProvider);
+  private final RPCFetchDelayProvider rpcFetchDelayProvider = mock(RPCFetchDelayProvider.class);
 
   private RecentChainData recentChainData;
   private CustodyGroupCountManager custodyGroupCountManager;
@@ -77,7 +85,9 @@ public class DasSamplerBasicTest {
     sampler =
         new DasSamplerBasic(
             SPEC,
+            asyncRunner,
             currentSlotProvider,
+            rpcFetchDelayProvider,
             custody,
             retriever,
             custodyGroupCountManager,
@@ -108,6 +118,64 @@ public class DasSamplerBasicTest {
     sampler.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC);
 
     assertSamplerTracker(sidecar.getBeaconBlockRoot(), sidecar.getSlot(), remainingColumns);
+  }
+
+  @Test
+  void onNewValidatedDataColumnSidecar_shouldScheduleRPCFetchWhenDelayIsNonZero() {
+    final DataColumnSidecar sidecar =
+        dataStructureUtil.randomDataColumnSidecar(
+            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDICES.getFirst());
+
+    final List<UInt64> remainingColumns = SAMPLING_INDICES.subList(1, SAMPLING_INDICES.size());
+
+    when(rpcFetchDelayProvider.calculate(sidecar.getSlot())).thenReturn(Duration.ofSeconds(1));
+
+    sampler.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC);
+
+    assertRPCFetchInMillis(
+        sidecar.getSlot(), sidecar.getBeaconBlockRoot(), remainingColumns, 1_000);
+  }
+
+  @Test
+  void onAlreadyKnownDataColumn_shouldScheduleRPCFetchWhenDelayIsNonZero() {
+    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+
+    final DataColumnSlotAndIdentifier columnId =
+        new DataColumnSlotAndIdentifier(UInt64.ZERO, blockRoot, SAMPLING_INDICES.getFirst());
+    final List<UInt64> remainingColumns = SAMPLING_INDICES.subList(1, SAMPLING_INDICES.size());
+
+    when(rpcFetchDelayProvider.calculate(columnId.slot())).thenReturn(Duration.ofSeconds(1));
+
+    sampler.onAlreadyKnownDataColumn(columnId, RemoteOrigin.CUSTODY);
+
+    assertRPCFetchInMillis(columnId.slot(), columnId.blockRoot(), remainingColumns, 1_000);
+  }
+
+  @Test
+  void onNewValidatedDataColumnSidecar_shouldScheduleRPCFetchWhenDelayIsZero() {
+    final DataColumnSidecar sidecar =
+        dataStructureUtil.randomDataColumnSidecar(
+            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDICES.getFirst());
+
+    when(rpcFetchDelayProvider.calculate(sidecar.getSlot())).thenReturn(Duration.ZERO);
+
+    sampler.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC);
+
+    assertThat(asyncRunner.countDelayedActions()).isZero();
+  }
+
+  @Test
+  void onAlreadyKnownDataColumn_shouldScheduleRPCFetchWhenDelayIsZero() {
+    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+
+    final DataColumnSlotAndIdentifier columnId =
+        new DataColumnSlotAndIdentifier(UInt64.ZERO, blockRoot, SAMPLING_INDICES.getFirst());
+
+    when(rpcFetchDelayProvider.calculate(columnId.slot())).thenReturn(Duration.ZERO);
+
+    sampler.onAlreadyKnownDataColumn(columnId, RemoteOrigin.CUSTODY);
+
+    assertThat(asyncRunner.countDelayedActions()).isZero();
   }
 
   @Test
@@ -162,16 +230,14 @@ public class DasSamplerBasicTest {
         .when(retriever)
         .retrieve(any());
 
+    when(rpcFetchDelayProvider.calculate(slotAndBlockRoot.getSlot()))
+        .thenReturn(Duration.ofSeconds(1));
+
     // da check is requested
     sampler.checkDataAvailability(slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot());
 
-    // verify we call retrieve for all missing columns
-    for (final UInt64 missingColumn : SAMPLING_INDICES) {
-      verify(retriever)
-          .retrieve(
-              new DataColumnSlotAndIdentifier(
-                  slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot(), missingColumn));
-    }
+    assertRPCFetchInMillis(
+        slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot(), SAMPLING_INDICES, 1_000);
 
     // we receive one sidecar late, while retriever is still working
     sampler.onNewValidatedDataColumnSidecar(lateArrivedSidecar, RemoteOrigin.GOSSIP);
@@ -192,6 +258,21 @@ public class DasSamplerBasicTest {
 
     verifyNoMoreInteractions(retriever);
     verifyNoMoreInteractions(custody);
+  }
+
+  @Test
+  void checkDataAvailability_shouldRPCFetchImmediatelyIfNotPreviouslyScheduled() {
+    final SlotAndBlockRoot slotAndBlockRoot =
+        new SlotAndBlockRoot(dataStructureUtil.randomSlot(), dataStructureUtil.randomBytes32());
+
+    when(retriever.retrieve(any())).thenReturn(new SafeFuture<>());
+
+    when(rpcFetchDelayProvider.calculate(slotAndBlockRoot.getSlot())).thenReturn(Duration.ZERO);
+
+    sampler.checkDataAvailability(slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot());
+
+    assertRPCFetchInMillis(
+        slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot(), SAMPLING_INDICES, 0);
   }
 
   @Test
@@ -329,5 +410,36 @@ public class DasSamplerBasicTest {
                                   new DataColumnSlotAndIdentifier(slot, blockRoot, columnIndex))
                           .toList());
             });
+  }
+
+  private void assertRPCFetchInMillis(
+      final UInt64 slot,
+      final Bytes32 blockRoot,
+      final List<UInt64> missingColumns,
+      final int millisFromNow) {
+
+    if (millisFromNow > 0) {
+      // advance up to one millis from the due
+      stubTimeProvider.advanceTimeByMillis(millisFromNow - 1);
+      // verify scheduled but not due for execution
+      assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+      asyncRunner.executeDueActions();
+      assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+
+      // than advance to the due
+      stubTimeProvider.advanceTimeByMillis(1);
+
+      // due time arrived
+      assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+      asyncRunner.executeDueActions();
+    }
+
+    // no delayed actions, we expect fetch already triggered
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(0);
+
+    // verify we call retrieve for all missing columns
+    for (final UInt64 missingColumn : missingColumns) {
+      verify(retriever).retrieve(new DataColumnSlotAndIdentifier(slot, blockRoot, missingColumn));
+    }
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
@@ -47,12 +47,13 @@ class DataColumnSamplingTrackerTest {
   }
 
   @Test
-  void create_shouldInitializeWithAllColumnsMissing() {
+  void create_shouldInitializeWithAllColumnsMissingAndRPCNotFetched() {
     assertThat(tracker.slot()).isEqualTo(SLOT);
     assertThat(tracker.blockRoot()).isEqualTo(BLOCK_ROOT);
     assertThat(tracker.samplingRequirement()).isEqualTo(SAMPLING_REQUIREMENT);
     assertThat(tracker.missingColumns()).containsExactlyInAnyOrderElementsOf(SAMPLING_REQUIREMENT);
     assertThat(tracker.completionFuture()).isNotDone();
+    assertThat(tracker.rpcFetchScheduled().get()).isFalse();
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerTest.java
@@ -16,8 +16,6 @@ package tech.pegasys.teku.statetransition.forkchoice;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -101,34 +99,7 @@ class DataColumnSidecarAvailabilityCheckerTest {
     when(das.checkDataAvailability(any(), any()))
         .thenReturn(SafeFuture.completedFuture(listOfIndices));
     assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-
-    // do not call check yet
-    verify(das, never()).checkDataAvailability(any(), any());
-
     assertThat(checker.getAvailabilityCheckResult().get())
         .isEqualTo(DataAndValidationResult.validResult(listOfIndices));
-  }
-
-  @Test
-  void shouldNotCallSamplerMultipleTimesWhenGetAvailabilityCheckResultCalledMultipleTimes() {
-    when(das.checkSamplingEligibility(block.getMessage()))
-        .thenReturn(DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED);
-    when(das.checkDataAvailability(any(), any())).thenReturn(new SafeFuture<>());
-    assertThat(checker.initiateDataAvailabilityCheck()).isTrue();
-
-    // do not call check yet
-    verify(das, never()).checkDataAvailability(any(), any());
-
-    final SafeFuture<DataAndValidationResult<UInt64>> result1 =
-        checker.getAvailabilityCheckResult();
-
-    verify(das).checkDataAvailability(any(), any());
-
-    final SafeFuture<DataAndValidationResult<UInt64>> result2 =
-        checker.getAvailabilityCheckResult();
-
-    // still only called once
-    verify(das).checkDataAvailability(any(), any());
-    assertThat(result1).isSameAs(result2);
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -24,6 +24,9 @@ import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_KZG_PR
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_KZG_PRECOMPUTE_SUPERNODE;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.DEFAULT_MAXIMUM_ATTESTATION_COUNT;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MIN_WAIT_MILLIS;
+import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_TARGET_WAIT_MILLIS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
@@ -223,6 +226,7 @@ import tech.pegasys.teku.statetransition.util.DebugDataFileDumper;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
+import tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttesterSlashingValidator;
@@ -997,10 +1001,22 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
     final CurrentSlotProvider currentSlotProvider =
         CurrentSlotProvider.create(spec, recentChainData.getStore());
+    final RPCFetchDelayProvider rpcFetchDelayProvider =
+        RPCFetchDelayProvider.create(
+            spec,
+            timeProvider,
+            recentChainData,
+            currentSlotProvider,
+            DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS,
+            DEFAULT_MIN_WAIT_MILLIS,
+            DEFAULT_TARGET_WAIT_MILLIS);
+
     final DasSamplerBasic dasSampler =
         new DasSamplerBasic(
             spec,
+            beaconAsyncRunner,
             currentSlotProvider,
+            rpcFetchDelayProvider,
             dataColumnSidecarRecoveringCustody,
             recoveringSidecarRetriever,
             custodyGroupCountManager,


### PR DESCRIPTION
It applies the RPC fetch delay logic to Das Sampler

related to https://github.com/Consensys/teku/issues/9976

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds async, configurable RPC fetch delay to DAS data column sampling and triggers availability checks immediately when required, with full wiring and tests.
> 
> - **DAS Sampling (`DasSamplerBasic`)**:
>   - Introduce `AsyncRunner` and `RPCFetchDelayProvider` to schedule RPC fetches for missing columns with a computed delay; immediate fetch when delay is zero.
>   - Defer scheduling until first-seen, and guard via `rpcFetchScheduled` flag in `DataColumnSamplingTracker`.
>   - Fetch missing columns via RPC and forward newly retrieved columns to custody only if still missing.
> - **Tracker (`DataColumnSamplingTracker`)**:
>   - Add `rpcFetchScheduled` state and expose it alongside existing tracking/completion.
> - **Availability Checker**:
>   - Start DAS `checkDataAvailability` during `initiateDataAvailabilityCheck` for REQUIRED cases and flush immediately; simplify `getAvailabilityCheckResult`.
> - **Wiring**:
>   - In `BeaconChainController`, create and pass `RPCFetchDelayProvider` and `beaconAsyncRunner` to `DasSamplerBasic`.
>   - Reference tests (`ForkChoiceTestExecutor`) instantiate an async runner and use `RPCFetchDelayProvider.NO_DELAY` for deterministic behavior.
> - **Tests**:
>   - Expand unit tests to cover delayed vs immediate RPC fetch scheduling, tracker state, and availability checker flow; adjust assertions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05a8363776429322d7b6f279566d1f9edcb909ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->