### PR TITLE
add Gloas attestation gossip validation rules

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -329,6 +329,11 @@ public abstract class AttestationUtil {
   public abstract Attestation convertSingleAttestationToAggregated(
       final BeaconState state, final SingleAttestation singleAttestation);
 
+  public abstract AttestationValidationResult validateIndexValue(final UInt64 index);
+
+  public abstract AttestationValidationResult validatePayloadStatus(
+      final AttestationData attestationData, final Optional<UInt64> maybeBlockSlot);
+
   public enum SlotInclusionGossipValidationResult {
     IGNORE,
     SAVE_FOR_FUTURE

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationValidationResult.java
@@ -16,6 +16,21 @@ package tech.pegasys.teku.spec.logic.common.util;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+/**
+ * An attestation gossip validation helper that represents the result of an attestation validation
+ * check, encapsulating whether the check passed or failed.
+ *
+ * <p>This class is designed to be immutable and efficient.
+ *
+ * <ul>
+ *   <li>For a successful validation, the static singleton {@link #VALID} should be used via the
+ *       {@link #valid()} factory method to avoid unnecessary object creation.
+ *   <li>For a failed validation, an invalid result is created using the {@link #invalid(String)} or
+ *       {@link #invalid(Supplier)} factory methods. The failure reason is wrapped in a {@link
+ *       Supplier} to enable lazy evaluation. This avoids the cost of constructing complex reason
+ *       strings unless the reason is actually requested via {@link #getReason()}.
+ * </ul>
+ */
 public class AttestationValidationResult {
 
   public static final AttestationValidationResult VALID =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationValidationResult.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class AttestationValidationResult {
+
+  public static final AttestationValidationResult VALID =
+      new AttestationValidationResult(true, Optional.empty());
+
+  private final boolean isValid;
+  private final Optional<Supplier<String>> reason;
+
+  private AttestationValidationResult(
+      final boolean isValid, final Optional<Supplier<String>> reason) {
+    this.isValid = isValid;
+    this.reason = reason;
+  }
+
+  public static AttestationValidationResult valid() {
+    return VALID;
+  }
+
+  public static AttestationValidationResult invalid(final Supplier<String> reason) {
+    return new AttestationValidationResult(false, Optional.of(reason));
+  }
+
+  public static AttestationValidationResult invalid(final String reason) {
+    return new AttestationValidationResult(false, Optional.of(() -> reason));
+  }
+
+  public boolean isValid() {
+    return isValid;
+  }
+
+  public Optional<String> getReason() {
+    return reason.map(Supplier::get);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.AttestationUtilDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
@@ -198,6 +199,16 @@ public class AttestationUtilElectra extends AttestationUtilDeneb {
             .getCommitteeBitsSchema()
             .orElseThrow()
             .ofBits(singleAttestation.getFirstCommitteeIndex().intValue()));
+  }
+
+  @Override
+  public AttestationValidationResult validateIndexValue(final UInt64 index) {
+    // [REJECT] attestation.data.index == 0
+    if (!index.isZero()) {
+      return AttestationValidationResult.invalid(
+          () -> String.format("Attestation data index must be 0 for Electra, but was %s.", index));
+    }
+    return AttestationValidationResult.VALID;
   }
 
   private SszBitlist getSingleAttestationAggregationBits(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic.versions.gloas.util;
 
 import com.google.common.collect.Comparators;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLS;
@@ -23,7 +24,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
@@ -63,5 +66,36 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
     final Bytes signingRoot =
         miscHelpers.computeSigningRoot(indexedPayloadAttestation.getData(), domain);
     return BLS.fastAggregateVerify(pubKeys, signingRoot, indexedPayloadAttestation.getSignature());
+  }
+
+  @Override
+  public AttestationValidationResult validateIndexValue(final UInt64 index) {
+    // [REJECT] attestation.data.index < 2
+    if (!index.isLessThan(2)) {
+      return AttestationValidationResult.invalid(
+          () ->
+              String.format("Attestation data index must be 0 or 1 for Gloas, but was %s.", index));
+    }
+    return AttestationValidationResult.VALID;
+  }
+
+  @Override
+  public AttestationValidationResult validatePayloadStatus(
+      final AttestationData attestationData, final Optional<UInt64> maybeBlockSlot) {
+    // [REJECT] attestation.data.index == 0 if block.slot == attestation.data.slot.
+    return maybeBlockSlot
+        .map(
+            blockSlot -> {
+              if (blockSlot.equals(attestationData.getSlot())
+                  && !attestationData.getIndex().isZero()) {
+                return AttestationValidationResult.invalid(
+                    () ->
+                        String.format(
+                            "Payload status must be 0, but was %s.", attestationData.getIndex()));
+              } else {
+                return AttestationValidationResult.VALID;
+              }
+            })
+        .orElse(AttestationValidationResult.VALID);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
@@ -22,11 +22,13 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class AttestationUtilPhase0 extends AttestationUtil {
@@ -67,6 +69,19 @@ public class AttestationUtilPhase0 extends AttestationUtil {
   public Attestation convertSingleAttestationToAggregated(
       final BeaconState state, final SingleAttestation singleAttestation) {
     throw new UnsupportedOperationException("No Single Attestations before Electra");
+  }
+
+  @Override
+  public AttestationValidationResult validateIndexValue(final UInt64 index) {
+    // No index validation before Electra
+    return AttestationValidationResult.VALID;
+  }
+
+  @Override
+  public AttestationValidationResult validatePayloadStatus(
+      final AttestationData attestationData, final Optional<UInt64> maybeBlockSlot) {
+    // No payload status before Gloas
+    return AttestationValidationResult.VALID;
   }
 
   protected boolean isFromFarFuture(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResultWithState.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/InternalValidationResultWithState.java
@@ -51,6 +51,11 @@ public class InternalValidationResultWithState {
         InternalValidationResult.IGNORE, Optional.of(state));
   }
 
+  public static InternalValidationResultWithState reject(final String reason) {
+    return new InternalValidationResultWithState(
+        InternalValidationResult.create(ValidationResultCode.REJECT, reason), Optional.empty());
+  }
+
   @FormatMethod
   public static InternalValidationResultWithState reject(
       final String descriptionTemplate, final Object... args) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ElectraAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ElectraAttestationValidatorTest.java
@@ -84,7 +84,8 @@ public class ElectraAttestationValidatorTest extends DenebAttestationValidatorTe
     assertThat(validate(wrongAttestation))
         .isEqualTo(
             InternalValidationResult.reject(
-                "Rejecting attestation because attestation data index must be 0"));
+                "Attestation data index must be 0 for Electra, but was %s.",
+                wrongAttestation.getData().getIndex()));
   }
 
   @Test
@@ -115,6 +116,7 @@ public class ElectraAttestationValidatorTest extends DenebAttestationValidatorTe
     assertThat(validate(wrongAttestation))
         .isEqualTo(
             InternalValidationResult.reject(
-                "Rejecting attestation because attestation data index must be 0"));
+                "Attestation data index must be 0 for Electra, but was %s.",
+                wrongAttestation.getData().getIndex()));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+
+public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTest {
+
+  @Override
+  public Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter) {
+    return TestSpecFactory.createMinimalGloas(configAdapter);
+  }
+
+  @Override
+  @Test
+  @Disabled(
+      "This validation is applicable to Electra only. In Gloas, an index of 0 is a valid payload status.")
+  public void shouldRejectAggregateWithAttestationDataIndexNonZero() {}
+
+  @Override
+  @Test
+  @Disabled(
+      "This validation is applicable to Electra only. In Gloas, an index of 0 is a valid payload status.")
+  public void shouldRejectSingleAttestationWithAttestationDataIndexNonZero() {}
+
+  @Test
+  public void shouldRejectAggregateWithAttestationDataWithInvalidPayloadStatus() {
+    final Attestation attestation =
+        attestationGenerator.validAttestation(storageSystem.getChainHead());
+
+    final AttestationData correctAttestationData = attestation.getData();
+
+    final AttestationData invalidPayloadStatusValueData =
+        new AttestationData(
+            correctAttestationData.getSlot(),
+            UInt64.valueOf(2),
+            correctAttestationData.getBeaconBlockRoot(),
+            correctAttestationData.getSource(),
+            correctAttestationData.getTarget());
+
+    final Attestation wrongAttestation =
+        spec.getGenesisSchemaDefinitions()
+            .getAttestationSchema()
+            .create(
+                attestation.getAggregationBits(),
+                invalidPayloadStatusValueData,
+                attestation.getAggregateSignature(),
+                attestation::getCommitteeBitsRequired);
+
+    // Sanity check
+    assertThat(wrongAttestation.getData().getIndex()).isGreaterThan(UInt64.ONE);
+
+    assertThat(validate(wrongAttestation))
+        .isEqualTo(
+            InternalValidationResult.reject(
+                "Attestation data index must be 0 or 1 for Gloas, but was %s.",
+                wrongAttestation.getData().getIndex()));
+  }
+
+  @Test
+  public void shouldRejectSingleAttestationWithInvalidPayloadStatus() {
+    final Attestation attestation =
+        attestationGenerator.validAttestation(storageSystem.getChainHead());
+
+    final AttestationData correctAttestationData = attestation.getData();
+
+    final AttestationData invalidPayloadStatusValueData =
+        new AttestationData(
+            correctAttestationData.getSlot(),
+            UInt64.valueOf(2),
+            correctAttestationData.getBeaconBlockRoot(),
+            correctAttestationData.getSource(),
+            correctAttestationData.getTarget());
+
+    final Attestation wrongAttestation =
+        spec.getGenesisSchemaDefinitions()
+            .toVersionGloas()
+            .orElseThrow()
+            .getSingleAttestationSchema()
+            .create(
+                UInt64.ONE,
+                UInt64.ONE,
+                invalidPayloadStatusValueData,
+                attestation.getAggregateSignature());
+
+    // Sanity check
+    assertThat(wrongAttestation.getData().getIndex()).isGreaterThan(UInt64.ONE);
+
+    assertThat(validate(wrongAttestation))
+        .isEqualTo(
+            InternalValidationResult.reject(
+                "Attestation data index must be 0 or 1 for Gloas, but was %s.",
+                wrongAttestation.getData().getIndex()));
+  }
+
+  @Test
+  public void shouldRejectSingleAttestationWithIncorrectPayloadStatus() {
+    final Attestation attestation =
+        attestationGenerator.validAttestation(storageSystem.getChainHead());
+    final AttestationData correctAttestationData = attestation.getData();
+
+    final AttestationData invalidPayloadStatusValueData =
+        new AttestationData(
+            correctAttestationData.getSlot(),
+            ONE,
+            correctAttestationData.getBeaconBlockRoot(),
+            correctAttestationData.getSource(),
+            correctAttestationData.getTarget());
+
+    final Attestation wrongAttestation =
+        spec.getGenesisSchemaDefinitions()
+            .toVersionGloas()
+            .orElseThrow()
+            .getSingleAttestationSchema()
+            .create(
+                UInt64.ONE,
+                UInt64.ONE,
+                invalidPayloadStatusValueData,
+                attestation.getAggregateSignature());
+
+    assertThat(wrongAttestation.getData().getIndex()).isNotEqualTo(ZERO);
+    assertThat(validate(wrongAttestation))
+        .isEqualTo(
+            InternalValidationResult.reject(
+                "Payload status must be 0, but was %s.", wrongAttestation.getData().getIndex()));
+  }
+
+  @Test
+  public void shouldRejectAggregateAttestationWithIncorrectPayloadStatus() {
+    final Attestation attestation =
+        attestationGenerator.validAttestation(storageSystem.getChainHead());
+
+    final AttestationData correctAttestationData = attestation.getData();
+
+    final AttestationData invalidPayloadStatusValueData =
+        new AttestationData(
+            correctAttestationData.getSlot(),
+            UInt64.ONE,
+            correctAttestationData.getBeaconBlockRoot(),
+            correctAttestationData.getSource(),
+            correctAttestationData.getTarget());
+
+    final Attestation wrongAttestation =
+        spec.getGenesisSchemaDefinitions()
+            .getAttestationSchema()
+            .create(
+                attestation.getAggregationBits(),
+                invalidPayloadStatusValueData,
+                attestation.getAggregateSignature(),
+                attestation::getCommitteeBitsRequired);
+
+    // Sanity check
+    assertThat(wrongAttestation.getData().getIndex()).isNotEqualTo(UInt64.ZERO);
+
+    assertThat(validate(wrongAttestation))
+        .isEqualTo(
+            InternalValidationResult.reject(
+                "Payload status must be 0, but was %s.", wrongAttestation.getData().getIndex()));
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add Gloas attestations gossip validation rules (aggregate and single attestations)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#10065 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces fork-specific attestation gossip validations (including Gloas payload status) via new reusable validation APIs and updates validator logic/tests accordingly.
> 
> - **Attestation validation framework**:
>   - Add `AttestationValidationResult` utility for lightweight pass/fail with lazy reasons.
>   - Extend `AttestationUtil` with `validateIndexValue` and `validatePayloadStatus` hooks.
> - **Fork-specific rules**:
>   - **Phase0**: no-op for index/payload status.
>   - **Electra**: enforce `attestation.data.index == 0` with detailed reject reason.
>   - **Gloas**:
>     - Enforce `attestation.data.index < 2` (i.e., 0 or 1).
>     - Enforce payload status 0 when `block.slot == attestation.data.slot`.
>     - Add `isValidIndexedPayloadAttestation` (indices sorted/non-empty, aggregate signature verify).
> - **Validator integration**:
>   - `AttestationValidator` now delegates index/payload checks to fork-specific `AttestationUtil` and rejects with provided reasons.
>   - Add `InternalValidationResultWithState.reject(String)` helper.
> - **Tests**:
>   - Update Electra tests to new messages.
>   - Add comprehensive Gloas tests for index bounds and payload status on single/aggregate attestations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adac399cbe34638d7856e73203277d3b202720d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->