### PR TITLE
Clean up Gloas upgrade function

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -55,25 +55,24 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
             state -> {
               BeaconStateFields.copyCommonFieldsFromSource(state, preState);
 
-              state.setCurrentEpochParticipation(preStateFulu.getCurrentEpochParticipation());
-              state.setPreviousEpochParticipation(preStateFulu.getPreviousEpochParticipation());
-              state.setCurrentSyncCommittee(preStateFulu.getCurrentSyncCommittee());
-              state.setNextSyncCommittee(preStateFulu.getNextSyncCommittee());
-              state.setInactivityScores(preStateFulu.getInactivityScores());
-
               state.setFork(
                   new Fork(
                       preState.getFork().getCurrentVersion(),
                       specConfig.getGloasForkVersion(),
                       epoch));
 
-              // Removed `latest_execution_payload_header` in favour of
-              // `latest_execution_payload_bid
+              state.setPreviousEpochParticipation(preStateFulu.getPreviousEpochParticipation());
+              state.setCurrentEpochParticipation(preStateFulu.getCurrentEpochParticipation());
+              state.setInactivityScores(preStateFulu.getInactivityScores());
+              state.setCurrentSyncCommittee(preStateFulu.getCurrentSyncCommittee());
+              state.setNextSyncCommittee(preStateFulu.getNextSyncCommittee());
+
+              // New in Gloas
               state.setLatestExecutionPayloadBid(
                   schemaDefinitions.getExecutionPayloadBidSchema().getDefault());
 
-              state.setNextWithdrawalValidatorIndex(preStateFulu.getNextWithdrawalValidatorIndex());
               state.setNextWithdrawalIndex(preStateFulu.getNextWithdrawalIndex());
+              state.setNextWithdrawalValidatorIndex(preStateFulu.getNextWithdrawalValidatorIndex());
               state.setHistoricalSummaries(preStateFulu.getHistoricalSummaries());
               state.setDepositRequestsStartIndex(preStateFulu.getDepositRequestsStartIndex());
               state.setDepositBalanceToConsume(preStateFulu.getDepositBalanceToConsume());
@@ -86,6 +85,7 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
               state.setPendingPartialWithdrawals(preStateFulu.getPendingPartialWithdrawals());
               state.setPendingConsolidations(preStateFulu.getPendingConsolidations());
               state.setProposerLookahead(preStateFulu.getProposerLookahead());
+
               // New in Gloas
               final SszBitvector executionPayloadAvailability =
                   schemaDefinitions


### PR DESCRIPTION
## PR Description

* Set fields in the same order as the specs. Just a nit, makes reviewing easier.
  * There were a few instances of this. The diff sort of hides this.
* Simply say "new in gloas" for the bid field. 

Spec: https://github.com/ethereum/consensus-specs/blob/ab09e2e94fb61bc8cf3a24747db0473c2405b2ca/specs/gloas/fork.md?plain=1#L41-L103

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initializes new Gloas fields during the fork upgrade and aligns field-setting order with the spec.
> 
> - **State upgrade (`tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java`)**:
>   - Initialize Gloas-only fields:
>     - `latest_execution_payload_bid` set to schema default.
>     - `execution_payload_availability` bitvector sized to `slots_per_historical_root`.
>     - `builder_pending_payments` pre-filled with `2 * slots_per_epoch` defaults.
>     - `builder_pending_withdrawals` set to schema default.
>     - `latest_block_hash` copied from `latest_execution_payload_header.block_hash`.
>     - `latest_withdrawals_root` set to zero.
>   - Preserve/copy Fulu-era fields (participation, inactivity scores, sync committees, withdrawal indices, histories, pending ops, proposer lookahead) in spec-aligned order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 953d19b074a1b468db032d3113038367e9432221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->