### PR TITLE
changed das samplers to ignore cancelled exceptions

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -148,6 +148,7 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
                         tracker.samplingRequirement().size()));
               }
             })
+        .ignoreCancelException()
         .finishError(LOG);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -161,7 +161,7 @@ public class SimpleSidecarRetriever
 
     // here we make sure that if something goes wrong in the handle call we
     // log all the info to fix the bug
-    activeRpcRequest.finishStackTrace();
+    activeRpcRequest.ignoreCancelException().finishStackTrace();
 
     match.request.activeRpcRequest = new ActiveRequest(activeRpcRequest, match.peer);
     return true;


### PR DESCRIPTION
When testing with shorter timeouts, it became particularly evident that this will cause a lot of noise in the logs.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ignore canceled exceptions in DAS sampling and sidecar retrieval workflows to avoid noisy error logs.
> 
> - **DAS / Async handling**:
>   - `DasSamplerBasic.fetchMissingColumnsViaRPC(...)`: add `ignoreCancelException()` before `finishError(LOG)` on the collected retrieval future.
>   - `retriever/SimpleSidecarRetriever`: add `ignoreCancelException()` before `finishStackTrace()` on `activeRpcRequest` after request handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00af360a099d980b4c45359eb160644770470781. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->