### PR TITLE
updated PreSampler to guard against null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 ### Additions and Improvements
 
 ### Bug Fixes
+ - Fixed NPE in DasPreSampler (#10110).

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
@@ -48,6 +48,10 @@ public class DasPreSampler {
   }
 
   private boolean isSamplingRequired(final SignedBeaconBlock block) {
+    if (block == null) {
+      LOG.debug("SignedBeaconBlock was unexpectedly null");
+      return false;
+    }
     return sampler.checkSamplingEligibility(block.getMessage()) == REQUIRED;
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_OLD_EPOCH;
 import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -60,6 +62,13 @@ public class DasPreSamplerTest {
     verify(sampler).flush();
     verifyNoMoreInteractions(sampler);
     verifyNoInteractions(custody, custodyGroupCountManager);
+  }
+
+  @Test
+  void onNewPreImportedBlocks_shouldFilterNull() {
+    final List<SignedBeaconBlock> blocks = new ArrayList<>();
+    blocks.add(null);
+    assertDoesNotThrow(() -> dasPreSampler.onNewPreImportBlocks(blocks));
   }
 
   @Test


### PR DESCRIPTION
If this occurs we end up stalling, so this guard will at least stop the stall, but haven't discovered the reason that a null SignedBeaconBlock would be passed through this channel.

fixes #10110

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a null check in `DasPreSampler` to skip null `SignedBeaconBlock`s and updates tests and changelog.
> 
> - **Bug Fix**
>   - Add null guard in `DasPreSampler.isSamplingRequired` to skip null `SignedBeaconBlock`s and avoid NPEs; logs a debug message.
> - **Tests**
>   - Add `onNewPreImportedBlocks_shouldFilterNull` to ensure null blocks are filtered without errors.
> - **Changelog**
>   - Note bug fix: NPE in `DasPreSampler` resolved (#10110).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e3210fd7b31b27b4b16c883d4f4de7ef9b1da14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->