### PR TITLE
Some Gloas changes for `ChainBuilder`

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloas.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
-import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalContext;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalData;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
@@ -52,11 +52,11 @@ public class ExecutionPayloadFactoryGloas implements ExecutionPayloadFactory {
     final UInt64 proposalSlot = blockAndState.getSlot();
     final SchemaDefinitionsGloas schemaDefinitions =
         SchemaDefinitionsGloas.required(spec.atSlot(proposalSlot).getSchemaDefinitions());
-    final SafeFuture<ExecutionPayloadProposalContext> executionPayloadProposalContextFuture =
+    final SafeFuture<ExecutionPayloadProposalData> executionPayloadProposalDataFuture =
         getCachedGetPayloadResponseFuture(proposalSlot)
             .thenApply(
                 getPayloadResponse ->
-                    new ExecutionPayloadProposalContext(
+                    new ExecutionPayloadProposalData(
                         getPayloadResponse.getExecutionPayload(),
                         getPayloadResponse.getExecutionRequests().orElseThrow(),
                         schemaDefinitions
@@ -64,7 +64,7 @@ public class ExecutionPayloadFactoryGloas implements ExecutionPayloadFactory {
                             .createFromBlobsBundle(
                                 getPayloadResponse.getBlobsBundle().orElseThrow())));
     return spec.createNewUnsignedExecutionPayload(
-            proposalSlot, builderIndex, blockAndState, executionPayloadProposalContextFuture)
+            proposalSlot, builderIndex, blockAndState, executionPayloadProposalDataFuture)
         .thenApply(ExecutionPayloadAndState::executionPayload);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloas.java
@@ -50,6 +50,8 @@ public class ExecutionPayloadFactoryGloas implements ExecutionPayloadFactory {
   public SafeFuture<ExecutionPayloadEnvelope> createUnsignedExecutionPayload(
       final UInt64 builderIndex, final BeaconBlockAndState blockAndState) {
     final UInt64 proposalSlot = blockAndState.getSlot();
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(proposalSlot).getSchemaDefinitions());
     final SafeFuture<ExecutionPayloadProposalContext> executionPayloadProposalContextFuture =
         getCachedGetPayloadResponseFuture(proposalSlot)
             .thenApply(
@@ -57,8 +59,7 @@ public class ExecutionPayloadFactoryGloas implements ExecutionPayloadFactory {
                     new ExecutionPayloadProposalContext(
                         getPayloadResponse.getExecutionPayload(),
                         getPayloadResponse.getExecutionRequests().orElseThrow(),
-                        SchemaDefinitionsGloas.required(
-                                spec.atSlot(proposalSlot).getSchemaDefinitions())
+                        schemaDefinitions
                             .getBlobKzgCommitmentsSchema()
                             .createFromBlobsBundle(
                                 getPayloadResponse.getBlobsBundle().orElseThrow())));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -78,7 +78,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.epbs.ExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -908,6 +910,22 @@ public class Spec {
             parentBlockSigningRoot,
             bodyBuilder,
             blockProductionPerformance);
+  }
+
+  // Execution Payload Proposal
+  public SafeFuture<ExecutionPayloadAndState> createNewUnsignedExecutionPayload(
+      final UInt64 proposalSlot,
+      final UInt64 builderIndex,
+      final BeaconBlockAndState blockAndState,
+      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
+    return atSlot(proposalSlot)
+        .getExecutionPayloadProposalUtil()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Attempting to use execution payload proposal util when spec does not have execution payload proposal util"))
+        .createNewUnsignedExecutionPayload(
+            proposalSlot, builderIndex, blockAndState, getPayloadResponseFuture);
   }
 
   // Blind Block Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -114,7 +114,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProces
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
-import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalContext;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalData;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
@@ -917,7 +917,7 @@ public class Spec {
       final UInt64 proposalSlot,
       final UInt64 builderIndex,
       final BeaconBlockAndState blockAndState,
-      final SafeFuture<ExecutionPayloadProposalContext> executionPayloadProposalContextFuture) {
+      final SafeFuture<ExecutionPayloadProposalData> executionPayloadProposalDataFuture) {
     return atSlot(proposalSlot)
         .getExecutionPayloadProposalUtil()
         .orElseThrow(
@@ -925,7 +925,7 @@ public class Spec {
                 new IllegalStateException(
                     "Attempting to use execution payload proposal util when spec does not have execution payload proposal util"))
         .createNewUnsignedExecutionPayload(
-            proposalSlot, builderIndex, blockAndState, executionPayloadProposalContextFuture);
+            proposalSlot, builderIndex, blockAndState, executionPayloadProposalDataFuture);
   }
 
   // Blind Block Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -80,7 +80,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.epbs.ExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
-import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -115,6 +114,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProces
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalContext;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
@@ -917,7 +917,7 @@ public class Spec {
       final UInt64 proposalSlot,
       final UInt64 builderIndex,
       final BeaconBlockAndState blockAndState,
-      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
+      final SafeFuture<ExecutionPayloadProposalContext> executionPayloadProposalContextFuture) {
     return atSlot(proposalSlot)
         .getExecutionPayloadProposalUtil()
         .orElseThrow(
@@ -925,7 +925,7 @@ public class Spec {
                 new IllegalStateException(
                     "Attempting to use execution payload proposal util when spec does not have execution payload proposal util"))
         .createNewUnsignedExecutionPayload(
-            proposalSlot, builderIndex, blockAndState, getPayloadResponseFuture);
+            proposalSlot, builderIndex, blockAndState, executionPayloadProposalContextFuture);
   }
 
   // Blind Block Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/ExecutionPayloadAndState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/ExecutionPayloadAndState.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.epbs;
+
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+/** Helper datastructure that holds an unsigned execution payload with its corresponding state */
+public record ExecutionPayloadAndState(
+    ExecutionPayloadEnvelope executionPayload, BeaconState state) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.epbs;
+
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+/**
+ * Helper datastructure that holds a signed execution payload envelope with its corresponding state
+ */
+public record SignedExecutionPayloadAndState(
+    SignedExecutionPayloadEnvelope executionPayload, BeaconState state) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -127,6 +128,11 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
     return specLogic.getExecutionPayloadProcessor();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
+    return specLogic.getExecutionPayloadProposalUtil();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -81,4 +82,6 @@ public interface SpecLogic {
   Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor();
 
   Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor();
+
+  Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
@@ -40,7 +40,7 @@ public class ExecutionPayloadProposalUtil {
     this.executionPayloadProcessor = executionPayloadProcessor;
   }
 
-  public record ExecutionPayloadProposalContext(
+  public record ExecutionPayloadProposalData(
       ExecutionPayload executionPayload,
       ExecutionRequests executionRequests,
       SszList<SszKZGCommitment> kzgCommitments) {}
@@ -49,21 +49,21 @@ public class ExecutionPayloadProposalUtil {
       final UInt64 proposalSlot,
       final UInt64 builderIndex,
       final BeaconBlockAndState blockAndState,
-      final SafeFuture<ExecutionPayloadProposalContext> executionPayloadProposalContextFuture) {
+      final SafeFuture<ExecutionPayloadProposalData> executionPayloadProposalDataFuture) {
     final SafeFuture<ExecutionPayloadEnvelope> newExecutionPayload =
-        executionPayloadProposalContextFuture.thenApply(
-            executionPayloadProposalContext -> {
+        executionPayloadProposalDataFuture.thenApply(
+            executionPayloadProposalData -> {
               // Create initial execution payload with some stubs
               final Bytes32 tmpStateRoot = Bytes32.ZERO;
               return schemaDefinitions
                   .getExecutionPayloadEnvelopeSchema()
                   .create(
-                      executionPayloadProposalContext.executionPayload,
-                      executionPayloadProposalContext.executionRequests,
+                      executionPayloadProposalData.executionPayload,
+                      executionPayloadProposalData.executionRequests,
                       builderIndex,
                       blockAndState.getRoot(),
                       proposalSlot,
-                      executionPayloadProposalContext.kzgCommitments,
+                      executionPayloadProposalData.kzgCommitments,
                       tmpStateRoot);
             });
     return newExecutionPayload.thenApplyChecked(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
@@ -16,12 +16,15 @@ package tech.pegasys.teku.spec.logic.common.util;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.ExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadProcessor;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
@@ -37,27 +40,30 @@ public class ExecutionPayloadProposalUtil {
     this.executionPayloadProcessor = executionPayloadProcessor;
   }
 
+  public record ExecutionPayloadProposalContext(
+      ExecutionPayload executionPayload,
+      ExecutionRequests executionRequests,
+      SszList<SszKZGCommitment> kzgCommitments) {}
+
   public SafeFuture<ExecutionPayloadAndState> createNewUnsignedExecutionPayload(
       final UInt64 proposalSlot,
       final UInt64 builderIndex,
       final BeaconBlockAndState blockAndState,
-      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
+      final SafeFuture<ExecutionPayloadProposalContext> executionPayloadProposalContextFuture) {
     final SafeFuture<ExecutionPayloadEnvelope> newExecutionPayload =
-        getPayloadResponseFuture.thenApply(
-            getPayloadResponse -> {
+        executionPayloadProposalContextFuture.thenApply(
+            executionPayloadProposalContext -> {
               // Create initial execution payload with some stubs
               final Bytes32 tmpStateRoot = Bytes32.ZERO;
               return schemaDefinitions
                   .getExecutionPayloadEnvelopeSchema()
                   .create(
-                      getPayloadResponse.getExecutionPayload(),
-                      getPayloadResponse.getExecutionRequests().orElseThrow(),
+                      executionPayloadProposalContext.executionPayload,
+                      executionPayloadProposalContext.executionRequests,
                       builderIndex,
                       blockAndState.getRoot(),
                       proposalSlot,
-                      schemaDefinitions
-                          .getBlobKzgCommitmentsSchema()
-                          .createFromBlobsBundle(getPayloadResponse.getBlobsBundle().orElseThrow()),
+                      executionPayloadProposalContext.kzgCommitments,
                       tmpStateRoot);
             });
     return newExecutionPayload.thenApplyChecked(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.ExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadProcessor;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+public class ExecutionPayloadProposalUtil {
+
+  private final SchemaDefinitionsGloas schemaDefinitions;
+  private final ExecutionPayloadProcessor executionPayloadProcessor;
+
+  public ExecutionPayloadProposalUtil(
+      final SchemaDefinitionsGloas schemaDefinitions,
+      final ExecutionPayloadProcessor executionPayloadProcessor) {
+    this.schemaDefinitions = schemaDefinitions;
+    this.executionPayloadProcessor = executionPayloadProcessor;
+  }
+
+  public SafeFuture<ExecutionPayloadAndState> createNewUnsignedExecutionPayload(
+      final UInt64 proposalSlot,
+      final UInt64 builderIndex,
+      final BeaconBlockAndState blockAndState,
+      final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
+    final SafeFuture<ExecutionPayloadEnvelope> newExecutionPayload =
+        getPayloadResponseFuture.thenApply(
+            getPayloadResponse -> {
+              // Create initial execution payload with some stubs
+              final Bytes32 tmpStateRoot = Bytes32.ZERO;
+              return schemaDefinitions
+                  .getExecutionPayloadEnvelopeSchema()
+                  .create(
+                      getPayloadResponse.getExecutionPayload(),
+                      getPayloadResponse.getExecutionRequests().orElseThrow(),
+                      builderIndex,
+                      blockAndState.getRoot(),
+                      proposalSlot,
+                      schemaDefinitions
+                          .getBlobKzgCommitmentsSchema()
+                          .createFromBlobsBundle(getPayloadResponse.getBlobsBundle().orElseThrow()),
+                      tmpStateRoot);
+            });
+    return newExecutionPayload.thenApplyChecked(
+        executionPayload -> {
+          // Run state transition and set state root
+          final BeaconState newState =
+              blockAndState
+                  .getState()
+                  .updated(
+                      state ->
+                          executionPayloadProcessor.processUnsignedExecutionPayload(
+                              state, executionPayload, Optional.empty()));
+          return new ExecutionPayloadAndState(
+              executionPayload.copyWithNewStateRoot(newState.hashTreeRoot()), newState);
+        });
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValida
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -221,6 +222,11 @@ public class SpecLogicAltair extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -232,6 +233,11 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -241,6 +242,11 @@ public class SpecLogicCapella extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -237,6 +238,11 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -259,6 +260,11 @@ public class SpecLogicElectra extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -259,6 +260,11 @@ public class SpecLogicFulu extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -55,6 +56,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
   private final Optional<WithdrawalsHelpers> withdrawalsHelpers;
   private final Optional<ExecutionRequestsProcessor> executionRequestsProcessor;
   private final Optional<ExecutionPayloadProcessor> executionPayloadProcessor;
+  private final Optional<ExecutionPayloadProposalUtil> executionPayloadProposalUtil;
 
   private SpecLogicGloas(
       final PredicatesGloas predicates,
@@ -77,6 +79,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
       final BlindBlockUtilFulu blindBlockUtil,
       final SyncCommitteeUtil syncCommitteeUtil,
       final LightClientUtil lightClientUtil,
+      final ExecutionPayloadProposalUtil executionPayloadProposalUtil,
       final GloasStateUpgrade stateUpgrade) {
     super(
         predicates,
@@ -100,6 +103,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     this.executionRequestsProcessor = Optional.of(executionRequestsProcessor);
     this.withdrawalsHelpers = Optional.of(withdrawalsHelpers);
     this.executionPayloadProcessor = Optional.of(executionPayloadProcessor);
+    this.executionPayloadProposalUtil = Optional.of(executionPayloadProposalUtil);
   }
 
   public static SpecLogicGloas create(
@@ -211,6 +215,9 @@ public class SpecLogicGloas extends AbstractSpecLogic {
 
     final BlindBlockUtilFulu blindBlockUtil = new BlindBlockUtilFulu(schemaDefinitions);
 
+    final ExecutionPayloadProposalUtil executionPayloadProposalUtil =
+        new ExecutionPayloadProposalUtil(schemaDefinitions, executionPayloadProcessor);
+
     // State upgrade
     final GloasStateUpgrade stateUpgrade =
         new GloasStateUpgrade(config, schemaDefinitions, beaconStateAccessors);
@@ -236,6 +243,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
         blindBlockUtil,
         syncCommitteeUtil,
         lightClientUtil,
+        executionPayloadProposalUtil,
         stateUpgrade);
   }
 
@@ -267,5 +275,10 @@ public class SpecLogicGloas extends AbstractSpecLogic {
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
     return executionPayloadProcessor;
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
+    return executionPayloadProposalUtil;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValida
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -192,6 +193,11 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionPayloadProcessor> getExecutionPayloadProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayloadProposalUtil> getExecutionPayloadProposalUtil() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -87,7 +87,7 @@ public class BlockProposalTestUtil {
       final SszList<SignedVoluntaryExit> exits,
       final Optional<List<Bytes>> transactions,
       final Optional<Bytes32> terminalBlock,
-      final Optional<ExecutionPayload> maybeExecutionPayload,
+      final Optional<ExecutionPayload> executionPayload,
       final Optional<SyncAggregate> syncAggregate,
       final Optional<SszList<SignedBlsToExecutionChange>> blsToExecutionChange,
       final Optional<SszList<SszKZGCommitment>> kzgCommitments,
@@ -99,9 +99,6 @@ public class BlockProposalTestUtil {
     final BeaconState blockSlotState = spec.processSlots(state, newSlot);
     final BLSSignature randaoReveal =
         signer.createRandaoReveal(newEpoch, blockSlotState.getForkInfo()).join();
-    final ExecutionPayload executionPayload =
-        maybeExecutionPayload.orElseGet(
-            () -> createExecutionPayload(newSlot, blockSlotState, transactions, terminalBlock));
 
     final int proposerIndex = spec.getBeaconProposerIndex(blockSlotState, newSlot);
     return spec.createNewUnsignedBlock(
@@ -125,7 +122,9 @@ public class BlockProposalTestUtil {
                         dataStructureUtil.emptySyncAggregateIfRequiredByState(blockSlotState)));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayload(executionPayload);
+                builder.executionPayload(
+                    executionPayload.orElseGet(
+                        () -> createExecutionPayload(newSlot, state, transactions, terminalBlock)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(
@@ -142,7 +141,14 @@ public class BlockProposalTestUtil {
               if (builder.supportsSignedExecutionPayloadBid()) {
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(
-                        newSlot, executionPayload, blockSlotState, proposerIndex, kzgCommitments));
+                        newSlot,
+                        executionPayload.orElseGet(
+                            () ->
+                                createExecutionPayload(
+                                    newSlot, state, transactions, terminalBlock)),
+                        blockSlotState,
+                        proposerIndex,
+                        kzgCommitments));
               }
               if (builder.supportsPayloadAttestations()) {
                 builder.payloadAttestations(
@@ -177,7 +183,7 @@ public class BlockProposalTestUtil {
       final SszList<SignedVoluntaryExit> exits,
       final Optional<List<Bytes>> transactions,
       final Optional<Bytes32> terminalBlock,
-      final Optional<ExecutionPayload> maybeExecutionPayload,
+      final Optional<ExecutionPayload> executionPayload,
       final Optional<SszList<SignedBlsToExecutionChange>> blsToExecutionChange,
       final Optional<SszList<SszKZGCommitment>> kzgCommitments,
       final Optional<SszList<PayloadAttestation>> payloadAttestations)
@@ -186,9 +192,6 @@ public class BlockProposalTestUtil {
     final UInt64 newEpoch = spec.computeEpochAtSlot(newSlot);
     final BLSSignature randaoReveal =
         signer.createRandaoReveal(newEpoch, state.getForkInfo()).join();
-    final ExecutionPayload executionPayload =
-        maybeExecutionPayload.orElseGet(
-            () -> createExecutionPayload(newSlot, state, transactions, terminalBlock));
 
     final BeaconState blockSlotState = spec.processSlots(state, newSlot);
 
@@ -213,7 +216,9 @@ public class BlockProposalTestUtil {
                     dataStructureUtil.emptySyncAggregateIfRequiredByState(blockSlotState));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayload(executionPayload);
+                builder.executionPayload(
+                    executionPayload.orElseGet(
+                        () -> createExecutionPayload(newSlot, state, transactions, terminalBlock)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(
@@ -230,7 +235,14 @@ public class BlockProposalTestUtil {
               if (builder.supportsSignedExecutionPayloadBid()) {
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(
-                        newSlot, executionPayload, blockSlotState, proposerIndex, kzgCommitments));
+                        newSlot,
+                        executionPayload.orElseGet(
+                            () ->
+                                createExecutionPayload(
+                                    newSlot, state, transactions, terminalBlock)),
+                        blockSlotState,
+                        proposerIndex,
+                        kzgCommitments));
               }
               if (builder.supportsPayloadAttestations()) {
                 builder.payloadAttestations(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -124,7 +124,9 @@ public class BlockProposalTestUtil {
               if (builder.supportsExecutionPayload()) {
                 builder.executionPayload(
                     executionPayload.orElseGet(
-                        () -> createExecutionPayload(newSlot, state, transactions, terminalBlock)));
+                        () ->
+                            createExecutionPayload(
+                                newSlot, blockSlotState, transactions, terminalBlock)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(
@@ -145,7 +147,7 @@ public class BlockProposalTestUtil {
                         executionPayload.orElseGet(
                             () ->
                                 createExecutionPayload(
-                                    newSlot, state, transactions, terminalBlock)),
+                                    newSlot, blockSlotState, transactions, terminalBlock)),
                         blockSlotState,
                         proposerIndex,
                         kzgCommitments));
@@ -218,7 +220,9 @@ public class BlockProposalTestUtil {
               if (builder.supportsExecutionPayload()) {
                 builder.executionPayload(
                     executionPayload.orElseGet(
-                        () -> createExecutionPayload(newSlot, state, transactions, terminalBlock)));
+                        () ->
+                            createExecutionPayload(
+                                newSlot, blockSlotState, transactions, terminalBlock)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(
@@ -239,7 +243,7 @@ public class BlockProposalTestUtil {
                         executionPayload.orElseGet(
                             () ->
                                 createExecutionPayload(
-                                    newSlot, state, transactions, terminalBlock)),
+                                    newSlot, blockSlotState, transactions, terminalBlock)),
                         blockSlotState,
                         proposerIndex,
                         kzgCommitments));

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -59,7 +59,7 @@ import tech.pegasys.teku.spec.datastructures.util.BeaconBlockBodyLists;
 import tech.pegasys.teku.spec.datastructures.util.BlobsUtil;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
-import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalContext;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -142,8 +142,8 @@ public class BlockProposalTestUtil {
                 builder.executionRequests(dataStructureUtil.randomExecutionRequests());
               }
               if (builder.supportsSignedExecutionPayloadBid()) {
-                final ExecutionPayloadProposalContext executionPayloadProposalContext =
-                    new ExecutionPayloadProposalContext(
+                final ExecutionPayloadProposalData executionPayloadProposalData =
+                    new ExecutionPayloadProposalData(
                         executionPayload.orElseGet(
                             () ->
                                 createExecutionPayload(
@@ -152,7 +152,7 @@ public class BlockProposalTestUtil {
                         kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments));
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(
-                        newSlot, blockSlotState, proposerIndex, executionPayloadProposalContext));
+                        newSlot, blockSlotState, proposerIndex, executionPayloadProposalData));
               }
               if (builder.supportsPayloadAttestations()) {
                 builder.payloadAttestations(
@@ -239,8 +239,8 @@ public class BlockProposalTestUtil {
                 builder.executionRequests(dataStructureUtil.randomExecutionRequests());
               }
               if (builder.supportsSignedExecutionPayloadBid()) {
-                final ExecutionPayloadProposalContext executionPayloadProposalContext =
-                    new ExecutionPayloadProposalContext(
+                final ExecutionPayloadProposalData executionPayloadProposalData =
+                    new ExecutionPayloadProposalData(
                         executionPayload.orElseGet(
                             () ->
                                 createExecutionPayload(
@@ -249,7 +249,7 @@ public class BlockProposalTestUtil {
                         kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments));
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(
-                        newSlot, blockSlotState, proposerIndex, executionPayloadProposalContext));
+                        newSlot, blockSlotState, proposerIndex, executionPayloadProposalData));
               }
               if (builder.supportsPayloadAttestations()) {
                 builder.payloadAttestations(
@@ -334,11 +334,11 @@ public class BlockProposalTestUtil {
       final UInt64 newSlot,
       final BeaconState state,
       final int proposerIndex,
-      final ExecutionPayloadProposalContext executionPayloadProposalContext) {
+      final ExecutionPayloadProposalData executionPayloadProposalData) {
     final SpecVersion specVersion = spec.atSlot(newSlot);
     final SchemaDefinitionsGloas schemaDefinitions =
         SchemaDefinitionsGloas.required(specVersion.getSchemaDefinitions());
-    final ExecutionPayload executionPayload = executionPayloadProposalContext.executionPayload();
+    final ExecutionPayload executionPayload = executionPayloadProposalData.executionPayload();
     // self-building bid
     final ExecutionPayloadBid bid =
         schemaDefinitions
@@ -352,7 +352,7 @@ public class BlockProposalTestUtil {
                 UInt64.valueOf(proposerIndex),
                 newSlot,
                 UInt64.ZERO,
-                executionPayloadProposalContext.kzgCommitments().hashTreeRoot());
+                executionPayloadProposalData.kzgCommitments().hashTreeRoot());
     return schemaDefinitions
         .getSignedExecutionPayloadBidSchema()
         .create(bid, BLSSignature.infinity());

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ExecutionPayloadProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ExecutionPayloadProposalTestUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.generator;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalData;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.signatures.Signer;
+
+public class ExecutionPayloadProposalTestUtil {
+
+  private final Spec spec;
+
+  public ExecutionPayloadProposalTestUtil(final Spec spec) {
+    this.spec = spec;
+  }
+
+  public SafeFuture<SignedExecutionPayloadAndState> createExecutionPayload(
+      final Signer signer,
+      final UInt64 newSlot,
+      final UInt64 proposerIndex,
+      final BeaconBlockAndState blockAndState,
+      final ExecutionPayloadProposalData executionPayloadProposalData) {
+    return spec.createNewUnsignedExecutionPayload(
+            newSlot,
+            proposerIndex,
+            blockAndState,
+            SafeFuture.completedFuture(executionPayloadProposalData))
+        .thenCompose(
+            executionPayloadAndState -> {
+              // Sign execution payload and set signature
+              return signer
+                  .signExecutionPayloadEnvelope(
+                      executionPayloadAndState.executionPayload(),
+                      blockAndState.getState().getForkInfo())
+                  .thenApply(
+                      signature -> {
+                        final SignedExecutionPayloadEnvelope signedExecutionPayload =
+                            SchemaDefinitionsGloas.required(
+                                    spec.atSlot(newSlot).getSchemaDefinitions())
+                                .getSignedExecutionPayloadEnvelopeSchema()
+                                .create(executionPayloadAndState.executionPayload(), signature);
+                        return new SignedExecutionPayloadAndState(
+                            signedExecutionPayload, executionPayloadAndState.state());
+                      });
+            });
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -3054,11 +3054,11 @@ public final class DataStructureUtil {
             randomSszBitvector(getPtcSize()), randomPayloadAttestationData(), randomSignature());
   }
 
-  public SszList<PayloadAttestation> randomPayloadAttestations() {
-    final SszListSchema<PayloadAttestation, ?> schema =
-        BeaconBlockBodySchemaGloas.required(getGloasSchemaDefinitions().getBeaconBlockBodySchema())
-            .getPayloadAttestationsSchema();
-    return randomSszList(schema, this::randomPayloadAttestation, schema.getMaxLength());
+  public SszList<PayloadAttestation> emptyPayloadAttestations() {
+    return BeaconBlockBodySchemaGloas.required(
+            getGloasSchemaDefinitions().getBeaconBlockBodySchema())
+        .getPayloadAttestationsSchema()
+        .createFromElements(List.of());
   }
 
   public BuilderPendingWithdrawal randomBuilderPendingWithdrawal() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -734,7 +734,7 @@ public class BlockImporterTest {
             .generateBlockAtSlot(
                 currentSlot.minus(wsPeriodInSlots),
                 BlockOptions.create()
-                    .setBlsToExecutionChange(
+                    .setBlsToExecutionChanges(
                         blsToExecutionChangeGenerator.asSszList(
                             UInt64.ZERO, signedBlsToExecutionChange)));
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -283,6 +283,7 @@ public class BeaconChainUtil {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 false));
     return block;
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -234,12 +234,12 @@ public class ChainUpdater {
 
   public SignedBlockAndState advanceChainUntil(final UInt64 slot, final BlockOptions blockOptions) {
     UInt64 currentSlot = chainBuilder.getLatestSlot();
-    SignedBlockAndState latestSigneBlockAndState = chainBuilder.getLatestBlockAndState();
+    SignedBlockAndState latestSignedBlockAndState = chainBuilder.getLatestBlockAndState();
     while (currentSlot.isLessThan(slot)) {
       currentSlot = currentSlot.increment();
-      latestSigneBlockAndState = advanceChain(currentSlot, blockOptions);
+      latestSignedBlockAndState = advanceChain(currentSlot, blockOptions);
     }
-    return latestSigneBlockAndState;
+    return latestSignedBlockAndState;
   }
 
   public SignedBlockAndState advanceChain(final UInt64 slot) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Some changes to make easier to implement `ChainBuilder` for Gloas in the future.
- Also added ExecutionPayloadProposalUtil which is used in the `ChainBuilder` and is also similar to design to `BlockFactory` so it's good to have some consistency.

## Fixed Issue(s)
related to #10071

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce an execution payload proposal utility and API, integrate it into Gloas/Spec, add helper records, and update test builders/utilities to support ePBS payload creation and signing.
> 
> - **Core API/Spec**:
>   - Add `Spec#createNewUnsignedExecutionPayload(...)` delegating to `ExecutionPayloadProposalUtil`.
>   - Extend `SpecLogic` with `getExecutionPayloadProposalUtil()`; implement passthrough in `DelegatingSpecLogic` and return `Optional.empty()` for non-Gloas forks; provide concrete instance in `SpecLogicGloas`.
>   - New records: `epbs/ExecutionPayloadAndState` and `epbs/SignedExecutionPayloadAndState`.
> - **Gloas Validator**:
>   - Refactor `validator/coordinator/ExecutionPayloadFactoryGloas` to build `ExecutionPayloadProposalData` from cached EL response and use `Spec#createNewUnsignedExecutionPayload(...)`; return `ExecutionPayloadEnvelope` from `ExecutionPayloadAndState`.
> - **Test Fixtures/Builders**:
>   - Update `BlockProposalTestUtil` and `ChainBuilder` to support ePBS: cache `ExecutionPayloadProposalData`, create/signed execution payloads, track them by slot/root; add `ExecutionPayloadProposalTestUtil`.
>   - Expand `ChainBuilder.BlockOptions`: rename/accessors (`blsToExecutionChanges`), add `payloadAttestations`, `withholdExecutionPayload`, and state-transition flags; propagate through generation paths.
> - **Utilities**:
>   - `DataStructureUtil`: add `emptyPayloadAttestations()`, adjust execution payload parent hash selection, and minor helpers.
> - **Tests**:
>   - Adjust usages to renamed setters (`setBlsToExecutionChanges`) and variable name cleanup in `ChainUpdater`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ae7dc559c22535c70fbb859c1e95143d31b06ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->