### PR TITLE
Fix some Gloas datastructure nits

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloasImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloasImpl.java
@@ -156,6 +156,16 @@ public class BeaconBlockBodySchemaGloasImpl
     return new BeaconBlockBodyGloasImpl(this);
   }
 
+  @Override
+  public BeaconBlockBodyGloasImpl createFromBackingNode(final TreeNode node) {
+    return new BeaconBlockBodyGloasImpl(this, node);
+  }
+
+  @Override
+  public LongList getBlindedNodeGeneralizedIndices() {
+    return LongList.of();
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public SszListSchema<ProposerSlashing, ?> getProposerSlashingsSchema() {
@@ -196,11 +206,6 @@ public class BeaconBlockBodySchemaGloasImpl
   }
 
   @Override
-  public BeaconBlockBodyGloasImpl createFromBackingNode(final TreeNode node) {
-    return new BeaconBlockBodyGloasImpl(this, node);
-  }
-
-  @Override
   public ExecutionPayloadSchema<?> getExecutionPayloadSchema() {
     throw new UnsupportedOperationException("ExecutionPayload was removed in Gloas");
   }
@@ -223,8 +228,8 @@ public class BeaconBlockBodySchemaGloasImpl
   }
 
   @Override
-  public LongList getBlindedNodeGeneralizedIndices() {
-    return LongList.of();
+  public ExecutionRequestsSchema getExecutionRequestsSchema() {
+    throw new UnsupportedOperationException("ExecutionRequests were removed in Gloas");
   }
 
   @SuppressWarnings("unchecked")
@@ -232,10 +237,5 @@ public class BeaconBlockBodySchemaGloasImpl
   public SszListSchema<PayloadAttestation, ?> getPayloadAttestationsSchema() {
     return (SszListSchema<PayloadAttestation, ?>)
         getChildSchema(getFieldIndex(BlockBodyFields.PAYLOAD_ATTESTATIONS));
-  }
-
-  @Override
-  public ExecutionRequestsSchema getExecutionRequestsSchema() {
-    throw new UnsupportedOperationException("ExecutionRequests were removed in Gloas");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestationSchema.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestationSchema.java
@@ -31,10 +31,11 @@ public class IndexedPayloadAttestationSchema
 
   private static final SszFieldName ATTESTING_INDICES = () -> "attesting_indices";
 
-  public IndexedPayloadAttestationSchema(final long ptcSize, final SchemaRegistry schemaRegistry) {
+  public IndexedPayloadAttestationSchema(
+      final SpecConfigGloas specConfig, final SchemaRegistry schemaRegistry) {
     super(
         "IndexedPayloadAttestation",
-        namedSchema(ATTESTING_INDICES, SszUInt64ListSchema.create(ptcSize)),
+        namedSchema(ATTESTING_INDICES, SszUInt64ListSchema.create(specConfig.getPtcSize())),
         namedSchema("data", schemaRegistry.get(PAYLOAD_ATTESTATION_DATA_SCHEMA)),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBid.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBid.java
@@ -23,9 +23,9 @@ public class SignedExecutionPayloadBid
 
   SignedExecutionPayloadBid(
       final SignedExecutionPayloadBidSchema schema,
-      final ExecutionPayloadBid executionPayloadBid,
+      final ExecutionPayloadBid message,
       final BLSSignature signature) {
-    super(schema, executionPayloadBid, new SszSignature(signature));
+    super(schema, message, new SszSignature(signature));
   }
 
   SignedExecutionPayloadBid(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -945,8 +945,7 @@ public class SchemaRegistryBuilder {
         .withCreator(
             GLOAS,
             (registry, specConfig, schemaName) ->
-                new IndexedPayloadAttestationSchema(
-                    SpecConfigGloas.required(specConfig).getPtcSize(), registry))
+                new IndexedPayloadAttestationSchema(SpecConfigGloas.required(specConfig), registry))
         .build();
   }
 


### PR DESCRIPTION
## PR Description

* In `BeaconBlockBodySchemaGloasImpl`, group getter functions together in the correct order.
* Change parameter to `IndexedPayloadAttestationSchema` constructor to `SpecConfigGloas`.

This mirrors `PayloadAttestationSchema` here:

https://github.com/Consensys/teku/blob/d2a606fc6c07ddd0a6d5591c3636a08074638d91/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationSchema.java#L32-L36

* In `SignedExecutionPayloadBid`, change parameter name to `message`.

This mirrors `SignedExecutionPayloadEnvelope` here:

https://github.com/Consensys/teku/blob/d2a606fc6c07ddd0a6d5591c3636a08074638d91/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java#L25-L27

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders Gloas block body getters/overrides, updates IndexedPayloadAttestationSchema to accept SpecConfigGloas with registry wiring, and renames SignedExecutionPayloadBid constructor param to message.
> 
> - **Gloas datastructures**:
>   - `BeaconBlockBodySchemaGloasImpl`:
>     - Adds explicit overrides `createFromBackingNode` and `getBlindedNodeGeneralizedIndices`; groups getters in order.
>   - `SignedExecutionPayloadBid`:
>     - Renames constructor parameter to `message` and updates usage.
> - **Schemas/Registry**:
>   - `IndexedPayloadAttestationSchema`:
>     - Constructor now takes `SpecConfigGloas` and derives `ptcSize` via `specConfig.getPtcSize()`.
>   - `SchemaRegistryBuilder`:
>     - Updates provider to use the new `IndexedPayloadAttestationSchema(SpecConfigGloas, SchemaRegistry)` constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d16cb7a98c9b74c0cc7cb3e2cef636b27e43fdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->