### PR TITLE
[Stateless Proto] Execution proof availability checker

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -187,7 +187,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             transitionBlockValidator,
             true,
             DebugDataDumper.NOOP,
-            storageSystem.getMetricsSystem());
+            storageSystem.getMetricsSystem(),
+            Optional.empty());
     final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
 
     try {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -69,5 +69,5 @@ public class Constants {
   public static final int EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION = 1;
 
   // ZkChain prototype
-  public static final long MAX_EXECUTION_PROOF_SUBNETS = 1;
+  public static final long MAX_EXECUTION_PROOF_SUBNETS = 8;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -69,5 +69,5 @@ public class Constants {
   public static final int EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION = 1;
 
   // ZkChain prototype
-  public static final long MAX_EXECUTION_PROOF_SUBNETS = 8;
+  public static final long MAX_EXECUTION_PROOF_SUBNETS = 1;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityValidationResult.java
@@ -17,5 +17,6 @@ public enum AvailabilityValidationResult {
   NOT_REQUIRED,
   NOT_AVAILABLE,
   INVALID,
-  VALID
+  VALID,
+  OPTIMISTIC //used only with execution proofs
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/AvailabilityValidationResult.java
@@ -18,5 +18,5 @@ public enum AvailabilityValidationResult {
   NOT_AVAILABLE,
   INVALID,
   VALID,
-  OPTIMISTIC //used only with execution proofs
+  OPTIMISTIC // used only with execution proofs
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/DataAndValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/DataAndValidationResult.java
@@ -58,11 +58,11 @@ public record DataAndValidationResult<Data>(
         AvailabilityValidationResult.NOT_AVAILABLE, Collections.emptyList(), Optional.of(cause));
   }
 
-  //this should only be used with execution proofs
-    public static <Data> DataAndValidationResult<Data> optimisticValidResult() {
-        return new DataAndValidationResult<>(
-                AvailabilityValidationResult.OPTIMISTIC, Collections.emptyList(), Optional.empty());
-    }
+  // this should only be used with execution proofs
+  public static <Data> DataAndValidationResult<Data> optimisticValidResult() {
+    return new DataAndValidationResult<>(
+        AvailabilityValidationResult.OPTIMISTIC, Collections.emptyList(), Optional.empty());
+  }
 
   public boolean isValid() {
     return validationResult.equals(AvailabilityValidationResult.VALID);
@@ -89,7 +89,7 @@ public record DataAndValidationResult<Data>(
   }
 
   public boolean isOptimistic() {
-      return validationResult.equals(AvailabilityValidationResult.OPTIMISTIC);
+    return validationResult.equals(AvailabilityValidationResult.OPTIMISTIC);
   }
 
   public Optional<List<BlobSidecar>> getDataAsBlobSidecars() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/DataAndValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/availability/DataAndValidationResult.java
@@ -58,6 +58,12 @@ public record DataAndValidationResult<Data>(
         AvailabilityValidationResult.NOT_AVAILABLE, Collections.emptyList(), Optional.of(cause));
   }
 
+  //this should only be used with execution proofs
+    public static <Data> DataAndValidationResult<Data> optimisticValidResult() {
+        return new DataAndValidationResult<>(
+                AvailabilityValidationResult.OPTIMISTIC, Collections.emptyList(), Optional.empty());
+    }
+
   public boolean isValid() {
     return validationResult.equals(AvailabilityValidationResult.VALID);
   }
@@ -80,6 +86,10 @@ public record DataAndValidationResult<Data>(
 
   public boolean isSuccess() {
     return isValid() || isNotRequired();
+  }
+
+  public boolean isOptimistic() {
+      return validationResult.equals(AvailabilityValidationResult.OPTIMISTIC);
   }
 
   public Optional<List<BlobSidecar>> getDataAsBlobSidecars() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManager.java
@@ -25,18 +25,13 @@ import tech.pegasys.teku.spec.logic.common.statetransition.availability.Availabi
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
+import tech.pegasys.teku.statetransition.forkchoice.ExecutionProofsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
-public interface ExecutionProofManager extends AvailabilityCheckerFactory<ExecutionProof> {
+public interface ExecutionProofManager {
 
   ExecutionProofManager NOOP =
       new ExecutionProofManager() {
-
-        @Override
-        public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(
-            final SignedBeaconBlock block) {
-          return NOOP_EXECUTION_PROOF;
-        }
 
         @Override
         public SafeFuture<InternalValidationResult> onReceivedExecutionProofGossip(
@@ -62,6 +57,7 @@ public interface ExecutionProofManager extends AvailabilityCheckerFactory<Execut
         public SafeFuture<Void> generateProofs(SignedBlockContainer blockContainer) {
           return SafeFuture.COMPLETE;
         }
+
       };
 
   void onExecutionProofPublish(ExecutionProof executionProof, RemoteOrigin remoteOrigin);
@@ -80,4 +76,5 @@ public interface ExecutionProofManager extends AvailabilityCheckerFactory<Execut
   }
 
   SafeFuture<Void> generateProofs(SignedBlockContainer blockContainer);
+
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManager.java
@@ -13,19 +13,14 @@
 
 package tech.pegasys.teku.statetransition.executionproofs;
 
-import static tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker.NOOP_EXECUTION_PROOF;
-
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionProof;
-import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
-import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
-import tech.pegasys.teku.statetransition.forkchoice.ExecutionProofsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public interface ExecutionProofManager {
@@ -57,7 +52,6 @@ public interface ExecutionProofManager {
         public SafeFuture<Void> generateProofs(SignedBlockContainer blockContainer) {
           return SafeFuture.COMPLETE;
         }
-
       };
 
   void onExecutionProofPublish(ExecutionProof executionProof, RemoteOrigin remoteOrigin);
@@ -76,5 +70,4 @@ public interface ExecutionProofManager {
   }
 
   SafeFuture<Void> generateProofs(SignedBlockContainer blockContainer);
-
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
@@ -59,16 +59,15 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
   private final int minProofsRequired;
   private final Spec spec;
 
-
   public ExecutionProofManagerImpl(
-          final ExecutionProofGossipValidator executionProofGossipValidator,
-          final ExecutionProofGenerator executionProofGenerator,
-          final Consumer<ExecutionProof> onCreatedProof,
-          final boolean isProofGenerationEnabled,
-          final int minProofsRequired,
-          final Duration proofGenerationDelay,
-          final AsyncRunner asyncRunner,
-          final Spec spec) {
+      final ExecutionProofGossipValidator executionProofGossipValidator,
+      final ExecutionProofGenerator executionProofGenerator,
+      final Consumer<ExecutionProof> onCreatedProof,
+      final boolean isProofGenerationEnabled,
+      final int minProofsRequired,
+      final Duration proofGenerationDelay,
+      final AsyncRunner asyncRunner,
+      final Spec spec) {
     this.executionProofGossipValidator = executionProofGossipValidator;
     this.onCreatedProof = onCreatedProof;
     this.isProofGenerationEnabled = isProofGenerationEnabled;
@@ -76,7 +75,7 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
     this.executionProofGenerator = executionProofGenerator;
     this.proofGenerationDelay = proofGenerationDelay;
     this.asyncRunner = asyncRunner;
-      this.spec = spec;
+    this.spec = spec;
   }
 
   @Override
@@ -145,8 +144,8 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
               }
             }
             try {
-                //sleep for a 1/4 of the slot time based
-              Thread.sleep(spec.getSlotDurationMillis(block.getSlot())/4);
+              // sleep for a 1/4 of the slot time based
+              Thread.sleep(spec.getSlotDurationMillis(block.getSlot()) / 4);
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
               LOG.debug("Interrupted while waiting for validation of proofs");

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
@@ -148,8 +148,8 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
               // sleep for a 1/4 of the slot time based
               Thread.sleep(spec.getSlotDurationMillis(block.getSlot()) / 4);
             } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
               LOG.debug("Interrupted while waiting for validation of proofs");
+              throw new RuntimeException(e);
             }
           }
           LOG.debug("Checking proofs for block {}", block.getRoot());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
@@ -134,6 +134,7 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
               LOG.debug(
                   "Found valid proofs for block {} on attempt {}", block.getRoot(), attempt + 1);
               validationResult = SafeFuture.completedFuture(result);
+              break;
             } else {
               if (attempt == attemptsToGetProof - 1) {
                 validationResult =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionProof;
@@ -56,15 +57,18 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
   private final AsyncRunner asyncRunner;
   private final boolean isProofGenerationEnabled;
   private final int minProofsRequired;
+  private final Spec spec;
+
 
   public ExecutionProofManagerImpl(
-      final ExecutionProofGossipValidator executionProofGossipValidator,
-      final ExecutionProofGenerator executionProofGenerator,
-      final Consumer<ExecutionProof> onCreatedProof,
-      final boolean isProofGenerationEnabled,
-      final int minProofsRequired,
-      final Duration proofGenerationDelay,
-      final AsyncRunner asyncRunner) {
+          final ExecutionProofGossipValidator executionProofGossipValidator,
+          final ExecutionProofGenerator executionProofGenerator,
+          final Consumer<ExecutionProof> onCreatedProof,
+          final boolean isProofGenerationEnabled,
+          final int minProofsRequired,
+          final Duration proofGenerationDelay,
+          final AsyncRunner asyncRunner,
+          final Spec spec) {
     this.executionProofGossipValidator = executionProofGossipValidator;
     this.onCreatedProof = onCreatedProof;
     this.isProofGenerationEnabled = isProofGenerationEnabled;
@@ -72,6 +76,7 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
     this.executionProofGenerator = executionProofGenerator;
     this.proofGenerationDelay = proofGenerationDelay;
     this.asyncRunner = asyncRunner;
+      this.spec = spec;
   }
 
   @Override
@@ -140,8 +145,8 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
               }
             }
             try {
-              // TODO validate this is not blocking the thread pool
-              Thread.sleep(2000L);
+                //sleep for a 1/4 of the slot time based
+              Thread.sleep(spec.getSlotDurationMillis(block.getSlot())/4);
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
               LOG.debug("Interrupted while waiting for validation of proofs");

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/executionproofs/ExecutionProofManagerImpl.java
@@ -124,11 +124,12 @@ public class ExecutionProofManagerImpl implements ExecutionProofManager {
     for (int attempt = 0; attempt < attemptsToGetProof; attempt++) {
       final DataAndValidationResult<ExecutionProof> result = checkForValidProofs(block);
       if (result.isValid()) {
+          LOG.debug("Found valid proofs for block {} on attempt {}", block.getRoot(), attempt + 1);
         return SafeFuture.completedFuture(result);
       }
       try {
           //TODO validate this is not blocking the thread pool
-        Thread.sleep(100L);
+        Thread.sleep(2000L);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         return SafeFuture.completedFuture(DataAndValidationResult.notAvailable());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
@@ -72,7 +72,7 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
                 List<ExecutionProof> emptyList = Collections.emptyList();
                 return SafeFuture.completedFuture(
                     new DataAndValidationResult<>(
-                        AvailabilityValidationResult.INVALID, emptyList, daResult.cause()));
+                        AvailabilityValidationResult.NOT_AVAILABLE, emptyList, daResult.cause()));
               }
             });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
@@ -31,8 +31,8 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
   private final ExecutionProofManager executionProofManager;
   private final SafeFuture<DataAndValidationResult<ExecutionProof>> validationResult =
       new SafeFuture<>();
-  private SignedBeaconBlock block;
-  private AvailabilityChecker<?> delegate;
+  private final SignedBeaconBlock block;
+  private final AvailabilityChecker<?> delegate;
 
   public ExecutionProofsAvailabilityChecker(
       final ExecutionProofManager executionProofManager,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
@@ -18,6 +18,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionProof;
@@ -27,6 +29,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndV
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
 
 public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<ExecutionProof> {
+  private static final Logger LOG = LogManager.getLogger();
   private final ExecutionProofManager executionProofManager;
   private final SafeFuture<DataAndValidationResult<ExecutionProof>> validationResult =
       new SafeFuture<>();
@@ -62,6 +65,7 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
   public SafeFuture<DataAndValidationResult<ExecutionProof>> getAvailabilityCheckResult() {
       return delegate.getAvailabilityCheckResult().thenCompose(daResult ->{
           if(daResult.isSuccess()){
+              LOG.debug("Blob/DataColumn availability valid, proceeding to execution proofs validation");
                 return validationResult;
           }
           else {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
@@ -34,10 +34,13 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
   private SignedBeaconBlock block;
   private AvailabilityChecker<?> delegate;
 
-  public ExecutionProofsAvailabilityChecker(final ExecutionProofManager executionProofManager,final SignedBeaconBlock block ,final AvailabilityChecker<?> delegate) {
+  public ExecutionProofsAvailabilityChecker(
+      final ExecutionProofManager executionProofManager,
+      final SignedBeaconBlock block,
+      final AvailabilityChecker<?> delegate) {
     this.executionProofManager = executionProofManager;
-      this.delegate = delegate;
-      this.block = block;
+    this.delegate = delegate;
+    this.block = block;
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
@@ -64,6 +64,7 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
   @Override
   public SafeFuture<DataAndValidationResult<ExecutionProof>> getAvailabilityCheckResult() {
       return delegate.getAvailabilityCheckResult().thenCompose(daResult ->{
+          LOG.debug("Delegate Availability result: {}", daResult.validationResult());
           if(daResult.isSuccess()){
               LOG.debug("Blob/DataColumn availability valid, proceeding to execution proofs validation");
                 return validationResult;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
@@ -34,16 +34,10 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
   private SignedBeaconBlock block;
   private AvailabilityChecker<?> delegate;
 
-  public ExecutionProofsAvailabilityChecker(final ExecutionProofManager executionProofManager) {
+  public ExecutionProofsAvailabilityChecker(final ExecutionProofManager executionProofManager,final SignedBeaconBlock block ,final AvailabilityChecker<?> delegate) {
     this.executionProofManager = executionProofManager;
-  }
-
-  public void setDelegate(final AvailabilityChecker<?> delegate) {
-    this.delegate = delegate;
-  }
-
-  public void setBlock(final SignedBeaconBlock block) {
-    this.block = block;
+      this.delegate = delegate;
+      this.block = block;
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityChecker.java
@@ -16,8 +16,6 @@ package tech.pegasys.teku.statetransition.forkchoice;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -36,23 +34,21 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
   private SignedBeaconBlock block;
   private AvailabilityChecker<?> delegate;
 
-  public ExecutionProofsAvailabilityChecker(
-      final ExecutionProofManager executionProofManager) {
+  public ExecutionProofsAvailabilityChecker(final ExecutionProofManager executionProofManager) {
     this.executionProofManager = executionProofManager;
-
   }
 
-  public void setDelegate(final AvailabilityChecker<?> delegate){
-        this.delegate = delegate;
-    }
+  public void setDelegate(final AvailabilityChecker<?> delegate) {
+    this.delegate = delegate;
+  }
 
-    public void setBlock(final SignedBeaconBlock block) {
-        this.block = block;
-    }
+  public void setBlock(final SignedBeaconBlock block) {
+    this.block = block;
+  }
 
   @Override
   public boolean initiateDataAvailabilityCheck() {
-      delegate.initiateDataAvailabilityCheck();
+    delegate.initiateDataAvailabilityCheck();
     executionProofManager
         .validateBlockWithExecutionProofs(block)
         // should probably use a timeout based on slot time
@@ -63,23 +59,21 @@ public class ExecutionProofsAvailabilityChecker implements AvailabilityChecker<E
 
   @Override
   public SafeFuture<DataAndValidationResult<ExecutionProof>> getAvailabilityCheckResult() {
-      return delegate.getAvailabilityCheckResult().thenCompose(daResult ->{
-          LOG.debug("Delegate Availability result: {}", daResult.validationResult());
-          if(daResult.isSuccess()){
-              LOG.debug("Blob/DataColumn availability valid, proceeding to execution proofs validation");
+    return delegate
+        .getAvailabilityCheckResult()
+        .thenCompose(
+            daResult -> {
+              LOG.debug("Delegate Availability result: {}", daResult.validationResult());
+              if (daResult.isSuccess()) {
+                LOG.debug(
+                    "Blob/DataColumn availability valid, proceeding to execution proofs validation");
                 return validationResult;
-          }
-          else {
-              List<ExecutionProof> emptyList = Collections.emptyList();
-                return SafeFuture.completedFuture(new DataAndValidationResult<>(
-                        AvailabilityValidationResult.INVALID,
-                        emptyList,
-                        daResult.cause()
-                ));
-          }
-      });
-
-
+              } else {
+                List<ExecutionProof> emptyList = Collections.emptyList();
+                return SafeFuture.completedFuture(
+                    new DataAndValidationResult<>(
+                        AvailabilityValidationResult.INVALID, emptyList, daResult.cause()));
+              }
+            });
   }
-
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
@@ -1,0 +1,27 @@
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionProof;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
+import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
+
+public class ExecutionProofsAvailabilityCheckerFactory implements AvailabilityCheckerFactory<ExecutionProof> {
+
+    private final ExecutionProofManager executionProofManager;
+    private AvailabilityChecker<?> delegate;
+
+    public ExecutionProofsAvailabilityCheckerFactory(ExecutionProofManager executionProofManager) {
+        this.executionProofManager = executionProofManager;
+
+    }
+
+    public void setDelegate(final AvailabilityChecker<?> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(final SignedBeaconBlock block) {
+        return new ExecutionProofsAvailabilityChecker(executionProofManager, block, delegate);
+    }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -6,22 +19,23 @@ import tech.pegasys.teku.spec.logic.common.statetransition.availability.Availabi
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
 
-public class ExecutionProofsAvailabilityCheckerFactory implements AvailabilityCheckerFactory<ExecutionProof> {
+public class ExecutionProofsAvailabilityCheckerFactory
+    implements AvailabilityCheckerFactory<ExecutionProof> {
 
-    private final ExecutionProofManager executionProofManager;
-    private AvailabilityChecker<?> delegate;
+  private final ExecutionProofManager executionProofManager;
+  private AvailabilityChecker<?> delegate;
 
-    public ExecutionProofsAvailabilityCheckerFactory(ExecutionProofManager executionProofManager) {
-        this.executionProofManager = executionProofManager;
+  public ExecutionProofsAvailabilityCheckerFactory(ExecutionProofManager executionProofManager) {
+    this.executionProofManager = executionProofManager;
+  }
 
-    }
+  public void setDelegate(final AvailabilityChecker<?> delegate) {
+    this.delegate = delegate;
+  }
 
-    public void setDelegate(final AvailabilityChecker<?> delegate) {
-        this.delegate = delegate;
-    }
-
-    @Override
-    public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(final SignedBeaconBlock block) {
-        return new ExecutionProofsAvailabilityChecker(executionProofManager, block, delegate);
-    }
+  @Override
+  public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(
+      final SignedBeaconBlock block) {
+    return new ExecutionProofsAvailabilityChecker(executionProofManager, block, delegate);
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
@@ -34,10 +34,10 @@ public class ExecutionProofsAvailabilityCheckerFactory
     this.delegate = delegate;
   }
 
-    public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(
-            final SignedBeaconBlock block, final AvailabilityChecker<?> delegate) {
-        return new ExecutionProofsAvailabilityChecker(executionProofManager, block, delegate);
-    }
+  public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(
+      final SignedBeaconBlock block, final AvailabilityChecker<?> delegate) {
+    return new ExecutionProofsAvailabilityChecker(executionProofManager, block, delegate);
+  }
 
   @Override
   public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
@@ -25,7 +25,8 @@ public class ExecutionProofsAvailabilityCheckerFactory
   private final ExecutionProofManager executionProofManager;
   private AvailabilityChecker<?> delegate;
 
-  public ExecutionProofsAvailabilityCheckerFactory(ExecutionProofManager executionProofManager) {
+  public ExecutionProofsAvailabilityCheckerFactory(
+      final ExecutionProofManager executionProofManager) {
     this.executionProofManager = executionProofManager;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ExecutionProofsAvailabilityCheckerFactory.java
@@ -34,6 +34,11 @@ public class ExecutionProofsAvailabilityCheckerFactory
     this.delegate = delegate;
   }
 
+    public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(
+            final SignedBeaconBlock block, final AvailabilityChecker<?> delegate) {
+        return new ExecutionProofsAvailabilityChecker(executionProofManager, block, delegate);
+    }
+
   @Override
   public AvailabilityChecker<ExecutionProof> createAvailabilityChecker(
       final SignedBeaconBlock block) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -464,7 +464,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
       ExecutionProofsAvailabilityCheckerFactory availabilityCheckerFactory =
           executionProofsAvailabilityCheckerFactory.get();
-      availabilityChecker = availabilityCheckerFactory.createAvailabilityChecker(block,originalAvailabilityChecker);
+      availabilityChecker =
+          availabilityCheckerFactory.createAvailabilityChecker(block, originalAvailabilityChecker);
     } else {
       availabilityChecker = originalAvailabilityChecker;
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -464,6 +464,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       if(executionProofsAvailabilityChecker.isPresent()){
           availabilityChecker = executionProofsAvailabilityChecker.get();
           ((ExecutionProofsAvailabilityChecker)availabilityChecker).setDelegate(originalAvailabilityChecker);
+          ((ExecutionProofsAvailabilityChecker) availabilityChecker).setBlock(block);
       }
       else{
         availabilityChecker = originalAvailabilityChecker;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -464,9 +464,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
       ExecutionProofsAvailabilityCheckerFactory availabilityCheckerFactory =
           executionProofsAvailabilityCheckerFactory.get();
-      availabilityCheckerFactory.setDelegate(originalAvailabilityChecker);
-
-      availabilityChecker = availabilityCheckerFactory.createAvailabilityChecker(block);
+      availabilityChecker = availabilityCheckerFactory.createAvailabilityChecker(block,originalAvailabilityChecker);
     } else {
       availabilityChecker = originalAvailabilityChecker;
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -51,7 +51,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionProof;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -75,8 +74,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayl
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.statetransition.attestation.DeferredAttestations;
 import tech.pegasys.teku.statetransition.block.BlockImportPerformance;
-import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
-import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManagerImpl;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AttestationStateSelector;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
@@ -457,18 +454,18 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final CapturingIndexedAttestationCache indexedAttestationCache =
         IndexedAttestationCache.capturing();
 
-      final AvailabilityChecker<?> originalAvailabilityChecker =
-              forkChoiceUtil.createAvailabilityChecker(block);
+    final AvailabilityChecker<?> originalAvailabilityChecker =
+        forkChoiceUtil.createAvailabilityChecker(block);
 
-      final AvailabilityChecker<?> availabilityChecker;
-      if(executionProofsAvailabilityChecker.isPresent()){
-          availabilityChecker = executionProofsAvailabilityChecker.get();
-          ((ExecutionProofsAvailabilityChecker)availabilityChecker).setDelegate(originalAvailabilityChecker);
-          ((ExecutionProofsAvailabilityChecker) availabilityChecker).setBlock(block);
-      }
-      else{
-        availabilityChecker = originalAvailabilityChecker;
-      }
+    final AvailabilityChecker<?> availabilityChecker;
+    if (executionProofsAvailabilityChecker.isPresent()) {
+      availabilityChecker = executionProofsAvailabilityChecker.get();
+      ((ExecutionProofsAvailabilityChecker) availabilityChecker)
+          .setDelegate(originalAvailabilityChecker);
+      ((ExecutionProofsAvailabilityChecker) availabilityChecker).setBlock(block);
+    } else {
+      availabilityChecker = originalAvailabilityChecker;
+    }
 
     availabilityChecker.initiateDataAvailabilityCheck();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -51,7 +51,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionProof;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -67,7 +66,6 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
-import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
@@ -113,7 +111,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
   private final DebugDataDumper debugDataDumper;
 
-  private final Optional<ExecutionProofsAvailabilityCheckerFactory> executionProofsAvailabilityCheckerFactory;
+  private final Optional<ExecutionProofsAvailabilityCheckerFactory>
+      executionProofsAvailabilityCheckerFactory;
 
   public ForkChoice(
       final Spec spec,
@@ -126,7 +125,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final boolean forkChoiceLateBlockReorgEnabled,
       final DebugDataDumper debugDataDumper,
       final MetricsSystem metricsSystem,
-      final Optional<ExecutionProofsAvailabilityCheckerFactory> executionProofsAvailabilityCheckerFactory) {
+      final Optional<ExecutionProofsAvailabilityCheckerFactory>
+          executionProofsAvailabilityCheckerFactory) {
     this.spec = spec;
     this.forkChoiceExecutor = forkChoiceExecutor;
     this.forkChoiceStateProvider = forkChoiceStateProvider;
@@ -459,13 +459,14 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final AvailabilityChecker<?> originalAvailabilityChecker =
         forkChoiceUtil.createAvailabilityChecker(block);
 
-      final AvailabilityChecker<?> availabilityChecker;
+    final AvailabilityChecker<?> availabilityChecker;
     if (executionProofsAvailabilityCheckerFactory.isPresent()) {
 
-        ExecutionProofsAvailabilityCheckerFactory availabilityCheckerFactory = executionProofsAvailabilityCheckerFactory.get();
-        availabilityCheckerFactory.setDelegate(originalAvailabilityChecker);
+      ExecutionProofsAvailabilityCheckerFactory availabilityCheckerFactory =
+          executionProofsAvailabilityCheckerFactory.get();
+      availabilityCheckerFactory.setDelegate(originalAvailabilityChecker);
 
-        availabilityChecker = availabilityCheckerFactory.createAvailabilityChecker(block);
+      availabilityChecker = availabilityCheckerFactory.createAvailabilityChecker(block);
     } else {
       availabilityChecker = originalAvailabilityChecker;
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -107,6 +107,8 @@ import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
+import javax.swing.text.html.Option;
+
 class ForkChoiceTest {
 
   private final MetricsSystem metricsSystem = new StubMetricsSystem();
@@ -172,7 +174,8 @@ class ForkChoiceTest {
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             debugDataDumper,
-            metricsSystem);
+            metricsSystem,
+            Optional.empty());
 
     // Starting and mocks
     when(transitionBlockValidator.verifyAncestorTransitionBlock(any()))
@@ -422,7 +425,8 @@ class ForkChoiceTest {
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             DebugDataDumper.NOOP,
-            metricsSystem);
+            metricsSystem,
+            Optional.empty());
 
     final UInt64 currentSlot = recentChainData.getCurrentSlot().orElseThrow();
     final UInt64 lateBlockSlot = currentSlot.minus(1);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -107,8 +107,6 @@ import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
-import javax.swing.text.html.Option;
-
 class ForkChoiceTest {
 
   private final MetricsSystem metricsSystem = new StubMetricsSystem();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -732,11 +732,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
               zkConfig.proofDelayDurationInMs(),
               executionProofAsyncRunner.get(),
               spec);
-        executionProofsAvailabilityCheckerFactory =
+      executionProofsAvailabilityCheckerFactory =
           Optional.of(new ExecutionProofsAvailabilityCheckerFactory(executionProofManager));
     } else {
       executionProofManager = ExecutionProofManager.NOOP;
-        executionProofsAvailabilityCheckerFactory = Optional.empty();
+      executionProofsAvailabilityCheckerFactory = Optional.empty();
     }
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -376,7 +376,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile ExecutionPayloadBidManager executionPayloadBidManager;
   protected volatile ExecutionPayloadManager executionPayloadManager;
   protected volatile ExecutionProofManager executionProofManager;
-  protected volatile Optional<ExecutionProofsAvailabilityChecker> executionProofsAvailabilityChecker;
+  protected volatile Optional<ExecutionProofsAvailabilityChecker>
+      executionProofsAvailabilityChecker;
   protected volatile Optional<DasCustodySync> dasCustodySync = Optional.empty();
   protected volatile Optional<DataColumnSidecarRetriever> recoveringSidecarRetriever =
       Optional.empty();
@@ -726,10 +727,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
               zkConfig.statelessMinProofsRequired(),
               zkConfig.proofDelayDurationInMs(),
               executionProofAsyncRunner.get());
-        executionProofsAvailabilityChecker = Optional.of(new ExecutionProofsAvailabilityChecker(executionProofManager));
+      executionProofsAvailabilityChecker =
+          Optional.of(new ExecutionProofsAvailabilityChecker(executionProofManager));
     } else {
       executionProofManager = ExecutionProofManager.NOOP;
-        executionProofsAvailabilityChecker = Optional.empty();
+      executionProofsAvailabilityChecker = Optional.empty();
     }
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -727,8 +727,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               zkConfig.statelessMinProofsRequired(),
               zkConfig.proofDelayDurationInMs(),
               executionProofAsyncRunner.get(),
-              spec
-          );
+              spec);
       executionProofsAvailabilityChecker =
           Optional.of(new ExecutionProofsAvailabilityChecker(executionProofManager));
     } else {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -204,7 +204,7 @@ import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofGenerator
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofGeneratorImpl;
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManagerImpl;
-import tech.pegasys.teku.statetransition.forkchoice.ExecutionProofsAvailabilityChecker;
+import tech.pegasys.teku.statetransition.forkchoice.ExecutionProofsAvailabilityCheckerFactory;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifierImpl;
@@ -379,8 +379,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile ExecutionPayloadBidManager executionPayloadBidManager;
   protected volatile ExecutionPayloadManager executionPayloadManager;
   protected volatile ExecutionProofManager executionProofManager;
-  protected volatile Optional<ExecutionProofsAvailabilityChecker>
-      executionProofsAvailabilityChecker;
+  protected volatile Optional<ExecutionProofsAvailabilityCheckerFactory>
+      executionProofsAvailabilityCheckerFactory;
   protected volatile Optional<DasCustodySync> dasCustodySync = Optional.empty();
   protected volatile Optional<DataColumnSidecarRetriever> recoveringSidecarRetriever =
       Optional.empty();
@@ -732,11 +732,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
               zkConfig.proofDelayDurationInMs(),
               executionProofAsyncRunner.get(),
               spec);
-      executionProofsAvailabilityChecker =
-          Optional.of(new ExecutionProofsAvailabilityChecker(executionProofManager));
+        executionProofsAvailabilityCheckerFactory =
+          Optional.of(new ExecutionProofsAvailabilityCheckerFactory(executionProofManager));
     } else {
       executionProofManager = ExecutionProofManager.NOOP;
-      executionProofsAvailabilityChecker = Optional.empty();
+        executionProofsAvailabilityCheckerFactory = Optional.empty();
     }
   }
 
@@ -1380,7 +1380,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             beaconConfig.eth2NetworkConfig().isForkChoiceLateBlockReorgEnabled(),
             debugDataDumper,
             metricsSystem,
-            executionProofsAvailabilityChecker);
+            executionProofsAvailabilityCheckerFactory);
     forkChoiceTrigger =
         new ForkChoiceTrigger(
             forkChoice,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -726,7 +726,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
               zkConfig.generateExecutionProofsEnabled(),
               zkConfig.statelessMinProofsRequired(),
               zkConfig.proofDelayDurationInMs(),
-              executionProofAsyncRunner.get());
+              executionProofAsyncRunner.get(),
+              spec
+          );
       executionProofsAvailabilityChecker =
           Optional.of(new ExecutionProofsAvailabilityChecker(executionProofManager));
     } else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR adds the initial execution proof availability checker linked to the execution proof manager. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an execution proof availability checker layered over existing data availability checks and wires it through ForkChoice and BeaconChainController with async proof validation and new OPTIMISTIC result type.
> 
> - **Fork Choice / Validation**:
>   - Introduces `ExecutionProofsAvailabilityChecker` and `ExecutionProofsAvailabilityCheckerFactory` to validate execution proofs after underlying `AvailabilityChecker` succeeds.
>   - Extends `ForkChoice` constructor to accept optional `ExecutionProofsAvailabilityCheckerFactory` and wraps the original availability checker when present (`onBlock`).
> - **Execution Proofs**:
>   - Refactors `ExecutionProofManager` (no longer an `AvailabilityCheckerFactory`); `ExecutionProofManagerImpl` now performs async, retry-based proof validation using slot-duration backoff and requires a `Spec`.
>   - `validateBlockWithExecutionProofs` returns detailed `DataAndValidationResult`, propagating `NOT_AVAILABLE` when no valid proofs found; noop manager returns `NOT_REQUIRED`.
> - **Spec / Results**:
>   - Adds `AvailabilityValidationResult.OPTIMISTIC` and helper methods in `DataAndValidationResult` (e.g., `optimisticValidResult()`, `isOptimistic()`).
> - **Node Wiring**:
>   - `BeaconChainController`: initializes `ExecutionProofManagerImpl` and provides `ExecutionProofsAvailabilityCheckerFactory` to `ForkChoice` when stateless validation is enabled; otherwise uses NOOP and `Optional.empty()`.
> - **Tests / Reference**:
>   - Update `ForkChoice` construction in tests and reference executor to pass the new optional factory parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd77e8b0d356042f50d7643823835642e2b7e322. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->