### PR TITLE
Add a test to reconcile between CLI and docs

### DIFF
--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -74,4 +74,5 @@ dependencies {
 
   testImplementation project(':data:provider')
   testImplementation 'org.awaitility:awaitility'
+  testImplementation 'org.jsoup:jsoup'
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -479,7 +479,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  @Disabled("used for ad-hoc reconciliation between CLI and docs")
+  // @Disabled("used for ad-hoc reconciliation between CLI and docs")
   public void commandLineOptionsShouldBePresentInDocs() throws IOException {
     beaconNodeCommand.parse(new String[] {"--help"});
     beaconNodeCommand.parse(new String[] {"vc", "--help"});
@@ -514,7 +514,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
     if (!cliOnly.isEmpty() || !docsOnly.isEmpty()) {
       throw new AssertionError(
-          "Mismatch between CLI and Docs.\n"
+          "Mismatch between CLI and docs.\n"
               + "\uD83D\uDD0D CLI options missing from docs: "
               + cliOnly
               + "\n"

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -40,9 +40,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletionException;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -52,7 +54,12 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -168,18 +175,13 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     final String[] args = {"--help"};
 
     beaconNodeCommand.parse(args);
-    String str = getCommandLineOutput();
+    final String commandLineOutput = getCommandLineOutput();
 
-    final Pattern p = Pattern.compile("--[X][^ ]+");
-    final Matcher matcher = p.matcher(str);
-    final List<String> errors = new ArrayList<>();
-    while (matcher.find()) {
-      MatchResult current = matcher.toMatchResult();
-      LOG.debug("found {} at position {}", current.group().trim(), current.start());
-      errors.add(current.group().trim());
-    }
-
-    assertThat(errors).describedAs("Found --X command arguments not marked as hidden").isEmpty();
+    assertThat(
+            getCommandLineOptionsFromCommandLineOutput(
+                commandLineOutput, Pattern.compile("--X[^ ]+")))
+        .describedAs("Found --X command arguments not marked as hidden")
+        .isEmpty();
   }
 
   @Test
@@ -189,16 +191,11 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     final String[] args = {"-X"};
 
     beaconNodeCommand.parse(args);
+    final String commandLineOutput = getCommandLineOutput();
 
-    final Pattern p = Pattern.compile("--[^X][^ ]+=");
-    final Matcher matcher = p.matcher(getCommandLineOutput());
-    final List<String> errors = new ArrayList<>();
-    while (matcher.find()) {
-      final MatchResult current = matcher.toMatchResult();
-      LOG.debug("found {} at position {}", current.group().trim(), current.start());
-      errors.add(current.group().trim());
-    }
-    assertThat(errors)
+    assertThat(
+            getCommandLineOptionsFromCommandLineOutput(
+                commandLineOutput, Pattern.compile("--[^X][^ ]+=")))
         .describedAs("Found hidden command arguments not prefixed with --X")
         .isEmpty();
   }
@@ -481,6 +478,51 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     assertThat(trustedSetup).isPresent();
   }
 
+  @Test
+  @Disabled("used for ad-hoc reconciliation between CLI and docs")
+  public void commandLineOptionsShouldBePresentInDocs() throws IOException {
+    beaconNodeCommand.parse(new String[] {"--help"});
+    beaconNodeCommand.parse(new String[] {"vc", "--help"});
+    final String commandLineOutput = getCommandLineOutput();
+
+    final List<String> allCliOptionsWithoutHyphens =
+        getCommandLineOptionsFromCommandLineOutput(commandLineOutput, Pattern.compile("--[\\w-]+"))
+            .stream()
+            .map(option -> option.replaceFirst("--", ""))
+            .distinct()
+            .toList();
+
+    final List<String> docsCliOptions =
+        Stream.of(
+                Jsoup.connect("https://docs.teku.consensys.io/reference/cli").get(),
+                Jsoup.connect(
+                        "https://docs.teku.consensys.io/reference/cli/subcommands/validator-client")
+                    .get())
+            .flatMap(doc -> doc.selectStream("h2.anchor, h3.anchor"))
+            .flatMap(anchor -> anchor.selectStream("code"))
+            .map(Element::text)
+            .map(String::trim)
+            .toList();
+
+    final Set<String> cliOnly = new TreeSet<>(allCliOptionsWithoutHyphens);
+    docsCliOptions.forEach(cliOnly::remove);
+
+    final Set<String> docsOnly = new TreeSet<>(docsCliOptions);
+    allCliOptionsWithoutHyphens.forEach(docsOnly::remove);
+    // this option doesn't show in `teku vc --help` but it's available (see ValidatorClientOptions)
+    docsOnly.remove("sentry-config-file");
+
+    if (!cliOnly.isEmpty() || !docsOnly.isEmpty()) {
+      throw new AssertionError(
+          "Mismatch between CLI and Docs.\n"
+              + "\uD83D\uDD0D CLI options missing from docs: "
+              + cliOnly
+              + "\n"
+              + "\uD83D\uDCDA Docs options missing from CLI: "
+              + docsOnly);
+    }
+  }
+
   private Path createConfigFile() throws IOException {
     final URL configFile = BeaconNodeCommandTest.class.getResource("/complete_config.yaml");
     final String updatedConfig =
@@ -747,6 +789,18 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     Files.write(file, contents);
     file.toFile().deleteOnExit();
     return file;
+  }
+
+  private List<String> getCommandLineOptionsFromCommandLineOutput(
+      final String commandLineOutput, final Pattern pattern) {
+    final Matcher matcher = pattern.matcher(commandLineOutput);
+    final List<String> commandLineOptions = new ArrayList<>();
+    while (matcher.find()) {
+      final MatchResult current = matcher.toMatchResult();
+      LOG.debug("found {} at position {}", current.group().trim(), current.start());
+      commandLineOptions.add(current.group().trim());
+    }
+    return commandLineOptions;
   }
 
   @ParameterizedTest

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -55,9 +54,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -479,8 +476,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  // @Disabled("used for ad-hoc reconciliation between CLI and docs")
-  public void commandLineOptionsShouldBePresentInDocs() throws IOException {
+  @Disabled("used for ad-hoc reconciliation between CLI and docs")
+  public void verifyCliOptionsAndDocsConsistency() throws IOException {
     beaconNodeCommand.parse(new String[] {"--help"});
     beaconNodeCommand.parse(new String[] {"vc", "--help"});
     final String commandLineOutput = getCommandLineOutput();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add a test which is Disabled and can be run adhoc to reconcile between CLI and docs.

Current output:
```
java.lang.AssertionError: Mismatch between CLI and Docs.
🔍 CLI options missing from docs: [metrics-block-production-performance-tracking-enabled, p2p-subscribe-all-custody-subnets-enabled, validator-api-bearer-file]
📚 Docs options missing from CLI: []
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a disabled test to compare CLI options against docs using Jsoup, refactors tests to reuse an option-extraction helper, and adds the Jsoup test dependency.
> 
> - **Tests (`BeaconNodeCommandTest`)**:
>   - Add disabled ad-hoc test `verifyCliOptionsAndDocsConsistency` that scrapes docs via `Jsoup` and compares documented options with CLI help output.
>   - Refactor existing checks to use new `getCommandLineOptionsFromCommandLineOutput(...)` helper instead of inline regex loops.
> - **Build**:
>   - Add test dependency `org.jsoup:jsoup` in `teku/build.gradle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b833280364d5b825f874025cbdabe3c223a546c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->