### PR TITLE
Implement `RespondingEth2Peer` for Gloas testing

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.epbs;
 
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -20,4 +21,8 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
  * Helper datastructure that holds a signed execution payload envelope with its corresponding state
  */
 public record SignedExecutionPayloadAndState(
-    SignedExecutionPayloadEnvelope executionPayload, BeaconState state) {}
+    SignedExecutionPayloadEnvelope executionPayload, BeaconState state) {
+  public UInt64 getSlot() {
+    return executionPayload.getMessage().getSlot();
+  }
+}

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
+// TODO-GLOAS: https://github.com/Consensys/teku/issues/10071
 public class ChainUpdater {
 
   public final RecentChainData recentChainData;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix `RespondingEth2Peer` and make `ChainBuilder` more usable for Gloas

## Fixed Issue(s)
related to #10071 and #9974 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements execution payload envelope requests in `RespondingEth2Peer` and extends test utilities to produce, track, and stream signed execution payloads (with optional skipped state transition).
> 
> - **Networking**:
>   - Implement `requestExecutionPayloadEnvelopesByRoot` and `requestExecutionPayloadEnvelopesByRange` in `networking/eth2/.../RespondingEth2Peer` with pending request plumbing and lookup helpers.
> - **Test Fixtures**:
>   - **`ChainBuilder`**:
>     - Add execution-payload APIs: `getExecutionPayload(Bytes32)`, `getExecutionPayloadAndStateAtSlot(UInt64)`, `getExecutionPayloadStateAtSlot(UInt64)`, and `streamExecutionPayloadsAndStates(...)`.
>     - Track execution payloads by slot/root and use payload-derived state when appending new blocks.
>     - Pass `skipStateTransition` to execution payload creation.
>   - **`ExecutionPayloadProposalTestUtil`**:
>     - Support creating/singing `ExecutionPayloadEnvelope` when `skipStateTransition` is enabled; otherwise use existing flow and correct fork info source.
> - **Datastructures**:
>   - Add `getSlot()` accessor to `SignedExecutionPayloadAndState`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 643347a3e5b52d86c90a2f52c3ec74950d9275b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->