### PR TITLE
Update besu version to 25.11

### DIFF
--- a/beacon/sync/build.gradle
+++ b/beacon/sync/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testImplementation testFixtures(project(':infrastructure:metrics'))
     testImplementation testFixtures(project('::networking:eth2'))
     testImplementation testFixtures(project('::networking:p2p'))
-    testImplementation 'org.hyperledger.besu.internal:metrics-core'
+    testImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
 
     integrationTestImplementation testFixtures(project(':infrastructure:bls'))
     integrationTestImplementation testFixtures(project(':ethereum:statetransition'))
@@ -51,7 +51,7 @@ dependencies {
     testFixturesImplementation testFixtures(project(':infrastructure:metrics'))
 
     testFixturesImplementation 'org.mockito:mockito-core'
-    testFixturesImplementation 'org.hyperledger.besu:plugin-api'
-    testFixturesImplementation 'org.hyperledger.besu.internal:metrics-core'
+    testFixturesImplementation 'org.hyperledger.besu:besu-plugin-api'
+    testFixturesImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
     testFixturesImplementation 'com.google.guava:guava'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -987,21 +987,12 @@ subprojects {
     propertyTestRuntimeOnly.extendsFrom testRuntimeOnly
     referenceTestRuntimeOnly.extendsFrom testRuntimeOnly
 
-    // exclude until Besu dependencies start using io.consensys.protocols:jc-kzg-4844
-    implementation {
-      exclude(group: "tech.pegasys", module: "jc-kzg-4844")
-    }
-
     // Details at https://github.com/Hakky54/log-captor#using-log-captor-alongside-with-other-logging-libraries
     testImplementation {
       exclude(group: "org.apache.logging.log4j", module: "log4j-slf4j-impl")
       exclude(group: "org.apache.logging.log4j", module: "log4j-slf4j2-impl")
     }
 
-    // exclude until we update Besu dependencies (https://github.com/Consensys/teku/issues/10060)
-    configureEach {
-      exclude(group: "io.netty", module: "netty-codec-smtp")
-    }
   }
 
   def jarName = project.name

--- a/data/publisher/build.gradle
+++ b/data/publisher/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'org.hyperledger.besu.internal:metrics-core'
+    implementation 'org.hyperledger.besu.internal:besu-metrics-core'
     implementation 'com.squareup.okhttp3:okhttp'
     compileOnly 'com.github.oshi:oshi-core-java11'
 

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   referenceTestImplementation project(':infrastructure:time')
   referenceTestImplementation project(':data:dataexchange')
 
-  referenceTestImplementation 'org.hyperledger.besu:plugin-api'
+  referenceTestImplementation 'org.hyperledger.besu:besu-plugin-api'
   referenceTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
   referenceTestImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   referenceTestImplementation 'io.consensys.tuweni:tuweni-bytes'

--- a/ethereum/performance-trackers/build.gradle
+++ b/ethereum/performance-trackers/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  implementation 'org.hyperledger.besu:plugin-api'
+  implementation 'org.hyperledger.besu:besu-plugin-api'
   implementation project(':infrastructure:metrics')
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:time')

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -39,11 +39,11 @@ dependencies {
     testFixturesImplementation 'org.apache.logging.log4j:log4j-api'
     testFixturesImplementation 'io.consensys.tuweni:tuweni-units'
     testFixturesImplementation 'io.consensys.tuweni:tuweni-ssz'
-    testFixturesImplementation 'org.hyperledger.besu.internal:core'
-    testFixturesImplementation 'org.hyperledger.besu.internal:config'
+    testFixturesImplementation 'org.hyperledger.besu.internal:besu-ethereum-core'
+    testFixturesImplementation 'org.hyperledger.besu.internal:besu-config'
     testFixturesImplementation 'org.hyperledger.besu:besu-datatypes'
-    testFixturesImplementation 'org.hyperledger.besu:evm'
-    testFixturesImplementation 'org.hyperledger.besu:plugin-api'
+    testFixturesImplementation 'org.hyperledger.besu:besu-evm'
+    testFixturesImplementation 'org.hyperledger.besu:besu-plugin-api'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api'
     testFixturesImplementation project(':ethereum:performance-trackers')
     testFixturesImplementation project(':ethereum:execution-types')
@@ -77,5 +77,5 @@ dependencies {
     testImplementation testFixtures(project(':infrastructure:metrics'))
     testImplementation testFixtures(project(':infrastructure:time'))
 
-    testFixturesImplementation 'org.hyperledger.besu.internal:metrics-core'
+    testFixturesImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/interop/MergedGenesisTestBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/interop/MergedGenesisTestBuilder.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.CodeCache;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -43,8 +44,10 @@ public class MergedGenesisTestBuilder {
             MiningConfiguration.MINING_DISABLED,
             badBlockManager,
             false,
+            false,
             new NoOpMetricsSystem());
-    final GenesisState genesisState = GenesisState.fromConfig(configFile, protocolSchedule);
+    final GenesisState genesisState =
+        GenesisState.fromConfig(configFile, protocolSchedule, new CodeCache());
     final Block genesisBlock = genesisState.getBlock();
     final BlockHeader header = genesisBlock.getHeader();
 

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation project(':storage:api')
 
   implementation 'io.consensys.tuweni:tuweni-units'
-  implementation 'org.hyperledger.besu.internal:metrics-core'
+  implementation 'org.hyperledger.besu.internal:besu-metrics-core'
   implementation 'io.libp2p:jvm-libp2p'
 
   testImplementation testFixtures(project(':ethereum:spec'))

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -147,15 +147,15 @@ dependencyManagement {
 
     dependency 'io.prometheus:prometheus-metrics-bom:1.3.10'
 
-    dependencySet(group: 'org.hyperledger.besu.internal', version: '25.6.0') {
-      entry 'metrics-core'
-      entry 'core'
-      entry 'config'
+    dependencySet(group: 'org.hyperledger.besu.internal', version: '25.11.0') {
+      entry 'besu-metrics-core'
+      entry 'besu-ethereum-core'
+      entry 'besu-config'
     }
-    dependencySet(group: 'org.hyperledger.besu', version: '25.6.0') {
+    dependencySet(group: 'org.hyperledger.besu', version: '25.11.0') {
       entry 'besu-datatypes'
-      entry 'evm'
-      entry 'plugin-api'
+      entry 'besu-evm'
+      entry 'besu-plugin-api'
     }
 
     dependencySet(group: 'org.testcontainers', version: '1.21.3') {

--- a/infrastructure/events/build.gradle
+++ b/infrastructure/events/build.gradle
@@ -3,7 +3,7 @@ dependencies {
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:subscribers')
 
-  testImplementation 'org.hyperledger.besu.internal:metrics-core'
+  testImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
   testImplementation testFixtures(project(':infrastructure:async'))
 }
 

--- a/infrastructure/metrics/build.gradle
+++ b/infrastructure/metrics/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api 'org.hyperledger.besu:plugin-api'
+    api 'org.hyperledger.besu:besu-plugin-api'
 
     implementation project(':infrastructure:exceptions')
     implementation project(':infrastructure:io')
@@ -10,9 +10,9 @@ dependencies {
     implementation 'io.vertx:vertx-web'
     implementation 'io.consensys.tuweni:tuweni-units'
     implementation 'org.hdrhistogram:HdrHistogram'
-    implementation 'org.hyperledger.besu.internal:metrics-core'
+    implementation 'org.hyperledger.besu.internal:besu-metrics-core'
 
     testFixturesApi 'com.google.guava:guava'
-    testFixturesApi 'org.hyperledger.besu:plugin-api'
-    testFixturesImplementation 'org.hyperledger.besu.internal:metrics-core'
+    testFixturesApi 'org.hyperledger.besu:besu-plugin-api'
+    testFixturesImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
 }

--- a/infrastructure/serviceutils/build.gradle
+++ b/infrastructure/serviceutils/build.gradle
@@ -8,7 +8,7 @@ dependencies {
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:version')
 
-  implementation 'org.hyperledger.besu:plugin-api'
+  implementation 'org.hyperledger.besu:besu-plugin-api'
 
   testImplementation testFixtures(project(':infrastructure:async'))
 }

--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   testImplementation testFixtures(project(':networking:p2p'))
   testImplementation testFixtures(project(':storage'))
 
-  testImplementation 'org.hyperledger.besu.internal:metrics-core'
+  testImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
 
   integrationTestImplementation testFixtures(project(':ethereum:spec'))
   integrationTestImplementation testFixtures(project(':ethereum:statetransition'))
@@ -59,8 +59,8 @@ dependencies {
 
   testFixturesImplementation 'io.libp2p:jvm-libp2p'
   testFixturesImplementation 'org.mockito:mockito-core'
-  testFixturesImplementation 'org.hyperledger.besu:plugin-api'
-  testFixturesImplementation 'org.hyperledger.besu.internal:metrics-core'
+  testFixturesImplementation 'org.hyperledger.besu:besu-plugin-api'
+  testFixturesImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
   testFixturesImplementation 'org.apache.commons:commons-lang3'
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
 }

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':infrastructure:time'))
 
-  testImplementation 'org.hyperledger.besu.internal:metrics-core'
+  testImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
 
   testFixturesApi 'io.consensys.tuweni:tuweni-bytes'
 
@@ -44,8 +44,8 @@ dependencies {
   testFixturesImplementation testFixtures(project(':infrastructure:time'))
   testFixturesImplementation project(':infrastructure:subscribers')
 
-  testFixturesImplementation 'org.hyperledger.besu:plugin-api'
-  testFixturesImplementation 'org.hyperledger.besu.internal:metrics-core'
+  testFixturesImplementation 'org.hyperledger.besu:besu-plugin-api'
+  testFixturesImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
   testFixturesImplementation 'io.libp2p:jvm-libp2p'
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
 }

--- a/services/chainstorage/build.gradle
+++ b/services/chainstorage/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   implementation project(':storage:api')
   implementation project(':infrastructure:events')
 
-  implementation 'org.hyperledger.besu:plugin-api'
+  implementation 'org.hyperledger.besu:besu-plugin-api'
 
   testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':ethereum:execution-types'))

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -23,8 +23,8 @@ dependencies {
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'io.prometheus:prometheus-metrics-bom'
   implementation 'io.consensys.tuweni:tuweni-ssz'
-  implementation 'org.hyperledger.besu.internal:metrics-core'
-  implementation 'org.hyperledger.besu:plugin-api'
+  implementation 'org.hyperledger.besu.internal:besu-metrics-core'
+  implementation 'org.hyperledger.besu:besu-plugin-api'
   implementation 'org.rocksdb:rocksdbjni'
   implementation 'org.fusesource.leveldbjni:leveldbjni-win64'
   implementation 'org.fusesource.leveldbjni:leveldbjni-win32'
@@ -65,8 +65,8 @@ dependencies {
   testFixturesImplementation 'org.junit.jupiter:junit-jupiter-params'
   testFixturesImplementation 'com.google.guava:guava'
   testFixturesImplementation 'io.consensys.tuweni:tuweni-bytes'
-  testFixturesImplementation 'org.hyperledger.besu.internal:metrics-core'
-  testFixturesImplementation 'org.hyperledger.besu:plugin-api'
+  testFixturesImplementation 'org.hyperledger.besu.internal:besu-metrics-core'
+  testFixturesImplementation 'org.hyperledger.besu:besu-plugin-api'
 
 
   jmhImplementation testFixtures(project(':storage'))

--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -56,7 +56,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
   implementation 'io.consensys.tuweni:tuweni-ssz'
   implementation 'io.consensys.tuweni:tuweni-units'
-  implementation 'org.hyperledger.besu.internal:metrics-core'
+  implementation 'org.hyperledger.besu.internal:besu-metrics-core'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'org.xerial.snappy:snappy-java'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update besu dependencies to 25.11.0.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10060

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Besu to 25.11.0, migrate to new besu-* artifacts, and adapt genesis test builder to updated APIs.
> 
> - **Dependencies/Build**:
>   - Bump Besu to `25.11.0` and migrate artifacts across modules:
>     - Replace `org.hyperledger.besu:plugin-api` → `org.hyperledger.besu:besu-plugin-api`.
>     - Replace `org.hyperledger.besu:evm` → `org.hyperledger.besu:besu-evm`.
>     - Replace `org.hyperledger.besu.internal:core` → `org.hyperledger.besu.internal:besu-ethereum-core`.
>     - Replace `org.hyperledger.besu.internal:config` → `org.hyperledger.besu.internal:besu-config`.
>     - Replace `org.hyperledger.besu.internal:metrics-core` → `org.hyperledger.besu.internal:besu-metrics-core`.
>   - Update `gradle/versions.gradle` to new Besu coordinates and versions.
>   - Remove legacy excludes in root `build.gradle` related to `jc-kzg-4844` and `netty-codec-smtp`.
> - **Code/API adjustments**:
>   - Update `MergedGenesisTestBuilder` to new Besu APIs: add extra `false` flag to `MainnetProtocolSchedule.fromConfig` and use `GenesisState.fromConfig(..., new CodeCache())`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fda1d3fe89eda2f41f134ae4866dcf2475c093e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->