### PR TITLE
Simplify approving/adjusting RPC objects requests

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -13,13 +13,12 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
+import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -157,11 +156,9 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
     requestObjectsTrackers.put(RequestObject.DATA_COLUMN_SIDECAR, dataColumnSidecarsRequestTracker);
     requestObjectsTrackers.put(
         RequestObject.EXECUTION_PAYLOAD_ENVELOPE, executionPayloadEnvelopesRequestTracker);
-    Preconditions.checkState(
+    checkState(
         requestObjectsTrackers.size() == RequestObject.values().length,
-        "Some request objects trackers haven't been configured. Configured: %s, Required: %s",
-        requestObjectsTrackers.keySet(),
-        Arrays.toString(RequestObject.values()));
+        "NOT all request objects trackers have been configured");
     this.requestTracker = requestTracker;
     this.metricsSystem = metricsSystem;
     this.timeProvider = timeProvider;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -17,8 +17,11 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -104,9 +107,9 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
       Subscribers.create(true);
   private final AtomicInteger outstandingRequests = new AtomicInteger(0);
   private final AtomicInteger unansweredPings = new AtomicInteger();
-  private final RateTracker blockRequestTracker;
-  private final RateTracker blobSidecarsRequestTracker;
-  private final RateTracker dataColumnSidecarsRequestTracker;
+  // used to rate limit the number of objects returned to a peer
+  private final EnumMap<RequestObject, RateTracker> requestObjectsTrackers;
+  // used to rate limit the number of requests from a peer
   private final RateTracker requestTracker;
   private final MetricsSystem metricsSystem;
   private final TimeProvider timeProvider;
@@ -133,9 +136,10 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
       final MetadataMessagesFactory metadataMessagesFactory,
       final PeerChainValidator peerChainValidator,
       final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
-      final RateTracker blockRequestTracker,
+      final RateTracker blocksRequestTracker,
       final RateTracker blobSidecarsRequestTracker,
       final RateTracker dataColumnSidecarsRequestTracker,
+      final RateTracker executionPayloadEnvelopesRequestTracker,
       final RateTracker requestTracker,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {
@@ -147,9 +151,17 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
     this.metadataMessagesFactory = metadataMessagesFactory;
     this.peerChainValidator = peerChainValidator;
     this.dataColumnSidecarSignatureValidator = dataColumnSidecarSignatureValidator;
-    this.blockRequestTracker = blockRequestTracker;
-    this.blobSidecarsRequestTracker = blobSidecarsRequestTracker;
-    this.dataColumnSidecarsRequestTracker = dataColumnSidecarsRequestTracker;
+    requestObjectsTrackers = new EnumMap<>(RequestObject.class);
+    requestObjectsTrackers.put(RequestObject.BLOCK, blocksRequestTracker);
+    requestObjectsTrackers.put(RequestObject.BLOB_SIDECAR, blobSidecarsRequestTracker);
+    requestObjectsTrackers.put(RequestObject.DATA_COLUMN_SIDECAR, dataColumnSidecarsRequestTracker);
+    requestObjectsTrackers.put(
+        RequestObject.EXECUTION_PAYLOAD_ENVELOPE, executionPayloadEnvelopesRequestTracker);
+    Preconditions.checkState(
+        requestObjectsTrackers.size() == RequestObject.values().length,
+        "Some request objects trackers haven't been configured. Configured: %s, Required: %s",
+        requestObjectsTrackers.keySet(),
+        Arrays.toString(RequestObject.values()));
     this.requestTracker = requestTracker;
     this.metricsSystem = metricsSystem;
     this.timeProvider = timeProvider;
@@ -566,48 +578,26 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
-  public Optional<RequestKey> approveBlocksRequest(
-      final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
-    return getRequestKeyIfAvailable("blocks", blockRequestTracker, blocksCount, callback);
-  }
-
-  @Override
-  public void adjustBlocksRequest(final RequestKey requestKey, final long objectCount) {
-    adjustObjectsRequest(blockRequestTracker, requestKey, objectCount);
-  }
-
-  @Override
-  public Optional<RequestKey> approveBlobSidecarsRequest(
-      final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
+  public <T> Optional<RequestKey> approveObjectsRequest(
+      final RequestObject requestObject,
+      final ResponseCallback<T> callback,
+      final long objectsCount) {
     return getRequestKeyIfAvailable(
-        "blob sidecars", blobSidecarsRequestTracker, blobSidecarsCount, callback);
+        requestObject, requestObjectsTrackers.get(requestObject), objectsCount, callback);
   }
 
   @Override
-  public void adjustBlobSidecarsRequest(
-      final RequestKey blobSidecarsRequest, final long returnedBlobSidecarsCount) {
+  public void adjustObjectsRequest(
+      final RequestObject requestObject,
+      final RequestKey requestKey,
+      final long returnedObjectsCount) {
     adjustObjectsRequest(
-        blobSidecarsRequestTracker, blobSidecarsRequest, returnedBlobSidecarsCount);
+        requestObjectsTrackers.get(requestObject), requestKey, returnedObjectsCount);
   }
 
   @Override
   public long getAvailableDataColumnSidecarsRequestCount() {
-    return dataColumnSidecarsRequestTracker.getAvailableObjectCount();
-  }
-
-  @Override
-  public Optional<RequestKey> approveDataColumnSidecarsRequest(
-      final ResponseCallback<DataColumnSidecar> callback, final long dataColumnSidecarsCount) {
-    return getRequestKeyIfAvailable(
-        "data column sidecars",
-        dataColumnSidecarsRequestTracker,
-        dataColumnSidecarsCount,
-        callback);
-  }
-
-  @Override
-  public void adjustDataColumnSidecarsRequest(final RequestKey requestKey, final long objectCount) {
-    adjustObjectsRequest(dataColumnSidecarsRequestTracker, requestKey, objectCount);
+    return requestObjectsTrackers.get(RequestObject.DATA_COLUMN_SIDECAR).getAvailableObjectCount();
   }
 
   @Override
@@ -651,13 +641,14 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   private <T> Optional<RequestKey> getRequestKeyIfAvailable(
-      final String requestType,
-      final RateTracker requestTracker,
+      final RequestObject requestObject,
+      final RateTracker requestObjectsTracker,
       final long objectsCount,
       final ResponseCallback<T> callback) {
-    final Optional<RequestKey> maybeRequestKey = requestTracker.generateRequestKey(objectsCount);
+    final Optional<RequestKey> maybeRequestKey =
+        requestObjectsTracker.generateRequestKey(objectsCount);
     if (maybeRequestKey.isEmpty()) {
-      LOG.debug("Peer {} disconnected due to {} rate limits", getId(), requestType);
+      LOG.debug("Peer {} disconnected due to {} rate limits", getId(), requestObject);
       callback.completeWithErrorResponse(
           new RpcException(INVALID_REQUEST_CODE, "Peer has been rate limited"));
       disconnectCleanly(DisconnectReason.RATE_LIMITING).finishStackTrace();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -54,9 +54,10 @@ public interface Eth2Peer extends Peer, SyncSource {
       final MetadataMessagesFactory metadataMessagesFactory,
       final PeerChainValidator peerChainValidator,
       final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
-      final RateTracker blockRequestTracker,
+      final RateTracker blocksRequestTracker,
       final RateTracker blobSidecarsRequestTracker,
       final RateTracker dataColumnSidecarsRequestTracker,
+      final RateTracker executionPayloadEnvelopesRequestTracker,
       final RateTracker requestTracker,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {
@@ -69,9 +70,10 @@ public interface Eth2Peer extends Peer, SyncSource {
         metadataMessagesFactory,
         peerChainValidator,
         dataColumnSidecarSignatureValidator,
-        blockRequestTracker,
+        blocksRequestTracker,
         blobSidecarsRequestTracker,
         dataColumnSidecarsRequestTracker,
+        executionPayloadEnvelopesRequestTracker,
         requestTracker,
         metricsSystem,
         timeProvider);
@@ -133,22 +135,59 @@ public interface Eth2Peer extends Peer, SyncSource {
   <I extends RpcRequest, O extends SszData> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final RpcRequestBodySelector<I> requestBodySelector);
 
-  Optional<RequestKey> approveBlocksRequest(
-      ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
+  <T> Optional<RequestKey> approveObjectsRequest(
+      RequestObject requestObject, ResponseCallback<T> callback, long objectsCount);
 
-  void adjustBlocksRequest(RequestKey requestKey, long objectCount);
+  void adjustObjectsRequest(
+      RequestObject requestObject, RequestKey requestKey, long returnedObjectsCount);
 
-  Optional<RequestKey> approveBlobSidecarsRequest(
-      ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
+  default Optional<RequestKey> approveBlocksRequest(
+      final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
+    return approveObjectsRequest(RequestObject.BLOCK, callback, blocksCount);
+  }
 
-  void adjustBlobSidecarsRequest(RequestKey blobSidecarsRequest, long returnedBlobSidecarsCount);
+  default void adjustBlocksRequest(final RequestKey requestKey, final long returnedBlocksCount) {
+    adjustObjectsRequest(RequestObject.BLOCK, requestKey, returnedBlocksCount);
+  }
+
+  default Optional<RequestKey> approveBlobSidecarsRequest(
+      final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
+    return approveObjectsRequest(RequestObject.BLOB_SIDECAR, callback, blobSidecarsCount);
+  }
+
+  default void adjustBlobSidecarsRequest(
+      final RequestKey requestKey, final long returnedBlobSidecarsCount) {
+    adjustObjectsRequest(RequestObject.BLOB_SIDECAR, requestKey, returnedBlobSidecarsCount);
+  }
+
+  default Optional<RequestKey> approveDataColumnSidecarsRequest(
+      final ResponseCallback<DataColumnSidecar> callback, final long dataColumnSidecarsCount) {
+    return approveObjectsRequest(
+        RequestObject.DATA_COLUMN_SIDECAR, callback, dataColumnSidecarsCount);
+  }
+
+  default void adjustDataColumnSidecarsRequest(
+      final RequestKey requestKey, final long returnedDataColumnSidecarsCount) {
+    adjustObjectsRequest(
+        RequestObject.DATA_COLUMN_SIDECAR, requestKey, returnedDataColumnSidecarsCount);
+  }
+
+  default Optional<RequestKey> approveExecutionPayloadEnvelopesRequest(
+      final ResponseCallback<SignedExecutionPayloadEnvelope> callback,
+      final long executionPayloadEnvelopesCount) {
+    return approveObjectsRequest(
+        RequestObject.EXECUTION_PAYLOAD_ENVELOPE, callback, executionPayloadEnvelopesCount);
+  }
+
+  default void adjustExecutionPayloadEnvelopesRequest(
+      final RequestKey requestKey, final long returnedExecutionPayloadEnvelopesCount) {
+    adjustObjectsRequest(
+        RequestObject.EXECUTION_PAYLOAD_ENVELOPE,
+        requestKey,
+        returnedExecutionPayloadEnvelopesCount);
+  }
 
   long getAvailableDataColumnSidecarsRequestCount();
-
-  Optional<RequestKey> approveDataColumnSidecarsRequest(
-      ResponseCallback<DataColumnSidecar> callback, long dataColumnSidecarsCount);
-
-  void adjustDataColumnSidecarsRequest(RequestKey requestKey, long objectCount);
 
   boolean approveRequest();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -78,12 +78,14 @@ public class Eth2PeerFactory {
         PeerChainValidator.create(spec, metricsSystem, chainDataClient, requiredCheckpoint),
         dataColumnSidecarSignatureValidator,
         RateTracker.create(peerBlocksRateLimit, TIME_OUT, timeProvider, "blocks"),
-        RateTracker.create(peerBlobSidecarsRateLimit, TIME_OUT, timeProvider, "blobSidecars"),
+        RateTracker.create(peerBlobSidecarsRateLimit, TIME_OUT, timeProvider, "blob_sidecars"),
         RateTracker.create(
             peerBlocksRateLimit * spec.getNumberOfDataColumns().orElse(1),
             TIME_OUT,
             timeProvider,
-            "dataColumns"),
+            "data_column_sidecars"),
+        RateTracker.create(
+            peerBlocksRateLimit, TIME_OUT, timeProvider, "execution_payload_envelopes"),
         RateTracker.create(peerRequestLimit, TIME_OUT, timeProvider, "requestTracker"),
         metricsSystem,
         timeProvider);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestObject.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestObject.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.peers;
+
+public enum RequestObject {
+  BLOCK,
+  BLOB_SIDECAR,
+  DATA_COLUMN_SIDECAR,
+  EXECUTION_PAYLOAD_ENVELOPE
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -222,9 +222,9 @@ public class BeaconChainMethods {
             recentChainData,
             dasLogger),
         createExecutionPayloadEnvelopesByRoot(
-            spec, asyncRunner, peerLookup, rpcEncoding, recentChainData),
+            spec, asyncRunner, peerLookup, rpcEncoding, recentChainData, metricsSystem),
         createExecutionPayloadEnvelopesByRange(
-            spec, asyncRunner, peerLookup, rpcEncoding, recentChainData),
+            spec, asyncRunner, peerLookup, rpcEncoding, recentChainData, metricsSystem),
         createMetadata(spec, asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding),
         createPing(asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding));
   }
@@ -554,7 +554,8 @@ public class BeaconChainMethods {
           final AsyncRunner asyncRunner,
           final PeerLookup peerLookup,
           final RpcEncoding rpcEncoding,
-          final RecentChainData recentChainData) {
+          final RecentChainData recentChainData,
+          final MetricsSystem metricsSystem) {
 
     if (!spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
       return Optional.empty();
@@ -571,7 +572,8 @@ public class BeaconChainMethods {
 
     final ExecutionPayloadEnvelopesByRootMessageHandler
         executionPayloadEnvelopesByRootMessageHandler =
-            new ExecutionPayloadEnvelopesByRootMessageHandler();
+            new ExecutionPayloadEnvelopesByRootMessageHandler(
+                getSpecConfigGloas(spec), metricsSystem);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(
@@ -594,7 +596,8 @@ public class BeaconChainMethods {
           final AsyncRunner asyncRunner,
           final PeerLookup peerLookup,
           final RpcEncoding rpcEncoding,
-          final RecentChainData recentChainData) {
+          final RecentChainData recentChainData,
+          final MetricsSystem metricsSystem) {
 
     if (!spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
       return Optional.empty();
@@ -610,7 +613,8 @@ public class BeaconChainMethods {
 
     final ExecutionPayloadEnvelopesByRangeMessageHandler
         executionPayloadEnvelopesByRangeMessageHandler =
-            new ExecutionPayloadEnvelopesByRangeMessageHandler(getSpecConfigGloas(spec));
+            new ExecutionPayloadEnvelopesByRangeMessageHandler(
+                getSpecConfigGloas(spec), metricsSystem);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
@@ -110,7 +110,7 @@ public class DataColumnSidecarsByRangeMessageHandler
       final String protocolId,
       final Eth2Peer peer,
       final DataColumnSidecarsByRangeRequestMessage message,
-      final ResponseCallback<DataColumnSidecar> responseCallback) {
+      final ResponseCallback<DataColumnSidecar> callback) {
     final UInt64 startSlot = message.getStartSlot();
     final UInt64 endSlot = message.getMaxSlot();
     final List<UInt64> columns = message.getColumns();
@@ -123,13 +123,13 @@ public class DataColumnSidecarsByRangeMessageHandler
                     peer.getId().toBase58(), peer.getDiscoveryNodeId().orElseThrow()),
                 new DasReqRespLogger.ByRangeRequest(
                     message.getStartSlot(), message.getCount().intValue(), message.getColumns()));
-    final LoggingResponseCallback<DataColumnSidecar> responseCallbackWithLogging =
-        new LoggingResponseCallback<>(responseCallback, responseLogger);
+    final LoggingResponseCallback<DataColumnSidecar> callbackWithLogging =
+        new LoggingResponseCallback<>(callback, responseLogger);
 
     final int requestedCount = calculateRequestedCount(message);
 
     final Optional<RequestKey> maybeRequestKey =
-        peer.approveDataColumnSidecarsRequest(responseCallbackWithLogging, requestedCount);
+        peer.approveDataColumnSidecarsRequest(callbackWithLogging, requestedCount);
 
     if (!peer.approveRequest() || maybeRequestKey.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
@@ -155,7 +155,7 @@ public class DataColumnSidecarsByRangeMessageHandler
 
     final RequestState initialState =
         new RequestState(
-            responseCallbackWithLogging,
+            callbackWithLogging,
             specConfigFulu.getMaxRequestDataColumnSidecars(),
             startSlot,
             endSlot,
@@ -176,9 +176,9 @@ public class DataColumnSidecarsByRangeMessageHandler
           if (sentDataColumnSidecars != requestedCount) {
             peer.adjustDataColumnSidecarsRequest(maybeRequestKey.get(), sentDataColumnSidecars);
           }
-          responseCallbackWithLogging.completeSuccessfully();
+          callbackWithLogging.completeSuccessfully();
         },
-        error -> handleProcessingRequestError(error, responseCallbackWithLogging));
+        error -> handleProcessingRequestError(error, callbackWithLogging));
   }
 
   private int calculateRequestedCount(final DataColumnSidecarsByRangeRequestMessage message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
@@ -13,9 +13,21 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
+import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.peers.RequestKey;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
+import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
 
@@ -28,14 +40,66 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
     extends PeerRequiredLocalMessageHandler<
         ExecutionPayloadEnvelopesByRootRequestMessage, SignedExecutionPayloadEnvelope> {
 
-  public ExecutionPayloadEnvelopesByRootMessageHandler() {}
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final SpecConfigGloas config;
+  private final LabelledMetric<Counter> requestCounter;
+  private final Counter totalExecutionPayloadEnvelopesRequestedCounter;
+
+  public ExecutionPayloadEnvelopesByRootMessageHandler(
+      final SpecConfigGloas config, final MetricsSystem metricsSystem) {
+    this.config = config;
+    requestCounter =
+        metricsSystem.createLabelledCounter(
+            TekuMetricCategory.NETWORK,
+            "rpc_execution_payload_envelopes_by_root_requests_total",
+            "Total number of execution payload envelopes by root requests received",
+            "status");
+    totalExecutionPayloadEnvelopesRequestedCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.NETWORK,
+            "rpc_execution_payload_envelopes_by_root_requested_envelopes_total",
+            "Total number of execution payload envelopes requested in accepted execution payload envelopes by root requests from peers");
+  }
+
+  @Override
+  public Optional<RpcException> validateRequest(
+      final String protocolId, final ExecutionPayloadEnvelopesByRootRequestMessage request) {
+    if (request.size() > config.getMaxRequestPayloads()) {
+      requestCounter.labels("count_too_big").inc();
+      return Optional.of(
+          new RpcException(
+              INVALID_REQUEST_CODE,
+              String.format(
+                  "Only a maximum of %s execution payload envelopes can be requested per request",
+                  config.getMaxRequestPayloads())));
+    }
+    return Optional.empty();
+  }
 
   @Override
   public void onIncomingMessage(
       final String protocolId,
       final Eth2Peer peer,
       final ExecutionPayloadEnvelopesByRootRequestMessage message,
-      final ResponseCallback<SignedExecutionPayloadEnvelope> responseCallback) {
+      final ResponseCallback<SignedExecutionPayloadEnvelope> callback) {
+    LOG.trace(
+        "Peer {} requested {} execution payload envelopes with roots: {}",
+        peer.getId(),
+        message.size(),
+        message);
+
+    final Optional<RequestKey> maybeRequestKey =
+        peer.approveExecutionPayloadEnvelopesRequest(callback, message.size());
+
+    if (!peer.approveRequest() || maybeRequestKey.isEmpty()) {
+      requestCounter.labels("rate_limited").inc();
+      return;
+    }
+
+    requestCounter.labels("ok").inc();
+    totalExecutionPayloadEnvelopesRequestedCounter.inc(message.size());
+
     throw new UnsupportedOperationException("Not yet implemented");
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -64,9 +64,10 @@ class Eth2PeerTest {
   private final MetadataMessagesFactory metadataMessagesFactory =
       mock(MetadataMessagesFactory.class);
   private final PeerChainValidator peerChainValidator = mock(PeerChainValidator.class);
-  private final RateTracker blockRateTracker = mock(RateTracker.class);
+  private final RateTracker blocksRateTracker = mock(RateTracker.class);
   private final RateTracker blobSidecarsRateTracker = mock(RateTracker.class);
   private final RateTracker dataColumnSidecarsRateTracker = mock(RateTracker.class);
+  private final RateTracker executionPayloadEnvelopesRateTracker = mock(RateTracker.class);
   private final RateTracker rateTracker = mock(RateTracker.class);
   private final MetricsSystem metricsSystem = mock(MetricsSystem.class);
   private final TimeProvider timeProvider = mock(TimeProvider.class);
@@ -85,9 +86,10 @@ class Eth2PeerTest {
           metadataMessagesFactory,
           peerChainValidator,
           dataColumnSidecarSignatureValidator,
-          blockRateTracker,
+          blocksRateTracker,
           blobSidecarsRateTracker,
           dataColumnSidecarsRateTracker,
+          executionPayloadEnvelopesRateTracker,
           rateTracker,
           metricsSystem,
           timeProvider);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -390,38 +390,23 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
-  public Optional<RequestKey> approveBlocksRequest(
-      final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
+  public <T> Optional<RequestKey> approveObjectsRequest(
+      final RequestObject requestObject,
+      final ResponseCallback<T> callback,
+      final long objectsCount) {
     return Optional.of(new RequestKey(ZERO, 0));
   }
 
   @Override
-  public void adjustBlocksRequest(final RequestKey blockRequests, final long objectCount) {}
-
-  @Override
-  public Optional<RequestKey> approveBlobSidecarsRequest(
-      final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
-    return Optional.of(new RequestKey(ZERO, 0));
-  }
-
-  @Override
-  public void adjustBlobSidecarsRequest(
-      final RequestKey blobSidecarRequests, final long returnedBlobSidecarsCount) {}
+  public void adjustObjectsRequest(
+      final RequestObject requestObject,
+      final RequestKey requestKey,
+      final long returnedObjectsCount) {}
 
   @Override
   public long getAvailableDataColumnSidecarsRequestCount() {
     return 0;
   }
-
-  @Override
-  public Optional<RequestKey> approveDataColumnSidecarsRequest(
-      final ResponseCallback<DataColumnSidecar> callback, final long dataColumnSidecarsCount) {
-    return Optional.of(new RequestKey(ZERO, 0));
-  }
-
-  @Override
-  public void adjustDataColumnSidecarsRequest(
-      final RequestKey dataColumnSidecarRequests, final long objectCount) {}
 
   @Override
   public boolean approveRequest() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
It is a bit cumbersome and error prone to add new rate trackers for new objects, so did a small refactor to make it simpler and easier to use.

Used `default` methods in `Eth2Peer` interface to not break anything currently.

Added the execution payload envelopes approve/adjust as well as simply added it in the two new handlers for Gloas.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalizes per-object RPC rate limiting for peers and integrates execution payload envelope request approval and metrics into Gloas handlers.
> 
> - **Peers (rate limiting refactor)**:
>   - Replace per-type trackers with `EnumMap<RequestObject, RateTracker>` in `DefaultEth2Peer`; add generic `approveObjectsRequest`/`adjustObjectsRequest` and use defaults in `Eth2Peer` for blocks/blob/data column/execution payload envelopes.
>   - Update constructors/factory (`Eth2Peer.create`, `Eth2PeerFactory`) to pass trackers for `blocks`, `blob_sidecars`, `data_column_sidecars`, and `execution_payload_envelopes`; add `checkState` to ensure all trackers configured.
>   - Keep request-rate limiter (`requestTracker`) unchanged; expose `getAvailableDataColumnSidecarsRequestCount()` via new map.
> - **RPC methods/handlers (Gloas/Fulu)**:
>   - `BeaconChainMethods`: pass `MetricsSystem` to execution payload envelope handlers.
>   - `ExecutionPayloadEnvelopesByRoot/ByRangeMessageHandler`: add validation against spec limits, per-request counters, and rate limiting via peer `approveExecutionPayloadEnvelopesRequest`; record totals; still unimplemented responses.
>   - `DataColumnSidecarsByRangeMessageHandler`: switch to logging `callback` var and use new peer approve/adjust methods.
> - **Tests/fixtures**:
>   - Update tests and `RespondingEth2Peer` to new generic approve/adjust API and extra tracker; minor renames to match new parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c005883f3a6617523929fc2a2ac6cf796810ffae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->