### PR TITLE
Add specrefs for Gloas

### DIFF
--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -77,7 +77,6 @@ specrefs:
       - bytes_to_kzg_commitment#deneb
       - bytes_to_kzg_proof#deneb
       - compute_blob_kzg_proof#deneb
-      - compute_fork_version#fulu
       - compute_challenge#deneb
       - compute_kzg_proof#deneb
       - compute_kzg_proof_impl#deneb
@@ -168,14 +167,6 @@ specrefs:
       - upgrade_lc_update_to_electra
       - validate_light_client_update
 
-      # This function was added to the specs in Fulu
-      # Backported in the specs, but not necessary before Fulu
-      - compute_fork_version#altair
-      - compute_fork_version#bellatrix
-      - compute_fork_version#capella
-      - compute_fork_version#deneb
-      - compute_fork_version#electra
-
       # Still need to implement this for Electra
       - compute_weak_subjectivity_period#electra
 
@@ -220,7 +211,6 @@ specrefs:
       - get_sync_committee_message#altair
       - get_sync_committee_selection_proof#altair
       - get_sync_subcommittee_pubkeys#altair
-      - process_epoch#altair
       - process_justification_and_finalization#altair
       - process_rewards_and_penalties#altair
       - process_slashings#altair
@@ -241,7 +231,6 @@ specrefs:
 
       # Not implemented: capella
       - prepare_execution_payload#capella
-      - process_epoch#capella
       - process_execution_payload#capella
 
       # Not implemented: deneb
@@ -259,7 +248,6 @@ specrefs:
       - is_within_weak_subjectivity_period#electra
       - normalize_merkle_branch#electra
       - prepare_execution_payload#electra
-      - process_epoch#electra
       - process_execution_payload#electra
       - process_voluntary_exit#electra
 
@@ -268,19 +256,13 @@ specrefs:
       - get_data_column_sidecars#fulu
       - get_data_column_sidecars_from_block#fulu
       - get_data_column_sidecars_from_column_sidecar#fulu
-      - process_epoch#fulu
       - recover_matrix#fulu
 
       # Not implemented: gloas
-      - compute_balance_weighted_acceptance#gloas
-      - compute_balance_weighted_selection#gloas
-      - compute_fork_version#gloas
-      - compute_proposer_indices#gloas
       - get_aggregate_due_ms#gloas
       - get_ancestor#gloas
       - get_attestation_due_ms#gloas
       - get_attestation_participation_flag_indices#gloas
-      - get_builder_payment_quorum_threshold#gloas
       - get_checkpoint_block#gloas
       - get_contribution_due_ms#gloas
       - get_data_column_sidecars#gloas
@@ -291,28 +273,17 @@ specrefs:
       - get_expected_withdrawals#gloas
       - get_forkchoice_store#gloas
       - get_head#gloas
-      - get_indexed_payload_attestation#gloas
-      - get_next_sync_committee_indices#gloas
       - get_node_children#gloas
       - get_parent_payload_status#gloas
       - get_payload_attestation_message_signature#gloas
       - get_payload_status_tiebreaker#gloas
-      - get_pending_balance_to_withdraw#gloas
-      - get_ptc#gloas
       - get_ptc_assignment#gloas
       - get_sync_message_due_ms#gloas
       - get_weight#gloas
-      - has_builder_withdrawal_credential#gloas
-      - has_compounding_withdrawal_credential#gloas
-      - is_attestation_same_slot#gloas
-      - is_builder_payment_withdrawable#gloas
-      - is_builder_withdrawal_credential#gloas
       - is_merge_transition_complete#gloas
-      - is_parent_block_full#gloas
       - is_parent_node_full#gloas
       - is_payload_timely#gloas
       - is_supporting_vote#gloas
-      - is_valid_indexed_payload_attestation#gloas
       - notify_ptc_messages#gloas
       - on_block#gloas
       - on_execution_payload#gloas
@@ -320,21 +291,10 @@ specrefs:
       - prepare_execution_payload#gloas
       - process_attestation#gloas
       - process_block#gloas
-      - process_builder_pending_payments#gloas
-      - process_epoch#gloas
-      - process_execution_payload#gloas
-      - process_execution_payload_bid#gloas
-      - process_operations#gloas
-      - process_payload_attestation#gloas
       - process_proposer_slashing#gloas
       - process_slot#gloas
-      - process_withdrawals#gloas
-      - remove_flag#gloas
       - should_extend_payload#gloas
       - update_latest_messages#gloas
-      - upgrade_to_gloas#gloas
       - validate_merge_block#gloas
       - validate_on_attestation#gloas
       - verify_data_column_sidecar#gloas
-      - verify_execution_payload_bid_signature#gloas
-      - verify_execution_payload_envelope_signature#gloas

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -306,6 +306,27 @@
     PARTICIPATION_FLAG_WEIGHTS = [TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]
     </spec>
 
+- name: PAYLOAD_STATUS_EMPTY#gloas
+  sources: []
+  spec: |
+    <spec constant_var="PAYLOAD_STATUS_EMPTY" fork="gloas" hash="b78dfbcf">
+    PAYLOAD_STATUS_EMPTY: PayloadStatus = 1
+    </spec>
+
+- name: PAYLOAD_STATUS_FULL#gloas
+  sources: []
+  spec: |
+    <spec constant_var="PAYLOAD_STATUS_FULL" fork="gloas" hash="82f773dc">
+    PAYLOAD_STATUS_FULL: PayloadStatus = 2
+    </spec>
+
+- name: PAYLOAD_STATUS_PENDING#gloas
+  sources: []
+  spec: |
+    <spec constant_var="PAYLOAD_STATUS_PENDING" fork="gloas" hash="640761d7">
+    PAYLOAD_STATUS_PENDING: PayloadStatus = 0
+    </spec>
+
 - name: PROPOSER_WEIGHT
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -172,6 +172,61 @@
         return Epoch(epoch + 1 + MAX_SEED_LOOKAHEAD)
     </spec>
 
+- name: compute_balance_weighted_acceptance#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public boolean computeBalanceWeightedAcceptance(
+  spec: |
+    <spec fn="compute_balance_weighted_acceptance" fork="gloas" hash="9954dcd0">
+    def compute_balance_weighted_acceptance(
+        state: BeaconState, index: ValidatorIndex, seed: Bytes32, i: uint64
+    ) -> bool:
+        """
+        Return whether to accept the selection of the validator ``index``, with probability
+        proportional to its ``effective_balance``, and randomness given by ``seed`` and ``i``.
+        """
+        MAX_RANDOM_VALUE = 2**16 - 1
+        random_bytes = hash(seed + uint_to_bytes(i // 16))
+        offset = i % 16 * 2
+        random_value = bytes_to_uint64(random_bytes[offset : offset + 2])
+        effective_balance = state.validators[index].effective_balance
+        return effective_balance * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_ELECTRA * random_value
+    </spec>
+
+- name: compute_balance_weighted_selection#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public IntList computeBalanceWeightedSelection(
+  spec: |
+    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="2c9f1c23">
+    def compute_balance_weighted_selection(
+        state: BeaconState,
+        indices: Sequence[ValidatorIndex],
+        seed: Bytes32,
+        size: uint64,
+        shuffle_indices: bool,
+    ) -> Sequence[ValidatorIndex]:
+        """
+        Return ``size`` indices sampled by effective balance, using ``indices``
+        as candidates. If ``shuffle_indices`` is ``True``, candidate indices
+        are themselves sampled from ``indices`` by shuffling it, otherwise
+        ``indices`` is traversed in order.
+        """
+        total = uint64(len(indices))
+        assert total > 0
+        selected: List[ValidatorIndex] = []
+        i = uint64(0)
+        while len(selected) < size:
+            next_index = i % total
+            if shuffle_indices:
+                next_index = compute_shuffled_index(next_index, total, seed)
+            candidate_index = indices[next_index]
+            if compute_balance_weighted_acceptance(state, candidate_index, seed, i):
+                selected.append(candidate_index)
+            i += 1
+        return selected
+    </spec>
+
 - name: compute_columns_for_custody_group
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -394,6 +449,153 @@
         return GENESIS_FORK_VERSION
     </spec>
 
+- name: compute_fork_version#altair
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public Bytes4 computeForkVersion(
+  spec: |
+    <spec fn="compute_fork_version" fork="altair" hash="ac13fc52">
+    def compute_fork_version(epoch: Epoch) -> Version:
+        """
+        Return the fork version at the given ``epoch``.
+        """
+        if epoch >= ALTAIR_FORK_EPOCH:
+            return ALTAIR_FORK_VERSION
+        return GENESIS_FORK_VERSION
+    </spec>
+
+- name: compute_fork_version#bellatrix
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public Bytes4 computeForkVersion(
+  spec: |
+    <spec fn="compute_fork_version" fork="bellatrix" hash="2e5e09be">
+    def compute_fork_version(epoch: Epoch) -> Version:
+        """
+        Return the fork version at the given ``epoch``.
+        """
+        if epoch >= BELLATRIX_FORK_EPOCH:
+            return BELLATRIX_FORK_VERSION
+        if epoch >= ALTAIR_FORK_EPOCH:
+            return ALTAIR_FORK_VERSION
+        return GENESIS_FORK_VERSION
+    </spec>
+
+- name: compute_fork_version#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public Bytes4 computeForkVersion(
+  spec: |
+    <spec fn="compute_fork_version" fork="capella" hash="cf11ff98">
+    def compute_fork_version(epoch: Epoch) -> Version:
+        """
+        Return the fork version at the given ``epoch``.
+        """
+        if epoch >= CAPELLA_FORK_EPOCH:
+            return CAPELLA_FORK_VERSION
+        if epoch >= BELLATRIX_FORK_EPOCH:
+            return BELLATRIX_FORK_VERSION
+        if epoch >= ALTAIR_FORK_EPOCH:
+            return ALTAIR_FORK_VERSION
+        return GENESIS_FORK_VERSION
+    </spec>
+
+- name: compute_fork_version#deneb
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public Bytes4 computeForkVersion(
+  spec: |
+    <spec fn="compute_fork_version" fork="deneb" hash="287e691a">
+    def compute_fork_version(epoch: Epoch) -> Version:
+        """
+        Return the fork version at the given ``epoch``.
+        """
+        if epoch >= DENEB_FORK_EPOCH:
+            return DENEB_FORK_VERSION
+        if epoch >= CAPELLA_FORK_EPOCH:
+            return CAPELLA_FORK_VERSION
+        if epoch >= BELLATRIX_FORK_EPOCH:
+            return BELLATRIX_FORK_VERSION
+        if epoch >= ALTAIR_FORK_EPOCH:
+            return ALTAIR_FORK_VERSION
+        return GENESIS_FORK_VERSION
+    </spec>
+
+- name: compute_fork_version#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public Bytes4 computeForkVersion(
+  spec: |
+    <spec fn="compute_fork_version" fork="electra" hash="c142a405">
+    def compute_fork_version(epoch: Epoch) -> Version:
+        """
+        Return the fork version at the given ``epoch``.
+        """
+        if epoch >= ELECTRA_FORK_EPOCH:
+            return ELECTRA_FORK_VERSION
+        if epoch >= DENEB_FORK_EPOCH:
+            return DENEB_FORK_VERSION
+        if epoch >= CAPELLA_FORK_EPOCH:
+            return CAPELLA_FORK_VERSION
+        if epoch >= BELLATRIX_FORK_EPOCH:
+            return BELLATRIX_FORK_VERSION
+        if epoch >= ALTAIR_FORK_EPOCH:
+            return ALTAIR_FORK_VERSION
+        return GENESIS_FORK_VERSION
+    </spec>
+
+- name: compute_fork_version#fulu
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public Bytes4 computeForkVersion(
+  spec: |
+    <spec fn="compute_fork_version" fork="fulu" hash="6d472038">
+    def compute_fork_version(epoch: Epoch) -> Version:
+        """
+        Return the fork version at the given ``epoch``.
+        """
+        if epoch >= FULU_FORK_EPOCH:
+            return FULU_FORK_VERSION
+        if epoch >= ELECTRA_FORK_EPOCH:
+            return ELECTRA_FORK_VERSION
+        if epoch >= DENEB_FORK_EPOCH:
+            return DENEB_FORK_VERSION
+        if epoch >= CAPELLA_FORK_EPOCH:
+            return CAPELLA_FORK_VERSION
+        if epoch >= BELLATRIX_FORK_EPOCH:
+            return BELLATRIX_FORK_VERSION
+        if epoch >= ALTAIR_FORK_EPOCH:
+            return ALTAIR_FORK_VERSION
+        return GENESIS_FORK_VERSION
+    </spec>
+
+- name: compute_fork_version#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+      search: public Bytes4 computeForkVersion(
+  spec: |
+    <spec fn="compute_fork_version" fork="gloas" hash="b6fccd63">
+    def compute_fork_version(epoch: Epoch) -> Version:
+        """
+        Return the fork version at the given ``epoch``.
+        """
+        if epoch >= GLOAS_FORK_EPOCH:
+            return GLOAS_FORK_VERSION
+        if epoch >= FULU_FORK_EPOCH:
+            return FULU_FORK_VERSION
+        if epoch >= ELECTRA_FORK_EPOCH:
+            return ELECTRA_FORK_VERSION
+        if epoch >= DENEB_FORK_EPOCH:
+            return DENEB_FORK_VERSION
+        if epoch >= CAPELLA_FORK_EPOCH:
+            return CAPELLA_FORK_VERSION
+        if epoch >= BELLATRIX_FORK_EPOCH:
+            return BELLATRIX_FORK_VERSION
+        if epoch >= ALTAIR_FORK_EPOCH:
+            return ALTAIR_FORK_VERSION
+        return GENESIS_FORK_VERSION
+    </spec>
+
 - name: compute_proposer_index
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -464,6 +666,27 @@
         start_slot = compute_start_slot_at_epoch(epoch)
         seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
         return [compute_proposer_index(state, indices, seed) for seed in seeds]
+    </spec>
+
+- name: compute_proposer_indices#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public List<Integer> computeProposerIndices(
+  spec: |
+    <spec fn="compute_proposer_indices" fork="gloas" hash="8aed10df">
+    def compute_proposer_indices(
+        state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
+    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+        """
+        Return the proposer indices for the given ``epoch``.
+        """
+        start_slot = compute_start_slot_at_epoch(epoch)
+        seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
+        # [Modified in Gloas:EIP7732]
+        return [
+            compute_balance_weighted_selection(state, indices, seed, size=1, shuffle_indices=True)[0]
+            for seed in seeds
+        ]
     </spec>
 
 - name: compute_shuffled_index
@@ -782,6 +1005,17 @@
         return get_slot_component_duration_ms(AGGREGATE_DUE_BPS)
     </spec>
 
+- name: get_aggregate_due_ms#gloas
+  sources: []
+  spec: |
+    <spec fn="get_aggregate_due_ms" fork="gloas" hash="33a26a53">
+    def get_aggregate_due_ms(epoch: Epoch) -> uint64:
+        # [New in Gloas]
+        if epoch >= GLOAS_FORK_EPOCH:
+            return get_slot_component_duration_ms(AGGREGATE_DUE_BPS_GLOAS)
+        return get_slot_component_duration_ms(AGGREGATE_DUE_BPS)
+    </spec>
+
 - name: get_ancestor
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -793,6 +1027,30 @@
         if block.slot > slot:
             return get_ancestor(store, block.parent_root, slot)
         return root
+    </spec>
+
+- name: get_ancestor#gloas
+  sources: []
+  spec: |
+    <spec fn="get_ancestor" fork="gloas" hash="bc5140b8">
+    def get_ancestor(store: Store, root: Root, slot: Slot) -> ForkChoiceNode:
+        """
+        Returns the beacon block root and the payload status of the ancestor of the beacon block
+        with ``root`` at ``slot``. If the beacon block with ``root`` is already at ``slot`` or we are
+        requesting an ancestor "in the future", it returns ``PAYLOAD_STATUS_PENDING``.
+        """
+        block = store.blocks[root]
+        if block.slot <= slot:
+            return ForkChoiceNode(root=root, payload_status=PAYLOAD_STATUS_PENDING)
+
+        parent = store.blocks[block.parent_root]
+        if parent.slot > slot:
+            return get_ancestor(store, block.parent_root, slot)
+        else:
+            return ForkChoiceNode(
+                root=block.parent_root,
+                payload_status=get_parent_payload_status(store, block),
+            )
     </spec>
 
 - name: get_attestation_component_deltas
@@ -836,6 +1094,17 @@
   spec: |
     <spec fn="get_attestation_due_ms" fork="phase0" hash="d3b17e38">
     def get_attestation_due_ms(epoch: Epoch) -> uint64:
+        return get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
+    </spec>
+
+- name: get_attestation_due_ms#gloas
+  sources: []
+  spec: |
+    <spec fn="get_attestation_due_ms" fork="gloas" hash="b99d28c7">
+    def get_attestation_due_ms(epoch: Epoch) -> uint64:
+        # [New in Gloas]
+        if epoch >= GLOAS_FORK_EPOCH:
+            return get_slot_component_duration_ms(ATTESTATION_DUE_BPS_GLOAS)
         return get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
     </spec>
 
@@ -918,6 +1187,56 @@
         if is_matching_source and inclusion_delay <= integer_squareroot(SLOTS_PER_EPOCH):
             participation_flag_indices.append(TIMELY_SOURCE_FLAG_INDEX)
         # [Modified in Deneb:EIP7045]
+        if is_matching_target:
+            participation_flag_indices.append(TIMELY_TARGET_FLAG_INDEX)
+        if is_matching_head and inclusion_delay == MIN_ATTESTATION_INCLUSION_DELAY:
+            participation_flag_indices.append(TIMELY_HEAD_FLAG_INDEX)
+
+        return participation_flag_indices
+    </spec>
+
+- name: get_attestation_participation_flag_indices#gloas
+  sources: []
+  spec: |
+    <spec fn="get_attestation_participation_flag_indices" fork="gloas" hash="aeb30d51">
+    def get_attestation_participation_flag_indices(
+        state: BeaconState, data: AttestationData, inclusion_delay: uint64
+    ) -> Sequence[int]:
+        """
+        Return the flag indices that are satisfied by an attestation.
+        """
+        # Matching source
+        if data.target.epoch == get_current_epoch(state):
+            justified_checkpoint = state.current_justified_checkpoint
+        else:
+            justified_checkpoint = state.previous_justified_checkpoint
+        is_matching_source = data.source == justified_checkpoint
+
+        # Matching target
+        target_root = get_block_root(state, data.target.epoch)
+        target_root_matches = data.target.root == target_root
+        is_matching_target = is_matching_source and target_root_matches
+
+        # [New in Gloas:EIP7732]
+        if is_attestation_same_slot(state, data):
+            assert data.index == 0
+            payload_matches = True
+        else:
+            slot_index = data.slot % SLOTS_PER_HISTORICAL_ROOT
+            payload_index = state.execution_payload_availability[slot_index]
+            payload_matches = data.index == payload_index
+
+        # Matching head
+        head_root = get_block_root_at_slot(state, data.slot)
+        head_root_matches = data.beacon_block_root == head_root
+        # [Modified in Gloas:EIP7732]
+        is_matching_head = is_matching_target and head_root_matches and payload_matches
+
+        assert is_matching_source
+
+        participation_flag_indices = []
+        if is_matching_source and inclusion_delay <= integer_squareroot(SLOTS_PER_EPOCH):
+            participation_flag_indices.append(TIMELY_SOURCE_FLAG_INDEX)
         if is_matching_target:
             participation_flag_indices.append(TIMELY_TARGET_FLAG_INDEX)
         if is_matching_head and inclusion_delay == MIN_ATTESTATION_INCLUSION_DELAY:
@@ -1165,6 +1484,33 @@
         return bls.Sign(privkey, signing_root)
     </spec>
 
+- name: get_builder_payment_quorum_threshold#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public UInt64 getBuilderPaymentQuorumThreshold(
+  spec: |
+    <spec fn="get_builder_payment_quorum_threshold" fork="gloas" hash="a64b7ffb">
+    def get_builder_payment_quorum_threshold(state: BeaconState) -> uint64:
+        """
+        Calculate the quorum threshold for builder payments.
+        """
+        per_slot_balance = get_total_active_balance(state) // SLOTS_PER_EPOCH
+        quorum = per_slot_balance * BUILDER_PAYMENT_THRESHOLD_NUMERATOR
+        return uint64(quorum // BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
+    </spec>
+
+- name: get_checkpoint_block#gloas
+  sources: []
+  spec: |
+    <spec fn="get_checkpoint_block" fork="gloas" hash="e238b732">
+    def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
+        """
+        Compute the checkpoint block for epoch ``epoch`` in the chain of block ``root``
+        """
+        epoch_first_slot = compute_start_slot_at_epoch(epoch)
+        return get_ancestor(store, root, epoch_first_slot).root
+    </spec>
+
 - name: get_committee_assignment
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -1255,6 +1601,17 @@
         return get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS)
     </spec>
 
+- name: get_contribution_due_ms#gloas
+  sources: []
+  spec: |
+    <spec fn="get_contribution_due_ms" fork="gloas" hash="69183c6c">
+    def get_contribution_due_ms(epoch: Epoch) -> uint64:
+        # [New in Gloas]
+        if epoch >= GLOAS_FORK_EPOCH:
+            return get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS_GLOAS)
+        return get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS)
+    </spec>
+
 - name: get_current_epoch
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -1307,6 +1664,98 @@
 
         assert len(custody_groups) == len(set(custody_groups))
         return sorted(custody_groups)
+    </spec>
+
+- name: get_data_column_sidecars#gloas
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars" fork="gloas" hash="c8d64ac9">
+    def get_data_column_sidecars(
+        # [Modified in Gloas:EIP7732]
+        # Removed `signed_block_header`
+        # [New in Gloas:EIP7732]
+        beacon_block_root: Root,
+        # [New in Gloas:EIP7732]
+        slot: Slot,
+        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+        # [Modified in Gloas:EIP7732]
+        # Removed `kzg_commitments_inclusion_proof`
+        cells_and_kzg_proofs: Sequence[
+            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
+        ],
+    ) -> Sequence[DataColumnSidecar]:
+        """
+        Given a beacon block root and the commitments, cells/proofs associated with
+        each blob in the block, assemble the sidecars which can be distributed to peers.
+        """
+        assert len(cells_and_kzg_proofs) == len(kzg_commitments)
+
+        sidecars = []
+        for column_index in range(NUMBER_OF_COLUMNS):
+            column_cells, column_proofs = [], []
+            for cells, proofs in cells_and_kzg_proofs:
+                column_cells.append(cells[column_index])
+                column_proofs.append(proofs[column_index])
+            sidecars.append(
+                DataColumnSidecar(
+                    index=column_index,
+                    column=column_cells,
+                    kzg_commitments=kzg_commitments,
+                    kzg_proofs=column_proofs,
+                    slot=slot,
+                    beacon_block_root=beacon_block_root,
+                )
+            )
+        return sidecars
+    </spec>
+
+- name: get_data_column_sidecars_from_block#gloas
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="8ac19a18">
+    def get_data_column_sidecars_from_block(
+        signed_block: SignedBeaconBlock,
+        # [New in Gloas:EIP7732]
+        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+        cells_and_kzg_proofs: Sequence[
+            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
+        ],
+    ) -> Sequence[DataColumnSidecar]:
+        """
+        Given a signed block and the cells/proofs associated with each blob in the
+        block, assemble the sidecars which can be distributed to peers.
+        """
+        beacon_block_root = hash_tree_root(signed_block.message)
+        return get_data_column_sidecars(
+            beacon_block_root,
+            signed_block.message.slot,
+            blob_kzg_commitments,
+            cells_and_kzg_proofs,
+        )
+    </spec>
+
+- name: get_data_column_sidecars_from_column_sidecar#gloas
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="a1052a1c">
+    def get_data_column_sidecars_from_column_sidecar(
+        sidecar: DataColumnSidecar,
+        cells_and_kzg_proofs: Sequence[
+            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
+        ],
+    ) -> Sequence[DataColumnSidecar]:
+        """
+        Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
+        to the commitments it contains, assemble all sidecars for distribution to peers.
+        """
+        assert len(cells_and_kzg_proofs) == len(sidecar.kzg_commitments)
+
+        return get_data_column_sidecars(
+            sidecar.beacon_block_root,
+            sidecar.slot,
+            sidecar.kzg_commitments,
+            cells_and_kzg_proofs,
+        )
     </spec>
 
 - name: get_domain
@@ -1420,6 +1869,30 @@
             ),
             default=default_vote,
         )
+    </spec>
+
+- name: get_execution_payload_bid_signature#gloas
+  sources: []
+  spec: |
+    <spec fn="get_execution_payload_bid_signature" fork="gloas" hash="c09cbb78">
+    def get_execution_payload_bid_signature(
+        state: BeaconState, bid: ExecutionPayloadBid, privkey: int
+    ) -> BLSSignature:
+        domain = get_domain(state, DOMAIN_BEACON_BUILDER, compute_epoch_at_slot(bid.slot))
+        signing_root = compute_signing_root(bid, domain)
+        return bls.Sign(privkey, signing_root)
+    </spec>
+
+- name: get_execution_payload_envelope_signature#gloas
+  sources: []
+  spec: |
+    <spec fn="get_execution_payload_envelope_signature" fork="gloas" hash="7291faa5">
+    def get_execution_payload_envelope_signature(
+        state: BeaconState, envelope: ExecutionPayloadEnvelope, privkey: int
+    ) -> BLSSignature:
+        domain = get_domain(state, DOMAIN_BEACON_BUILDER, compute_epoch_at_slot(state.slot))
+        signing_root = compute_signing_root(envelope, domain)
+        return bls.Sign(privkey, signing_root)
     </spec>
 
 - name: get_execution_requests
@@ -1614,6 +2087,121 @@
         return withdrawals, processed_partial_withdrawals_count
     </spec>
 
+- name: get_expected_withdrawals#gloas
+  sources: []
+  spec: |
+    <spec fn="get_expected_withdrawals" fork="gloas" hash="5791eda3">
+    def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64, uint64]:
+        epoch = get_current_epoch(state)
+        withdrawal_index = state.next_withdrawal_index
+        validator_index = state.next_withdrawal_validator_index
+        withdrawals: List[Withdrawal] = []
+        processed_partial_withdrawals_count = 0
+        processed_builder_withdrawals_count = 0
+
+        # [New in Gloas:EIP7732]
+        # Sweep for builder payments
+        for withdrawal in state.builder_pending_withdrawals:
+            if (
+                withdrawal.withdrawable_epoch > epoch
+                or len(withdrawals) + 1 == MAX_WITHDRAWALS_PER_PAYLOAD
+            ):
+                break
+            if is_builder_payment_withdrawable(state, withdrawal):
+                total_withdrawn = sum(
+                    w.amount for w in withdrawals if w.validator_index == withdrawal.builder_index
+                )
+                balance = state.balances[withdrawal.builder_index] - total_withdrawn
+                builder = state.validators[withdrawal.builder_index]
+                if builder.slashed:
+                    withdrawable_balance = min(balance, withdrawal.amount)
+                elif balance > MIN_ACTIVATION_BALANCE:
+                    withdrawable_balance = min(balance - MIN_ACTIVATION_BALANCE, withdrawal.amount)
+                else:
+                    withdrawable_balance = 0
+
+                if withdrawable_balance > 0:
+                    withdrawals.append(
+                        Withdrawal(
+                            index=withdrawal_index,
+                            validator_index=withdrawal.builder_index,
+                            address=withdrawal.fee_recipient,
+                            amount=withdrawable_balance,
+                        )
+                    )
+                    withdrawal_index += WithdrawalIndex(1)
+            processed_builder_withdrawals_count += 1
+
+        # Sweep for pending partial withdrawals
+        bound = min(
+            len(withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
+            MAX_WITHDRAWALS_PER_PAYLOAD - 1,
+        )
+        for withdrawal in state.pending_partial_withdrawals:
+            if withdrawal.withdrawable_epoch > epoch or len(withdrawals) == bound:
+                break
+
+            validator = state.validators[withdrawal.validator_index]
+            has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
+            total_withdrawn = sum(
+                w.amount for w in withdrawals if w.validator_index == withdrawal.validator_index
+            )
+            balance = state.balances[withdrawal.validator_index] - total_withdrawn
+            has_excess_balance = balance > MIN_ACTIVATION_BALANCE
+            if (
+                validator.exit_epoch == FAR_FUTURE_EPOCH
+                and has_sufficient_effective_balance
+                and has_excess_balance
+            ):
+                withdrawable_balance = min(balance - MIN_ACTIVATION_BALANCE, withdrawal.amount)
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=withdrawal.validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        amount=withdrawable_balance,
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+
+            processed_partial_withdrawals_count += 1
+
+        # Sweep for remaining.
+        bound = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
+        for _ in range(bound):
+            validator = state.validators[validator_index]
+            total_withdrawn = sum(w.amount for w in withdrawals if w.validator_index == validator_index)
+            balance = state.balances[validator_index] - total_withdrawn
+            if is_fully_withdrawable_validator(validator, balance, epoch):
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        amount=balance,
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+            elif is_partially_withdrawable_validator(validator, balance):
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        amount=balance - get_max_effective_balance(validator),
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+            if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
+                break
+            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+        return (
+            withdrawals,
+            processed_builder_withdrawals_count,
+            processed_partial_withdrawals_count,
+        )
+    </spec>
+
 - name: get_finality_delay
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -1657,6 +2245,64 @@
             elif flag_index != TIMELY_HEAD_FLAG_INDEX:
                 penalties[index] += Gwei(base_reward * weight // WEIGHT_DENOMINATOR)
         return rewards, penalties
+    </spec>
+
+- name: get_forkchoice_store#gloas
+  sources: []
+  spec: |
+    <spec fn="get_forkchoice_store" fork="gloas" hash="59983cbd">
+    def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
+        assert anchor_block.state_root == hash_tree_root(anchor_state)
+        anchor_root = hash_tree_root(anchor_block)
+        anchor_epoch = get_current_epoch(anchor_state)
+        justified_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
+        finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
+        proposer_boost_root = Root()
+        return Store(
+            time=uint64(anchor_state.genesis_time + SECONDS_PER_SLOT * anchor_state.slot),
+            genesis_time=anchor_state.genesis_time,
+            justified_checkpoint=justified_checkpoint,
+            finalized_checkpoint=finalized_checkpoint,
+            unrealized_justified_checkpoint=justified_checkpoint,
+            unrealized_finalized_checkpoint=finalized_checkpoint,
+            proposer_boost_root=proposer_boost_root,
+            equivocating_indices=set(),
+            blocks={anchor_root: copy(anchor_block)},
+            block_states={anchor_root: copy(anchor_state)},
+            checkpoint_states={justified_checkpoint: copy(anchor_state)},
+            unrealized_justifications={anchor_root: justified_checkpoint},
+            # [New in Gloas:EIP7732]
+            execution_payload_states={anchor_root: copy(anchor_state)},
+            ptc_vote={anchor_root: Vector[boolean, PTC_SIZE]()},
+        )
+    </spec>
+
+- name: get_head#gloas
+  sources: []
+  spec: |
+    <spec fn="get_head" fork="gloas" hash="d03052ed">
+    def get_head(store: Store) -> ForkChoiceNode:
+        # Get filtered block tree that only includes viable branches
+        blocks = get_filtered_block_tree(store)
+        # Execute the LMD-GHOST fork-choice
+        head = ForkChoiceNode(
+            root=store.justified_checkpoint.root,
+            payload_status=PAYLOAD_STATUS_PENDING,
+        )
+
+        while True:
+            children = get_node_children(store, blocks, head)
+            if len(children) == 0:
+                return head
+            # Sort by latest attesting balance with ties broken lexicographically
+            head = max(
+                children,
+                key=lambda child: (
+                    get_weight(store, child),
+                    child.root,
+                    get_payload_status_tiebreaker(store, child),
+                ),
+            )
     </spec>
 
 - name: get_head_deltas
@@ -1744,6 +2390,29 @@
             attesting_indices=sorted(attesting_indices),
             data=attestation.data,
             signature=attestation.signature,
+        )
+    </spec>
+
+- name: get_indexed_payload_attestation#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public IndexedPayloadAttestation getIndexedPayloadAttestation(
+  spec: |
+    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="91fab311">
+    def get_indexed_payload_attestation(
+        state: BeaconState, slot: Slot, payload_attestation: PayloadAttestation
+    ) -> IndexedPayloadAttestation:
+        """
+        Return the indexed payload attestation corresponding to ``payload_attestation``.
+        """
+        ptc = get_ptc(state, slot)
+        bits = payload_attestation.aggregation_bits
+        attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
+
+        return IndexedPayloadAttestation(
+            attesting_indices=sorted(attesting_indices),
+            data=payload_attestation.data,
+            signature=payload_attestation.signature,
         )
     </spec>
 
@@ -1846,6 +2515,58 @@
         return sync_committee_indices
     </spec>
 
+- name: get_next_sync_committee_indices#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public IntList getNextSyncCommitteeIndices(
+  spec: |
+    <spec fn="get_next_sync_committee_indices" fork="gloas" hash="4078cd19">
+    def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
+        """
+        Return the sync committee indices, with possible duplicates, for the next sync committee.
+        """
+        epoch = Epoch(get_current_epoch(state) + 1)
+        seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
+        indices = get_active_validator_indices(state, epoch)
+        return compute_balance_weighted_selection(
+            state, indices, seed, size=SYNC_COMMITTEE_SIZE, shuffle_indices=True
+        )
+    </spec>
+
+- name: get_node_children#gloas
+  sources: []
+  spec: |
+    <spec fn="get_node_children" fork="gloas" hash="b6012515">
+    def get_node_children(
+        store: Store, blocks: Dict[Root, BeaconBlock], node: ForkChoiceNode
+    ) -> Sequence[ForkChoiceNode]:
+        if node.payload_status == PAYLOAD_STATUS_PENDING:
+            children = [ForkChoiceNode(root=node.root, payload_status=PAYLOAD_STATUS_EMPTY)]
+            if node.root in store.execution_payload_states:
+                children.append(ForkChoiceNode(root=node.root, payload_status=PAYLOAD_STATUS_FULL))
+            return children
+        else:
+            return [
+                ForkChoiceNode(root=root, payload_status=PAYLOAD_STATUS_PENDING)
+                for root in blocks.keys()
+                if (
+                    blocks[root].parent_root == node.root
+                    and node.payload_status == get_parent_payload_status(store, blocks[root])
+                )
+            ]
+    </spec>
+
+- name: get_parent_payload_status#gloas
+  sources: []
+  spec: |
+    <spec fn="get_parent_payload_status" fork="gloas" hash="4ab82d16">
+    def get_parent_payload_status(store: Store, block: BeaconBlock) -> PayloadStatus:
+        parent = store.blocks[block.parent_root]
+        parent_block_hash = block.body.signed_execution_payload_bid.message.parent_block_hash
+        message_block_hash = parent.body.signed_execution_payload_bid.message.block_hash
+        return PAYLOAD_STATUS_FULL if parent_block_hash == message_block_hash else PAYLOAD_STATUS_EMPTY
+    </spec>
+
 - name: get_payload_attestation_due_ms#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1856,6 +2577,36 @@
     <spec fn="get_payload_attestation_due_ms" fork="gloas" hash="16f3b9cb">
     def get_payload_attestation_due_ms(epoch: Epoch) -> uint64:
         return get_slot_component_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)
+    </spec>
+
+- name: get_payload_attestation_message_signature#gloas
+  sources: []
+  spec: |
+    <spec fn="get_payload_attestation_message_signature" fork="gloas" hash="e2a06b4b">
+    def get_payload_attestation_message_signature(
+        state: BeaconState, attestation: PayloadAttestationMessage, privkey: int
+    ) -> BLSSignature:
+        domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
+        signing_root = compute_signing_root(attestation.data, domain)
+        return bls.Sign(privkey, signing_root)
+    </spec>
+
+- name: get_payload_status_tiebreaker#gloas
+  sources: []
+  spec: |
+    <spec fn="get_payload_status_tiebreaker" fork="gloas" hash="5ca841c3">
+    def get_payload_status_tiebreaker(store: Store, node: ForkChoiceNode) -> uint8:
+        if node.payload_status == PAYLOAD_STATUS_PENDING or store.blocks[
+            node.root
+        ].slot + 1 != get_current_slot(store):
+            return node.payload_status
+        else:
+            # To decide on a payload from the previous slot, choose
+            # between FULL and EMPTY based on `should_extend_payload`
+            if node.payload_status == PAYLOAD_STATUS_EMPTY:
+                return 1
+            else:
+                return 2 if should_extend_payload(store, node.root) else 0
     </spec>
 
 - name: get_pending_balance_to_withdraw
@@ -1869,6 +2620,34 @@
             withdrawal.amount
             for withdrawal in state.pending_partial_withdrawals
             if withdrawal.validator_index == validator_index
+        )
+    </spec>
+
+- name: get_pending_balance_to_withdraw#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public UInt64 getPendingBalanceToWithdraw(
+  spec: |
+    <spec fn="get_pending_balance_to_withdraw" fork="gloas" hash="e8e7fc8a">
+    def get_pending_balance_to_withdraw(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
+        return (
+            sum(
+                withdrawal.amount
+                for withdrawal in state.pending_partial_withdrawals
+                if withdrawal.validator_index == validator_index
+            )
+            # [New in Gloas:EIP7732]
+            + sum(
+                withdrawal.amount
+                for withdrawal in state.builder_pending_withdrawals
+                if withdrawal.builder_index == validator_index
+            )
+            # [New in Gloas:EIP7732]
+            + sum(
+                payment.withdrawal.amount
+                for payment in state.builder_pending_payments
+                if payment.withdrawal.builder_index == validator_index
+            )
         )
     </spec>
 
@@ -1976,6 +2755,50 @@
         return (committee_weight * PROPOSER_SCORE_BOOST) // 100
     </spec>
 
+- name: get_ptc#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public IntList getPtc(
+  spec: |
+    <spec fn="get_ptc" fork="gloas" hash="ae15f761">
+    def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
+        """
+        Get the payload timeliness committee for the given ``slot``.
+        """
+        epoch = compute_epoch_at_slot(slot)
+        seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
+        indices: List[ValidatorIndex] = []
+        # Concatenate all committees for this slot in order
+        committees_per_slot = get_committee_count_per_slot(state, epoch)
+        for i in range(committees_per_slot):
+            committee = get_beacon_committee(state, slot, CommitteeIndex(i))
+            indices.extend(committee)
+        return compute_balance_weighted_selection(
+            state, indices, seed, size=PTC_SIZE, shuffle_indices=False
+        )
+    </spec>
+
+- name: get_ptc_assignment#gloas
+  sources: []
+  spec: |
+    <spec fn="get_ptc_assignment" fork="gloas" hash="6db8c274">
+    def get_ptc_assignment(
+        state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
+    ) -> Optional[Slot]:
+        """
+        Returns the slot during the requested epoch in which the validator with index `validator_index`
+        is a member of the PTC. Returns None if no assignment is found.
+        """
+        next_epoch = Epoch(get_current_epoch(state) + 1)
+        assert epoch <= next_epoch
+
+        start_slot = compute_start_slot_at_epoch(epoch)
+        for slot in range(start_slot, start_slot + SLOTS_PER_EPOCH):
+            if validator_index in get_ptc(state, Slot(slot)):
+                return Slot(slot)
+        return None
+    </spec>
+
 - name: get_randao_mix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -2055,6 +2878,17 @@
   spec: |
     <spec fn="get_sync_message_due_ms" fork="altair" hash="4d86dced">
     def get_sync_message_due_ms(epoch: Epoch) -> uint64:
+        return get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)
+    </spec>
+
+- name: get_sync_message_due_ms#gloas
+  sources: []
+  spec: |
+    <spec fn="get_sync_message_due_ms" fork="gloas" hash="6af451b5">
+    def get_sync_message_due_ms(epoch: Epoch) -> uint64:
+        # [New in Gloas]
+        if epoch >= GLOAS_FORK_EPOCH:
+            return get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS_GLOAS)
         return get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)
     </spec>
 
@@ -2268,6 +3102,68 @@
         return attestation_score + proposer_score
     </spec>
 
+- name: get_weight#gloas
+  sources: []
+  spec: |
+    <spec fn="get_weight" fork="gloas" hash="c16cb497">
+    def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
+        if node.payload_status == PAYLOAD_STATUS_PENDING or store.blocks[
+            node.root
+        ].slot + 1 != get_current_slot(store):
+            state = store.checkpoint_states[store.justified_checkpoint]
+            unslashed_and_active_indices = [
+                i
+                for i in get_active_validator_indices(state, get_current_epoch(state))
+                if not state.validators[i].slashed
+            ]
+            attestation_score = Gwei(
+                sum(
+                    state.validators[i].effective_balance
+                    for i in unslashed_and_active_indices
+                    if (
+                        i in store.latest_messages
+                        and i not in store.equivocating_indices
+                        and is_supporting_vote(store, node, store.latest_messages[i])
+                    )
+                )
+            )
+
+            if store.proposer_boost_root == Root():
+                # Return only attestation score if `proposer_boost_root` is not set
+                return attestation_score
+
+            # Calculate proposer score if `proposer_boost_root` is set
+            proposer_score = Gwei(0)
+
+            # `proposer_boost_root` is treated as a vote for the
+            # proposer's block in the current slot. Proposer boost
+            # is applied accordingly to all ancestors
+            message = LatestMessage(
+                slot=get_current_slot(store),
+                root=store.proposer_boost_root,
+                payload_present=False,
+            )
+            if is_supporting_vote(store, node, message):
+                proposer_score = get_proposer_score(store)
+
+            return attestation_score + proposer_score
+        else:
+            return Gwei(0)
+    </spec>
+
+- name: has_builder_withdrawal_credential#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+      search: public boolean hasBuilderWithdrawalCredential(
+  spec: |
+    <spec fn="has_builder_withdrawal_credential" fork="gloas" hash="5376d784">
+    def has_builder_withdrawal_credential(validator: Validator) -> bool:
+        """
+        Check if ``validator`` has an 0x03 prefixed "builder" withdrawal credential.
+        """
+        return is_builder_withdrawal_credential(validator.withdrawal_credentials)
+    </spec>
+
 - name: has_compounding_withdrawal_credential
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
@@ -2279,6 +3175,23 @@
         Check if ``validator`` has an 0x02 prefixed "compounding" withdrawal credential.
         """
         return is_compounding_withdrawal_credential(validator.withdrawal_credentials)
+    </spec>
+
+- name: has_compounding_withdrawal_credential#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+      search: public boolean hasCompoundingWithdrawalCredential(
+  spec: |
+    <spec fn="has_compounding_withdrawal_credential" fork="gloas" hash="2d37ec04">
+    def has_compounding_withdrawal_credential(validator: Validator) -> bool:
+        """
+        Check if ``validator`` has an 0x02 or 0x03 prefixed withdrawal credential.
+        """
+        if is_compounding_withdrawal_credential(validator.withdrawal_credentials):
+            return True
+        if is_builder_withdrawal_credential(validator.withdrawal_credentials):
+            return True
+        return False
     </spec>
 
 - name: has_eth1_withdrawal_credential
@@ -2522,6 +3435,53 @@
             return pubkey in state.next_sync_committee.pubkeys
     </spec>
 
+- name: is_attestation_same_slot#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public boolean isAttestationSameSlot(
+  spec: |
+    <spec fn="is_attestation_same_slot" fork="gloas" hash="0a194ce7">
+    def is_attestation_same_slot(state: BeaconState, data: AttestationData) -> bool:
+        """
+        Check if the attestation is for the block proposed at the attestation slot.
+        """
+        if data.slot == 0:
+            return True
+
+        blockroot = data.beacon_block_root
+        slot_blockroot = get_block_root_at_slot(state, data.slot)
+        prev_blockroot = get_block_root_at_slot(state, Slot(data.slot - 1))
+
+        return blockroot == slot_blockroot and blockroot != prev_blockroot
+    </spec>
+
+- name: is_builder_payment_withdrawable#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: private boolean isBuilderPaymentWithdrawable(
+  spec: |
+    <spec fn="is_builder_payment_withdrawable" fork="gloas" hash="2a0397c1">
+    def is_builder_payment_withdrawable(
+        state: BeaconState, withdrawal: BuilderPendingWithdrawal
+    ) -> bool:
+        """
+        Check if the builder is slashed and not yet withdrawable.
+        """
+        builder = state.validators[withdrawal.builder_index]
+        current_epoch = compute_epoch_at_slot(state.slot)
+        return builder.withdrawable_epoch >= current_epoch or not builder.slashed
+    </spec>
+
+- name: is_builder_withdrawal_credential#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+      search: public boolean isBuilderWithdrawalCredential(
+  spec: |
+    <spec fn="is_builder_withdrawal_credential" fork="gloas" hash="2ae5294b">
+    def is_builder_withdrawal_credential(withdrawal_credentials: Bytes32) -> bool:
+        return withdrawal_credentials[:1] == BUILDER_WITHDRAWAL_PREFIX
+    </spec>
+
 - name: is_compounding_withdrawal_credential
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
@@ -2729,6 +3689,18 @@
         return state.latest_execution_payload_header != ExecutionPayloadHeader()
     </spec>
 
+- name: is_merge_transition_complete#gloas
+  sources: []
+  spec: |
+    <spec fn="is_merge_transition_complete" fork="gloas" hash="38872f35">
+    def is_merge_transition_complete(state: BeaconState) -> bool:
+        bid = ExecutionPayloadBid()
+        kzgs = List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]()
+        bid.blob_kzg_commitments_root = kzgs.hash_tree_root()
+
+        return state.latest_execution_payload_bid != bid
+    </spec>
+
 - name: is_optimistic
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
@@ -2737,6 +3709,24 @@
     <spec fn="is_optimistic" fork="bellatrix" hash="d5afd615">
     def is_optimistic(opt_store: OptimisticStore, block: BeaconBlock) -> bool:
         return hash_tree_root(block) in opt_store.optimistic_roots
+    </spec>
+
+- name: is_parent_block_full#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+      search: public boolean isParentBlockFull(
+  spec: |
+    <spec fn="is_parent_block_full" fork="gloas" hash="b59640c9">
+    def is_parent_block_full(state: BeaconState) -> bool:
+        return state.latest_execution_payload_bid.block_hash == state.latest_block_hash
+    </spec>
+
+- name: is_parent_node_full#gloas
+  sources: []
+  spec: |
+    <spec fn="is_parent_node_full" fork="gloas" hash="4fc2d12c">
+    def is_parent_node_full(store: Store, block: BeaconBlock) -> bool:
+        return get_parent_payload_status(store, block) == PAYLOAD_STATUS_FULL
     </spec>
 
 - name: is_parent_strong
@@ -2792,6 +3782,26 @@
             and has_max_effective_balance
             and has_excess_balance
         )
+    </spec>
+
+- name: is_payload_timely#gloas
+  sources: []
+  spec: |
+    <spec fn="is_payload_timely" fork="gloas" hash="ae36e125">
+    def is_payload_timely(store: Store, root: Root) -> bool:
+        """
+        Return whether the execution payload for the beacon block with root ``root``
+        was voted as present by the PTC, and was locally determined to be available.
+        """
+        # The beacon block root must be known
+        assert root in store.ptc_vote
+
+        # If the payload is not locally available, the payload
+        # is not considered available regardless of the PTC vote
+        if root not in store.execution_payload_states:
+            return False
+
+        return sum(store.ptc_vote[root]) > PAYLOAD_TIMELY_THRESHOLD
     </spec>
 
 - name: is_proposing_on_time
@@ -2850,6 +3860,34 @@
         return (not validator.slashed) and (
             validator.activation_epoch <= epoch < validator.withdrawable_epoch
         )
+    </spec>
+
+- name: is_supporting_vote#gloas
+  sources: []
+  spec: |
+    <spec fn="is_supporting_vote" fork="gloas" hash="c65a637a">
+    def is_supporting_vote(store: Store, node: ForkChoiceNode, message: LatestMessage) -> bool:
+        """
+        Returns whether a vote for ``message.root`` supports the chain containing the beacon block ``node.root`` with the
+        payload contents indicated by ``node.payload_status`` as head during slot ``node.slot``.
+        """
+        block = store.blocks[node.root]
+        if node.root == message.root:
+            if node.payload_status == PAYLOAD_STATUS_PENDING:
+                return True
+            if message.slot <= block.slot:
+                return False
+            if message.payload_present:
+                return node.payload_status == PAYLOAD_STATUS_FULL
+            else:
+                return node.payload_status == PAYLOAD_STATUS_EMPTY
+
+        else:
+            ancestor = get_ancestor(store, message.root, block.slot)
+            return node.root == ancestor.root and (
+                node.payload_status == PAYLOAD_STATUS_PENDING
+                or node.payload_status == ancestor.payload_status
+            )
     </spec>
 
 - name: is_sync_committee_aggregator
@@ -2924,6 +3962,31 @@
         domain = get_domain(state, DOMAIN_BEACON_ATTESTER, indexed_attestation.data.target.epoch)
         signing_root = compute_signing_root(indexed_attestation.data, domain)
         return bls.FastAggregateVerify(pubkeys, signing_root, indexed_attestation.signature)
+    </spec>
+
+- name: is_valid_indexed_payload_attestation#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+      search: public boolean isValidIndexedPayloadAttestation(
+  spec: |
+    <spec fn="is_valid_indexed_payload_attestation" fork="gloas" hash="cf1e65b5">
+    def is_valid_indexed_payload_attestation(
+        state: BeaconState, indexed_payload_attestation: IndexedPayloadAttestation
+    ) -> bool:
+        """
+        Check if ``indexed_payload_attestation`` is non-empty, has sorted indices, and has
+        a valid aggregate signature.
+        """
+        # Verify indices are non-empty and sorted
+        indices = indexed_payload_attestation.attesting_indices
+        if len(indices) == 0 or not indices == sorted(indices):
+            return False
+
+        # Verify aggregate signature
+        pubkeys = [state.validators[i].pubkey for i in indices]
+        domain = get_domain(state, DOMAIN_PTC_ATTESTER, None)
+        signing_root = compute_signing_root(indexed_payload_attestation.data, domain)
+        return bls.FastAggregateVerify(pubkeys, signing_root, indexed_payload_attestation.signature)
     </spec>
 
 - name: is_valid_merkle_branch
@@ -3038,6 +4101,35 @@
     def max_message_size() -> uint64:
         # Allow 1024 bytes for framing and encoding overhead but at least 1MiB in case MAX_PAYLOAD_SIZE is small.
         return max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1024 * 1024)
+    </spec>
+
+- name: notify_ptc_messages#gloas
+  sources: []
+  spec: |
+    <spec fn="notify_ptc_messages" fork="gloas" hash="2245929f">
+    def notify_ptc_messages(
+        store: Store, state: BeaconState, payload_attestations: Sequence[PayloadAttestation]
+    ) -> None:
+        """
+        Extracts a list of ``PayloadAttestationMessage`` from ``payload_attestations`` and updates the store with them
+        These Payload attestations are assumed to be in the beacon block hence signature verification is not needed
+        """
+        if state.slot == 0:
+            return
+        for payload_attestation in payload_attestations:
+            indexed_payload_attestation = get_indexed_payload_attestation(
+                state, Slot(state.slot - 1), payload_attestation
+            )
+            for idx in indexed_payload_attestation.attesting_indices:
+                on_payload_attestation_message(
+                    store,
+                    PayloadAttestationMessage(
+                        validator_index=idx,
+                        data=payload_attestation.data,
+                        signature=BLSSignature(),
+                    ),
+                    is_from_block=True,
+                )
     </spec>
 
 - name: on_attestation
@@ -3399,6 +4491,145 @@
         compute_pulled_up_tip(store, block_root)
     </spec>
 
+- name: on_block#gloas
+  sources: []
+  spec: |
+    <spec fn="on_block" fork="gloas" hash="690a9aa0">
+    def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
+        """
+        Run ``on_block`` upon receiving a new block.
+        """
+        block = signed_block.message
+        # Parent block must be known
+        assert block.parent_root in store.block_states
+
+        # Check if this blocks builds on empty or full parent block
+        parent_block = store.blocks[block.parent_root]
+        bid = block.body.signed_execution_payload_bid.message
+        parent_bid = parent_block.body.signed_execution_payload_bid.message
+        # Make a copy of the state to avoid mutability issues
+        if is_parent_node_full(store, block):
+            assert block.parent_root in store.execution_payload_states
+            state = copy(store.execution_payload_states[block.parent_root])
+        else:
+            assert bid.parent_block_hash == parent_bid.parent_block_hash
+            state = copy(store.block_states[block.parent_root])
+
+        # Blocks cannot be in the future. If they are, their consideration must be delayed until they are in the past.
+        current_slot = get_current_slot(store)
+        assert current_slot >= block.slot
+
+        # Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        assert block.slot > finalized_slot
+        # Check block is a descendant of the finalized block at the checkpoint finalized slot
+        finalized_checkpoint_block = get_checkpoint_block(
+            store,
+            block.parent_root,
+            store.finalized_checkpoint.epoch,
+        )
+        assert store.finalized_checkpoint.root == finalized_checkpoint_block
+
+        # Check the block is valid and compute the post-state
+        block_root = hash_tree_root(block)
+        state_transition(state, signed_block, True)
+
+        # Add new block to the store
+        store.blocks[block_root] = block
+        # Add new state for this block to the store
+        store.block_states[block_root] = state
+        # Add a new PTC voting for this block to the store
+        store.ptc_vote[block_root] = [False] * PTC_SIZE
+
+        # Notify the store about the payload_attestations in the block
+        notify_ptc_messages(store, state, block.body.payload_attestations)
+        # Add proposer score boost if the block is timely
+        seconds_since_genesis = store.time - store.genesis_time
+        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
+        epoch = get_current_store_epoch(store)
+        attestation_threshold_ms = get_attestation_due_ms(epoch)
+        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
+        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
+        store.block_timeliness[hash_tree_root(block)] = is_timely
+
+        # Add proposer score boost if the block is timely and not conflicting with an existing block
+        is_first_block = store.proposer_boost_root == Root()
+        if is_timely and is_first_block:
+            store.proposer_boost_root = hash_tree_root(block)
+
+        # Update checkpoints in store if necessary
+        update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
+
+        # Eagerly compute unrealized justification and finality.
+        compute_pulled_up_tip(store, block_root)
+    </spec>
+
+- name: on_execution_payload#gloas
+  sources: []
+  spec: |
+    <spec fn="on_execution_payload" fork="gloas" hash="49b534de">
+    def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEnvelope) -> None:
+        """
+        Run ``on_execution_payload`` upon receiving a new execution payload.
+        """
+        envelope = signed_envelope.message
+        # The corresponding beacon block root needs to be known
+        assert envelope.beacon_block_root in store.block_states
+
+        # Check if blob data is available
+        # If not, this payload MAY be queued and subsequently considered when blob data becomes available
+        assert is_data_available(envelope.beacon_block_root)
+
+        # Make a copy of the state to avoid mutability issues
+        state = copy(store.block_states[envelope.beacon_block_root])
+
+        # Process the execution payload
+        process_execution_payload(state, signed_envelope, EXECUTION_ENGINE)
+
+        # Add new state for this payload to the store
+        store.execution_payload_states[envelope.beacon_block_root] = state
+    </spec>
+
+- name: on_payload_attestation_message#gloas
+  sources: []
+  spec: |
+    <spec fn="on_payload_attestation_message" fork="gloas" hash="71fe48d3">
+    def on_payload_attestation_message(
+        store: Store, ptc_message: PayloadAttestationMessage, is_from_block: bool = False
+    ) -> None:
+        """
+        Run ``on_payload_attestation_message`` upon receiving a new ``ptc_message`` directly on the wire.
+        """
+        # The beacon block root must be known
+        data = ptc_message.data
+        # PTC attestation must be for a known block. If block is unknown, delay consideration until the block is found
+        state = store.block_states[data.beacon_block_root]
+        ptc = get_ptc(state, data.slot)
+        # PTC votes can only change the vote for their assigned beacon block, return early otherwise
+        if data.slot != state.slot:
+            return
+        # Check that the attester is from the PTC
+        assert ptc_message.validator_index in ptc
+
+        # Verify the signature and check that its for the current slot if it is coming from the wire
+        if not is_from_block:
+            # Check that the attestation is for the current slot
+            assert data.slot == get_current_slot(store)
+            # Verify the signature
+            assert is_valid_indexed_payload_attestation(
+                state,
+                IndexedPayloadAttestation(
+                    attesting_indices=[ptc_message.validator_index],
+                    data=data,
+                    signature=ptc_message.signature,
+                ),
+            )
+        # Update the ptc vote for the block
+        ptc_index = ptc.index(ptc_message.validator_index)
+        ptc_vote = store.ptc_vote[data.beacon_block_root]
+        ptc_vote[ptc_index] = data.payload_present
+    </spec>
+
 - name: on_tick
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -3413,6 +4644,39 @@
             previous_time = store.genesis_time + (get_current_slot(store) + 1) * SECONDS_PER_SLOT
             on_tick_per_slot(store, previous_time)
         on_tick_per_slot(store, time)
+    </spec>
+
+- name: prepare_execution_payload#gloas
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="gloas" hash="3e12a9e7">
+    def prepare_execution_payload(
+        state: BeaconState,
+        safe_block_hash: Hash32,
+        finalized_block_hash: Hash32,
+        suggested_fee_recipient: ExecutionAddress,
+        execution_engine: ExecutionEngine,
+    ) -> Optional[PayloadId]:
+        # Verify consistency of the parent hash with respect to the previous execution payload bid
+        parent_hash = state.latest_execution_payload_bid.block_hash
+
+        # [Modified in Gloas:EIP7732]
+        # Set the forkchoice head and initiate the payload build process
+        withdrawals, _, _ = get_expected_withdrawals(state)
+
+        payload_attributes = PayloadAttributes(
+            timestamp=compute_time_at_slot(state, state.slot),
+            prev_randao=get_randao_mix(state, get_current_epoch(state)),
+            suggested_fee_recipient=suggested_fee_recipient,
+            withdrawals=withdrawals,
+            parent_beacon_block_root=hash_tree_root(state.latest_block_header),
+        )
+        return execution_engine.notify_forkchoice_updated(
+            head_block_hash=parent_hash,
+            safe_block_hash=safe_block_hash,
+            finalized_block_hash=finalized_block_hash,
+            payload_attributes=payload_attributes,
+        )
     </spec>
 
 - name: process_attestation#phase0
@@ -3608,6 +4872,93 @@
         increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
     </spec>
 
+- name: process_attestation#gloas
+  sources: []
+  spec: |
+    <spec fn="process_attestation" fork="gloas" hash="2258b5bb">
+    def process_attestation(state: BeaconState, attestation: Attestation) -> None:
+        data = attestation.data
+        assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
+        assert data.target.epoch == compute_epoch_at_slot(data.slot)
+        assert data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot
+
+        # [Modified in Gloas:EIP7732]
+        assert data.index < 2
+        committee_indices = get_committee_indices(attestation.committee_bits)
+        committee_offset = 0
+        for committee_index in committee_indices:
+            assert committee_index < get_committee_count_per_slot(state, data.target.epoch)
+            committee = get_beacon_committee(state, data.slot, committee_index)
+            committee_attesters = set(
+                attester_index
+                for i, attester_index in enumerate(committee)
+                if attestation.aggregation_bits[committee_offset + i]
+            )
+            assert len(committee_attesters) > 0
+            committee_offset += len(committee)
+
+        # Bitfield length matches total number of participants
+        assert len(attestation.aggregation_bits) == committee_offset
+
+        # Participation flag indices
+        participation_flag_indices = get_attestation_participation_flag_indices(
+            state, data, state.slot - data.slot
+        )
+
+        # Verify signature
+        assert is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation))
+
+        # [Modified in Gloas:EIP7732]
+        if data.target.epoch == get_current_epoch(state):
+            current_epoch_target = True
+            epoch_participation = state.current_epoch_participation
+            payment = state.builder_pending_payments[SLOTS_PER_EPOCH + data.slot % SLOTS_PER_EPOCH]
+        else:
+            current_epoch_target = False
+            epoch_participation = state.previous_epoch_participation
+            payment = state.builder_pending_payments[data.slot % SLOTS_PER_EPOCH]
+
+        proposer_reward_numerator = 0
+        for index in get_attesting_indices(state, attestation):
+            # [New in Gloas:EIP7732]
+            # For same-slot attestations, check if we are setting any new flags.
+            # If we are, this validator has not contributed to this slot's quorum yet.
+            will_set_new_flag = False
+
+            for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
+                if flag_index in participation_flag_indices and not has_flag(
+                    epoch_participation[index], flag_index
+                ):
+                    epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
+                    proposer_reward_numerator += get_base_reward(state, index) * weight
+                    # [New in Gloas:EIP7732]
+                    will_set_new_flag = True
+
+            # [New in Gloas:EIP7732]
+            # Add weight for same-slot attestations when any new flag is set.
+            # This ensures each validator contributes exactly once per slot.
+            if (
+                will_set_new_flag
+                and is_attestation_same_slot(state, data)
+                and payment.withdrawal.amount > 0
+            ):
+                payment.weight += state.validators[index].effective_balance
+
+        # Reward proposer
+        proposer_reward_denominator = (
+            (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIGHT_DENOMINATOR // PROPOSER_WEIGHT
+        )
+        proposer_reward = Gwei(proposer_reward_numerator // proposer_reward_denominator)
+        increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
+
+        # [New in Gloas:EIP7732]
+        # Update builder payment weight
+        if current_epoch_target:
+            state.builder_pending_payments[SLOTS_PER_EPOCH + data.slot % SLOTS_PER_EPOCH] = payment
+        else:
+            state.builder_pending_payments[data.slot % SLOTS_PER_EPOCH] = payment
+    </spec>
+
 - name: process_attester_slashing
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -3715,6 +5066,25 @@
         process_sync_aggregate(state, block.body.sync_aggregate)
     </spec>
 
+- name: process_block#gloas
+  sources: []
+  spec: |
+    <spec fn="process_block" fork="gloas" hash="cc0f05ee">
+    def process_block(state: BeaconState, block: BeaconBlock) -> None:
+        process_block_header(state, block)
+        # [Modified in Gloas:EIP7732]
+        process_withdrawals(state)
+        # [Modified in Gloas:EIP7732]
+        # Removed `process_execution_payload`
+        # [New in Gloas:EIP7732]
+        process_execution_payload_bid(state, block)
+        process_randao(state, block.body)
+        process_eth1_data(state, block.body)
+        # [Modified in Gloas:EIP7732]
+        process_operations(state, block.body)
+        process_sync_aggregate(state, block.body.sync_aggregate)
+    </spec>
+
 - name: process_block_header
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -3772,6 +5142,30 @@
         validator.withdrawal_credentials = (
             ETH1_ADDRESS_WITHDRAWAL_PREFIX + b"\x00" * 11 + address_change.to_execution_address
         )
+    </spec>
+
+- name: process_builder_pending_payments#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
+      search: public void processBuilderPendingPayments(
+  spec: |
+    <spec fn="process_builder_pending_payments" fork="gloas" hash="04362ccc">
+    def process_builder_pending_payments(state: BeaconState) -> None:
+        """
+        Processes the builder pending payments from the previous epoch.
+        """
+        quorum = get_builder_payment_quorum_threshold(state)
+        for payment in state.builder_pending_payments[:SLOTS_PER_EPOCH]:
+            if payment.weight > quorum:
+                amount = payment.withdrawal.amount
+                exit_queue_epoch = compute_exit_epoch_and_update_churn(state, amount)
+                withdrawable_epoch = exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
+                payment.withdrawal.withdrawable_epoch = Epoch(withdrawable_epoch)
+                state.builder_pending_withdrawals.append(payment.withdrawal)
+
+        old_payments = state.builder_pending_payments[SLOTS_PER_EPOCH:]
+        new_payments = [BuilderPendingPayment() for _ in range(SLOTS_PER_EPOCH)]
+        state.builder_pending_payments = old_payments + new_payments
     </spec>
 
 - name: process_consolidation_request
@@ -3984,7 +5378,7 @@
                 )
     </spec>
 
-- name: process_epoch
+- name: process_epoch#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public BeaconState processEpoch(
@@ -4001,6 +5395,183 @@
         process_randao_mixes_reset(state)
         process_historical_roots_update(state)
         process_participation_record_updates(state)
+    </spec>
+
+- name: process_epoch#altair
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BeaconState processEpoch(
+  spec: |
+    <spec fn="process_epoch" fork="altair" hash="d84c7ecd">
+    def process_epoch(state: BeaconState) -> None:
+        # [Modified in Altair]
+        process_justification_and_finalization(state)
+        # [New in Altair]
+        process_inactivity_updates(state)
+        # [Modified in Altair]
+        process_rewards_and_penalties(state)
+        process_registry_updates(state)
+        # [Modified in Altair]
+        process_slashings(state)
+        process_eth1_data_reset(state)
+        process_effective_balance_updates(state)
+        process_slashings_reset(state)
+        process_randao_mixes_reset(state)
+        process_historical_roots_update(state)
+        # [New in Altair]
+        process_participation_flag_updates(state)
+        # [New in Altair]
+        process_sync_committee_updates(state)
+    </spec>
+
+- name: process_epoch#bellatrix
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BeaconState processEpoch(
+  spec: |
+    <spec fn="process_epoch" fork="bellatrix" hash="d84c7ecd">
+    def process_epoch(state: BeaconState) -> None:
+        # [Modified in Altair]
+        process_justification_and_finalization(state)
+        # [New in Altair]
+        process_inactivity_updates(state)
+        # [Modified in Altair]
+        process_rewards_and_penalties(state)
+        process_registry_updates(state)
+        # [Modified in Altair]
+        process_slashings(state)
+        process_eth1_data_reset(state)
+        process_effective_balance_updates(state)
+        process_slashings_reset(state)
+        process_randao_mixes_reset(state)
+        process_historical_roots_update(state)
+        # [New in Altair]
+        process_participation_flag_updates(state)
+        # [New in Altair]
+        process_sync_committee_updates(state)
+    </spec>
+
+- name: process_epoch#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BeaconState processEpoch(
+  spec: |
+    <spec fn="process_epoch" fork="capella" hash="c1257690">
+    def process_epoch(state: BeaconState) -> None:
+        process_justification_and_finalization(state)
+        process_inactivity_updates(state)
+        process_rewards_and_penalties(state)
+        process_registry_updates(state)
+        process_slashings(state)
+        process_eth1_data_reset(state)
+        process_effective_balance_updates(state)
+        process_slashings_reset(state)
+        process_randao_mixes_reset(state)
+        # [Modified in Capella]
+        process_historical_summaries_update(state)
+        process_participation_flag_updates(state)
+        process_sync_committee_updates(state)
+    </spec>
+
+- name: process_epoch#deneb
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BeaconState processEpoch(
+  spec: |
+    <spec fn="process_epoch" fork="deneb" hash="c1257690">
+    def process_epoch(state: BeaconState) -> None:
+        process_justification_and_finalization(state)
+        process_inactivity_updates(state)
+        process_rewards_and_penalties(state)
+        process_registry_updates(state)
+        process_slashings(state)
+        process_eth1_data_reset(state)
+        process_effective_balance_updates(state)
+        process_slashings_reset(state)
+        process_randao_mixes_reset(state)
+        # [Modified in Capella]
+        process_historical_summaries_update(state)
+        process_participation_flag_updates(state)
+        process_sync_committee_updates(state)
+    </spec>
+
+- name: process_epoch#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BeaconState processEpoch(
+  spec: |
+    <spec fn="process_epoch" fork="electra" hash="505b801d">
+    def process_epoch(state: BeaconState) -> None:
+        process_justification_and_finalization(state)
+        process_inactivity_updates(state)
+        process_rewards_and_penalties(state)
+        # [Modified in Electra:EIP7251]
+        process_registry_updates(state)
+        # [Modified in Electra:EIP7251]
+        process_slashings(state)
+        process_eth1_data_reset(state)
+        # [New in Electra:EIP7251]
+        process_pending_deposits(state)
+        # [New in Electra:EIP7251]
+        process_pending_consolidations(state)
+        # [Modified in Electra:EIP7251]
+        process_effective_balance_updates(state)
+        process_slashings_reset(state)
+        process_randao_mixes_reset(state)
+        process_historical_summaries_update(state)
+        process_participation_flag_updates(state)
+        process_sync_committee_updates(state)
+    </spec>
+
+- name: process_epoch#fulu
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BeaconState processEpoch(
+  spec: |
+    <spec fn="process_epoch" fork="fulu" hash="420a4a68">
+    def process_epoch(state: BeaconState) -> None:
+        process_justification_and_finalization(state)
+        process_inactivity_updates(state)
+        process_rewards_and_penalties(state)
+        process_registry_updates(state)
+        process_slashings(state)
+        process_eth1_data_reset(state)
+        process_pending_deposits(state)
+        process_pending_consolidations(state)
+        process_effective_balance_updates(state)
+        process_slashings_reset(state)
+        process_randao_mixes_reset(state)
+        process_historical_summaries_update(state)
+        process_participation_flag_updates(state)
+        process_sync_committee_updates(state)
+        # [New in Fulu:EIP7917]
+        process_proposer_lookahead(state)
+    </spec>
+
+- name: process_epoch#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public BeaconState processEpoch(
+  spec: |
+    <spec fn="process_epoch" fork="gloas" hash="32184972">
+    def process_epoch(state: BeaconState) -> None:
+        process_justification_and_finalization(state)
+        process_inactivity_updates(state)
+        process_rewards_and_penalties(state)
+        process_registry_updates(state)
+        process_slashings(state)
+        process_eth1_data_reset(state)
+        process_pending_deposits(state)
+        process_pending_consolidations(state)
+        process_effective_balance_updates(state)
+        process_slashings_reset(state)
+        process_randao_mixes_reset(state)
+        process_historical_summaries_update(state)
+        process_participation_flag_updates(state)
+        process_sync_committee_updates(state)
+        process_proposer_lookahead(state)
+        # [New in Gloas:EIP7732]
+        process_builder_pending_payments(state)
     </spec>
 
 - name: process_eth1_data
@@ -4194,6 +5765,172 @@
         )
     </spec>
 
+- name: process_execution_payload#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
+      search: public void processUnsignedExecutionPayload(
+  spec: |
+    <spec fn="process_execution_payload" fork="gloas" hash="200702e3">
+    def process_execution_payload(
+        state: BeaconState,
+        # [Modified in Gloas:EIP7732]
+        # Removed `body`
+        # [New in Gloas:EIP7732]
+        signed_envelope: SignedExecutionPayloadEnvelope,
+        execution_engine: ExecutionEngine,
+        # [New in Gloas:EIP7732]
+        verify: bool = True,
+    ) -> None:
+        envelope = signed_envelope.message
+        payload = envelope.payload
+
+        # Verify signature
+        if verify:
+            assert verify_execution_payload_envelope_signature(state, signed_envelope)
+
+        # Cache latest block header state root
+        previous_state_root = hash_tree_root(state)
+        if state.latest_block_header.state_root == Root():
+            state.latest_block_header.state_root = previous_state_root
+
+        # Verify consistency with the beacon block
+        assert envelope.beacon_block_root == hash_tree_root(state.latest_block_header)
+        assert envelope.slot == state.slot
+
+        # Verify consistency with the committed bid
+        committed_bid = state.latest_execution_payload_bid
+        assert envelope.builder_index == committed_bid.builder_index
+        assert committed_bid.blob_kzg_commitments_root == hash_tree_root(envelope.blob_kzg_commitments)
+
+        # Verify the withdrawals root
+        assert hash_tree_root(payload.withdrawals) == state.latest_withdrawals_root
+
+        # Verify the gas_limit
+        assert committed_bid.gas_limit == payload.gas_limit
+        # Verify the block hash
+        assert committed_bid.block_hash == payload.block_hash
+        # Verify consistency of the parent hash with respect to the previous execution payload
+        assert payload.parent_hash == state.latest_block_hash
+        # Verify prev_randao
+        assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
+        # Verify timestamp
+        assert payload.timestamp == compute_time_at_slot(state, state.slot)
+        # Verify commitments are under limit
+        assert (
+            len(envelope.blob_kzg_commitments)
+            <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+        )
+        # Verify the execution payload is valid
+        versioned_hashes = [
+            kzg_commitment_to_versioned_hash(commitment) for commitment in envelope.blob_kzg_commitments
+        ]
+        requests = envelope.execution_requests
+        assert execution_engine.verify_and_notify_new_payload(
+            NewPayloadRequest(
+                execution_payload=payload,
+                versioned_hashes=versioned_hashes,
+                parent_beacon_block_root=state.latest_block_header.parent_root,
+                execution_requests=requests,
+            )
+        )
+
+        def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
+            for operation in operations:
+                fn(state, operation)
+
+        for_ops(requests.deposits, process_deposit_request)
+        for_ops(requests.withdrawals, process_withdrawal_request)
+        for_ops(requests.consolidations, process_consolidation_request)
+
+        # Queue the builder payment
+        payment = state.builder_pending_payments[SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH]
+        amount = payment.withdrawal.amount
+        if amount > 0:
+            exit_queue_epoch = compute_exit_epoch_and_update_churn(state, amount)
+            payment.withdrawal.withdrawable_epoch = Epoch(
+                exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
+            )
+            state.builder_pending_withdrawals.append(payment.withdrawal)
+        state.builder_pending_payments[SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH] = (
+            BuilderPendingPayment()
+        )
+
+        # Cache the execution payload hash
+        state.execution_payload_availability[state.slot % SLOTS_PER_HISTORICAL_ROOT] = 0b1
+        state.latest_block_hash = payload.block_hash
+
+        # Verify the state root
+        if verify:
+            assert envelope.state_root == hash_tree_root(state)
+    </spec>
+
+- name: process_execution_payload_bid#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: public void processExecutionPayloadBid(
+  spec: |
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="bfc45bf8">
+    def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> None:
+        signed_bid = block.body.signed_execution_payload_bid
+        bid = signed_bid.message
+        builder_index = bid.builder_index
+        builder = state.validators[builder_index]
+
+        amount = bid.value
+        # For self-builds, amount must be zero regardless of withdrawal credential prefix
+        if builder_index == block.proposer_index:
+            assert amount == 0
+            assert signed_bid.signature == bls.G2_POINT_AT_INFINITY
+        else:
+            # Non-self builds require builder withdrawal credential
+            assert has_builder_withdrawal_credential(builder)
+            assert verify_execution_payload_bid_signature(state, signed_bid)
+
+        assert is_active_validator(builder, get_current_epoch(state))
+        assert not builder.slashed
+
+        # Check that the builder is active, non-slashed, and has funds to cover the bid
+        pending_payments = sum(
+            payment.withdrawal.amount
+            for payment in state.builder_pending_payments
+            if payment.withdrawal.builder_index == builder_index
+        )
+        pending_withdrawals = sum(
+            withdrawal.amount
+            for withdrawal in state.builder_pending_withdrawals
+            if withdrawal.builder_index == builder_index
+        )
+        assert (
+            amount == 0
+            or state.balances[builder_index]
+            >= amount + pending_payments + pending_withdrawals + MIN_ACTIVATION_BALANCE
+        )
+
+        # Verify that the bid is for the current slot
+        assert bid.slot == block.slot
+        # Verify that the bid is for the right parent block
+        assert bid.parent_block_hash == state.latest_block_hash
+        assert bid.parent_block_root == block.parent_root
+
+        # Record the pending payment if there is some payment
+        if amount > 0:
+            pending_payment = BuilderPendingPayment(
+                weight=0,
+                withdrawal=BuilderPendingWithdrawal(
+                    fee_recipient=bid.fee_recipient,
+                    amount=amount,
+                    builder_index=builder_index,
+                    withdrawable_epoch=FAR_FUTURE_EPOCH,
+                ),
+            )
+            state.builder_pending_payments[SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH] = (
+                pending_payment
+            )
+
+        # Cache the signed execution payload bid
+        state.latest_execution_payload_bid = bid
+    </spec>
+
 - name: process_historical_roots_update
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -4361,6 +6098,46 @@
         for_ops(body.execution_requests.consolidations, process_consolidation_request)
     </spec>
 
+- name: process_operations#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: protected void processOperationsNoValidation(
+  spec: |
+    <spec fn="process_operations" fork="gloas" hash="ba4ce754">
+    def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
+        # Disable former deposit mechanism once all prior deposits are processed
+        eth1_deposit_index_limit = min(
+            state.eth1_data.deposit_count, state.deposit_requests_start_index
+        )
+        if state.eth1_deposit_index < eth1_deposit_index_limit:
+            assert len(body.deposits) == min(
+                MAX_DEPOSITS, eth1_deposit_index_limit - state.eth1_deposit_index
+            )
+        else:
+            assert len(body.deposits) == 0
+
+        def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
+            for operation in operations:
+                fn(state, operation)
+
+        # [Modified in Gloas:EIP7732]
+        for_ops(body.proposer_slashings, process_proposer_slashing)
+        for_ops(body.attester_slashings, process_attester_slashing)
+        # [Modified in Gloas:EIP7732]
+        for_ops(body.attestations, process_attestation)
+        for_ops(body.deposits, process_deposit)
+        for_ops(body.voluntary_exits, process_voluntary_exit)
+        for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
+        # [Modified in Gloas:EIP7732]
+        # Removed `process_deposit_request`
+        # [Modified in Gloas:EIP7732]
+        # Removed `process_withdrawal_request`
+        # [Modified in Gloas:EIP7732]
+        # Removed `process_consolidation_request`
+        # [New in Gloas:EIP7732]
+        for_ops(body.payload_attestations, process_payload_attestation)
+    </spec>
+
 - name: process_participation_flag_updates
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -4384,6 +6161,28 @@
         # Rotate current/previous epoch attestations
         state.previous_epoch_attestations = state.current_epoch_attestations
         state.current_epoch_attestations = []
+    </spec>
+
+- name: process_payload_attestation#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: public void processPayloadAttestations(
+  spec: |
+    <spec fn="process_payload_attestation" fork="gloas" hash="a299be3b">
+    def process_payload_attestation(
+        state: BeaconState, payload_attestation: PayloadAttestation
+    ) -> None:
+        data = payload_attestation.data
+
+        # Check that the attestation is for the parent beacon block
+        assert data.beacon_block_root == state.latest_block_header.parent_root
+        # Check that the attestation is for the previous slot
+        assert data.slot + 1 == state.slot
+        # Verify signature
+        indexed_payload_attestation = get_indexed_payload_attestation(
+            state, data.slot, payload_attestation
+        )
+        assert is_valid_indexed_payload_attestation(state, indexed_payload_attestation)
     </spec>
 
 - name: process_pending_consolidations
@@ -4532,6 +6331,46 @@
             )
             signing_root = compute_signing_root(signed_header.message, domain)
             assert bls.Verify(proposer.pubkey, signing_root, signed_header.signature)
+
+        slash_validator(state, header_1.proposer_index)
+    </spec>
+
+- name: process_proposer_slashing#gloas
+  sources: []
+  spec: |
+    <spec fn="process_proposer_slashing" fork="gloas" hash="10bda1c5">
+    def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSlashing) -> None:
+        header_1 = proposer_slashing.signed_header_1.message
+        header_2 = proposer_slashing.signed_header_2.message
+
+        # Verify header slots match
+        assert header_1.slot == header_2.slot
+        # Verify header proposer indices match
+        assert header_1.proposer_index == header_2.proposer_index
+        # Verify the headers are different
+        assert header_1 != header_2
+        # Verify the proposer is slashable
+        proposer = state.validators[header_1.proposer_index]
+        assert is_slashable_validator(proposer, get_current_epoch(state))
+        # Verify signatures
+        for signed_header in (proposer_slashing.signed_header_1, proposer_slashing.signed_header_2):
+            domain = get_domain(
+                state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(signed_header.message.slot)
+            )
+            signing_root = compute_signing_root(signed_header.message, domain)
+            assert bls.Verify(proposer.pubkey, signing_root, signed_header.signature)
+
+        # [New in Gloas:EIP7732]
+        # Remove the BuilderPendingPayment corresponding to
+        # this proposal if it is still in the 2-epoch window.
+        slot = header_1.slot
+        proposal_epoch = compute_epoch_at_slot(slot)
+        if proposal_epoch == get_current_epoch(state):
+            payment_index = SLOTS_PER_EPOCH + slot % SLOTS_PER_EPOCH
+            state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+        elif proposal_epoch == get_previous_epoch(state):
+            payment_index = slot % SLOTS_PER_EPOCH
+            state.builder_pending_payments[payment_index] = BuilderPendingPayment()
 
         slash_validator(state, header_1.proposer_index)
     </spec>
@@ -4726,6 +6565,25 @@
         # Cache block root
         previous_block_root = hash_tree_root(state.latest_block_header)
         state.block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_block_root
+    </spec>
+
+- name: process_slot#gloas
+  sources: []
+  spec: |
+    <spec fn="process_slot" fork="gloas" hash="976fd16f">
+    def process_slot(state: BeaconState) -> None:
+        # Cache state root
+        previous_state_root = hash_tree_root(state)
+        state.state_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_state_root
+        # Cache latest block header state root
+        if state.latest_block_header.state_root == Bytes32():
+            state.latest_block_header.state_root = previous_state_root
+        # Cache block root
+        previous_block_root = hash_tree_root(state.latest_block_header)
+        state.block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_block_root
+        # [New in Gloas:EIP7732]
+        # Unset the next payload availability
+        state.execution_payload_availability[(state.slot + 1) % SLOTS_PER_HISTORICAL_ROOT] = 0b0
     </spec>
 
 - name: process_slots
@@ -4998,6 +6856,64 @@
             state.next_withdrawal_validator_index = next_validator_index
     </spec>
 
+- name: process_withdrawals#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: public void processWithdrawals(
+  spec: |
+    <spec fn="process_withdrawals" fork="gloas" hash="505dadda">
+    def process_withdrawals(
+        state: BeaconState,
+        # [Modified in Gloas:EIP7732]
+        # Removed `payload`
+    ) -> None:
+        # [New in Gloas:EIP7732]
+        # Return early if the parent block is empty
+        if not is_parent_block_full(state):
+            return
+
+        # [Modified in Gloas:EIP7732]
+        # Get information about the expected withdrawals
+        withdrawals, processed_builder_withdrawals_count, processed_partial_withdrawals_count = (
+            get_expected_withdrawals(state)
+        )
+        withdrawals_list = List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](withdrawals)
+        state.latest_withdrawals_root = hash_tree_root(withdrawals_list)
+        for withdrawal in withdrawals:
+            decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
+
+        # [New in Gloas:EIP7732]
+        # Update the pending builder withdrawals
+        state.builder_pending_withdrawals = [
+            w
+            for w in state.builder_pending_withdrawals[:processed_builder_withdrawals_count]
+            if not is_builder_payment_withdrawable(state, w)
+        ] + state.builder_pending_withdrawals[processed_builder_withdrawals_count:]
+
+        # Update pending partial withdrawals
+        state.pending_partial_withdrawals = state.pending_partial_withdrawals[
+            processed_partial_withdrawals_count:
+        ]
+
+        # Update the next withdrawal index if this block contained withdrawals
+        if len(withdrawals) != 0:
+            latest_withdrawal = withdrawals[-1]
+            state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
+
+        # Update the next validator index to start the next withdrawal sweep
+        if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
+            # Next sweep starts after the latest withdrawal's validator index
+            next_validator_index = ValidatorIndex(
+                (withdrawals[-1].validator_index + 1) % len(state.validators)
+            )
+            state.next_withdrawal_validator_index = next_validator_index
+        else:
+            # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
+            next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
+            next_validator_index = ValidatorIndex(next_index % len(state.validators))
+            state.next_withdrawal_validator_index = next_validator_index
+    </spec>
+
 - name: queue_excess_active_balance
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
@@ -5023,6 +6939,17 @@
             )
     </spec>
 
+- name: remove_flag#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public byte removeFlag(
+  spec: |
+    <spec fn="remove_flag" fork="gloas" hash="2566cb90">
+    def remove_flag(flags: ParticipationFlags, flag_index: int) -> ParticipationFlags:
+        flag = ParticipationFlags(2**flag_index)
+        return flags & ~flag
+    </spec>
+
 - name: saturating_sub
   sources:
     - file: infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -5034,6 +6961,20 @@
         Computes a - b, saturating at numeric bounds.
         """
         return a - b if a > b else 0
+    </spec>
+
+- name: should_extend_payload#gloas
+  sources: []
+  spec: |
+    <spec fn="should_extend_payload" fork="gloas" hash="cbdd2370">
+    def should_extend_payload(store: Store, root: Root) -> bool:
+        proposer_root = store.proposer_boost_root
+        return (
+            is_payload_timely(store, root)
+            or proposer_root == Root()
+            or store.blocks[proposer_root].parent_root != root
+            or is_parent_node_full(store, store.blocks[proposer_root])
+        )
     </spec>
 
 - name: should_override_forkchoice_update
@@ -5327,6 +7268,26 @@
         # Update finalized checkpoint
         if finalized_checkpoint.epoch > store.finalized_checkpoint.epoch:
             store.finalized_checkpoint = finalized_checkpoint
+    </spec>
+
+- name: update_latest_messages#gloas
+  sources: []
+  spec: |
+    <spec fn="update_latest_messages" fork="gloas" hash="f75dff96">
+    def update_latest_messages(
+        store: Store, attesting_indices: Sequence[ValidatorIndex], attestation: Attestation
+    ) -> None:
+        slot = attestation.data.slot
+        beacon_block_root = attestation.data.beacon_block_root
+        payload_present = attestation.data.index == 1
+        non_equivocating_attesting_indices = [
+            i for i in attesting_indices if i not in store.equivocating_indices
+        ]
+        for i in non_equivocating_attesting_indices:
+            if i not in store.latest_messages or slot > store.latest_messages[i].slot:
+                store.latest_messages[i] = LatestMessage(
+                    slot=slot, root=beacon_block_root, payload_present=payload_present
+                )
     </spec>
 
 - name: upgrade_to_altair
@@ -5728,6 +7689,77 @@
         return post
     </spec>
 
+- name: upgrade_to_gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+      search: public BeaconStateGloas upgrade(
+  spec: |
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="e147526b">
+    def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
+        epoch = fulu.get_current_epoch(pre)
+
+        post = BeaconState(
+            genesis_time=pre.genesis_time,
+            genesis_validators_root=pre.genesis_validators_root,
+            slot=pre.slot,
+            fork=Fork(
+                previous_version=pre.fork.current_version,
+                # [Modified in Gloas:EIP7732]
+                current_version=GLOAS_FORK_VERSION,
+                epoch=epoch,
+            ),
+            latest_block_header=pre.latest_block_header,
+            block_roots=pre.block_roots,
+            state_roots=pre.state_roots,
+            historical_roots=pre.historical_roots,
+            eth1_data=pre.eth1_data,
+            eth1_data_votes=pre.eth1_data_votes,
+            eth1_deposit_index=pre.eth1_deposit_index,
+            validators=pre.validators,
+            balances=pre.balances,
+            randao_mixes=pre.randao_mixes,
+            slashings=pre.slashings,
+            previous_epoch_participation=pre.previous_epoch_participation,
+            current_epoch_participation=pre.current_epoch_participation,
+            justification_bits=pre.justification_bits,
+            previous_justified_checkpoint=pre.previous_justified_checkpoint,
+            current_justified_checkpoint=pre.current_justified_checkpoint,
+            finalized_checkpoint=pre.finalized_checkpoint,
+            inactivity_scores=pre.inactivity_scores,
+            current_sync_committee=pre.current_sync_committee,
+            next_sync_committee=pre.next_sync_committee,
+            # [Modified in Gloas:EIP7732]
+            # Removed `latest_execution_payload_header`
+            # [New in Gloas:EIP7732]
+            latest_execution_payload_bid=ExecutionPayloadBid(),
+            next_withdrawal_index=pre.next_withdrawal_index,
+            next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
+            historical_summaries=pre.historical_summaries,
+            deposit_requests_start_index=pre.deposit_requests_start_index,
+            deposit_balance_to_consume=pre.deposit_balance_to_consume,
+            exit_balance_to_consume=pre.exit_balance_to_consume,
+            earliest_exit_epoch=pre.earliest_exit_epoch,
+            consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
+            earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
+            pending_deposits=pre.pending_deposits,
+            pending_partial_withdrawals=pre.pending_partial_withdrawals,
+            pending_consolidations=pre.pending_consolidations,
+            proposer_lookahead=pre.proposer_lookahead,
+            # [New in Gloas:EIP7732]
+            execution_payload_availability=[0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)],
+            # [New in Gloas:EIP7732]
+            builder_pending_payments=[BuilderPendingPayment() for _ in range(2 * SLOTS_PER_EPOCH)],
+            # [New in Gloas:EIP7732]
+            builder_pending_withdrawals=[],
+            # [New in Gloas:EIP7732]
+            latest_block_hash=pre.latest_execution_payload_header.block_hash,
+            # [New in Gloas:EIP7732]
+            latest_withdrawals_root=Root(),
+        )
+
+        return post
+    </spec>
+
 - name: validate_merge_block
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/BellatrixTransitionHelpers.java
@@ -5749,6 +7781,36 @@
             return
 
         pow_block = get_pow_block(block.body.execution_payload.parent_hash)
+        # Check if `pow_block` is available
+        assert pow_block is not None
+        pow_parent = get_pow_block(pow_block.parent_hash)
+        # Check if `pow_parent` is available
+        assert pow_parent is not None
+        # Check if `pow_block` is a valid terminal PoW block
+        assert is_valid_terminal_pow_block(pow_block, pow_parent)
+    </spec>
+
+- name: validate_merge_block#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_merge_block" fork="gloas" hash="1b577110">
+    def validate_merge_block(block: BeaconBlock) -> None:
+        """
+        Check the parent PoW block of execution payload is a valid terminal PoW block.
+
+        Note: Unavailable PoW block(s) may later become available,
+        and a client software MAY delay a call to ``validate_merge_block``
+        until the PoW block(s) become available.
+        """
+        if TERMINAL_BLOCK_HASH != Hash32():
+            # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
+            assert compute_epoch_at_slot(block.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
+            assert (
+                block.body.signed_execution_payload_bid.message.parent_block_hash == TERMINAL_BLOCK_HASH
+            )
+            return
+
+        pow_block = get_pow_block(block.body.signed_execution_payload_bid.message.parent_block_hash)
         # Check if `pow_block` is available
         assert pow_block is not None
         pow_parent = get_pow_block(pow_block.parent_hash)
@@ -5789,6 +7851,48 @@
 
         # Attestations can only affect the fork choice of subsequent slots.
         # Delay consideration in the fork choice until their slot is in the past.
+        assert get_current_slot(store) >= attestation.data.slot + 1
+    </spec>
+
+- name: validate_on_attestation#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_on_attestation" fork="gloas" hash="4a56bc6c">
+    def validate_on_attestation(store: Store, attestation: Attestation, is_from_block: bool) -> None:
+        target = attestation.data.target
+
+        # If the given attestation is not from a beacon block message,
+        # we have to check the target epoch scope.
+        if not is_from_block:
+            validate_target_epoch_against_current_time(store, attestation)
+
+        # Check that the epoch number and slot number are matching.
+        assert target.epoch == compute_epoch_at_slot(attestation.data.slot)
+
+        # Attestation target must be for a known block. If target block
+        # is unknown, delay consideration until block is found.
+        assert target.root in store.blocks
+
+        # Attestations must be for a known block. If block
+        # is unknown, delay consideration until the block is found.
+        assert attestation.data.beacon_block_root in store.blocks
+        # Attestations must not be for blocks in the future.
+        # If not, the attestation should not be considered.
+        block_slot = store.blocks[attestation.data.beacon_block_root].slot
+        assert block_slot <= attestation.data.slot
+
+        # [New in Gloas:EIP7732]
+        assert attestation.data.index in [0, 1]
+        if block_slot == attestation.data.slot:
+            assert attestation.data.index == 0
+
+        # LMD vote must be consistent with FFG vote target
+        assert target.root == get_checkpoint_block(
+            store, attestation.data.beacon_block_root, target.epoch
+        )
+
+        # Attestations can only affect the fork-choice of subsequent slots.
+        # Delay consideration in the fork-choice until their slot is in the past.
         assert get_current_slot(store) >= attestation.data.slot + 1
     </spec>
 
@@ -5857,6 +7961,37 @@
         return True
     </spec>
 
+- name: verify_data_column_sidecar#gloas
+  sources: []
+  spec: |
+    <spec fn="verify_data_column_sidecar" fork="gloas" hash="8838c4fd">
+    def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
+        """
+        Verify if the data column sidecar is valid.
+        """
+        # The sidecar index must be within the valid range
+        if sidecar.index >= NUMBER_OF_COLUMNS:
+            return False
+
+        # A sidecar for zero blobs is invalid
+        if len(sidecar.kzg_commitments) == 0:
+            return False
+
+        # [Modified in Gloas:EIP7732]
+        # Check that the sidecar respects the blob limit
+        epoch = compute_epoch_at_slot(sidecar.slot)
+        if len(sidecar.kzg_commitments) > get_blob_parameters(epoch).max_blobs_per_block:
+            return False
+
+        # The column length must be equal to the number of commitments/proofs
+        if len(sidecar.column) != len(sidecar.kzg_commitments) or len(sidecar.column) != len(
+            sidecar.kzg_proofs
+        ):
+            return False
+
+        return True
+    </spec>
+
 - name: verify_data_column_sidecar_inclusion_proof
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -5896,6 +8031,38 @@
             cells=sidecar.column,
             proofs_bytes=sidecar.kzg_proofs,
         )
+    </spec>
+
+- name: verify_execution_payload_bid_signature#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+      search: public boolean verifyExecutionPayloadBidSignature(
+  spec: |
+    <spec fn="verify_execution_payload_bid_signature" fork="gloas" hash="cbe813b1">
+    def verify_execution_payload_bid_signature(
+        state: BeaconState, signed_bid: SignedExecutionPayloadBid
+    ) -> bool:
+        builder = state.validators[signed_bid.message.builder_index]
+        signing_root = compute_signing_root(
+            signed_bid.message, get_domain(state, DOMAIN_BEACON_BUILDER)
+        )
+        return bls.Verify(builder.pubkey, signing_root, signed_bid.signature)
+    </spec>
+
+- name: verify_execution_payload_envelope_signature#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
+      search: private boolean verifyExecutionPayloadEnvelopeSignature(
+  spec: |
+    <spec fn="verify_execution_payload_envelope_signature" fork="gloas" hash="a85e73c3">
+    def verify_execution_payload_envelope_signature(
+        state: BeaconState, signed_envelope: SignedExecutionPayloadEnvelope
+    ) -> bool:
+        builder = state.validators[signed_envelope.message.builder_index]
+        signing_root = compute_signing_root(
+            signed_envelope.message, get_domain(state, DOMAIN_BEACON_BUILDER)
+        )
+        return bls.Verify(builder.pubkey, signing_root, signed_envelope.signature)
     </spec>
 
 - name: voting_period_start_time


### PR DESCRIPTION
## PR Description

I noticed that many implemented Gloas functions did not have specrefs.

This PR adds specrefs for ones that I could find.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds extensive Gloas/EIP-7732 specrefs (forkchoice, payload attestations, builder payments, execution payload handling, withdrawals, timings) and backfills fork-version/process_epoch specs across forks, plus new Gloas payload status constants.
> 
> - **Gloas (EIP-7732) specrefs**:
>   - Forkchoice: `get_head`, `get_weight`, `get_node_children`, `get_parent_payload_status`, `get_payload_status_tiebreaker`, `is_supporting_vote`, `should_extend_payload`, `update_latest_messages`, `get_forkchoice_store`.
>   - Payload attestations/PTC: `get_ptc`, `get_ptc_assignment`, `get_indexed_payload_attestation`, `get_payload_attestation_message_signature`, `notify_ptc_messages`, `on_payload_attestation_message`, `process_payload_attestation`, `is_payload_timely`.
>   - Builder payments & withdrawals: `process_builder_pending_payments`, `get_builder_payment_quorum_threshold`, `get_expected_withdrawals#gloas`, `process_withdrawals#gloas`, `is_builder_payment_withdrawable`, `has_builder_withdrawal_credential`, related helpers.
>   - Execution payload flow: `process_execution_payload#gloas`, `on_execution_payload`, `prepare_execution_payload#gloas`, `verify_execution_payload_*`, `process_execution_payload_bid`, `is_parent_node_full`.
>   - Block/attestation processing: `process_block#gloas`, `process_attestation#gloas`, `validate_on_attestation#gloas`, `on_block#gloas`.
>   - Data availability/sidecars: `get_data_column_sidecars*#gloas`, `verify_data_column_sidecar#gloas`.
>   - Timing helpers: `get_aggregate_due_ms#gloas`, `get_attestation_due_ms#gloas`, `get_contribution_due_ms#gloas`, `get_sync_message_due_ms#gloas`.
>   - Proposer/sync-committee selection: `compute_balance_weighted_*`, `compute_proposer_indices#gloas`, `get_next_sync_committee_indices#gloas`.
>   - Merge validation: `validate_merge_block#gloas`; misc helpers like `is_attestation_same_slot`, `get_checkpoint_block`.
> - **Constants**:
>   - Add Gloas payload status enums: `PAYLOAD_STATUS_PENDING`, `PAYLOAD_STATUS_EMPTY`, `PAYLOAD_STATUS_FULL`.
> - **Cross-fork backfills**:
>   - Add `compute_fork_version` specs for `altair`→`gloas` and `process_epoch` specs for multiple forks.
> - **Config updates** (`specrefs/.ethspecify.yml`):
>   - Move many Gloas functions from "Not implemented" to implemented; adjust exceptions; remove redundant entries; align with new specrefs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40e27f886ffd67bc3e8cdb01faa41722cd685e60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->