### PR TITLE
Autofill missing specrefs & standardize naming

### DIFF
--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -2,6 +2,9 @@ version: v1.6.0
 style: full
 
 specrefs:
+  auto_standardize_names: true
+  auto_add_missing_entries: true
+
   files:
     - configs.yml
     - constants.yml

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -1,4 +1,4 @@
-- name: AGGREGATE_DUE_BPS
+- name: AGGREGATE_DUE_BPS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "AGGREGATE_DUE_BPS:"
@@ -7,7 +7,7 @@
     AGGREGATE_DUE_BPS: uint64 = 6667
     </spec>
 
-- name: AGGREGATE_DUE_BPS_GLOAS
+- name: AGGREGATE_DUE_BPS_GLOAS#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "AGGREGATE_DUE_BPS_GLOAS:"
@@ -16,7 +16,7 @@
     AGGREGATE_DUE_BPS_GLOAS: uint64 = 5000
     </spec>
 
-- name: ALTAIR_FORK_EPOCH
+- name: ALTAIR_FORK_EPOCH#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ALTAIR_FORK_EPOCH:"
@@ -25,7 +25,7 @@
     ALTAIR_FORK_EPOCH: Epoch = 74240
     </spec>
 
-- name: ALTAIR_FORK_VERSION
+- name: ALTAIR_FORK_VERSION#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ALTAIR_FORK_VERSION:"
@@ -34,7 +34,7 @@
     ALTAIR_FORK_VERSION: Version = '0x01000000'
     </spec>
 
-- name: ATTESTATION_DUE_BPS
+- name: ATTESTATION_DUE_BPS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "^ATTESTATION_DUE_BPS:"
@@ -44,7 +44,7 @@
     ATTESTATION_DUE_BPS: uint64 = 3333
     </spec>
 
-- name: ATTESTATION_DUE_BPS_GLOAS
+- name: ATTESTATION_DUE_BPS_GLOAS#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_DUE_BPS_GLOAS:"
@@ -53,7 +53,7 @@
     ATTESTATION_DUE_BPS_GLOAS: uint64 = 2500
     </spec>
 
-- name: ATTESTATION_PROPAGATION_SLOT_RANGE
+- name: ATTESTATION_PROPAGATION_SLOT_RANGE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_PROPAGATION_SLOT_RANGE:"
@@ -62,7 +62,7 @@
     ATTESTATION_PROPAGATION_SLOT_RANGE = 32
     </spec>
 
-- name: ATTESTATION_SUBNET_COUNT
+- name: ATTESTATION_SUBNET_COUNT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_SUBNET_COUNT:"
@@ -71,7 +71,7 @@
     ATTESTATION_SUBNET_COUNT = 64
     </spec>
 
-- name: ATTESTATION_SUBNET_EXTRA_BITS
+- name: ATTESTATION_SUBNET_EXTRA_BITS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_SUBNET_EXTRA_BITS:"
@@ -80,7 +80,7 @@
     ATTESTATION_SUBNET_EXTRA_BITS = 0
     </spec>
 
-- name: ATTESTATION_SUBNET_PREFIX_BITS
+- name: ATTESTATION_SUBNET_PREFIX_BITS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_SUBNET_PREFIX_BITS:"
@@ -89,7 +89,7 @@
     ATTESTATION_SUBNET_PREFIX_BITS: int = 6
     </spec>
 
-- name: BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
+- name: BALANCE_PER_ADDITIONAL_CUSTODY_GROUP#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BALANCE_PER_ADDITIONAL_CUSTODY_GROUP:"
@@ -98,7 +98,7 @@
     BALANCE_PER_ADDITIONAL_CUSTODY_GROUP: Gwei = 32000000000
     </spec>
 
-- name: BELLATRIX_FORK_EPOCH
+- name: BELLATRIX_FORK_EPOCH#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BELLATRIX_FORK_EPOCH:"
@@ -107,7 +107,7 @@
     BELLATRIX_FORK_EPOCH: Epoch = 144896
     </spec>
 
-- name: BELLATRIX_FORK_VERSION
+- name: BELLATRIX_FORK_VERSION#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BELLATRIX_FORK_VERSION:"
@@ -116,7 +116,7 @@
     BELLATRIX_FORK_VERSION: Version = '0x02000000'
     </spec>
 
-- name: BLOB_SCHEDULE
+- name: BLOB_SCHEDULE#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BLOB_SCHEDULE:"
@@ -134,7 +134,7 @@
     )
     </spec>
 
-- name: BLOB_SIDECAR_SUBNET_COUNT
+- name: BLOB_SIDECAR_SUBNET_COUNT#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BLOB_SIDECAR_SUBNET_COUNT:"
@@ -143,7 +143,7 @@
     BLOB_SIDECAR_SUBNET_COUNT = 6
     </spec>
 
-- name: BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
+- name: BLOB_SIDECAR_SUBNET_COUNT_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BLOB_SIDECAR_SUBNET_COUNT_ELECTRA:"
@@ -152,7 +152,7 @@
     BLOB_SIDECAR_SUBNET_COUNT_ELECTRA = 9
     </spec>
 
-- name: CAPELLA_FORK_EPOCH
+- name: CAPELLA_FORK_EPOCH#capella
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CAPELLA_FORK_EPOCH:"
@@ -161,7 +161,7 @@
     CAPELLA_FORK_EPOCH: Epoch = 194048
     </spec>
 
-- name: CAPELLA_FORK_VERSION
+- name: CAPELLA_FORK_VERSION#capella
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CAPELLA_FORK_VERSION:"
@@ -170,7 +170,7 @@
     CAPELLA_FORK_VERSION: Version = '0x03000000'
     </spec>
 
-- name: CHURN_LIMIT_QUOTIENT
+- name: CHURN_LIMIT_QUOTIENT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CHURN_LIMIT_QUOTIENT:"
@@ -179,7 +179,7 @@
     CHURN_LIMIT_QUOTIENT: uint64 = 65536
     </spec>
 
-- name: CONTRIBUTION_DUE_BPS
+- name: CONTRIBUTION_DUE_BPS#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CONTRIBUTION_DUE_BPS:"
@@ -188,7 +188,7 @@
     CONTRIBUTION_DUE_BPS: uint64 = 6667
     </spec>
 
-- name: CONTRIBUTION_DUE_BPS_GLOAS
+- name: CONTRIBUTION_DUE_BPS_GLOAS#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CONTRIBUTION_DUE_BPS_GLOAS:"
@@ -197,7 +197,7 @@
     CONTRIBUTION_DUE_BPS_GLOAS: uint64 = 5000
     </spec>
 
-- name: CUSTODY_REQUIREMENT
+- name: CUSTODY_REQUIREMENT#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "^CUSTODY_REQUIREMENT:"
@@ -207,7 +207,7 @@
     CUSTODY_REQUIREMENT = 4
     </spec>
 
-- name: DATA_COLUMN_SIDECAR_SUBNET_COUNT
+- name: DATA_COLUMN_SIDECAR_SUBNET_COUNT#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "DATA_COLUMN_SIDECAR_SUBNET_COUNT:"
@@ -216,7 +216,7 @@
     DATA_COLUMN_SIDECAR_SUBNET_COUNT = 128
     </spec>
 
-- name: DENEB_FORK_EPOCH
+- name: DENEB_FORK_EPOCH#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "DENEB_FORK_EPOCH:"
@@ -225,7 +225,7 @@
     DENEB_FORK_EPOCH: Epoch = 269568
     </spec>
 
-- name: DENEB_FORK_VERSION
+- name: DENEB_FORK_VERSION#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "DENEB_FORK_VERSION:"
@@ -234,7 +234,7 @@
     DENEB_FORK_VERSION: Version = '0x04000000'
     </spec>
 
-- name: EJECTION_BALANCE
+- name: EJECTION_BALANCE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "EJECTION_BALANCE:"
@@ -243,7 +243,7 @@
     EJECTION_BALANCE: Gwei = 16000000000
     </spec>
 
-- name: ELECTRA_FORK_EPOCH
+- name: ELECTRA_FORK_EPOCH#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ELECTRA_FORK_EPOCH:"
@@ -252,7 +252,7 @@
     ELECTRA_FORK_EPOCH: Epoch = 364032
     </spec>
 
-- name: ELECTRA_FORK_VERSION
+- name: ELECTRA_FORK_VERSION#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ELECTRA_FORK_VERSION:"
@@ -261,7 +261,7 @@
     ELECTRA_FORK_VERSION: Version = '0x05000000'
     </spec>
 
-- name: EPOCHS_PER_SUBNET_SUBSCRIPTION
+- name: EPOCHS_PER_SUBNET_SUBSCRIPTION#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "EPOCHS_PER_SUBNET_SUBSCRIPTION:"
@@ -270,7 +270,7 @@
     EPOCHS_PER_SUBNET_SUBSCRIPTION = 256
     </spec>
 
-- name: ETH1_FOLLOW_DISTANCE
+- name: ETH1_FOLLOW_DISTANCE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ETH1_FOLLOW_DISTANCE:"
@@ -279,7 +279,7 @@
     ETH1_FOLLOW_DISTANCE: uint64 = 2048
     </spec>
 
-- name: FULU_FORK_EPOCH
+- name: FULU_FORK_EPOCH#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "FULU_FORK_EPOCH:"
@@ -288,7 +288,7 @@
     FULU_FORK_EPOCH: Epoch = 411392
     </spec>
 
-- name: FULU_FORK_VERSION
+- name: FULU_FORK_VERSION#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "FULU_FORK_VERSION:"
@@ -297,7 +297,7 @@
     FULU_FORK_VERSION: Version = '0x06000000'
     </spec>
 
-- name: GENESIS_DELAY
+- name: GENESIS_DELAY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "GENESIS_DELAY:"
@@ -306,7 +306,7 @@
     GENESIS_DELAY: uint64 = 604800
     </spec>
 
-- name: GENESIS_FORK_VERSION
+- name: GENESIS_FORK_VERSION#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "GENESIS_FORK_VERSION:"
@@ -315,7 +315,7 @@
     GENESIS_FORK_VERSION: Version = '0x00000000'
     </spec>
 
-- name: GLOAS_FORK_EPOCH
+- name: GLOAS_FORK_EPOCH#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "GLOAS_FORK_EPOCH:"
@@ -324,7 +324,7 @@
     GLOAS_FORK_EPOCH: Epoch = 18446744073709551615
     </spec>
 
-- name: GLOAS_FORK_VERSION
+- name: GLOAS_FORK_VERSION#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "GLOAS_FORK_VERSION:"
@@ -333,7 +333,7 @@
     GLOAS_FORK_VERSION: Version = '0x07000000'
     </spec>
 
-- name: INACTIVITY_SCORE_BIAS
+- name: INACTIVITY_SCORE_BIAS#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "INACTIVITY_SCORE_BIAS:"
@@ -342,7 +342,7 @@
     INACTIVITY_SCORE_BIAS: uint64 = 4
     </spec>
 
-- name: INACTIVITY_SCORE_RECOVERY_RATE
+- name: INACTIVITY_SCORE_RECOVERY_RATE#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "INACTIVITY_SCORE_RECOVERY_RATE:"
@@ -351,7 +351,7 @@
     INACTIVITY_SCORE_RECOVERY_RATE: uint64 = 16
     </spec>
 
-- name: MAXIMUM_GOSSIP_CLOCK_DISPARITY
+- name: MAXIMUM_GOSSIP_CLOCK_DISPARITY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAXIMUM_GOSSIP_CLOCK_DISPARITY:"
@@ -360,7 +360,7 @@
     MAXIMUM_GOSSIP_CLOCK_DISPARITY = 500
     </spec>
 
-- name: MAX_BLOBS_PER_BLOCK
+- name: MAX_BLOBS_PER_BLOCK#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "^MAX_BLOBS_PER_BLOCK:"
@@ -370,7 +370,7 @@
     MAX_BLOBS_PER_BLOCK: uint64 = 6
     </spec>
 
-- name: MAX_BLOBS_PER_BLOCK_ELECTRA
+- name: MAX_BLOBS_PER_BLOCK_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_BLOBS_PER_BLOCK_ELECTRA:"
@@ -379,7 +379,7 @@
     MAX_BLOBS_PER_BLOCK_ELECTRA: uint64 = 9
     </spec>
 
-- name: MAX_PAYLOAD_SIZE
+- name: MAX_PAYLOAD_SIZE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_PAYLOAD_SIZE:"
@@ -388,7 +388,7 @@
     MAX_PAYLOAD_SIZE = 10485760
     </spec>
 
-- name: MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT
+- name: MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT:"
@@ -397,7 +397,7 @@
     MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT: uint64 = 8
     </spec>
 
-- name: MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT
+- name: MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT:"
@@ -406,7 +406,7 @@
     MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT: Gwei = 256000000000
     </spec>
 
-- name: MAX_REQUEST_BLOB_SIDECARS
+- name: MAX_REQUEST_BLOB_SIDECARS#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_BLOB_SIDECARS:"
@@ -415,7 +415,7 @@
     MAX_REQUEST_BLOB_SIDECARS = 768
     </spec>
 
-- name: MAX_REQUEST_BLOB_SIDECARS_ELECTRA
+- name: MAX_REQUEST_BLOB_SIDECARS_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_BLOB_SIDECARS_ELECTRA:"
@@ -424,7 +424,7 @@
     MAX_REQUEST_BLOB_SIDECARS_ELECTRA = 1152
     </spec>
 
-- name: MAX_REQUEST_BLOCKS
+- name: MAX_REQUEST_BLOCKS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_BLOCKS:"
@@ -433,7 +433,7 @@
     MAX_REQUEST_BLOCKS = 1024
     </spec>
 
-- name: MAX_REQUEST_BLOCKS_DENEB
+- name: MAX_REQUEST_BLOCKS_DENEB#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_BLOCKS_DENEB:"
@@ -442,7 +442,7 @@
     MAX_REQUEST_BLOCKS_DENEB = 128
     </spec>
 
-- name: MAX_REQUEST_DATA_COLUMN_SIDECARS
+- name: MAX_REQUEST_DATA_COLUMN_SIDECARS#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_DATA_COLUMN_SIDECARS:"
@@ -451,7 +451,7 @@
     MAX_REQUEST_DATA_COLUMN_SIDECARS = 16384
     </spec>
 
-- name: MAX_REQUEST_PAYLOADS
+- name: MAX_REQUEST_PAYLOADS#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_PAYLOADS:"
@@ -460,7 +460,7 @@
     MAX_REQUEST_PAYLOADS = 128
     </spec>
 
-- name: MESSAGE_DOMAIN_INVALID_SNAPPY
+- name: MESSAGE_DOMAIN_INVALID_SNAPPY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MESSAGE_DOMAIN_INVALID_SNAPPY:"
@@ -469,7 +469,7 @@
     MESSAGE_DOMAIN_INVALID_SNAPPY: DomainType = '0x00000000'
     </spec>
 
-- name: MESSAGE_DOMAIN_VALID_SNAPPY
+- name: MESSAGE_DOMAIN_VALID_SNAPPY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MESSAGE_DOMAIN_VALID_SNAPPY:"
@@ -478,7 +478,7 @@
     MESSAGE_DOMAIN_VALID_SNAPPY: DomainType = '0x01000000'
     </spec>
 
-- name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
+- name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS:"
@@ -487,7 +487,7 @@
     MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS = 4096
     </spec>
 
-- name: MIN_EPOCHS_FOR_BLOCK_REQUESTS
+- name: MIN_EPOCHS_FOR_BLOCK_REQUESTS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_EPOCHS_FOR_BLOCK_REQUESTS:"
@@ -496,7 +496,7 @@
     MIN_EPOCHS_FOR_BLOCK_REQUESTS = 33024
     </spec>
 
-- name: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
+- name: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS:"
@@ -505,7 +505,7 @@
     MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS = 4096
     </spec>
 
-- name: MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+- name: MIN_GENESIS_ACTIVE_VALIDATOR_COUNT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT:"
@@ -514,7 +514,7 @@
     MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: uint64 = 16384
     </spec>
 
-- name: MIN_GENESIS_TIME
+- name: MIN_GENESIS_TIME#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_GENESIS_TIME:"
@@ -523,7 +523,7 @@
     MIN_GENESIS_TIME: uint64 = 1606824000
     </spec>
 
-- name: MIN_PER_EPOCH_CHURN_LIMIT
+- name: MIN_PER_EPOCH_CHURN_LIMIT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_PER_EPOCH_CHURN_LIMIT:"
@@ -532,7 +532,7 @@
     MIN_PER_EPOCH_CHURN_LIMIT: uint64 = 4
     </spec>
 
-- name: MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA
+- name: MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA:"
@@ -541,7 +541,7 @@
     MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA: Gwei = 128000000000
     </spec>
 
-- name: MIN_VALIDATOR_WITHDRAWABILITY_DELAY
+- name: MIN_VALIDATOR_WITHDRAWABILITY_DELAY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_VALIDATOR_WITHDRAWABILITY_DELAY:"
@@ -550,7 +550,7 @@
     MIN_VALIDATOR_WITHDRAWABILITY_DELAY: uint64 = 256
     </spec>
 
-- name: NUMBER_OF_CUSTODY_GROUPS
+- name: NUMBER_OF_CUSTODY_GROUPS#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "NUMBER_OF_CUSTODY_GROUPS:"
@@ -559,7 +559,7 @@
     NUMBER_OF_CUSTODY_GROUPS = 128
     </spec>
 
-- name: PAYLOAD_ATTESTATION_DUE_BPS
+- name: PAYLOAD_ATTESTATION_DUE_BPS#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "PAYLOAD_ATTESTATION_DUE_BPS:"
@@ -568,7 +568,7 @@
     PAYLOAD_ATTESTATION_DUE_BPS: uint64 = 7500
     </spec>
 
-- name: PROPOSER_REORG_CUTOFF_BPS
+- name: PROPOSER_REORG_CUTOFF_BPS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "PROPOSER_REORG_CUTOFF_BPS:"
@@ -577,7 +577,7 @@
     PROPOSER_REORG_CUTOFF_BPS: uint64 = 1667
     </spec>
 
-- name: PROPOSER_SCORE_BOOST
+- name: PROPOSER_SCORE_BOOST#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "PROPOSER_SCORE_BOOST:"
@@ -586,7 +586,7 @@
     PROPOSER_SCORE_BOOST: uint64 = 40
     </spec>
 
-- name: REORG_HEAD_WEIGHT_THRESHOLD
+- name: REORG_HEAD_WEIGHT_THRESHOLD#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "REORG_HEAD_WEIGHT_THRESHOLD:"
@@ -595,7 +595,7 @@
     REORG_HEAD_WEIGHT_THRESHOLD: uint64 = 20
     </spec>
 
-- name: REORG_MAX_EPOCHS_SINCE_FINALIZATION
+- name: REORG_MAX_EPOCHS_SINCE_FINALIZATION#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "REORG_MAX_EPOCHS_SINCE_FINALIZATION:"
@@ -604,7 +604,7 @@
     REORG_MAX_EPOCHS_SINCE_FINALIZATION: Epoch = 2
     </spec>
 
-- name: REORG_PARENT_WEIGHT_THRESHOLD
+- name: REORG_PARENT_WEIGHT_THRESHOLD#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "REORG_PARENT_WEIGHT_THRESHOLD:"
@@ -613,7 +613,7 @@
     REORG_PARENT_WEIGHT_THRESHOLD: uint64 = 160
     </spec>
 
-- name: SAMPLES_PER_SLOT
+- name: SAMPLES_PER_SLOT#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SAMPLES_PER_SLOT:"
@@ -622,7 +622,7 @@
     SAMPLES_PER_SLOT = 8
     </spec>
 
-- name: SECONDS_PER_ETH1_BLOCK
+- name: SECONDS_PER_ETH1_BLOCK#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SECONDS_PER_ETH1_BLOCK:"
@@ -631,7 +631,7 @@
     SECONDS_PER_ETH1_BLOCK: uint64 = 14
     </spec>
 
-- name: SECONDS_PER_SLOT
+- name: SECONDS_PER_SLOT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SECONDS_PER_SLOT:"
@@ -640,7 +640,7 @@
     SECONDS_PER_SLOT: uint64 = 12
     </spec>
 
-- name: SHARD_COMMITTEE_PERIOD
+- name: SHARD_COMMITTEE_PERIOD#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SHARD_COMMITTEE_PERIOD:"
@@ -649,7 +649,7 @@
     SHARD_COMMITTEE_PERIOD: uint64 = 256
     </spec>
 
-- name: SLOT_DURATION_MS
+- name: SLOT_DURATION_MS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SLOT_DURATION_MS:"
@@ -658,7 +658,7 @@
     SLOT_DURATION_MS: uint64 = 12000
     </spec>
 
-- name: SUBNETS_PER_NODE
+- name: SUBNETS_PER_NODE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SUBNETS_PER_NODE:"
@@ -667,7 +667,7 @@
     SUBNETS_PER_NODE = 2
     </spec>
 
-- name: SYNC_MESSAGE_DUE_BPS
+- name: SYNC_MESSAGE_DUE_BPS#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SYNC_MESSAGE_DUE_BPS:"
@@ -676,7 +676,7 @@
     SYNC_MESSAGE_DUE_BPS: uint64 = 3333
     </spec>
 
-- name: SYNC_MESSAGE_DUE_BPS_GLOAS
+- name: SYNC_MESSAGE_DUE_BPS_GLOAS#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SYNC_MESSAGE_DUE_BPS_GLOAS:"
@@ -685,7 +685,7 @@
     SYNC_MESSAGE_DUE_BPS_GLOAS: uint64 = 2500
     </spec>
 
-- name: TERMINAL_BLOCK_HASH
+- name: TERMINAL_BLOCK_HASH#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "TERMINAL_BLOCK_HASH:"
@@ -694,7 +694,7 @@
     TERMINAL_BLOCK_HASH: Hash32 = '0x0000000000000000000000000000000000000000000000000000000000000000'
     </spec>
 
-- name: TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
+- name: TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH:"
@@ -703,7 +703,7 @@
     TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH = 18446744073709551615
     </spec>
 
-- name: TERMINAL_TOTAL_DIFFICULTY
+- name: TERMINAL_TOTAL_DIFFICULTY#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "TERMINAL_TOTAL_DIFFICULTY:"
@@ -712,7 +712,7 @@
     TERMINAL_TOTAL_DIFFICULTY = 58750000000000000000000
     </spec>
 
-- name: VALIDATOR_CUSTODY_REQUIREMENT
+- name: VALIDATOR_CUSTODY_REQUIREMENT#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "VALIDATOR_CUSTODY_REQUIREMENT:"

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -1,4 +1,4 @@
-- name: BASE_REWARDS_PER_EPOCH
+- name: BASE_REWARDS_PER_EPOCH#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
       search: BASE_REWARDS_PER_EPOCH =
@@ -7,7 +7,14 @@
     BASE_REWARDS_PER_EPOCH: uint64 = 4
     </spec>
 
-- name: BLS_MODULUS
+- name: BASIS_POINTS#phase0
+  sources: []
+  spec: |
+    <spec constant_var="BASIS_POINTS" fork="phase0" hash="cb0c8561">
+    BASIS_POINTS: uint64 = 10000
+    </spec>
+
+- name: BLS_MODULUS#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
       search: BLS_MODULUS =
@@ -16,7 +23,7 @@
     BLS_MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513
     </spec>
 
-- name: BLS_WITHDRAWAL_PREFIX
+- name: BLS_WITHDRAWAL_PREFIX#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
       search: BLS_WITHDRAWAL_PREFIX =
@@ -25,7 +32,7 @@
     BLS_WITHDRAWAL_PREFIX: Bytes1 = '0x00'
     </spec>
 
-- name: BUILDER_PAYMENT_THRESHOLD_DENOMINATOR
+- name: BUILDER_PAYMENT_THRESHOLD_DENOMINATOR#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
       search: BUILDER_PAYMENT_THRESHOLD_DENOMINATOR =
@@ -34,7 +41,7 @@
     BUILDER_PAYMENT_THRESHOLD_DENOMINATOR: uint64 = 10
     </spec>
 
-- name: BUILDER_PAYMENT_THRESHOLD_NUMERATOR
+- name: BUILDER_PAYMENT_THRESHOLD_NUMERATOR#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
       search: BUILDER_PAYMENT_THRESHOLD_NUMERATOR =
@@ -43,7 +50,7 @@
     BUILDER_PAYMENT_THRESHOLD_NUMERATOR: uint64 = 6
     </spec>
 
-- name: BUILDER_WITHDRAWAL_PREFIX
+- name: BUILDER_WITHDRAWAL_PREFIX#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
       search: BUILDER_WITHDRAWAL_PREFIX =
@@ -52,7 +59,14 @@
     BUILDER_WITHDRAWAL_PREFIX: Bytes1 = '0x03'
     </spec>
 
-- name: BYTES_PER_FIELD_ELEMENT
+- name: BYTES_PER_COMMITMENT#deneb
+  sources: []
+  spec: |
+    <spec constant_var="BYTES_PER_COMMITMENT" fork="deneb" hash="c46710b5">
+    BYTES_PER_COMMITMENT: uint64 = 48
+    </spec>
+
+- name: BYTES_PER_FIELD_ELEMENT#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
       search: BYTES_PER_FIELD_ELEMENT =
@@ -61,7 +75,14 @@
     BYTES_PER_FIELD_ELEMENT: uint64 = 32
     </spec>
 
-- name: COMPOUNDING_WITHDRAWAL_PREFIX
+- name: BYTES_PER_PROOF#deneb
+  sources: []
+  spec: |
+    <spec constant_var="BYTES_PER_PROOF" fork="deneb" hash="7fec794e">
+    BYTES_PER_PROOF: uint64 = 48
+    </spec>
+
+- name: COMPOUNDING_WITHDRAWAL_PREFIX#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
       search: COMPOUNDING_WITHDRAWAL_PREFIX =
@@ -70,7 +91,7 @@
     COMPOUNDING_WITHDRAWAL_PREFIX: Bytes1 = '0x02'
     </spec>
 
-- name: CONSOLIDATION_REQUEST_TYPE
+- name: CONSOLIDATION_REQUEST_TYPE#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ConsolidationRequest.java
       search: REQUEST_TYPE =
@@ -79,7 +100,7 @@
     CONSOLIDATION_REQUEST_TYPE: Bytes1 = '0x02'
     </spec>
 
-- name: DEPOSIT_CONTRACT_TREE_DEPTH
+- name: DEPOSIT_CONTRACT_TREE_DEPTH#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
       search: DEPOSIT_CONTRACT_TREE_DEPTH =
@@ -90,7 +111,7 @@
     DEPOSIT_CONTRACT_TREE_DEPTH: uint64 = 2**5
     </spec>
 
-- name: DEPOSIT_REQUEST_TYPE
+- name: DEPOSIT_REQUEST_TYPE#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/DepositRequest.java
       search: REQUEST_TYPE =
@@ -99,7 +120,7 @@
     DEPOSIT_REQUEST_TYPE: Bytes1 = '0x00'
     </spec>
 
-- name: DOMAIN_AGGREGATE_AND_PROOF
+- name: DOMAIN_AGGREGATE_AND_PROOF#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: AGGREGATE_AND_PROOF =
@@ -108,7 +129,14 @@
     DOMAIN_AGGREGATE_AND_PROOF: DomainType = '0x06000000'
     </spec>
 
-- name: DOMAIN_BEACON_ATTESTER
+- name: DOMAIN_APPLICATION_MASK#phase0
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_APPLICATION_MASK" fork="phase0" hash="82d95c51">
+    DOMAIN_APPLICATION_MASK: DomainType = '0x00000001'
+    </spec>
+
+- name: DOMAIN_BEACON_ATTESTER#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: BEACON_ATTESTER =
@@ -117,7 +145,7 @@
     DOMAIN_BEACON_ATTESTER: DomainType = '0x01000000'
     </spec>
 
-- name: DOMAIN_BEACON_BUILDER
+- name: DOMAIN_BEACON_BUILDER#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: BEACON_BUILDER =
@@ -126,7 +154,7 @@
     DOMAIN_BEACON_BUILDER: DomainType = '0x1B000000'
     </spec>
 
-- name: DOMAIN_BEACON_PROPOSER
+- name: DOMAIN_BEACON_PROPOSER#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: BEACON_PROPOSER =
@@ -135,7 +163,7 @@
     DOMAIN_BEACON_PROPOSER: DomainType = '0x00000000'
     </spec>
 
-- name: DOMAIN_BLS_TO_EXECUTION_CHANGE
+- name: DOMAIN_BLS_TO_EXECUTION_CHANGE#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: BLS_TO_EXECUTION_CHANGE =
@@ -144,7 +172,7 @@
     DOMAIN_BLS_TO_EXECUTION_CHANGE: DomainType = '0x0A000000'
     </spec>
 
-- name: DOMAIN_CONTRIBUTION_AND_PROOF
+- name: DOMAIN_CONTRIBUTION_AND_PROOF#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: CONTRIBUTION_AND_PROOF =
@@ -153,7 +181,7 @@
     DOMAIN_CONTRIBUTION_AND_PROOF: DomainType = '0x09000000'
     </spec>
 
-- name: DOMAIN_DEPOSIT
+- name: DOMAIN_DEPOSIT#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: DEPOSIT =
@@ -162,7 +190,7 @@
     DOMAIN_DEPOSIT: DomainType = '0x03000000'
     </spec>
 
-- name: DOMAIN_PTC_ATTESTER
+- name: DOMAIN_PTC_ATTESTER#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: PTC_ATTESTER =
@@ -171,7 +199,7 @@
     DOMAIN_PTC_ATTESTER: DomainType = '0x0C000000'
     </spec>
 
-- name: DOMAIN_RANDAO
+- name: DOMAIN_RANDAO#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: RANDAO =
@@ -180,7 +208,7 @@
     DOMAIN_RANDAO: DomainType = '0x02000000'
     </spec>
 
-- name: DOMAIN_SELECTION_PROOF
+- name: DOMAIN_SELECTION_PROOF#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: Bytes4 SELECTION_PROOF =
@@ -189,7 +217,7 @@
     DOMAIN_SELECTION_PROOF: DomainType = '0x05000000'
     </spec>
 
-- name: DOMAIN_SYNC_COMMITTEE
+- name: DOMAIN_SYNC_COMMITTEE#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: SYNC_COMMITTEE =
@@ -198,7 +226,7 @@
     DOMAIN_SYNC_COMMITTEE: DomainType = '0x07000000'
     </spec>
 
-- name: DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF
+- name: DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: SYNC_COMMITTEE_SELECTION_PROOF =
@@ -207,7 +235,7 @@
     DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF: DomainType = '0x08000000'
     </spec>
 
-- name: DOMAIN_VOLUNTARY_EXIT
+- name: DOMAIN_VOLUNTARY_EXIT#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: VOLUNTARY_EXIT =
@@ -216,7 +244,14 @@
     DOMAIN_VOLUNTARY_EXIT: DomainType = '0x04000000'
     </spec>
 
-- name: ETH1_ADDRESS_WITHDRAWAL_PREFIX
+- name: ENDIANNESS#phase0
+  sources: []
+  spec: |
+    <spec constant_var="ENDIANNESS" fork="phase0" hash="76922bbc">
+    ENDIANNESS = 'little'
+    </spec>
+
+- name: ETH1_ADDRESS_WITHDRAWAL_PREFIX#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/WithdrawalPrefixes.java
       search: ETH1_ADDRESS_WITHDRAWAL_PREFIX =
@@ -225,7 +260,7 @@
     ETH1_ADDRESS_WITHDRAWAL_PREFIX: Bytes1 = '0x01'
     </spec>
 
-- name: ETH_TO_GWEI
+- name: ETH_TO_GWEI#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/EthConstants.java
       search: ETH_TO_GWEI =
@@ -234,7 +269,7 @@
     ETH_TO_GWEI: uint64 = 10**9
     </spec>
 
-- name: FAR_FUTURE_EPOCH
+- name: FAR_FUTURE_EPOCH#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
       search: FAR_FUTURE_EPOCH =
@@ -243,7 +278,14 @@
     FAR_FUTURE_EPOCH: Epoch = 2**64 - 1
     </spec>
 
-- name: FULL_EXIT_REQUEST_AMOUNT
+- name: FIAT_SHAMIR_PROTOCOL_DOMAIN#deneb
+  sources: []
+  spec: |
+    <spec constant_var="FIAT_SHAMIR_PROTOCOL_DOMAIN" fork="deneb" hash="b1198e8c">
+    FIAT_SHAMIR_PROTOCOL_DOMAIN = b'FSBLOBVERIFY_V1_'
+    </spec>
+
+- name: FULL_EXIT_REQUEST_AMOUNT#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
       search: FULL_EXIT_REQUEST_AMOUNT =
@@ -252,7 +294,21 @@
     FULL_EXIT_REQUEST_AMOUNT: uint64 = 0
     </spec>
 
-- name: GENESIS_EPOCH
+- name: G1_POINT_AT_INFINITY#deneb
+  sources: []
+  spec: |
+    <spec constant_var="G1_POINT_AT_INFINITY" fork="deneb" hash="974ad898">
+    G1_POINT_AT_INFINITY: Bytes48 = b'\xc0' + b'\x00' * 47
+    </spec>
+
+- name: G2_POINT_AT_INFINITY#altair
+  sources: []
+  spec: |
+    <spec constant_var="G2_POINT_AT_INFINITY" fork="altair" hash="55ddc9fd">
+    G2_POINT_AT_INFINITY: BLSSignature = b'\xc0' + b'\x00' * 95
+    </spec>
+
+- name: GENESIS_EPOCH#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
       search: GENESIS_EPOCH =
@@ -261,7 +317,7 @@
     GENESIS_EPOCH: Epoch = 0
     </spec>
 
-- name: GENESIS_SLOT
+- name: GENESIS_SLOT#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
       search: GENESIS_SLOT =
@@ -270,7 +326,14 @@
     GENESIS_SLOT: Slot = 0
     </spec>
 
-- name: JUSTIFICATION_BITS_LENGTH
+- name: INTERVALS_PER_SLOT#phase0
+  sources: []
+  spec: |
+    <spec constant_var="INTERVALS_PER_SLOT" fork="phase0" hash="3352e419">
+    INTERVALS_PER_SLOT: uint64 = 3
+    </spec>
+
+- name: JUSTIFICATION_BITS_LENGTH#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
       search: JUSTIFICATION_BITS_LENGTH =
@@ -279,7 +342,28 @@
     JUSTIFICATION_BITS_LENGTH: uint64 = 4
     </spec>
 
-- name: MAX_CONCURRENT_REQUESTS
+- name: KZG_ENDIANNESS#deneb
+  sources: []
+  spec: |
+    <spec constant_var="KZG_ENDIANNESS" fork="deneb" hash="b67e714d">
+    KZG_ENDIANNESS = 'big'
+    </spec>
+
+- name: KZG_SETUP_G2_LENGTH#deneb
+  sources: []
+  spec: |
+    <spec constant_var="KZG_SETUP_G2_LENGTH" fork="deneb" hash="6cb8d5fd">
+    KZG_SETUP_G2_LENGTH = 65
+    </spec>
+
+- name: KZG_SETUP_G2_MONOMIAL#deneb
+  sources: []
+  spec: |
+    <spec constant_var="KZG_SETUP_G2_MONOMIAL" fork="deneb" hash="4e0f802f">
+    KZG_SETUP_G2_MONOMIAL: Vector[G2Point, KZG_SETUP_G2_LENGTH] = ['0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8', '0xb5bfd7dd8cdeb128843bc287230af38926187075cbfbefa81009a2ce615ac53d2914e5870cb452d2afaaab24f3499f72185cbfee53492714734429b7b38608e23926c911cceceac9a36851477ba4c60b087041de621000edc98edada20c1def2', '0xb5337ba0ce5d37224290916e268e2060e5c14f3f9fc9e1ec3af5a958e7a0303122500ce18f1a4640bf66525bd10e763501fe986d86649d8d45143c08c3209db3411802c226e9fe9a55716ac4a0c14f9dcef9e70b2bb309553880dc5025eab3cc', '0xb3c1dcdc1f62046c786f0b82242ef283e7ed8f5626f72542aa2c7a40f14d9094dd1ebdbd7457ffdcdac45fd7da7e16c51200b06d791e5e43e257e45efdf0bd5b06cd2333beca2a3a84354eb48662d83aef5ecf4e67658c851c10b13d8d87c874', '0x954d91c7688983382609fca9e211e461f488a5971fd4e40d7e2892037268eacdfd495cfa0a7ed6eb0eb11ac3ae6f651716757e7526abe1e06c64649d80996fd3105c20c4c94bc2b22d97045356fe9d791f21ea6428ac48db6f9e68e30d875280', '0x88a6b6bb26c51cf9812260795523973bb90ce80f6820b6c9048ab366f0fb96e48437a7f7cb62aedf64b11eb4dfefebb0147608793133d32003cb1f2dc47b13b5ff45f1bb1b2408ea45770a08dbfaec60961acb8119c47b139a13b8641e2c9487', '0x85cd7be9728bd925d12f47fb04b32d9fad7cab88788b559f053e69ca18e463113ecc8bbb6dbfb024835f901b3a957d3108d6770fb26d4c8be0a9a619f6e3a4bf15cbfd48e61593490885f6cee30e4300c5f9cf5e1c08e60a2d5b023ee94fcad0', '0x80477dba360f04399821a48ca388c0fa81102dd15687fea792ee8c1114e00d1bc4839ad37ac58900a118d863723acfbe08126ea883be87f50e4eabe3b5e72f5d9e041db8d9b186409fd4df4a7dde38c0e0a3b1ae29b098e5697e7f110b6b27e4', '0xb7a6aec08715a9f8672a2b8c367e407be37e59514ac19dd4f0942a68007bba3923df22da48702c63c0d6b3efd3c2d04e0fe042d8b5a54d562f9f33afc4865dcbcc16e99029e25925580e87920c399e710d438ac1ce3a6dc9b0d76c064a01f6f7', '0xac1b001edcea02c8258aeffbf9203114c1c874ad88dae1184fadd7d94cd09053649efd0ca413400e6e9b5fa4eac33261000af88b6bd0d2abf877a4f0355d2fb4d6007adb181695201c5432e50b850b51b3969f893bddf82126c5a71b042b7686', '0x90043fda4de53fb364fab2c04be5296c215599105ecff0c12e4917c549257125775c29f2507124d15f56e30447f367db0596c33237242c02d83dfd058735f1e3c1ff99069af55773b6d51d32a68bf75763f59ec4ee7267932ae426522b8aaab6', '0xa8660ce853e9dc08271bf882e29cd53397d63b739584dda5263da4c7cc1878d0cf6f3e403557885f557e184700575fee016ee8542dec22c97befe1d10f414d22e84560741cdb3e74c30dda9b42eeaaf53e27822de2ee06e24e912bf764a9a533', '0x8fe3921a96d0d065e8aa8fce9aa42c8e1461ca0470688c137be89396dd05103606dab6cdd2a4591efd6addf72026c12e065da7be276dee27a7e30afa2bd81c18f1516e7f068f324d0bad9570b95f6bd02c727cd2343e26db0887c3e4e26dceda', '0x8ae1ad97dcb9c192c9a3933541b40447d1dc4eebf380151440bbaae1e120cc5cdf1bcea55180b128d8e180e3af623815191d063cc0d7a47d55fb7687b9d87040bf7bc1a7546b07c61db5ccf1841372d7c2fe4a5431ffff829f3c2eb590b0b710', '0x8c2fa96870a88150f7876c931e2d3cc2adeaaaf5c73ef5fa1cf9dfa0991ae4819f9321af7e916e5057d87338e630a2f21242c29d76963cf26035b548d2a63d8ad7bd6efefa01c1df502cbdfdfe0334fb21ceb9f686887440f713bf17a89b8081', '0xb9aa98e2f02bb616e22ee5dd74c7d1049321ac9214d093a738159850a1dbcc7138cb8d26ce09d8296368fd5b291d74fa17ac7cc1b80840fdd4ee35e111501e3fa8485b508baecda7c1ab7bd703872b7d64a2a40b3210b6a70e8a6ffe0e5127e3', '0x9292db67f8771cdc86854a3f614a73805bf3012b48f1541e704ea4015d2b6b9c9aaed36419769c87c49f9e3165f03edb159c23b3a49c4390951f78e1d9b0ad997129b17cdb57ea1a6638794c0cca7d239f229e589c5ae4f9fe6979f7f8cba1d7', '0x91cd9e86550f230d128664f7312591fee6a84c34f5fc7aed557bcf986a409a6de722c4330453a305f06911d2728626e611acfdf81284f77f60a3a1595053a9479964fd713117e27c0222cc679674b03bc8001501aaf9b506196c56de29429b46', '0xa9516b73f605cc31b89c68b7675dc451e6364595243d235339437f556cf22d745d4250c1376182273be2d99e02c10eee047410a43eff634d051aeb784e76cb3605d8e079b9eb6ad1957dfdf77e1cd32ce4a573c9dfcc207ca65af6eb187f6c3d', '0xa9667271f7d191935cc8ad59ef3ec50229945faea85bfdfb0d582090f524436b348aaa0183b16a6231c00332fdac2826125b8c857a2ed9ec66821cfe02b3a2279be2412441bc2e369b255eb98614e4be8490799c4df22f18d47d24ec70bba5f7', '0xa4371144d2aa44d70d3cb9789096d3aa411149a6f800cb46f506461ee8363c8724667974252f28aea61b6030c05930ac039c1ee64bb4bd56532a685cae182bf2ab935eee34718cffcb46cae214c77aaca11dbb1320faf23c47247db1da04d8dc', '0x89a7eb441892260b7e81168c386899cd84ffc4a2c5cad2eae0d1ab9e8b5524662e6f660fe3f8bfe4c92f60b060811bc605b14c5631d16709266886d7885a5eb5930097127ec6fb2ebbaf2df65909cf48f253b3d5e22ae48d3e9a2fd2b01f447e', '0x9648c42ca97665b5eccb49580d8532df05eb5a68db07f391a2340769b55119eaf4c52fe4f650c09250fa78a76c3a1e271799b8333cc2628e3d4b4a6a3e03da1f771ecf6516dd63236574a7864ff07e319a6f11f153406280d63af9e2b5713283', '0x9663bf6dd446ea7a90658ee458578d4196dc0b175ef7fcfa75f44d41670850774c2e46c5a6be132a2c072a3c0180a24f0305d1acac49d2d79878e5cda80c57feda3d01a6af12e78b5874e2a4b3717f11c97503b41a4474e2e95b179113726199', '0xb212aeb4814e0915b432711b317923ed2b09e076aaf558c3ae8ef83f9e15a83f9ea3f47805b2750ab9e8106cb4dc6ad003522c84b03dc02829978a097899c773f6fb31f7fe6b8f2d836d96580f216fec20158f1590c3e0d7850622e15194db05', '0x925f005059bf07e9ceccbe66c711b048e236ade775720d0fe479aebe6e23e8af281225ad18e62458dc1b03b42ad4ca290d4aa176260604a7aad0d9791337006fbdebe23746f8060d42876f45e4c83c3643931392fde1cd13ff8bddf8111ef974', '0x9553edb22b4330c568e156a59ef03b26f5c326424f830fe3e8c0b602f08c124730ffc40bc745bec1a22417adb22a1a960243a10565c2be3066bfdb841d1cd14c624cd06e0008f4beb83f972ce6182a303bee3fcbcabc6cfe48ec5ae4b7941bfc', '0x935f5a404f0a78bdcce709899eda0631169b366a669e9b58eacbbd86d7b5016d044b8dfc59ce7ed8de743ae16c2343b50e2f925e88ba6319e33c3fc76b314043abad7813677b4615c8a97eb83cc79de4fedf6ccbcfa4d4cbf759a5a84e4d9742', '0xa5b014ab936eb4be113204490e8b61cd38d71da0dec7215125bcd131bf3ab22d0a32ce645bca93e7b3637cf0c2db3d6601a0ddd330dc46f9fae82abe864ffc12d656c88eb50c20782e5bb6f75d18760666f43943abb644b881639083e122f557', '0x935b7298ae52862fa22bf03bfc1795b34c70b181679ae27de08a9f5b4b884f824ef1b276b7600efa0d2f1d79e4a470d51692fd565c5cf8343dd80e5d3336968fc21c09ba9348590f6206d4424eb229e767547daefa98bc3aa9f421158dee3f2a', '0x9830f92446e708a8f6b091cc3c38b653505414f8b6507504010a96ffda3bcf763d5331eb749301e2a1437f00e2415efb01b799ad4c03f4b02de077569626255ac1165f96ea408915d4cf7955047620da573e5c439671d1fa5c833fb11de7afe6', '0x840dcc44f673fff3e387af2bb41e89640f2a70bcd2b92544876daa92143f67c7512faf5f90a04b7191de01f3e2b1bde00622a20dc62ca23bbbfaa6ad220613deff43908382642d4d6a86999f662efd64b1df448b68c847cfa87630a3ffd2ec76', '0x92950c895ed54f7f876b2fda17ecc9c41b7accfbdd42c210cc5b475e0737a7279f558148531b5c916e310604a1de25a80940c94fe5389ae5d6a5e9c371be67bceea1877f5401725a6595bcf77ece60905151b6dfcb68b75ed2e708c73632f4fd', '0x8010246bf8e94c25fd029b346b5fbadb404ef6f44a58fd9dd75acf62433d8cc6db66974f139a76e0c26dddc1f329a88214dbb63276516cf325c7869e855d07e0852d622c332ac55609ba1ec9258c45746a2aeb1af0800141ee011da80af175d4', '0xb0f1bad257ebd187bdc3f37b23f33c6a5d6a8e1f2de586080d6ada19087b0e2bf23b79c1b6da1ee82271323f5bdf3e1b018586b54a5b92ab6a1a16bb3315190a3584a05e6c37d5ca1e05d702b9869e27f513472bcdd00f4d0502a107773097da', '0x9636d24f1ede773ce919f309448dd7ce023f424afd6b4b69cb98c2a988d849a283646dc3e469879daa1b1edae91ae41f009887518e7eb5578f88469321117303cd3ac2d7aee4d9cb5f82ab9ae3458e796dfe7c24284b05815acfcaa270ff22e2', '0xb373feb5d7012fd60578d7d00834c5c81df2a23d42794fed91aa9535a4771fde0341c4da882261785e0caca40bf83405143085e7f17e55b64f6c5c809680c20b050409bf3702c574769127c854d27388b144b05624a0e24a1cbcc4d08467005b', '0xb15680648949ce69f82526e9b67d9b55ce5c537dc6ab7f3089091a9a19a6b90df7656794f6edc87fb387d21573ffc847062623685931c2790a508cbc8c6b231dd2c34f4d37d4706237b1407673605a604bcf6a50cc0b1a2db20485e22b02c17e', '0x8817e46672d40c8f748081567b038a3165f87994788ec77ee8daea8587f5540df3422f9e120e94339be67f186f50952504cb44f61e30a5241f1827e501b2de53c4c64473bcc79ab887dd277f282fbfe47997a930dd140ac08b03efac88d81075', '0xa6e4ef6c1d1098f95aae119905f87eb49b909d17f9c41bcfe51127aa25fee20782ea884a7fdf7d5e9c245b5a5b32230b07e0dbf7c6743bf52ee20e2acc0b269422bd6cf3c07115df4aa85b11b2c16630a07c974492d9cdd0ec325a3fabd95044', '0x8634aa7c3d00e7f17150009698ce440d8e1b0f13042b624a722ace68ead870c3d2212fbee549a2c190e384d7d6ac37ce14ab962c299ea1218ef1b1489c98906c91323b94c587f1d205a6edd5e9d05b42d591c26494a6f6a029a2aadb5f8b6f67', '0x821a58092900bdb73decf48e13e7a5012a3f88b06288a97b855ef51306406e7d867d613d9ec738ebacfa6db344b677d21509d93f3b55c2ebf3a2f2a6356f875150554c6fff52e62e3e46f7859be971bf7dd9d5b3e1d799749c8a97c2e04325df', '0x8dba356577a3a388f782e90edb1a7f3619759f4de314ad5d95c7cc6e197211446819c4955f99c5fc67f79450d2934e3c09adefc91b724887e005c5190362245eec48ce117d0a94d6fa6db12eda4ba8dde608fbbd0051f54dcf3bb057adfb2493', '0xa32a690dc95c23ed9fb46443d9b7d4c2e27053a7fcc216d2b0020a8cf279729c46114d2cda5772fd60a97016a07d6c5a0a7eb085a18307d34194596f5b541cdf01b2ceb31d62d6b55515acfd2b9eec92b27d082fbc4dc59fc63b551eccdb8468', '0xa040f7f4be67eaf0a1d658a3175d65df21a7dbde99bfa893469b9b43b9d150fc2e333148b1cb88cfd0447d88fa1a501d126987e9fdccb2852ecf1ba907c2ca3d6f97b055e354a9789854a64ecc8c2e928382cf09dda9abde42bbdf92280cdd96', '0x864baff97fa60164f91f334e0c9be00a152a416556b462f96d7c43b59fe1ebaff42f0471d0bf264976f8aa6431176eb905bd875024cf4f76c13a70bede51dc3e47e10b9d5652d30d2663b3af3f08d5d11b9709a0321aba371d2ef13174dcfcaf', '0x95a46f32c994133ecc22db49bad2c36a281d6b574c83cfee6680b8c8100466ca034b815cfaedfbf54f4e75188e661df901abd089524e1e0eb0bf48d48caa9dd97482d2e8c1253e7e8ac250a32fd066d5b5cb08a8641bdd64ecfa48289dca83a3', '0xa2cce2be4d12144138cb91066e0cd0542c80b478bf467867ebef9ddaf3bd64e918294043500bf5a9f45ee089a8d6ace917108d9ce9e4f41e7e860cbce19ac52e791db3b6dde1c4b0367377b581f999f340e1d6814d724edc94cb07f9c4730774', '0xb145f203eee1ac0a1a1731113ffa7a8b0b694ef2312dabc4d431660f5e0645ef5838e3e624cfe1228cfa248d48b5760501f93e6ab13d3159fc241427116c4b90359599a4cb0a86d0bb9190aa7fabff482c812db966fd2ce0a1b48cb8ac8b3bca', '0xadabe5d215c608696e03861cbd5f7401869c756b3a5aadc55f41745ad9478145d44393fec8bb6dfc4ad9236dc62b9ada0f7ca57fe2bae1b71565dbf9536d33a68b8e2090b233422313cc96afc7f1f7e0907dc7787806671541d6de8ce47c4cd0', '0xae7845fa6b06db53201c1080e01e629781817f421f28956589c6df3091ec33754f8a4bd4647a6bb1c141ac22731e3c1014865d13f3ed538dcb0f7b7576435133d9d03be655f8fbb4c9f7d83e06d1210aedd45128c2b0c9bab45a9ddde1c862a5', '0x9159eaa826a24adfa7adf6e8d2832120ebb6eccbeb3d0459ffdc338548813a2d239d22b26451fda98cc0c204d8e1ac69150b5498e0be3045300e789bcb4e210d5cd431da4bdd915a21f407ea296c20c96608ded0b70d07188e96e6c1a7b9b86b', '0xa9fc6281e2d54b46458ef564ffaed6944bff71e389d0acc11fa35d3fcd8e10c1066e0dde5b9b6516f691bb478e81c6b20865281104dcb640e29dc116daae2e884f1fe6730d639dbe0e19a532be4fb337bf52ae8408446deb393d224eee7cfa50', '0x84291a42f991bfb36358eedead3699d9176a38f6f63757742fdbb7f631f2c70178b1aedef4912fed7b6cf27e88ddc7eb0e2a6aa4b999f3eb4b662b93f386c8d78e9ac9929e21f4c5e63b12991fcde93aa64a735b75b535e730ff8dd2abb16e04', '0xa1b7fcacae181495d91765dfddf26581e8e39421579c9cbd0dd27a40ea4c54af3444a36bf85a11dda2114246eaddbdd619397424bb1eb41b5a15004b902a590ede5742cd850cf312555be24d2df8becf48f5afba5a8cd087cb7be0a521728386', '0x92feaaf540dbd84719a4889a87cdd125b7e995a6782911931fef26da9afcfbe6f86aaf5328fe1f77631491ce6239c5470f44c7791506c6ef1626803a5794e76d2be0af92f7052c29ac6264b7b9b51f267ad820afc6f881460521428496c6a5f1', '0xa525c925bfae1b89320a5054acc1fa11820f73d0cf28d273092b305467b2831fab53b6daf75fb926f332782d50e2522a19edcd85be5eb72f1497193c952d8cd0bcc5d43b39363b206eae4cb1e61668bde28a3fb2fc1e0d3d113f6dfadb799717', '0x98752bb6f5a44213f40eda6aa4ff124057c1b13b6529ab42fe575b9afa66e59b9c0ed563fb20dff62130c436c3e905ee17dd8433ba02c445b1d67182ab6504a90bbe12c26a754bbf734665c622f76c62fe2e11dd43ce04fd2b91a8463679058b', '0xa9aa9a84729f7c44219ff9e00e651e50ddea3735ef2a73fdf8ed8cd271961d8ed7af5cd724b713a89a097a3fe65a3c0202f69458a8b4c157c62a85668b12fc0d3957774bc9b35f86c184dd03bfefd5c325da717d74192cc9751c2073fe9d170e', '0xb221c1fd335a4362eff504cd95145f122bf93ea02ae162a3fb39c75583fc13a932d26050e164da97cff3e91f9a7f6ff80302c19dd1916f24acf6b93b62f36e9665a8785413b0c7d930c7f1668549910f849bca319b00e59dd01e5dec8d2edacc', '0xa71e2b1e0b16d754b848f05eda90f67bedab37709550171551050c94efba0bfc282f72aeaaa1f0330041461f5e6aa4d11537237e955e1609a469d38ed17f5c2a35a1752f546db89bfeff9eab78ec944266f1cb94c1db3334ab48df716ce408ef', '0xb990ae72768779ba0b2e66df4dd29b3dbd00f901c23b2b4a53419226ef9232acedeb498b0d0687c463e3f1eead58b20b09efcefa566fbfdfe1c6e48d32367936142d0a734143e5e63cdf86be7457723535b787a9cfcfa32fe1d61ad5a2617220', '0x8d27e7fbff77d5b9b9bbc864d5231fecf817238a6433db668d5a62a2c1ee1e5694fdd90c3293c06cc0cb15f7cbeab44d0d42be632cb9ff41fc3f6628b4b62897797d7b56126d65b694dcf3e298e3561ac8813fbd7296593ced33850426df42db', '0xa92039a08b5502d5b211a7744099c9f93fa8c90cedcb1d05e92f01886219dd464eb5fb0337496ad96ed09c987da4e5f019035c5b01cc09b2a18b8a8dd419bc5895388a07e26958f6bd26751929c25f89b8eb4a299d822e2d26fec9ef350e0d3c', '0x92dcc5a1c8c3e1b28b1524e3dd6dbecd63017c9201da9dbe077f1b82adc08c50169f56fc7b5a3b28ec6b89254de3e2fd12838a761053437883c3e01ba616670cea843754548ef84bcc397de2369adcca2ab54cd73c55dc68d87aec3fc2fe4f10']
+    </spec>
+
+- name: MAX_CONCURRENT_REQUESTS#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: MAX_CONCURRENT_REQUESTS =
@@ -288,7 +372,14 @@
     MAX_CONCURRENT_REQUESTS = 2
     </spec>
 
-- name: NODE_ID_BITS
+- name: MAX_REQUEST_LIGHT_CLIENT_UPDATES#altair
+  sources: []
+  spec: |
+    <spec constant_var="MAX_REQUEST_LIGHT_CLIENT_UPDATES" fork="altair" hash="aa7e3917">
+    MAX_REQUEST_LIGHT_CLIENT_UPDATES = 2**7
+    </spec>
+
+- name: NODE_ID_BITS#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: NODE_ID_BITS =
@@ -297,7 +388,7 @@
     NODE_ID_BITS = 256
     </spec>
 
-- name: PARTICIPATION_FLAG_WEIGHTS
+- name: PARTICIPATION_FLAG_WEIGHTS#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/MiscHelpersAltair.java
       search: PARTICIPATION_FLAG_WEIGHTS =
@@ -327,7 +418,14 @@
     PAYLOAD_STATUS_PENDING: PayloadStatus = 0
     </spec>
 
-- name: PROPOSER_WEIGHT
+- name: PRIMITIVE_ROOT_OF_UNITY#deneb
+  sources: []
+  spec: |
+    <spec constant_var="PRIMITIVE_ROOT_OF_UNITY" fork="deneb" hash="004e6753">
+    PRIMITIVE_ROOT_OF_UNITY = 7
+    </spec>
+
+- name: PROPOSER_WEIGHT#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: PROPOSER_WEIGHT =
@@ -336,7 +434,21 @@
     PROPOSER_WEIGHT: uint64 = 8
     </spec>
 
-- name: SAFETY_DECAY
+- name: RANDOM_CHALLENGE_KZG_BATCH_DOMAIN#deneb
+  sources: []
+  spec: |
+    <spec constant_var="RANDOM_CHALLENGE_KZG_BATCH_DOMAIN" fork="deneb" hash="a994f6c6">
+    RANDOM_CHALLENGE_KZG_BATCH_DOMAIN = b'RCKZGBATCH___V1_'
+    </spec>
+
+- name: RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN#fulu
+  sources: []
+  spec: |
+    <spec constant_var="RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN" fork="fulu" hash="907a9534">
+    RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN = b'RCKZGCBATCH__V1_'
+    </spec>
+
+- name: SAFETY_DECAY#phase0
   sources:
     - file: ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfig.java
       search: SAFETY_DECAY =
@@ -345,7 +457,7 @@
     SAFETY_DECAY: uint64 = 10
     </spec>
 
-- name: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY
+- name: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY =
@@ -354,7 +466,7 @@
     SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY = 128
     </spec>
 
-- name: SYNC_COMMITTEE_SUBNET_COUNT
+- name: SYNC_COMMITTEE_SUBNET_COUNT#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: SYNC_COMMITTEE_SUBNET_COUNT =
@@ -363,7 +475,7 @@
     SYNC_COMMITTEE_SUBNET_COUNT = 4
     </spec>
 
-- name: SYNC_REWARD_WEIGHT
+- name: SYNC_REWARD_WEIGHT#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: SYNC_REWARD_WEIGHT =
@@ -372,7 +484,7 @@
     SYNC_REWARD_WEIGHT: uint64 = 2
     </spec>
 
-- name: TARGET_AGGREGATORS_PER_COMMITTEE
+- name: TARGET_AGGREGATORS_PER_COMMITTEE#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ValidatorConstants.java
       search: TARGET_AGGREGATORS_PER_COMMITTEE =
@@ -381,7 +493,7 @@
     TARGET_AGGREGATORS_PER_COMMITTEE = 2**4
     </spec>
 
-- name: TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE
+- name: TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ValidatorConstants.java
       search: TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE =
@@ -390,7 +502,7 @@
     TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE = 2**4
     </spec>
 
-- name: TIMELY_HEAD_FLAG_INDEX
+- name: TIMELY_HEAD_FLAG_INDEX#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
       search: TIMELY_HEAD_FLAG_INDEX =
@@ -399,7 +511,7 @@
     TIMELY_HEAD_FLAG_INDEX = 2
     </spec>
 
-- name: TIMELY_HEAD_WEIGHT
+- name: TIMELY_HEAD_WEIGHT#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: TIMELY_HEAD_WEIGHT =
@@ -408,7 +520,7 @@
     TIMELY_HEAD_WEIGHT: uint64 = 14
     </spec>
 
-- name: TIMELY_SOURCE_FLAG_INDEX
+- name: TIMELY_SOURCE_FLAG_INDEX#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
       search: TIMELY_SOURCE_FLAG_INDEX =
@@ -417,7 +529,7 @@
     TIMELY_SOURCE_FLAG_INDEX = 0
     </spec>
 
-- name: TIMELY_SOURCE_WEIGHT
+- name: TIMELY_SOURCE_WEIGHT#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: TIMELY_SOURCE_WEIGHT =
@@ -426,7 +538,7 @@
     TIMELY_SOURCE_WEIGHT: uint64 = 14
     </spec>
 
-- name: TIMELY_TARGET_FLAG_INDEX
+- name: TIMELY_TARGET_FLAG_INDEX#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
       search: TIMELY_TARGET_FLAG_INDEX =
@@ -435,7 +547,7 @@
     TIMELY_TARGET_FLAG_INDEX = 1
     </spec>
 
-- name: TIMELY_TARGET_WEIGHT
+- name: TIMELY_TARGET_WEIGHT#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: TIMELY_TARGET_WEIGHT =
@@ -444,7 +556,28 @@
     TIMELY_TARGET_WEIGHT: uint64 = 26
     </spec>
 
-- name: UNSET_DEPOSIT_REQUESTS_START_INDEX
+- name: UINT256_MAX#fulu
+  sources: []
+  spec: |
+    <spec constant_var="UINT256_MAX" fork="fulu" hash="57a47f45">
+    UINT256_MAX: uint256 = 2**256 - 1
+    </spec>
+
+- name: UINT64_MAX#phase0
+  sources: []
+  spec: |
+    <spec constant_var="UINT64_MAX" fork="phase0" hash="0efe6bd6">
+    UINT64_MAX: uint64 = 2**64 - 1
+    </spec>
+
+- name: UINT64_MAX_SQRT#phase0
+  sources: []
+  spec: |
+    <spec constant_var="UINT64_MAX_SQRT" fork="phase0" hash="28d7e92a">
+    UINT64_MAX_SQRT: uint64 = 4294967295
+    </spec>
+
+- name: UNSET_DEPOSIT_REQUESTS_START_INDEX#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
       search: UNSET_DEPOSIT_REQUESTS_START_INDEX =
@@ -453,7 +586,7 @@
     UNSET_DEPOSIT_REQUESTS_START_INDEX: uint64 = 2**64 - 1
     </spec>
 
-- name: VERSIONED_HASH_VERSION_KZG
+- name: VERSIONED_HASH_VERSION_KZG#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
       search: VERSIONED_HASH_VERSION_KZG =
@@ -462,7 +595,7 @@
     VERSIONED_HASH_VERSION_KZG: Bytes1 = '0x01'
     </spec>
 
-- name: WEIGHT_DENOMINATOR
+- name: WEIGHT_DENOMINATOR#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: WEIGHT_DENOMINATOR =
@@ -471,7 +604,7 @@
     WEIGHT_DENOMINATOR: uint64 = 64
     </spec>
 
-- name: WITHDRAWAL_REQUEST_TYPE
+- name: WITHDRAWAL_REQUEST_TYPE#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/WithdrawalRequest.java
       search: REQUEST_TYPE =

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -1,4 +1,4 @@
-- name: AggregateAndProof
+- name: AggregateAndProof#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProof.java
   spec: |
@@ -16,7 +16,19 @@
         selection_proof: BLSSignature
     </spec>
 
-- name: AttestationPhase0
+- name: AggregateAndProof#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProof.java
+  spec: |
+    <spec container="AggregateAndProof" fork="electra" hash="a7f482d7">
+    class AggregateAndProof(Container):
+        aggregator_index: ValidatorIndex
+        # [Modified in Electra:EIP7549]
+        aggregate: Attestation
+        selection_proof: BLSSignature
+    </spec>
+
+- name: Attestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
@@ -30,7 +42,7 @@
         signature: BLSSignature
     </spec>
 
-- name: AttestationElectra
+- name: Attestation#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Attestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSchema.java
@@ -47,7 +59,7 @@
         committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]
     </spec>
 
-- name: AttestationData
+- name: AttestationData#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationData.java
   spec: |
@@ -60,7 +72,7 @@
         target: Checkpoint
     </spec>
 
-- name: AttesterSlashing
+- name: AttesterSlashing#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashing.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSchema.java
@@ -70,6 +82,12 @@
         attestation_1: IndexedAttestation
         attestation_2: IndexedAttestation
     </spec>
+
+- name: AttesterSlashing#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashing.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSchema.java
+  spec: |
     <spec container="AttesterSlashing" fork="electra" hash="2b9f773d">
     class AttesterSlashing(Container):
         # [Modified in Electra:EIP7549]
@@ -78,7 +96,7 @@
         attestation_2: IndexedAttestation
     </spec>
 
-- name: BLSToExecutionChange
+- name: BLSToExecutionChange#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/BlsToExecutionChange.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/BlsToExecutionChangeSchema.java
@@ -90,7 +108,7 @@
         to_execution_address: ExecutionAddress
     </spec>
 
-- name: BeaconBlock
+- name: BeaconBlock#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlock.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockSchema.java
@@ -104,7 +122,7 @@
         body: BeaconBlockBody
     </spec>
 
-- name: BeaconBlockBodyPhase0
+- name: BeaconBlockBody#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
@@ -122,7 +140,7 @@
         voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
     </spec>
 
-- name: BeaconBlockBodyAltair
+- name: BeaconBlockBody#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltair.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairImpl.java
@@ -144,7 +162,7 @@
         sync_aggregate: SyncAggregate
     </spec>
 
-- name: BeaconBlockBodyBellatrix
+- name: BeaconBlockBody#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixImpl.java
@@ -167,7 +185,7 @@
         execution_payload: ExecutionPayload
     </spec>
 
-- name: BeaconBlockBodyCapella
+- name: BeaconBlockBody#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaImpl.java
@@ -191,7 +209,7 @@
         bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
     </spec>
 
-- name: BeaconBlockBodyDeneb
+- name: BeaconBlockBody#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebImpl.java
@@ -217,7 +235,7 @@
         blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     </spec>
 
-- name: BeaconBlockBodyElectra
+- name: BeaconBlockBody#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodyElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/electra/BeaconBlockBodyElectraImpl.java
@@ -245,7 +263,7 @@
         execution_requests: ExecutionRequests
     </spec>
 
-- name: BeaconBlockBodyGloas
+- name: BeaconBlockBody#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloasImpl.java
@@ -277,7 +295,7 @@
         payload_attestations: List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]
     </spec>
 
-- name: BeaconBlockHeader
+- name: BeaconBlockHeader#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeader.java
   spec: |
@@ -290,7 +308,7 @@
         body_root: Root
     </spec>
 
-- name: BeaconStatePhase0
+- name: BeaconState#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Impl.java
@@ -323,7 +341,7 @@
         finalized_checkpoint: Checkpoint
     </spec>
 
-- name: BeaconStateAltair
+- name: BeaconState#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltair.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltairImpl.java
@@ -364,7 +382,7 @@
         next_sync_committee: SyncCommittee
     </spec>
 
-- name: BeaconStateBellatrix
+- name: BeaconState#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrixImpl.java
@@ -402,7 +420,7 @@
         latest_execution_payload_header: ExecutionPayloadHeader
     </spec>
 
-- name: BeaconStateCapella
+- name: BeaconState#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaImpl.java
@@ -446,7 +464,7 @@
         historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
     </spec>
 
-- name: BeaconStateDeneb
+- name: BeaconState#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/BeaconStateDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/BeaconStateDenebImpl.java
@@ -487,7 +505,7 @@
         historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
     </spec>
 
-- name: BeaconStateElectra
+- name: BeaconState#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/BeaconStateElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/BeaconStateElectraImpl.java
@@ -545,7 +563,7 @@
         pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
     </spec>
 
-- name: BeaconStateFulu
+- name: BeaconState#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/BeaconStateFulu.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/BeaconStateFuluImpl.java
@@ -596,7 +614,7 @@
         proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
     </spec>
 
-- name: BeaconStateGloas
+- name: BeaconState#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloasImpl.java
@@ -659,7 +677,7 @@
         latest_withdrawals_root: Root
     </spec>
 
-- name: BlobIdentifier
+- name: BlobIdentifier#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobIdentifier.java
   spec: |
@@ -669,7 +687,7 @@
         index: BlobIndex
     </spec>
 
-- name: BlobSidecar
+- name: BlobSidecar#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecar.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarSchema.java
@@ -684,7 +702,7 @@
         kzg_commitment_inclusion_proof: Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]
     </spec>
 
-- name: BuilderPendingPayment
+- name: BuilderPendingPayment#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPayment.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPaymentSchema.java
@@ -695,7 +713,7 @@
         withdrawal: BuilderPendingWithdrawal
     </spec>
 
-- name: BuilderPendingWithdrawal
+- name: BuilderPendingWithdrawal#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingWithdrawal.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingWithdrawalSchema.java
@@ -708,7 +726,7 @@
         withdrawable_epoch: Epoch
     </spec>
 
-- name: Checkpoint
+- name: Checkpoint#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Checkpoint.java
   spec: |
@@ -718,7 +736,7 @@
         root: Root
     </spec>
 
-- name: ConsolidationRequest
+- name: ConsolidationRequest#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ConsolidationRequest.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ConsolidationRequestSchema.java
@@ -730,7 +748,7 @@
         target_pubkey: BLSPubkey
     </spec>
 
-- name: ContributionAndProof
+- name: ContributionAndProof#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProof.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProofSchema.java
@@ -742,7 +760,7 @@
         selection_proof: BLSSignature
     </spec>
 
-- name: DataColumnSidecarFulu
+- name: DataColumnSidecar#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarFulu.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecarSchemaFulu.java
@@ -757,7 +775,7 @@
         kzg_commitments_inclusion_proof: Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH]
     </spec>
 
-- name: DataColumnSidecarGloas
+- name: DataColumnSidecar#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarSchemaGloas.java
@@ -778,7 +796,7 @@
         beacon_block_root: Root
     </spec>
 
-- name: DataColumnsByRootIdentifier
+- name: DataColumnsByRootIdentifier#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/DataColumnsByRootIdentifier.java
   spec: |
@@ -788,7 +806,7 @@
         columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
     </spec>
 
-- name: Deposit
+- name: Deposit#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Deposit.java
   spec: |
@@ -798,7 +816,7 @@
         data: DepositData
     </spec>
 
-- name: DepositData
+- name: DepositData#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositData.java
   spec: |
@@ -810,7 +828,7 @@
         signature: BLSSignature
     </spec>
 
-- name: DepositMessage
+- name: DepositMessage#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessage.java
   spec: |
@@ -821,7 +839,7 @@
         amount: Gwei
     </spec>
 
-- name: DepositRequest
+- name: DepositRequest#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/DepositRequest.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/DepositRequestSchema.java
@@ -835,7 +853,17 @@
         index: uint64
     </spec>
 
-- name: Eth1Data
+- name: Eth1Block#phase0
+  sources: []
+  spec: |
+    <spec container="Eth1Block" fork="phase0" hash="0a5c6b45">
+    class Eth1Block(Container):
+        timestamp: uint64
+        deposit_root: Root
+        deposit_count: uint64
+    </spec>
+
+- name: Eth1Data#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1Data.java
   spec: |
@@ -846,7 +874,7 @@
         block_hash: Hash32
     </spec>
 
-- name: ExecutionPayloadBellatrix
+- name: ExecutionPayload#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBuilderBellatrix.java
@@ -870,7 +898,7 @@
         transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     </spec>
 
-- name: ExecutionPayloadCapella
+- name: ExecutionPayload#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadCapellaImpl.java
@@ -897,7 +925,7 @@
         withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     </spec>
 
-- name: ExecutionPayloadDeneb
+- name: ExecutionPayload#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadDenebImpl.java
@@ -927,7 +955,7 @@
         excess_blob_gas: uint64
     </spec>
 
-- name: ExecutionPayloadBid
+- name: ExecutionPayloadBid#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
@@ -945,7 +973,7 @@
         blob_kzg_commitments_root: Root
     </spec>
 
-- name: ExecutionPayloadEnvelope
+- name: ExecutionPayloadEnvelope#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelope.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelopeSchema.java
@@ -961,7 +989,7 @@
         state_root: Root
     </spec>
 
-- name: ExecutionPayloadHeaderBellatrix
+- name: ExecutionPayloadHeader#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBuilderBellatrix.java
@@ -985,7 +1013,7 @@
         transactions_root: Root
     </spec>
 
-- name: ExecutionPayloadHeaderCapella
+- name: ExecutionPayloadHeader#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderCapellaImpl.java
@@ -1012,7 +1040,7 @@
         withdrawals_root: Root
     </spec>
 
-- name: ExecutionPayloadHeaderDeneb
+- name: ExecutionPayloadHeader#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderDenebImpl.java
@@ -1042,7 +1070,7 @@
         excess_blob_gas: uint64
     </spec>
 
-- name: ExecutionRequests
+- name: ExecutionRequests#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequests.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsBuilderElectra.java
@@ -1058,7 +1086,7 @@
         consolidations: List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
     </spec>
 
-- name: Fork
+- name: Fork#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Fork.java
   spec: |
@@ -1069,7 +1097,16 @@
         epoch: Epoch
     </spec>
 
-- name: ForkData
+- name: ForkChoiceNode#gloas
+  sources: []
+  spec: |
+    <spec container="ForkChoiceNode" fork="gloas" hash="755a4b34">
+    class ForkChoiceNode(Container):
+        root: Root
+        payload_status: PayloadStatus  # One of PAYLOAD_STATUS_* values
+    </spec>
+
+- name: ForkData#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/ForkData.java
   spec: |
@@ -1079,7 +1116,7 @@
         genesis_validators_root: Root
     </spec>
 
-- name: HistoricalBatch
+- name: HistoricalBatch#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/HistoricalBatch.java
   spec: |
@@ -1089,7 +1126,7 @@
         state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
     </spec>
 
-- name: HistoricalSummary
+- name: HistoricalSummary#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/capella/HistoricalSummary.java
   spec: |
@@ -1099,7 +1136,7 @@
         state_summary_root: Root
     </spec>
 
-- name: IndexedAttestation
+- name: IndexedAttestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
@@ -1112,7 +1149,7 @@
         signature: BLSSignature
     </spec>
 
-- name: IndexedAttestationElectra
+- name: IndexedAttestation#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSchema.java
@@ -1126,7 +1163,7 @@
         signature: BLSSignature
     </spec>
 
-- name: IndexedPayloadAttestation
+- name: IndexedPayloadAttestation#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/IndexedPayloadAttestationSchema.java
@@ -1138,7 +1175,7 @@
         signature: BLSSignature
     </spec>
 
-- name: LightClientBootstrap
+- name: LightClientBootstrap#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientBootstrap.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientBootstrapSchema.java
@@ -1152,7 +1189,37 @@
         current_sync_committee_branch: CurrentSyncCommitteeBranch
     </spec>
 
-- name: LightClientHeader
+- name: LightClientBootstrap#capella
+  sources: []
+  spec: |
+    <spec container="LightClientBootstrap" fork="capella" style="diff" hash="85f4f5fe">
+
+    </spec>
+
+- name: LightClientFinalityUpdate#altair
+  sources: []
+  spec: |
+    <spec container="LightClientFinalityUpdate" fork="altair" hash="d392e9f3">
+    class LightClientFinalityUpdate(Container):
+        # Header attested to by the sync committee
+        attested_header: LightClientHeader
+        # Finalized header corresponding to `attested_header.beacon.state_root`
+        finalized_header: LightClientHeader
+        finality_branch: FinalityBranch
+        # Sync committee aggregate signature
+        sync_aggregate: SyncAggregate
+        # Slot at which the aggregate signature was created (untrusted)
+        signature_slot: Slot
+    </spec>
+
+- name: LightClientFinalityUpdate#capella
+  sources: []
+  spec: |
+    <spec container="LightClientFinalityUpdate" fork="capella" style="diff" hash="9d2b55dd">
+
+    </spec>
+
+- name: LightClientHeader#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientHeader.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientHeaderSchema.java
@@ -1162,7 +1229,40 @@
         beacon: BeaconBlockHeader
     </spec>
 
-- name: LightClientUpdate
+- name: LightClientHeader#capella
+  sources: []
+  spec: |
+    <spec container="LightClientHeader" fork="capella" style="diff" hash="b625e61e">
+    --- altair
+    +++ capella
+    @@ -1,2 +1,4 @@
+     class LightClientHeader(Container):
+         beacon: BeaconBlockHeader
+    +    execution: ExecutionPayloadHeader
+    +    execution_branch: ExecutionBranch
+    </spec>
+
+- name: LightClientOptimisticUpdate#altair
+  sources: []
+  spec: |
+    <spec container="LightClientOptimisticUpdate" fork="altair" hash="0818d65f">
+    class LightClientOptimisticUpdate(Container):
+        # Header attested to by the sync committee
+        attested_header: LightClientHeader
+        # Sync committee aggregate signature
+        sync_aggregate: SyncAggregate
+        # Slot at which the aggregate signature was created (untrusted)
+        signature_slot: Slot
+    </spec>
+
+- name: LightClientOptimisticUpdate#capella
+  sources: []
+  spec: |
+    <spec container="LightClientOptimisticUpdate" fork="capella" style="diff" hash="bdce7b1d">
+
+    </spec>
+
+- name: LightClientUpdate#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdate.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateSchema.java
@@ -1183,7 +1283,14 @@
         signature_slot: Slot
     </spec>
 
-- name: MatrixEntry
+- name: LightClientUpdate#capella
+  sources: []
+  spec: |
+    <spec container="LightClientUpdate" fork="capella" style="diff" hash="8d215165">
+
+    </spec>
+
+- name: MatrixEntry#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/MatrixEntry.java
   spec: |
@@ -1195,7 +1302,7 @@
         row_index: RowIndex
     </spec>
 
-- name: PayloadAttestation
+- name: PayloadAttestation#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationSchema.java
@@ -1207,7 +1314,7 @@
         signature: BLSSignature
     </spec>
 
-- name: PayloadAttestationData
+- name: PayloadAttestationData#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationData.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationDataSchema.java
@@ -1220,7 +1327,7 @@
         blob_data_available: boolean
     </spec>
 
-- name: PayloadAttestationMessage
+- name: PayloadAttestationMessage#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationMessage.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationMessageSchema.java
@@ -1232,7 +1339,7 @@
         signature: BLSSignature
     </spec>
 
-- name: PendingAttestation
+- name: PendingAttestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/PendingAttestation.java
   spec: |
@@ -1244,7 +1351,7 @@
         proposer_index: ValidatorIndex
     </spec>
 
-- name: PendingConsolidation
+- name: PendingConsolidation#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingConsolidation.java
   spec: |
@@ -1254,7 +1361,7 @@
         target_index: ValidatorIndex
     </spec>
 
-- name: PendingDeposit
+- name: PendingDeposit#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingDeposit.java
   spec: |
@@ -1267,7 +1374,7 @@
         slot: Slot
     </spec>
 
-- name: PendingPartialWithdrawal
+- name: PendingPartialWithdrawal#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingPartialWithdrawal.java
   spec: |
@@ -1278,7 +1385,7 @@
         withdrawable_epoch: Epoch
     </spec>
 
-- name: PowBlock
+- name: PowBlock#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/PowBlock.java
   spec: |
@@ -1289,7 +1396,7 @@
         total_difficulty: uint256
     </spec>
 
-- name: ProposerSlashing
+- name: ProposerSlashing#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashing.java
   spec: |
@@ -1299,7 +1406,7 @@
         signed_header_2: SignedBeaconBlockHeader
     </spec>
 
-- name: SignedAggregateAndProof
+- name: SignedAggregateAndProof#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProof.java
   spec: |
@@ -1315,7 +1422,18 @@
         signature: BLSSignature
     </spec>
 
-- name: SignedBLSToExecutionChange
+- name: SignedAggregateAndProof#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProof.java
+  spec: |
+    <spec container="SignedAggregateAndProof" fork="electra" hash="7e784e12">
+    class SignedAggregateAndProof(Container):
+        # [Modified in Electra:EIP7549]
+        message: AggregateAndProof
+        signature: BLSSignature
+    </spec>
+
+- name: SignedBLSToExecutionChange#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedBlsToExecutionChange.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedBlsToExecutionChangeSchema.java
@@ -1326,7 +1444,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SignedBeaconBlock
+- name: SignedBeaconBlock#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSchema.java
@@ -1337,7 +1455,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SignedBeaconBlockHeader
+- name: SignedBeaconBlockHeader#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeader.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderSchema.java
@@ -1348,7 +1466,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SignedContributionAndProof
+- name: SignedContributionAndProof#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SignedContributionAndProof.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SignedContributionAndProofSchema.java
@@ -1359,7 +1477,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SignedExecutionPayloadBid
+- name: SignedExecutionPayloadBid#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBid.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBidSchema.java
@@ -1370,7 +1488,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SignedExecutionPayloadEnvelope
+- name: SignedExecutionPayloadEnvelope#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelopeSchema.java
@@ -1381,7 +1499,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SignedVoluntaryExit
+- name: SignedVoluntaryExit#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExit.java
   spec: |
@@ -1391,7 +1509,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SigningData
+- name: SigningData#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/SigningData.java
   spec: |
@@ -1401,7 +1519,7 @@
         domain: Domain
     </spec>
 
-- name: SingleAttestation
+- name: SingleAttestation#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SingleAttestationSchema.java
@@ -1414,7 +1532,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SyncAggregate
+- name: SyncAggregate#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregate.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregateSchema.java
@@ -1425,7 +1543,7 @@
         sync_committee_signature: BLSSignature
     </spec>
 
-- name: SyncAggregatorSelectionData
+- name: SyncAggregatorSelectionData#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncAggregatorSelectionData.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncAggregatorSelectionDataSchema.java
@@ -1436,7 +1554,7 @@
         subcommittee_index: uint64
     </spec>
 
-- name: SyncCommittee
+- name: SyncCommittee#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/SyncCommittee.java
   spec: |
@@ -1446,7 +1564,7 @@
         aggregate_pubkey: BLSPubkey
     </spec>
 
-- name: SyncCommitteeContribution
+- name: SyncCommitteeContribution#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContribution.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContributionSchema.java
@@ -1460,7 +1578,7 @@
         signature: BLSSignature
     </spec>
 
-- name: SyncCommitteeMessage
+- name: SyncCommitteeMessage#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeMessage.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeMessageSchema.java
@@ -1473,7 +1591,7 @@
         signature: BLSSignature
     </spec>
 
-- name: Validator
+- name: Validator#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
   spec: |
@@ -1489,7 +1607,7 @@
         withdrawable_epoch: Epoch
     </spec>
 
-- name: VoluntaryExit
+- name: VoluntaryExit#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExit.java
   spec: |
@@ -1499,7 +1617,7 @@
         validator_index: ValidatorIndex
     </spec>
 
-- name: Withdrawal
+- name: Withdrawal#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/Withdrawal.java
   spec: |
@@ -1511,7 +1629,7 @@
         amount: Gwei
     </spec>
 
-- name: WithdrawalRequest
+- name: WithdrawalRequest#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/WithdrawalRequest.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/WithdrawalRequestSchema.java

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -1,4 +1,4 @@
-- name: BlobParameters
+- name: BlobParameters#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BlobParameters.java
   spec: |
@@ -8,7 +8,7 @@
         max_blobs_per_block: uint64
     </spec>
 
-- name: BlobsBundleDeneb
+- name: BlobsBundle#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BlobsBundle.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BlobsBundleSchema.java
@@ -22,7 +22,7 @@
         blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     </spec>
 
-- name: BlobsBundleFulu
+- name: BlobsBundle#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BlobsBundle.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BlobsBundleSchema.java
@@ -37,7 +37,7 @@
         blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     </spec>
 
-- name: GetPayloadResponseV1
+- name: GetPayloadResponse#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV1.java
@@ -47,7 +47,7 @@
         execution_payload: ExecutionPayload
     </spec>
 
-- name: GetPayloadResponseV2
+- name: GetPayloadResponse#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
@@ -58,7 +58,7 @@
         block_value: uint256
     </spec>
 
-- name: GetPayloadResponseV3
+- name: GetPayloadResponse#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV3Response.java
@@ -71,7 +71,7 @@
         blobs_bundle: BlobsBundle
     </spec>
 
-- name: GetPayloadResponseV4
+- name: GetPayloadResponse#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
@@ -85,7 +85,7 @@
         execution_requests: Sequence[bytes]
     </spec>
 
-- name: GetPayloadResponseV5
+- name: GetPayloadResponse#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV5Response.java
@@ -99,7 +99,58 @@
         execution_requests: Sequence[bytes]
     </spec>
 
-- name: NewPayloadRequest
+- name: LatestMessage#phase0
+  sources: []
+  spec: |
+    <spec dataclass="LatestMessage" fork="phase0" hash="44e832d0">
+    @dataclass(eq=True, frozen=True)
+    class LatestMessage(object):
+        epoch: Epoch
+        root: Root
+    </spec>
+
+- name: LatestMessage#gloas
+  sources: []
+  spec: |
+    <spec dataclass="LatestMessage" fork="gloas" style="diff" hash="a0030894">
+    --- phase0
+    +++ gloas
+    @@ -1,4 +1,5 @@
+     @dataclass(eq=True, frozen=True)
+     class LatestMessage(object):
+    -    epoch: Epoch
+    +    slot: Slot
+         root: Root
+    +    payload_present: boolean
+    </spec>
+
+- name: LightClientStore#altair
+  sources: []
+  spec: |
+    <spec dataclass="LightClientStore" fork="altair" hash="24725cec">
+    class LightClientStore(object):
+        # Header that is finalized
+        finalized_header: LightClientHeader
+        # Sync committees corresponding to the finalized header
+        current_sync_committee: SyncCommittee
+        next_sync_committee: SyncCommittee
+        # Best available header to switch finalized head to if we see nothing else
+        best_valid_update: Optional[LightClientUpdate]
+        # Most recent available reasonably-safe header
+        optimistic_header: LightClientHeader
+        # Max number of active participants in a sync committee (used to calculate safety threshold)
+        previous_max_active_participants: uint64
+        current_max_active_participants: uint64
+    </spec>
+
+- name: LightClientStore#capella
+  sources: []
+  spec: |
+    <spec dataclass="LightClientStore" fork="capella" style="diff" hash="04b41062">
+
+    </spec>
+
+- name: NewPayloadRequest#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
   spec: |
@@ -107,12 +158,22 @@
     class NewPayloadRequest(object):
         execution_payload: ExecutionPayload
     </spec>
+
+- name: NewPayloadRequest#deneb
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
+  spec: |
     <spec dataclass="NewPayloadRequest" fork="deneb" hash="26cf2e26">
     class NewPayloadRequest(object):
         execution_payload: ExecutionPayload
         versioned_hashes: Sequence[VersionedHash]
         parent_beacon_block_root: Root
     </spec>
+
+- name: NewPayloadRequest#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
+  spec: |
     <spec dataclass="NewPayloadRequest" fork="electra" hash="b1f69cc9">
     class NewPayloadRequest(object):
         execution_payload: ExecutionPayload
@@ -122,7 +183,18 @@
         execution_requests: ExecutionRequests
     </spec>
 
-- name: PayloadAttributesV1
+- name: OptimisticStore#bellatrix
+  sources: []
+  spec: |
+    <spec dataclass="OptimisticStore" fork="bellatrix" hash="a2b2182c">
+    class OptimisticStore(object):
+        optimistic_roots: Set[Root]
+        head_block_root: Root
+        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
+        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+    </spec>
+
+- name: PayloadAttributes#bellatrix
   sources:
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV1.java
   spec: |
@@ -133,7 +205,7 @@
         suggested_fee_recipient: ExecutionAddress
     </spec>
 
-- name: PayloadAttributesV2
+- name: PayloadAttributes#capella
   sources:
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
   spec: |
@@ -146,7 +218,7 @@
         withdrawals: Sequence[Withdrawal]
     </spec>
 
-- name: PayloadAttributesV3
+- name: PayloadAttributes#deneb
   sources:
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
   spec: |
@@ -158,4 +230,39 @@
         withdrawals: Sequence[Withdrawal]
         # [New in Deneb:EIP4788]
         parent_beacon_block_root: Root
+    </spec>
+
+- name: Store#phase0
+  sources: []
+  spec: |
+    <spec dataclass="Store" fork="phase0" hash="abe525d6">
+    class Store(object):
+        time: uint64
+        genesis_time: uint64
+        justified_checkpoint: Checkpoint
+        finalized_checkpoint: Checkpoint
+        unrealized_justified_checkpoint: Checkpoint
+        unrealized_finalized_checkpoint: Checkpoint
+        proposer_boost_root: Root
+        equivocating_indices: Set[ValidatorIndex]
+        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
+        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+        block_timeliness: Dict[Root, boolean] = field(default_factory=dict)
+        checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
+        latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
+        unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+    </spec>
+
+- name: Store#gloas
+  sources: []
+  spec: |
+    <spec dataclass="Store" fork="gloas" style="diff" hash="d979eb1c">
+    --- phase0
+    +++ gloas
+    @@ -13,3 +13,5 @@
+         checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
+         latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
+         unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+    +    execution_payload_states: Dict[Root, BeaconState] = field(default_factory=dict)
+    +    ptc_vote: Dict[Root, Vector[boolean, PTC_SIZE]] = field(default_factory=dict)
     </spec>

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1,4 +1,23 @@
-- name: add_flag
+- name: _fft_field#fulu
+  sources: []
+  spec: |
+    <spec fn="_fft_field" fork="fulu" hash="d9de8aaf">
+    def _fft_field(
+        vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement]
+    ) -> Sequence[BLSFieldElement]:
+        if len(vals) == 1:
+            return vals
+        L = _fft_field(vals[::2], roots_of_unity[::2])
+        R = _fft_field(vals[1::2], roots_of_unity[::2])
+        o = [BLSFieldElement(0) for _ in vals]
+        for i, (x, y) in enumerate(zip(L, R)):
+            y_times_root = y * roots_of_unity[i]
+            o[i] = x + y_times_root
+            o[i + len(L)] = x - y_times_root
+        return o
+    </spec>
+
+- name: add_flag#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/MiscHelpersAltair.java
       search: public byte addFlag(
@@ -10,6 +29,21 @@
         """
         flag = ParticipationFlags(2**flag_index)
         return flags | flag
+    </spec>
+
+- name: add_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="add_polynomialcoeff" fork="fulu" hash="a1ecc770">
+    def add_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoeff:
+        """
+        Sum the coefficient form polynomials ``a`` and ``b``.
+        """
+        a, b = (a, b) if len(a) >= len(b) else (b, a)
+        length_a, length_b = len(a), len(b)
+        return PolynomialCoeff(
+            [a[i] + (b[i] if i < length_b else BLSFieldElement(0)) for i in range(length_a)]
+        )
     </spec>
 
 - name: add_validator_to_registry#phase0
@@ -42,6 +76,13 @@
         set_or_append_list(state.previous_epoch_participation, index, ParticipationFlags(0b0000_0000))
         set_or_append_list(state.current_epoch_participation, index, ParticipationFlags(0b0000_0000))
         set_or_append_list(state.inactivity_scores, index, uint64(0))
+    </spec>
+
+- name: add_validator_to_registry#electra
+  sources: []
+  spec: |
+    <spec fn="add_validator_to_registry" fork="electra" style="diff" hash="7970ce24">
+
     </spec>
 
 - name: apply_deposit#phase0
@@ -111,7 +152,30 @@
         )
     </spec>
 
-- name: apply_pending_deposit
+- name: apply_light_client_update#altair
+  sources: []
+  spec: |
+    <spec fn="apply_light_client_update" fork="altair" hash="211a52c9">
+    def apply_light_client_update(store: LightClientStore, update: LightClientUpdate) -> None:
+        store_period = compute_sync_committee_period_at_slot(store.finalized_header.beacon.slot)
+        update_finalized_period = compute_sync_committee_period_at_slot(
+            update.finalized_header.beacon.slot
+        )
+        if not is_next_sync_committee_known(store):
+            assert update_finalized_period == store_period
+            store.next_sync_committee = update.next_sync_committee
+        elif update_finalized_period == store_period + 1:
+            store.current_sync_committee = store.next_sync_committee
+            store.next_sync_committee = update.next_sync_committee
+            store.previous_max_active_participants = store.current_max_active_participants
+            store.current_max_active_participants = 0
+        if update.finalized_header.beacon.slot > store.finalized_header.beacon.slot:
+            store.finalized_header = update.finalized_header
+            if store.finalized_header.beacon.slot > store.optimistic_header.beacon.slot:
+                store.optimistic_header = store.finalized_header
+    </spec>
+
+- name: apply_pending_deposit#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void applyPendingDeposits(
@@ -135,7 +199,179 @@
             increase_balance(state, validator_index, deposit.amount)
     </spec>
 
-- name: bytes_to_uint64
+- name: bit_reversal_permutation#deneb
+  sources: []
+  spec: |
+    <spec fn="bit_reversal_permutation" fork="deneb" hash="fac0c3df">
+    def bit_reversal_permutation(sequence: Sequence[T]) -> Sequence[T]:
+        """
+        Return a copy with bit-reversed permutation. The permutation is an involution (inverts itself).
+
+        The input and output are a sequence of generic type ``T`` objects.
+        """
+        return [sequence[reverse_bits(i, len(sequence))] for i in range(len(sequence))]
+    </spec>
+
+- name: blob_to_kzg_commitment#deneb
+  sources: []
+  spec: |
+    <spec fn="blob_to_kzg_commitment" fork="deneb" hash="7242a6a3">
+    def blob_to_kzg_commitment(blob: Blob) -> KZGCommitment:
+        """
+        Public method.
+        """
+        assert len(blob) == BYTES_PER_BLOB
+        return g1_lincomb(bit_reversal_permutation(KZG_SETUP_G1_LAGRANGE), blob_to_polynomial(blob))
+    </spec>
+
+- name: blob_to_polynomial#deneb
+  sources: []
+  spec: |
+    <spec fn="blob_to_polynomial" fork="deneb" hash="2e36fb31">
+    def blob_to_polynomial(blob: Blob) -> Polynomial:
+        """
+        Convert a blob to list of BLS field scalars.
+        """
+        polynomial = Polynomial()
+        for i in range(FIELD_ELEMENTS_PER_BLOB):
+            value = bytes_to_bls_field(
+                blob[i * BYTES_PER_FIELD_ELEMENT : (i + 1) * BYTES_PER_FIELD_ELEMENT]
+            )
+            polynomial[i] = value
+        return polynomial
+    </spec>
+
+- name: block_to_light_client_header#altair
+  sources: []
+  spec: |
+    <spec fn="block_to_light_client_header" fork="altair" hash="94342f64">
+    def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
+        return LightClientHeader(
+            beacon=BeaconBlockHeader(
+                slot=block.message.slot,
+                proposer_index=block.message.proposer_index,
+                parent_root=block.message.parent_root,
+                state_root=block.message.state_root,
+                body_root=hash_tree_root(block.message.body),
+            ),
+        )
+    </spec>
+
+- name: block_to_light_client_header#capella
+  sources: []
+  spec: |
+    <spec fn="block_to_light_client_header" fork="capella" style="diff" hash="597ddeac">
+    --- altair
+    +++ capella
+    @@ -1,4 +1,32 @@
+     def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
+    +    epoch = compute_epoch_at_slot(block.message.slot)
+    +
+    +    if epoch >= CAPELLA_FORK_EPOCH:
+    +        payload = block.message.body.execution_payload
+    +        execution_header = ExecutionPayloadHeader(
+    +            parent_hash=payload.parent_hash,
+    +            fee_recipient=payload.fee_recipient,
+    +            state_root=payload.state_root,
+    +            receipts_root=payload.receipts_root,
+    +            logs_bloom=payload.logs_bloom,
+    +            prev_randao=payload.prev_randao,
+    +            block_number=payload.block_number,
+    +            gas_limit=payload.gas_limit,
+    +            gas_used=payload.gas_used,
+    +            timestamp=payload.timestamp,
+    +            extra_data=payload.extra_data,
+    +            base_fee_per_gas=payload.base_fee_per_gas,
+    +            block_hash=payload.block_hash,
+    +            transactions_root=hash_tree_root(payload.transactions),
+    +            withdrawals_root=hash_tree_root(payload.withdrawals),
+    +        )
+    +        execution_branch = ExecutionBranch(
+    +            compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX)
+    +        )
+    +    else:
+    +        execution_header = ExecutionPayloadHeader()
+    +        execution_branch = ExecutionBranch()
+    +
+         return LightClientHeader(
+             beacon=BeaconBlockHeader(
+                 slot=block.message.slot,
+    @@ -7,4 +35,6 @@
+                 state_root=block.message.state_root,
+                 body_root=hash_tree_root(block.message.body),
+             ),
+    +        execution=execution_header,
+    +        execution_branch=execution_branch,
+         )
+    </spec>
+
+- name: block_to_light_client_header#deneb
+  sources: []
+  spec: |
+    <spec fn="block_to_light_client_header" fork="deneb" style="diff" hash="b5ed5bf8">
+    --- capella
+    +++ deneb
+    @@ -20,6 +20,11 @@
+                 transactions_root=hash_tree_root(payload.transactions),
+                 withdrawals_root=hash_tree_root(payload.withdrawals),
+             )
+    +
+    +        if epoch >= DENEB_FORK_EPOCH:
+    +            execution_header.blob_gas_used = payload.blob_gas_used
+    +            execution_header.excess_blob_gas = payload.excess_blob_gas
+    +
+             execution_branch = ExecutionBranch(
+                 compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX)
+             )
+    </spec>
+
+- name: bls_field_to_bytes#deneb
+  sources: []
+  spec: |
+    <spec fn="bls_field_to_bytes" fork="deneb" hash="2b84ce7c">
+    def bls_field_to_bytes(x: BLSFieldElement) -> Bytes32:
+        return int.to_bytes(int(x), 32, KZG_ENDIANNESS)
+    </spec>
+
+- name: bytes_to_bls_field#deneb
+  sources: []
+  spec: |
+    <spec fn="bytes_to_bls_field" fork="deneb" hash="0cfd397d">
+    def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
+        """
+        Convert untrusted bytes to a trusted and validated BLS scalar field element.
+        This function does not accept inputs greater than the BLS modulus.
+        """
+        field_element = int.from_bytes(b, KZG_ENDIANNESS)
+        assert field_element < BLS_MODULUS
+        return BLSFieldElement(field_element)
+    </spec>
+
+- name: bytes_to_kzg_commitment#deneb
+  sources: []
+  spec: |
+    <spec fn="bytes_to_kzg_commitment" fork="deneb" hash="2d0ccdc3">
+    def bytes_to_kzg_commitment(b: Bytes48) -> KZGCommitment:
+        """
+        Convert untrusted bytes into a trusted and validated KZGCommitment.
+        """
+        validate_kzg_g1(b)
+        return KZGCommitment(b)
+    </spec>
+
+- name: bytes_to_kzg_proof#deneb
+  sources: []
+  spec: |
+    <spec fn="bytes_to_kzg_proof" fork="deneb" hash="fcf9a902">
+    def bytes_to_kzg_proof(b: Bytes48) -> KZGProof:
+        """
+        Convert untrusted bytes into a trusted and validated KZGProof.
+        """
+        validate_kzg_g1(b)
+        return KZGProof(b)
+    </spec>
+
+- name: bytes_to_uint64#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
       search: public static UInt64 bytesToUInt64(
@@ -148,7 +384,7 @@
         return uint64(int.from_bytes(data, ENDIANNESS))
     </spec>
 
-- name: calculate_committee_fraction
+- name: calculate_committee_fraction#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 calculateCommitteeFraction(
@@ -159,7 +395,32 @@
         return Gwei((committee_weight * committee_percent) // 100)
     </spec>
 
-- name: compute_activation_exit_epoch
+- name: cell_to_coset_evals#fulu
+  sources: []
+  spec: |
+    <spec fn="cell_to_coset_evals" fork="fulu" hash="db38f921">
+    def cell_to_coset_evals(cell: Cell) -> CosetEvals:
+        """
+        Convert an untrusted ``Cell`` into a trusted ``CosetEvals``.
+        """
+        evals = CosetEvals()
+        for i in range(FIELD_ELEMENTS_PER_CELL):
+            start = i * BYTES_PER_FIELD_ELEMENT
+            end = (i + 1) * BYTES_PER_FIELD_ELEMENT
+            evals[i] = bytes_to_bls_field(cell[start:end])
+        return evals
+    </spec>
+
+- name: check_if_validator_active#phase0
+  sources: []
+  spec: |
+    <spec fn="check_if_validator_active" fork="phase0" hash="66fe85e7">
+    def check_if_validator_active(state: BeaconState, validator_index: ValidatorIndex) -> bool:
+        validator = state.validators[validator_index]
+        return is_active_validator(validator, get_current_epoch(state))
+    </spec>
+
+- name: compute_activation_exit_epoch#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeActivationExitEpoch(
@@ -227,7 +488,109 @@
         return selected
     </spec>
 
-- name: compute_columns_for_custody_group
+- name: compute_blob_kzg_proof#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_blob_kzg_proof" fork="deneb" hash="b35a2651">
+    def compute_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes48) -> KZGProof:
+        """
+        Given a blob, return the KZG proof that is used to verify it against the commitment.
+        This method does not verify that the commitment is correct with respect to `blob`.
+        Public method.
+        """
+        assert len(blob) == BYTES_PER_BLOB
+        assert len(commitment_bytes) == BYTES_PER_COMMITMENT
+        commitment = bytes_to_kzg_commitment(commitment_bytes)
+        polynomial = blob_to_polynomial(blob)
+        evaluation_challenge = compute_challenge(blob, commitment)
+        proof, _ = compute_kzg_proof_impl(polynomial, evaluation_challenge)
+        return proof
+    </spec>
+
+- name: compute_cells#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_cells" fork="fulu" hash="20f94f5f">
+    def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
+        """
+        Given a blob, extend it and return all the cells of the extended blob.
+
+        Public method.
+        """
+        assert len(blob) == BYTES_PER_BLOB
+
+        polynomial = blob_to_polynomial(blob)
+        polynomial_coeff = polynomial_eval_to_coeff(polynomial)
+
+        cells = []
+        for i in range(CELLS_PER_EXT_BLOB):
+            coset = coset_for_cell(CellIndex(i))
+            ys = CosetEvals([evaluate_polynomialcoeff(polynomial_coeff, z) for z in coset])
+            cells.append(coset_evals_to_cell(CosetEvals(ys)))
+        return cells
+    </spec>
+
+- name: compute_cells_and_kzg_proofs#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_cells_and_kzg_proofs" fork="fulu" hash="0751dcee">
+    def compute_cells_and_kzg_proofs(
+        blob: Blob,
+    ) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
+        """
+        Compute all the cell proofs for an extended blob. This is an inefficient O(n^2) algorithm,
+        for performant implementation the FK20 algorithm that runs in O(n log n) should be
+        used instead.
+
+        Public method.
+        """
+        assert len(blob) == BYTES_PER_BLOB
+
+        polynomial = blob_to_polynomial(blob)
+        polynomial_coeff = polynomial_eval_to_coeff(polynomial)
+        return compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff)
+    </spec>
+
+- name: compute_cells_and_kzg_proofs_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_cells_and_kzg_proofs_polynomialcoeff" fork="fulu" hash="954c9e52">
+    def compute_cells_and_kzg_proofs_polynomialcoeff(
+        polynomial_coeff: PolynomialCoeff,
+    ) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
+        """
+        Helper function which computes cells/proofs for a polynomial in coefficient form.
+        """
+        cells, proofs = [], []
+        for i in range(CELLS_PER_EXT_BLOB):
+            coset = coset_for_cell(CellIndex(i))
+            proof, ys = compute_kzg_proof_multi_impl(polynomial_coeff, coset)
+            cells.append(coset_evals_to_cell(CosetEvals(ys)))
+            proofs.append(proof)
+        return cells, proofs
+    </spec>
+
+- name: compute_challenge#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_challenge" fork="deneb" hash="137cf666">
+    def compute_challenge(blob: Blob, commitment: KZGCommitment) -> BLSFieldElement:
+        """
+        Return the Fiat-Shamir challenge required by the rest of the protocol.
+        """
+
+        # Append the degree of the polynomial as a domain separator
+        degree_poly = int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 16, KZG_ENDIANNESS)
+        data = FIAT_SHAMIR_PROTOCOL_DOMAIN + degree_poly
+
+        data += blob
+        data += commitment
+
+        # Transcript has been prepared: time to create the challenge
+        return hash_to_bls_field(data)
+    </spec>
+
+- name: compute_columns_for_custody_group#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<UInt64> computeColumnsForCustodyGroup(
@@ -241,7 +604,7 @@
         ]
     </spec>
 
-- name: compute_committee
+- name: compute_committee#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public IntList computeCommittee(
@@ -261,7 +624,7 @@
         ]
     </spec>
 
-- name: compute_consolidation_epoch_and_update_churn
+- name: compute_consolidation_epoch_and_update_churn#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public UInt64 computeConsolidationEpochAndUpdateChurn(
@@ -296,7 +659,7 @@
         return state.earliest_consolidation_epoch
     </spec>
 
-- name: compute_domain
+- name: compute_domain#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public Bytes32 computeDomain\($
@@ -317,7 +680,7 @@
         return Domain(domain_type + fork_data_root[:28])
     </spec>
 
-- name: compute_epoch_at_slot
+- name: compute_epoch_at_slot#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeEpochAtSlot(
@@ -330,7 +693,7 @@
         return Epoch(slot // SLOTS_PER_EPOCH)
     </spec>
 
-- name: compute_exit_epoch_and_update_churn
+- name: compute_exit_epoch_and_update_churn#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public UInt64 computeExitEpochAndUpdateChurn(
@@ -361,7 +724,7 @@
         return state.earliest_exit_epoch
     </spec>
 
-- name: compute_fork_data_root
+- name: compute_fork_data_root#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: protected Bytes32 computeForkDataRoot(
@@ -436,7 +799,7 @@
         )
     </spec>
 
-- name: compute_fork_version
+- name: compute_fork_version#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public Bytes4 computeForkVersion(
@@ -596,7 +959,183 @@
         return GENESIS_FORK_VERSION
     </spec>
 
-- name: compute_proposer_index
+- name: compute_kzg_proof#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_kzg_proof" fork="deneb" hash="84fcdaa4">
+    def compute_kzg_proof(blob: Blob, z_bytes: Bytes32) -> Tuple[KZGProof, Bytes32]:
+        """
+        Compute KZG proof at point `z` for the polynomial represented by `blob`.
+        Do this by computing the quotient polynomial in evaluation form: q(x) = (p(x) - p(z)) / (x - z).
+        Public method.
+        """
+        assert len(blob) == BYTES_PER_BLOB
+        assert len(z_bytes) == BYTES_PER_FIELD_ELEMENT
+        polynomial = blob_to_polynomial(blob)
+        proof, y = compute_kzg_proof_impl(polynomial, bytes_to_bls_field(z_bytes))
+        return proof, int(y).to_bytes(BYTES_PER_FIELD_ELEMENT, KZG_ENDIANNESS)
+    </spec>
+
+- name: compute_kzg_proof_impl#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_kzg_proof_impl" fork="deneb" hash="d9093c49">
+    def compute_kzg_proof_impl(
+        polynomial: Polynomial, z: BLSFieldElement
+    ) -> Tuple[KZGProof, BLSFieldElement]:
+        """
+        Helper function for `compute_kzg_proof()` and `compute_blob_kzg_proof()`.
+        """
+        roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB))
+
+        # For all x_i, compute p(x_i) - p(z)
+        y = evaluate_polynomial_in_evaluation_form(polynomial, z)
+        polynomial_shifted = [p - y for p in polynomial]
+
+        # For all x_i, compute (x_i - z)
+        denominator_poly = [x - z for x in roots_of_unity_brp]
+
+        # Compute the quotient polynomial directly in evaluation form
+        quotient_polynomial = [BLSFieldElement(0)] * FIELD_ELEMENTS_PER_BLOB
+        for i, (a, b) in enumerate(zip(polynomial_shifted, denominator_poly)):
+            if b == BLSFieldElement(0):
+                # The denominator is zero hence `z` is a root of unity: we must handle it as a special case
+                quotient_polynomial[i] = compute_quotient_eval_within_domain(
+                    roots_of_unity_brp[i], polynomial, y
+                )
+            else:
+                # Compute: q(x_i) = (p(x_i) - p(z)) / (x_i - z).
+                quotient_polynomial[i] = a / b
+
+        return KZGProof(
+            g1_lincomb(bit_reversal_permutation(KZG_SETUP_G1_LAGRANGE), quotient_polynomial)
+        ), y
+    </spec>
+
+- name: compute_kzg_proof_multi_impl#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_kzg_proof_multi_impl" fork="fulu" hash="6fd3df17">
+    def compute_kzg_proof_multi_impl(
+        polynomial_coeff: PolynomialCoeff, zs: Coset
+    ) -> Tuple[KZGProof, CosetEvals]:
+        """
+        Compute a KZG multi-evaluation proof for a set of `k` points.
+
+        This is done by committing to the following quotient polynomial:
+            Q(X) = f(X) - I(X) / Z(X)
+        Where:
+            - I(X) is the degree `k-1` polynomial that agrees with f(x) at all `k` points
+            - Z(X) is the degree `k` polynomial that evaluates to zero on all `k` points
+
+        We further note that since the degree of I(X) is less than the degree of Z(X),
+        the computation can be simplified in monomial form to Q(X) = f(X) / Z(X).
+        """
+
+        # For all points, compute the evaluation of those points
+        ys = CosetEvals([evaluate_polynomialcoeff(polynomial_coeff, z) for z in zs])
+
+        # Compute Z(X)
+        denominator_poly = vanishing_polynomialcoeff(zs)
+
+        # Compute the quotient polynomial directly in monomial form
+        quotient_polynomial = divide_polynomialcoeff(polynomial_coeff, denominator_poly)
+
+        return KZGProof(
+            g1_lincomb(KZG_SETUP_G1_MONOMIAL[: len(quotient_polynomial)], quotient_polynomial)
+        ), ys
+    </spec>
+
+- name: compute_matrix#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_matrix" fork="fulu" hash="b39370ca">
+    def compute_matrix(blobs: Sequence[Blob]) -> Sequence[MatrixEntry]:
+        """
+        Return the full, flattened sequence of matrix entries.
+
+        This helper demonstrates the relationship between blobs and the matrix of cells/proofs.
+        The data structure for storing cells/proofs is implementation-dependent.
+        """
+        matrix = []
+        for blob_index, blob in enumerate(blobs):
+            cells, proofs = compute_cells_and_kzg_proofs(blob)
+            for cell_index, (cell, proof) in enumerate(zip(cells, proofs)):
+                matrix.append(
+                    MatrixEntry(
+                        cell=cell,
+                        kzg_proof=proof,
+                        row_index=blob_index,
+                        column_index=cell_index,
+                    )
+                )
+        return matrix
+    </spec>
+
+- name: compute_merkle_proof#altair
+  sources: []
+  spec: |
+    <spec fn="compute_merkle_proof" fork="altair" hash="073d848c">
+    def compute_merkle_proof(object: SSZObject, index: GeneralizedIndex) -> Sequence[Bytes32]: ...
+    </spec>
+
+- name: compute_new_state_root#phase0
+  sources: []
+  spec: |
+    <spec fn="compute_new_state_root" fork="phase0" hash="ad3c03b7">
+    def compute_new_state_root(state: BeaconState, block: BeaconBlock) -> Root:
+        temp_state: BeaconState = state.copy()
+        signed_block = SignedBeaconBlock(message=block)
+        state_transition(temp_state, signed_block, validate_result=False)
+        return hash_tree_root(temp_state)
+    </spec>
+
+- name: compute_on_chain_aggregate#electra
+  sources: []
+  spec: |
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="128055d6">
+    def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
+        aggregates = sorted(
+            network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0]
+        )
+
+        data = aggregates[0].data
+        aggregation_bits = Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]()
+        for a in aggregates:
+            for b in a.aggregation_bits:
+                aggregation_bits.append(b)
+
+        signature = bls.Aggregate([a.signature for a in aggregates])
+
+        committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
+        committee_flags = [(index in committee_indices) for index in range(0, MAX_COMMITTEES_PER_SLOT)]
+        committee_bits = Bitvector[MAX_COMMITTEES_PER_SLOT](committee_flags)
+
+        return Attestation(
+            aggregation_bits=aggregation_bits,
+            data=data,
+            committee_bits=committee_bits,
+            signature=signature,
+        )
+    </spec>
+
+- name: compute_powers#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_powers" fork="deneb" hash="fb1c0187">
+    def compute_powers(x: BLSFieldElement, n: uint64) -> Sequence[BLSFieldElement]:
+        """
+        Return ``x`` to power of [0, n-1], if n > 0. When n==0, an empty array is returned.
+        """
+        current_power = BLSFieldElement(1)
+        powers = []
+        for _ in range(n):
+            powers.append(current_power)
+            current_power = current_power * x
+        return powers
+    </spec>
+
+- name: compute_proposer_index#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public int computeProposerIndex(
@@ -621,7 +1160,7 @@
             i += 1
     </spec>
 
-- name: compute_proposer_index
+- name: compute_proposer_index#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public int computeProposerIndex(
@@ -651,7 +1190,7 @@
             i += 1
     </spec>
 
-- name: compute_proposer_indices
+- name: compute_proposer_indices#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<Integer> computeProposerIndices(
@@ -689,7 +1228,71 @@
         ]
     </spec>
 
-- name: compute_shuffled_index
+- name: compute_pulled_up_tip#phase0
+  sources: []
+  spec: |
+    <spec fn="compute_pulled_up_tip" fork="phase0" hash="ef9c1f02">
+    def compute_pulled_up_tip(store: Store, block_root: Root) -> None:
+        state = store.block_states[block_root].copy()
+        # Pull up the post-state of the block to the next epoch boundary
+        process_justification_and_finalization(state)
+
+        store.unrealized_justifications[block_root] = state.current_justified_checkpoint
+        update_unrealized_checkpoints(
+            store, state.current_justified_checkpoint, state.finalized_checkpoint
+        )
+
+        # If the block is from a prior epoch, apply the realized values
+        block_epoch = compute_epoch_at_slot(store.blocks[block_root].slot)
+        current_epoch = get_current_store_epoch(store)
+        if block_epoch < current_epoch:
+            update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
+    </spec>
+
+- name: compute_quotient_eval_within_domain#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_quotient_eval_within_domain" fork="deneb" hash="b1df34e2">
+    def compute_quotient_eval_within_domain(
+        z: BLSFieldElement, polynomial: Polynomial, y: BLSFieldElement
+    ) -> BLSFieldElement:
+        """
+        Given `y == p(z)` for a polynomial `p(x)`, compute `q(z)`: the KZG quotient polynomial evaluated at `z` for the
+        special case where `z` is in roots of unity.
+
+        For more details, read https://dankradfeist.de/ethereum/2021/06/18/pcs-multiproofs.html section "Dividing
+        when one of the points is zero". The code below computes q(x_m) for the roots of unity special case.
+        """
+        roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB))
+        result = BLSFieldElement(0)
+        for i, omega_i in enumerate(roots_of_unity_brp):
+            if omega_i == z:  # skip the evaluation point in the sum
+                continue
+
+            f_i = polynomial[i] - y
+            numerator = f_i * omega_i
+            denominator = z * (z - omega_i)
+            result += numerator / denominator
+
+        return result
+    </spec>
+
+- name: compute_roots_of_unity#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_roots_of_unity" fork="deneb" hash="647fd611">
+    def compute_roots_of_unity(order: uint64) -> Sequence[BLSFieldElement]:
+        """
+        Return roots of unity of ``order``.
+        """
+        assert (BLS_MODULUS - 1) % int(order) == 0
+        root_of_unity = BLSFieldElement(
+            pow(PRIMITIVE_ROOT_OF_UNITY, (BLS_MODULUS - 1) // int(order), BLS_MODULUS)
+        )
+        return compute_powers(root_of_unity, order)
+    </spec>
+
+- name: compute_shuffled_index#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public int computeShuffledIndex(
@@ -717,7 +1320,23 @@
         return index
     </spec>
 
-- name: compute_signing_root
+- name: compute_signed_block_header#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_signed_block_header" fork="deneb" hash="552442e1">
+    def compute_signed_block_header(signed_block: SignedBeaconBlock) -> SignedBeaconBlockHeader:
+        block = signed_block.message
+        block_header = BeaconBlockHeader(
+            slot=block.slot,
+            proposer_index=block.proposer_index,
+            parent_root=block.parent_root,
+            state_root=block.state_root,
+            body_root=hash_tree_root(block.body),
+        )
+        return SignedBeaconBlockHeader(message=block_header, signature=signed_block.signature)
+    </spec>
+
+- name: compute_signing_root#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public Bytes computeSigningRoot(final Merkleizable object, final Bytes32 domain)
@@ -735,7 +1354,7 @@
         )
     </spec>
 
-- name: compute_slots_since_epoch_start
+- name: compute_slots_since_epoch_start#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: private UInt64 computeSlotsSinceEpochStart(
@@ -745,7 +1364,7 @@
         return slot - compute_start_slot_at_epoch(compute_epoch_at_slot(slot))
     </spec>
 
-- name: compute_start_slot_at_epoch
+- name: compute_start_slot_at_epoch#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeStartSlotAtEpoch(
@@ -758,7 +1377,7 @@
         return Slot(epoch * SLOTS_PER_EPOCH)
     </spec>
 
-- name: compute_subnet_for_attestation
+- name: compute_subnet_for_attestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
       search: public int computeSubnetForAttestation(
@@ -797,7 +1416,7 @@
         return SubnetID(blob_index % BLOB_SIDECAR_SUBNET_COUNT_ELECTRA)
     </spec>
 
-- name: compute_subnet_for_data_column_sidecar
+- name: compute_subnet_for_data_column_sidecar#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public UInt64 computeSubnetForDataColumnSidecar(
@@ -807,7 +1426,34 @@
         return SubnetID(column_index % DATA_COLUMN_SIDECAR_SUBNET_COUNT)
     </spec>
 
-- name: compute_subscribed_subnet
+- name: compute_subnets_for_sync_committee#altair
+  sources: []
+  spec: |
+    <spec fn="compute_subnets_for_sync_committee" fork="altair" hash="637ad33a">
+    def compute_subnets_for_sync_committee(
+        state: BeaconState, validator_index: ValidatorIndex
+    ) -> Set[SubnetID]:
+        next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
+        if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(
+            next_slot_epoch
+        ):
+            sync_committee = state.current_sync_committee
+        else:
+            sync_committee = state.next_sync_committee
+
+        target_pubkey = state.validators[validator_index].pubkey
+        sync_committee_indices = [
+            index for index, pubkey in enumerate(sync_committee.pubkeys) if pubkey == target_pubkey
+        ]
+        return set(
+            [
+                SubnetID(index // (SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT))
+                for index in sync_committee_indices
+            ]
+        )
+    </spec>
+
+- name: compute_subscribed_subnet#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: protected UInt64 computeSubscribedSubnet(
@@ -827,7 +1473,7 @@
         return SubnetID((permutated_prefix + index) % ATTESTATION_SUBNET_COUNT)
     </spec>
 
-- name: compute_subscribed_subnets
+- name: compute_subscribed_subnets#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public List<UInt64> computeSubscribedSubnets(
@@ -837,7 +1483,7 @@
         return [compute_subscribed_subnet(node_id, epoch, index) for index in range(SUBNETS_PER_NODE)]
     </spec>
 
-- name: compute_sync_committee_period
+- name: compute_sync_committee_period#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: private UInt64 computeSyncCommitteePeriod(
@@ -847,7 +1493,15 @@
         return epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
     </spec>
 
-- name: compute_time_at_slot
+- name: compute_sync_committee_period_at_slot#altair
+  sources: []
+  spec: |
+    <spec fn="compute_sync_committee_period_at_slot" fork="altair" hash="6ad449b8">
+    def compute_sync_committee_period_at_slot(slot: Slot) -> uint64:
+        return compute_sync_committee_period(compute_epoch_at_slot(slot))
+    </spec>
+
+- name: compute_time_at_slot#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeTimeAtSlot(
@@ -856,6 +1510,39 @@
     def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
         slots_since_genesis = slot - GENESIS_SLOT
         return uint64(state.genesis_time + slots_since_genesis * SECONDS_PER_SLOT)
+    </spec>
+
+- name: compute_verify_cell_kzg_proof_batch_challenge#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_verify_cell_kzg_proof_batch_challenge" fork="fulu" hash="8d3b11a0">
+    def compute_verify_cell_kzg_proof_batch_challenge(
+        commitments: Sequence[KZGCommitment],
+        commitment_indices: Sequence[CommitmentIndex],
+        cell_indices: Sequence[CellIndex],
+        cosets_evals: Sequence[CosetEvals],
+        proofs: Sequence[KZGProof],
+    ) -> BLSFieldElement:
+        """
+        Compute a random challenge ``r`` used in the universal verification equation. To compute the
+        challenge, ``RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN`` and all data that can influence the
+        verification is hashed together to deterministically generate a "random" field element via
+        the Fiat-Shamir heuristic.
+        """
+        hashinput = RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN
+        hashinput += int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 8, KZG_ENDIANNESS)
+        hashinput += int.to_bytes(FIELD_ELEMENTS_PER_CELL, 8, KZG_ENDIANNESS)
+        hashinput += int.to_bytes(len(commitments), 8, KZG_ENDIANNESS)
+        hashinput += int.to_bytes(len(cell_indices), 8, KZG_ENDIANNESS)
+        for commitment in commitments:
+            hashinput += commitment
+        for k, coset_evals in enumerate(cosets_evals):
+            hashinput += int.to_bytes(commitment_indices[k], 8, KZG_ENDIANNESS)
+            hashinput += int.to_bytes(cell_indices[k], 8, KZG_ENDIANNESS)
+            for coset_eval in coset_evals:
+                hashinput += bls_field_to_bytes(coset_eval)
+            hashinput += proofs[k]
+        return hash_to_bls_field(hashinput)
     </spec>
 
 - name: compute_weak_subjectivity_period#phase0
@@ -893,7 +1580,318 @@
         return ws_period
     </spec>
 
-- name: decrease_balance
+- name: compute_weak_subjectivity_period#electra
+  sources: []
+  spec: |
+    <spec fn="compute_weak_subjectivity_period" fork="electra" style="diff" hash="8d95104c">
+    --- phase0
+    +++ electra
+    @@ -2,26 +2,11 @@
+         """
+         Returns the weak subjectivity period for the current ``state``.
+         This computation takes into account the effect of:
+    -        - validator set churn (bounded by ``get_validator_churn_limit()`` per epoch), and
+    -        - validator balance top-ups (bounded by ``MAX_DEPOSITS * SLOTS_PER_EPOCH`` per epoch).
+    +        - validator set churn (bounded by ``get_balance_churn_limit()`` per epoch)
+         A detailed calculation can be found at:
+    -    https://github.com/runtimeverification/beacon-chain-verification/blob/master/weak-subjectivity/weak-subjectivity-analysis.pdf
+    +    https://notes.ethereum.org/@CarlBeek/electra_weak_subjectivity
+         """
+    -    ws_period = MIN_VALIDATOR_WITHDRAWABILITY_DELAY
+    -    N = len(get_active_validator_indices(state, get_current_epoch(state)))
+    -    t = get_total_active_balance(state) // N // ETH_TO_GWEI
+    -    T = MAX_EFFECTIVE_BALANCE // ETH_TO_GWEI
+    -    delta = get_validator_churn_limit(state)
+    -    Delta = MAX_DEPOSITS * SLOTS_PER_EPOCH
+    -    D = SAFETY_DECAY
+    -
+    -    if T * (200 + 3 * D) < t * (200 + 12 * D):
+    -        epochs_for_validator_set_churn = (
+    -            N * (t * (200 + 12 * D) - T * (200 + 3 * D)) // (600 * delta * (2 * t + T))
+    -        )
+    -        epochs_for_balance_top_ups = N * (200 + 3 * D) // (600 * Delta)
+    -        ws_period += max(epochs_for_validator_set_churn, epochs_for_balance_top_ups)
+    -    else:
+    -        ws_period += 3 * N * D * t // (200 * Delta * (T - t))
+    -
+    -    return ws_period
+    +    t = get_total_active_balance(state)
+    +    delta = get_balance_churn_limit(state)
+    +    epochs_for_validator_set_churn = SAFETY_DECAY * t // (2 * delta * 100)
+    +    return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
+    </spec>
+
+- name: construct_vanishing_polynomial#fulu
+  sources: []
+  spec: |
+    <spec fn="construct_vanishing_polynomial" fork="fulu" hash="eba304bb">
+    def construct_vanishing_polynomial(
+        missing_cell_indices: Sequence[CellIndex],
+    ) -> Sequence[BLSFieldElement]:
+        """
+        Given the cells indices that are missing from the data, compute the polynomial that vanishes at every point that
+        corresponds to a missing field element.
+
+        This method assumes that all of the cells cannot be missing. In this case the vanishing polynomial
+        could be computed as Z(x) = x^n - 1, where `n` is FIELD_ELEMENTS_PER_EXT_BLOB.
+
+        We never encounter this case however because this method is used solely for recovery and recovery only
+        works if at least half of the cells are available.
+        """
+        # Get the small domain
+        roots_of_unity_reduced = compute_roots_of_unity(CELLS_PER_EXT_BLOB)
+
+        # Compute polynomial that vanishes at all the missing cells (over the small domain)
+        short_zero_poly = vanishing_polynomialcoeff(
+            [
+                roots_of_unity_reduced[reverse_bits(missing_cell_index, CELLS_PER_EXT_BLOB)]
+                for missing_cell_index in missing_cell_indices
+            ]
+        )
+
+        # Extend vanishing polynomial to full domain using the closed form of the vanishing polynomial over a coset
+        zero_poly_coeff = [BLSFieldElement(0)] * FIELD_ELEMENTS_PER_EXT_BLOB
+        for i, coeff in enumerate(short_zero_poly):
+            zero_poly_coeff[i * FIELD_ELEMENTS_PER_CELL] = coeff
+
+        return zero_poly_coeff
+    </spec>
+
+- name: coset_evals_to_cell#fulu
+  sources: []
+  spec: |
+    <spec fn="coset_evals_to_cell" fork="fulu" hash="394b0ba9">
+    def coset_evals_to_cell(coset_evals: CosetEvals) -> Cell:
+        """
+        Convert a trusted ``CosetEval`` into an untrusted ``Cell``.
+        """
+        cell = []
+        for i in range(FIELD_ELEMENTS_PER_CELL):
+            cell += bls_field_to_bytes(coset_evals[i])
+        return Cell(cell)
+    </spec>
+
+- name: coset_fft_field#fulu
+  sources: []
+  spec: |
+    <spec fn="coset_fft_field" fork="fulu" hash="c4e7376b">
+    def coset_fft_field(
+        vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement], inv: bool = False
+    ) -> Sequence[BLSFieldElement]:
+        """
+        Computes an FFT/IFFT over a coset of the roots of unity.
+        This is useful for when one wants to divide by a polynomial which
+        vanishes on one or more elements in the domain.
+        """
+        vals = [v for v in vals]  # copy
+
+        def shift_vals(
+            vals: Sequence[BLSFieldElement], factor: BLSFieldElement
+        ) -> Sequence[BLSFieldElement]:
+            """
+            Multiply each entry in `vals` by succeeding powers of `factor`
+            i.e., [vals[0] * factor^0, vals[1] * factor^1, ..., vals[n] * factor^n]
+            """
+            updated_vals: List[BLSFieldElement] = []
+            shift = BLSFieldElement(1)
+            for i in range(len(vals)):
+                updated_vals.append(vals[i] * shift)
+                shift = shift * factor
+            return updated_vals
+
+        # This is the coset generator; it is used to compute a FFT/IFFT over a coset of
+        # the roots of unity.
+        shift_factor = BLSFieldElement(PRIMITIVE_ROOT_OF_UNITY)
+        if inv:
+            vals = fft_field(vals, roots_of_unity, inv)
+            return shift_vals(vals, shift_factor.inverse())
+        else:
+            vals = shift_vals(vals, shift_factor)
+            return fft_field(vals, roots_of_unity, inv)
+    </spec>
+
+- name: coset_for_cell#fulu
+  sources: []
+  spec: |
+    <spec fn="coset_for_cell" fork="fulu" hash="9462c88f">
+    def coset_for_cell(cell_index: CellIndex) -> Coset:
+        """
+        Get the coset for a given ``cell_index``.
+        Precisely, consider the group of roots of unity of order FIELD_ELEMENTS_PER_CELL * CELLS_PER_EXT_BLOB.
+        Let G = {1, g, g^2, ...} denote its subgroup of order FIELD_ELEMENTS_PER_CELL.
+        Then, the coset is defined as h * G = {h, hg, hg^2, ...}.
+        This function, returns the coset.
+        """
+        assert cell_index < CELLS_PER_EXT_BLOB
+        roots_of_unity_brp = bit_reversal_permutation(
+            compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
+        )
+        return Coset(
+            roots_of_unity_brp[
+                FIELD_ELEMENTS_PER_CELL * cell_index : FIELD_ELEMENTS_PER_CELL * (cell_index + 1)
+            ]
+        )
+    </spec>
+
+- name: coset_shift_for_cell#fulu
+  sources: []
+  spec: |
+    <spec fn="coset_shift_for_cell" fork="fulu" hash="c8359618">
+    def coset_shift_for_cell(cell_index: CellIndex) -> BLSFieldElement:
+        """
+        Get the shift that determines the coset for a given ``cell_index``.
+        Precisely, consider the group of roots of unity of order FIELD_ELEMENTS_PER_CELL * CELLS_PER_EXT_BLOB.
+        Let G = {1, g, g^2, ...} denote its subgroup of order FIELD_ELEMENTS_PER_CELL.
+        Then, the coset is defined as h * G = {h, hg, hg^2, ...} for an element h.
+        This function returns h.
+        """
+        assert cell_index < CELLS_PER_EXT_BLOB
+        roots_of_unity_brp = bit_reversal_permutation(
+            compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
+        )
+        return roots_of_unity_brp[FIELD_ELEMENTS_PER_CELL * cell_index]
+    </spec>
+
+- name: create_light_client_bootstrap#altair
+  sources: []
+  spec: |
+    <spec fn="create_light_client_bootstrap" fork="altair" hash="54e41304">
+    def create_light_client_bootstrap(
+        state: BeaconState, block: SignedBeaconBlock
+    ) -> LightClientBootstrap:
+        assert compute_epoch_at_slot(state.slot) >= ALTAIR_FORK_EPOCH
+
+        assert state.slot == state.latest_block_header.slot
+        header = state.latest_block_header.copy()
+        header.state_root = hash_tree_root(state)
+        assert hash_tree_root(header) == hash_tree_root(block.message)
+
+        return LightClientBootstrap(
+            header=block_to_light_client_header(block),
+            current_sync_committee=state.current_sync_committee,
+            current_sync_committee_branch=CurrentSyncCommitteeBranch(
+                compute_merkle_proof(state, current_sync_committee_gindex_at_slot(state.slot))
+            ),
+        )
+    </spec>
+
+- name: create_light_client_finality_update#altair
+  sources: []
+  spec: |
+    <spec fn="create_light_client_finality_update" fork="altair" hash="21956507">
+    def create_light_client_finality_update(update: LightClientUpdate) -> LightClientFinalityUpdate:
+        return LightClientFinalityUpdate(
+            attested_header=update.attested_header,
+            finalized_header=update.finalized_header,
+            finality_branch=update.finality_branch,
+            sync_aggregate=update.sync_aggregate,
+            signature_slot=update.signature_slot,
+        )
+    </spec>
+
+- name: create_light_client_optimistic_update#altair
+  sources: []
+  spec: |
+    <spec fn="create_light_client_optimistic_update" fork="altair" hash="5a993ad2">
+    def create_light_client_optimistic_update(update: LightClientUpdate) -> LightClientOptimisticUpdate:
+        return LightClientOptimisticUpdate(
+            attested_header=update.attested_header,
+            sync_aggregate=update.sync_aggregate,
+            signature_slot=update.signature_slot,
+        )
+    </spec>
+
+- name: create_light_client_update#altair
+  sources: []
+  spec: |
+    <spec fn="create_light_client_update" fork="altair" hash="cde7d86c">
+    def create_light_client_update(
+        state: BeaconState,
+        block: SignedBeaconBlock,
+        attested_state: BeaconState,
+        attested_block: SignedBeaconBlock,
+        finalized_block: Optional[SignedBeaconBlock],
+    ) -> LightClientUpdate:
+        assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
+        assert (
+            sum(block.message.body.sync_aggregate.sync_committee_bits)
+            >= MIN_SYNC_COMMITTEE_PARTICIPANTS
+        )
+
+        assert state.slot == state.latest_block_header.slot
+        header = state.latest_block_header.copy()
+        header.state_root = hash_tree_root(state)
+        assert hash_tree_root(header) == hash_tree_root(block.message)
+        update_signature_period = compute_sync_committee_period_at_slot(block.message.slot)
+
+        assert attested_state.slot == attested_state.latest_block_header.slot
+        attested_header = attested_state.latest_block_header.copy()
+        attested_header.state_root = hash_tree_root(attested_state)
+        assert (
+            hash_tree_root(attested_header)
+            == hash_tree_root(attested_block.message)
+            == block.message.parent_root
+        )
+        update_attested_period = compute_sync_committee_period_at_slot(attested_block.message.slot)
+
+        update = LightClientUpdate()
+
+        update.attested_header = block_to_light_client_header(attested_block)
+
+        # `next_sync_committee` is only useful if the message is signed by the current sync committee
+        if update_attested_period == update_signature_period:
+            update.next_sync_committee = attested_state.next_sync_committee
+            update.next_sync_committee_branch = NextSyncCommitteeBranch(
+                compute_merkle_proof(
+                    attested_state, next_sync_committee_gindex_at_slot(attested_state.slot)
+                )
+            )
+
+        # Indicate finality whenever possible
+        if finalized_block is not None:
+            if finalized_block.message.slot != GENESIS_SLOT:
+                update.finalized_header = block_to_light_client_header(finalized_block)
+                assert (
+                    hash_tree_root(update.finalized_header.beacon)
+                    == attested_state.finalized_checkpoint.root
+                )
+            else:
+                assert attested_state.finalized_checkpoint.root == Bytes32()
+            update.finality_branch = FinalityBranch(
+                compute_merkle_proof(attested_state, finalized_root_gindex_at_slot(attested_state.slot))
+            )
+
+        update.sync_aggregate = block.message.body.sync_aggregate
+        update.signature_slot = block.message.slot
+
+        return update
+    </spec>
+
+- name: current_sync_committee_gindex_at_slot#altair
+  sources: []
+  spec: |
+    <spec fn="current_sync_committee_gindex_at_slot" fork="altair" hash="caf087c0">
+    def current_sync_committee_gindex_at_slot(_slot: Slot) -> GeneralizedIndex:
+        return CURRENT_SYNC_COMMITTEE_GINDEX
+    </spec>
+
+- name: current_sync_committee_gindex_at_slot#electra
+  sources: []
+  spec: |
+    <spec fn="current_sync_committee_gindex_at_slot" fork="electra" style="diff" hash="6f71f075">
+    --- altair
+    +++ electra
+    @@ -1,2 +1,6 @@
+    -def current_sync_committee_gindex_at_slot(_slot: Slot) -> GeneralizedIndex:
+    +def current_sync_committee_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+    +    epoch = compute_epoch_at_slot(slot)
+    +
+    +    if epoch >= ELECTRA_FORK_EPOCH:
+    +        return CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA
+         return CURRENT_SYNC_COMMITTEE_GINDEX
+    </spec>
+
+- name: decrease_balance#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
       search: public void decreaseBalance(
@@ -906,7 +1904,30 @@
         state.balances[index] = 0 if delta > state.balances[index] else state.balances[index] - delta
     </spec>
 
-- name: eth_aggregate_pubkeys
+- name: divide_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="divide_polynomialcoeff" fork="fulu" hash="7cf7d709">
+    def divide_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoeff:
+        """
+        Long polynomial division for two coefficient form polynomials ``a`` and ``b``.
+        """
+        a = PolynomialCoeff(a[:])  # copy
+        o = PolynomialCoeff([])
+        apos = len(a) - 1
+        bpos = len(b) - 1
+        diff = apos - bpos
+        while diff >= 0:
+            quot = a[apos] / b[bpos]
+            o.insert(0, quot)
+            for i in range(bpos, -1, -1):
+                a[diff + i] = a[diff + i] - b[i] * quot
+            apos -= 1
+            diff -= 1
+        return o
+    </spec>
+
+- name: eth_aggregate_pubkeys#altair
   sources:
     - file: infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSPublicKey.java
       search: public static BLSPublicKey aggregate(
@@ -931,7 +1952,7 @@
         return result
     </spec>
 
-- name: eth_fast_aggregate_verify
+- name: eth_fast_aggregate_verify#altair
   sources:
     - file: infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
       search: public static boolean fastAggregateVerify(
@@ -948,7 +1969,174 @@
         return bls.FastAggregateVerify(pubkeys, message, signature)
     </spec>
 
-- name: get_activation_exit_churn_limit
+- name: evaluate_polynomial_in_evaluation_form#deneb
+  sources: []
+  spec: |
+    <spec fn="evaluate_polynomial_in_evaluation_form" fork="deneb" hash="d4c8a11a">
+    def evaluate_polynomial_in_evaluation_form(
+        polynomial: Polynomial, z: BLSFieldElement
+    ) -> BLSFieldElement:
+        """
+        Evaluate a polynomial (in evaluation form) at an arbitrary point ``z``.
+        - When ``z`` is in the domain, the evaluation can be found by indexing the polynomial at the
+        position that ``z`` is in the domain.
+        - When ``z`` is not in the domain, the barycentric formula is used:
+           f(z) = (z**WIDTH - 1) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (z - DOMAIN[i])
+        """
+        width = len(polynomial)
+        assert width == FIELD_ELEMENTS_PER_BLOB
+        inverse_width = BLSFieldElement(width).inverse()
+
+        roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB))
+
+        # If we are asked to evaluate within the domain, we already know the answer
+        if z in roots_of_unity_brp:
+            eval_index = roots_of_unity_brp.index(z)
+            return polynomial[eval_index]
+
+        result = BLSFieldElement(0)
+        for i in range(width):
+            a = polynomial[i] * roots_of_unity_brp[i]
+            b = z - roots_of_unity_brp[i]
+            result += a / b
+        r = z.pow(BLSFieldElement(width)) - BLSFieldElement(1)
+        result = result * r * inverse_width
+        return result
+    </spec>
+
+- name: evaluate_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="evaluate_polynomialcoeff" fork="fulu" hash="629b29c4">
+    def evaluate_polynomialcoeff(
+        polynomial_coeff: PolynomialCoeff, z: BLSFieldElement
+    ) -> BLSFieldElement:
+        """
+        Evaluate a coefficient form polynomial at ``z`` using Horner's schema.
+        """
+        y = BLSFieldElement(0)
+        for coef in polynomial_coeff[::-1]:
+            y = y * z + coef
+        return y
+    </spec>
+
+- name: fft_field#fulu
+  sources: []
+  spec: |
+    <spec fn="fft_field" fork="fulu" hash="6568b8ab">
+    def fft_field(
+        vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement], inv: bool = False
+    ) -> Sequence[BLSFieldElement]:
+        if inv:
+            # Inverse FFT
+            invlen = BLSFieldElement(len(vals)).pow(BLSFieldElement(BLS_MODULUS - 2))
+            return [
+                x * invlen
+                for x in _fft_field(vals, list(roots_of_unity[0:1]) + list(roots_of_unity[:0:-1]))
+            ]
+        else:
+            # Regular FFT
+            return _fft_field(vals, roots_of_unity)
+    </spec>
+
+- name: filter_block_tree#phase0
+  sources: []
+  spec: |
+    <spec fn="filter_block_tree" fork="phase0" hash="a1924421">
+    def filter_block_tree(store: Store, block_root: Root, blocks: Dict[Root, BeaconBlock]) -> bool:
+        block = store.blocks[block_root]
+        children = [
+            root for root in store.blocks.keys() if store.blocks[root].parent_root == block_root
+        ]
+
+        # If any children branches contain expected finalized/justified checkpoints,
+        # add to filtered block-tree and signal viability to parent.
+        if any(children):
+            filter_block_tree_result = [filter_block_tree(store, child, blocks) for child in children]
+            if any(filter_block_tree_result):
+                blocks[block_root] = block
+                return True
+            return False
+
+        current_epoch = get_current_store_epoch(store)
+        voting_source = get_voting_source(store, block_root)
+
+        # The voting source should be either at the same height as the store's justified checkpoint or
+        # not more than two epochs ago
+        correct_justified = (
+            store.justified_checkpoint.epoch == GENESIS_EPOCH
+            or voting_source.epoch == store.justified_checkpoint.epoch
+            or voting_source.epoch + 2 >= current_epoch
+        )
+
+        finalized_checkpoint_block = get_checkpoint_block(
+            store,
+            block_root,
+            store.finalized_checkpoint.epoch,
+        )
+
+        correct_finalized = (
+            store.finalized_checkpoint.epoch == GENESIS_EPOCH
+            or store.finalized_checkpoint.root == finalized_checkpoint_block
+        )
+
+        # If expected finalized/justified, add to viable block-tree and signal viability to parent.
+        if correct_justified and correct_finalized:
+            blocks[block_root] = block
+            return True
+
+        # Otherwise, branch not viable
+        return False
+    </spec>
+
+- name: finalized_root_gindex_at_slot#altair
+  sources: []
+  spec: |
+    <spec fn="finalized_root_gindex_at_slot" fork="altair" hash="9028cbc5">
+    def finalized_root_gindex_at_slot(_slot: Slot) -> GeneralizedIndex:
+        return FINALIZED_ROOT_GINDEX
+    </spec>
+
+- name: finalized_root_gindex_at_slot#electra
+  sources: []
+  spec: |
+    <spec fn="finalized_root_gindex_at_slot" fork="electra" style="diff" hash="bc7a7fe9">
+    --- altair
+    +++ electra
+    @@ -1,2 +1,6 @@
+    -def finalized_root_gindex_at_slot(_slot: Slot) -> GeneralizedIndex:
+    +def finalized_root_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+    +    epoch = compute_epoch_at_slot(slot)
+    +
+    +    if epoch >= ELECTRA_FORK_EPOCH:
+    +        return FINALIZED_ROOT_GINDEX_ELECTRA
+         return FINALIZED_ROOT_GINDEX
+    </spec>
+
+- name: g1_lincomb#deneb
+  sources: []
+  spec: |
+    <spec fn="g1_lincomb" fork="deneb" hash="c227e313">
+    def g1_lincomb(
+        points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElement]
+    ) -> KZGCommitment:
+        """
+        BLS multiscalar multiplication in G1. This can be naively implemented using double-and-add.
+        """
+        assert len(points) == len(scalars)
+
+        if len(points) == 0:
+            return bls.G1_to_bytes48(bls.Z1())
+
+        points_g1 = []
+        for point in points:
+            points_g1.append(bls.bytes48_to_G1(point))
+
+        result = bls.multi_exp(points_g1, scalars)
+        return KZGCommitment(bls.G1_to_bytes48(result))
+    </spec>
+
+- name: get_activation_exit_churn_limit#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public UInt64 getActivationExitChurnLimit(
@@ -961,7 +2149,7 @@
         return min(MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT, get_balance_churn_limit(state))
     </spec>
 
-- name: get_active_validator_indices
+- name: get_active_validator_indices#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public IntList getActiveValidatorIndices(
@@ -976,7 +2164,21 @@
         ]
     </spec>
 
-- name: get_aggregate_and_proof_signature
+- name: get_aggregate_and_proof#phase0
+  sources: []
+  spec: |
+    <spec fn="get_aggregate_and_proof" fork="phase0" hash="bb7f6018">
+    def get_aggregate_and_proof(
+        state: BeaconState, aggregator_index: ValidatorIndex, aggregate: Attestation, privkey: int
+    ) -> AggregateAndProof:
+        return AggregateAndProof(
+            aggregator_index=aggregator_index,
+            aggregate=aggregate,
+            selection_proof=get_slot_signature(state, aggregate.data.slot, privkey),
+        )
+    </spec>
+
+- name: get_aggregate_and_proof_signature#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
       search: public Bytes signingRootForSignAggregateAndProof(
@@ -1016,7 +2218,16 @@
         return get_slot_component_duration_ms(AGGREGATE_DUE_BPS)
     </spec>
 
-- name: get_ancestor
+- name: get_aggregate_signature#phase0
+  sources: []
+  spec: |
+    <spec fn="get_aggregate_signature" fork="phase0" hash="1797b223">
+    def get_aggregate_signature(attestations: Sequence[Attestation]) -> BLSSignature:
+        signatures = [attestation.signature for attestation in attestations]
+        return bls.Aggregate(signatures)
+    </spec>
+
+- name: get_ancestor#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public Optional<Bytes32> getAncestor(
@@ -1053,7 +2264,7 @@
             )
     </spec>
 
-- name: get_attestation_component_deltas
+- name: get_attestation_component_deltas#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applyAttestationComponentDelta(
@@ -1082,6 +2293,33 @@
                     rewards[index] += reward_numerator // (total_balance // increment)
             else:
                 penalties[index] += get_base_reward(state, index)
+        return rewards, penalties
+    </spec>
+
+- name: get_attestation_deltas#phase0
+  sources: []
+  spec: |
+    <spec fn="get_attestation_deltas" fork="phase0" hash="17fcc0d9">
+    def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
+        """
+        Return attestation reward/penalty deltas for each validator.
+        """
+        source_rewards, source_penalties = get_source_deltas(state)
+        target_rewards, target_penalties = get_target_deltas(state)
+        head_rewards, head_penalties = get_head_deltas(state)
+        inclusion_delay_rewards, _ = get_inclusion_delay_deltas(state)
+        _, inactivity_penalties = get_inactivity_penalty_deltas(state)
+
+        rewards = [
+            source_rewards[i] + target_rewards[i] + head_rewards[i] + inclusion_delay_rewards[i]
+            for i in range(len(state.validators))
+        ]
+
+        penalties = [
+            source_penalties[i] + target_penalties[i] + head_penalties[i] + inactivity_penalties[i]
+            for i in range(len(state.validators))
+        ]
+
         return rewards, penalties
     </spec>
 
@@ -1245,7 +2483,7 @@
         return participation_flag_indices
     </spec>
 
-- name: get_attestation_signature
+- name: get_attestation_signature#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
       search: public Bytes signingRootForSignAttestationData(
@@ -1257,6 +2495,18 @@
         domain = get_domain(state, DOMAIN_BEACON_ATTESTER, attestation_data.target.epoch)
         signing_root = compute_signing_root(attestation_data, domain)
         return bls.Sign(privkey, signing_root)
+    </spec>
+
+- name: get_attesting_balance#phase0
+  sources: []
+  spec: |
+    <spec fn="get_attesting_balance" fork="phase0" hash="bc7890c1">
+    def get_attesting_balance(state: BeaconState, attestations: Sequence[PendingAttestation]) -> Gwei:
+        """
+        Return the combined effective balance of the set of unslashed validators participating in ``attestations``.
+        Note: ``get_total_balance`` returns ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
+        """
+        return get_total_balance(state, get_unslashed_attesting_indices(state, attestations))
     </spec>
 
 - name: get_attesting_indices#phase0
@@ -1300,7 +2550,7 @@
         return output
     </spec>
 
-- name: get_balance_churn_limit
+- name: get_balance_churn_limit#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public UInt64 getBalanceChurnLimit(
@@ -1347,7 +2597,7 @@
         return Gwei(increments * get_base_reward_per_increment(state))
     </spec>
 
-- name: get_base_reward_per_increment
+- name: get_base_reward_per_increment#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public UInt64 getBaseRewardPerIncrement(
@@ -1361,7 +2611,7 @@
         )
     </spec>
 
-- name: get_beacon_committee
+- name: get_beacon_committee#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public IntList getBeaconCommittee(
@@ -1412,7 +2662,7 @@
         return state.proposer_lookahead[state.slot % SLOTS_PER_EPOCH]
     </spec>
 
-- name: get_beacon_proposer_indices
+- name: get_beacon_proposer_indices#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
       search: public List<Integer> getBeaconProposerIndices(
@@ -1429,7 +2679,7 @@
         return compute_proposer_indices(state, epoch, seed, indices)
     </spec>
 
-- name: get_blob_parameters
+- name: get_blob_parameters#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public BlobParameters getBlobParameters(
@@ -1445,7 +2695,32 @@
         return BlobParameters(ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK_ELECTRA)
     </spec>
 
-- name: get_block_root
+- name: get_blob_sidecars#deneb
+  sources: []
+  spec: |
+    <spec fn="get_blob_sidecars" fork="deneb" hash="0206e9a5">
+    def get_blob_sidecars(
+        signed_block: SignedBeaconBlock, blobs: Sequence[Blob], blob_kzg_proofs: Sequence[KZGProof]
+    ) -> Sequence[BlobSidecar]:
+        block = signed_block.message
+        signed_block_header = compute_signed_block_header(signed_block)
+        return [
+            BlobSidecar(
+                index=index,
+                blob=blob,
+                kzg_commitment=block.body.blob_kzg_commitments[index],
+                kzg_proof=blob_kzg_proofs[index],
+                signed_block_header=signed_block_header,
+                kzg_commitment_inclusion_proof=compute_merkle_proof(
+                    block.body,
+                    get_generalized_index(BeaconBlockBody, "blob_kzg_commitments", index),
+                ),
+            )
+            for index, blob in enumerate(blobs)
+        ]
+    </spec>
+
+- name: get_block_root#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public Bytes32 getBlockRoot(
@@ -1458,7 +2733,7 @@
         return get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch))
     </spec>
 
-- name: get_block_root_at_slot
+- name: get_block_root_at_slot#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public Bytes32 getBlockRootAtSlot(
@@ -1472,7 +2747,7 @@
         return state.block_roots[slot % SLOTS_PER_HISTORICAL_ROOT]
     </spec>
 
-- name: get_block_signature
+- name: get_block_signature#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
       search: public Bytes signingRootForSignBlock(
@@ -1499,6 +2774,18 @@
         return uint64(quorum // BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
     </spec>
 
+- name: get_checkpoint_block#phase0
+  sources: []
+  spec: |
+    <spec fn="get_checkpoint_block" fork="phase0" hash="9d8daa22">
+    def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
+        """
+        Compute the checkpoint block for epoch ``epoch`` in the chain of block ``root``
+        """
+        epoch_first_slot = compute_start_slot_at_epoch(epoch)
+        return get_ancestor(store, root, epoch_first_slot)
+    </spec>
+
 - name: get_checkpoint_block#gloas
   sources: []
   spec: |
@@ -1511,7 +2798,7 @@
         return get_ancestor(store, root, epoch_first_slot).root
     </spec>
 
-- name: get_committee_assignment
+- name: get_committee_assignment#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
       search: public Optional<CommitteeAssignment> getCommitteeAssignment(
@@ -1541,7 +2828,7 @@
         return None
     </spec>
 
-- name: get_committee_count_per_slot
+- name: get_committee_count_per_slot#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getCommitteeCountPerSlot(final BeaconState state, final UInt64 epoch)
@@ -1562,7 +2849,15 @@
         )
     </spec>
 
-- name: get_consolidation_churn_limit
+- name: get_committee_indices#electra
+  sources: []
+  spec: |
+    <spec fn="get_committee_indices" fork="electra" hash="fa701795">
+    def get_committee_indices(committee_bits: Bitvector) -> Sequence[CommitteeIndex]:
+        return [CommitteeIndex(index) for index, bit in enumerate(committee_bits) if bit]
+    </spec>
+
+- name: get_consolidation_churn_limit#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public UInt64 getConsolidationChurnLimit(
@@ -1572,7 +2867,30 @@
         return get_balance_churn_limit(state) - get_activation_exit_churn_limit(state)
     </spec>
 
-- name: get_contribution_and_proof_signature
+- name: get_contribution_and_proof#altair
+  sources: []
+  spec: |
+    <spec fn="get_contribution_and_proof" fork="altair" hash="ea4e6980">
+    def get_contribution_and_proof(
+        state: BeaconState,
+        aggregator_index: ValidatorIndex,
+        contribution: SyncCommitteeContribution,
+        privkey: int,
+    ) -> ContributionAndProof:
+        selection_proof = get_sync_committee_selection_proof(
+            state,
+            contribution.slot,
+            contribution.subcommittee_index,
+            privkey,
+        )
+        return ContributionAndProof(
+            aggregator_index=aggregator_index,
+            contribution=contribution,
+            selection_proof=selection_proof,
+        )
+    </spec>
+
+- name: get_contribution_and_proof_signature#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public Bytes getContributionAndProofSigningRoot(
@@ -1612,7 +2930,7 @@
         return get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS)
     </spec>
 
-- name: get_current_epoch
+- name: get_current_epoch#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getCurrentEpoch(
@@ -1625,7 +2943,7 @@
         return compute_epoch_at_slot(state.slot)
     </spec>
 
-- name: get_current_slot
+- name: get_current_slot#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
       search: public UInt64 getCurrentSlot(final UInt64 currentTime, final UInt64 genesisTime)
@@ -1635,7 +2953,15 @@
         return Slot(GENESIS_SLOT + get_slots_since_genesis(store))
     </spec>
 
-- name: get_custody_groups
+- name: get_current_store_epoch#phase0
+  sources: []
+  spec: |
+    <spec fn="get_current_store_epoch" fork="phase0" hash="4d86e690">
+    def get_current_store_epoch(store: Store) -> Epoch:
+        return compute_epoch_at_slot(get_current_slot(store))
+    </spec>
+
+- name: get_custody_groups#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<UInt64> computeCustodyColumnIndices(
@@ -1664,6 +2990,43 @@
 
         assert len(custody_groups) == len(set(custody_groups))
         return sorted(custody_groups)
+    </spec>
+
+- name: get_data_column_sidecars#fulu
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars" fork="fulu" hash="317fc596">
+    def get_data_column_sidecars(
+        signed_block_header: SignedBeaconBlockHeader,
+        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+        kzg_commitments_inclusion_proof: Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH],
+        cells_and_kzg_proofs: Sequence[
+            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
+        ],
+    ) -> Sequence[DataColumnSidecar]:
+        """
+        Given a signed block header and the commitments, inclusion proof, cells/proofs associated with
+        each blob in the block, assemble the sidecars which can be distributed to peers.
+        """
+        assert len(cells_and_kzg_proofs) == len(kzg_commitments)
+
+        sidecars = []
+        for column_index in range(NUMBER_OF_COLUMNS):
+            column_cells, column_proofs = [], []
+            for cells, proofs in cells_and_kzg_proofs:
+                column_cells.append(cells[column_index])
+                column_proofs.append(proofs[column_index])
+            sidecars.append(
+                DataColumnSidecar(
+                    index=column_index,
+                    column=column_cells,
+                    kzg_commitments=kzg_commitments,
+                    kzg_proofs=column_proofs,
+                    signed_block_header=signed_block_header,
+                    kzg_commitments_inclusion_proof=kzg_commitments_inclusion_proof,
+                )
+            )
+        return sidecars
     </spec>
 
 - name: get_data_column_sidecars#gloas
@@ -1709,6 +3072,34 @@
         return sidecars
     </spec>
 
+- name: get_data_column_sidecars_from_block#fulu
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="02ffae23">
+    def get_data_column_sidecars_from_block(
+        signed_block: SignedBeaconBlock,
+        cells_and_kzg_proofs: Sequence[
+            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
+        ],
+    ) -> Sequence[DataColumnSidecar]:
+        """
+        Given a signed block and the cells/proofs associated with each blob in the
+        block, assemble the sidecars which can be distributed to peers.
+        """
+        blob_kzg_commitments = signed_block.message.body.blob_kzg_commitments
+        signed_block_header = compute_signed_block_header(signed_block)
+        kzg_commitments_inclusion_proof = compute_merkle_proof(
+            signed_block.message.body,
+            get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"),
+        )
+        return get_data_column_sidecars(
+            signed_block_header,
+            blob_kzg_commitments,
+            kzg_commitments_inclusion_proof,
+            cells_and_kzg_proofs,
+        )
+    </spec>
+
 - name: get_data_column_sidecars_from_block#gloas
   sources: []
   spec: |
@@ -1730,6 +3121,30 @@
             beacon_block_root,
             signed_block.message.slot,
             blob_kzg_commitments,
+            cells_and_kzg_proofs,
+        )
+    </spec>
+
+- name: get_data_column_sidecars_from_column_sidecar#fulu
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4304cdec">
+    def get_data_column_sidecars_from_column_sidecar(
+        sidecar: DataColumnSidecar,
+        cells_and_kzg_proofs: Sequence[
+            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
+        ],
+    ) -> Sequence[DataColumnSidecar]:
+        """
+        Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
+        to the commitments it contains, assemble all sidecars for distribution to peers.
+        """
+        assert len(cells_and_kzg_proofs) == len(sidecar.kzg_commitments)
+
+        return get_data_column_sidecars(
+            sidecar.signed_block_header,
+            sidecar.kzg_commitments,
+            sidecar.kzg_commitments_inclusion_proof,
             cells_and_kzg_proofs,
         )
     </spec>
@@ -1758,7 +3173,7 @@
         )
     </spec>
 
-- name: get_domain
+- name: get_domain#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public Bytes32 getDomain(final ForkInfo forkInfo, final Bytes4 domainType, final UInt64 epoch)
@@ -1775,7 +3190,21 @@
         return compute_domain(domain_type, fork_version, state.genesis_validators_root)
     </spec>
 
-- name: get_epoch_signature
+- name: get_eligible_validator_indices#phase0
+  sources: []
+  spec: |
+    <spec fn="get_eligible_validator_indices" fork="phase0" hash="22a24ce4">
+    def get_eligible_validator_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
+        previous_epoch = get_previous_epoch(state)
+        return [
+            ValidatorIndex(index)
+            for index, v in enumerate(state.validators)
+            if is_active_validator(v, previous_epoch)
+            or (v.slashed and previous_epoch + 1 < v.withdrawable_epoch)
+        ]
+    </spec>
+
+- name: get_epoch_signature#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
       search: public Bytes signingRootForRandaoReveal(
@@ -1785,6 +3214,20 @@
         domain = get_domain(state, DOMAIN_RANDAO, compute_epoch_at_slot(block.slot))
         signing_root = compute_signing_root(compute_epoch_at_slot(block.slot), domain)
         return bls.Sign(privkey, signing_root)
+    </spec>
+
+- name: get_eth1_pending_deposit_count#electra
+  sources: []
+  spec: |
+    <spec fn="get_eth1_pending_deposit_count" fork="electra" hash="5dc54930">
+    def get_eth1_pending_deposit_count(state: BeaconState) -> uint64:
+        eth1_deposit_index_limit = min(
+            state.eth1_data.deposit_count, state.deposit_requests_start_index
+        )
+        if state.eth1_deposit_index < eth1_deposit_index_limit:
+            return min(MAX_DEPOSITS, eth1_deposit_index_limit - state.eth1_deposit_index)
+        else:
+            return uint64(0)
     </spec>
 
 - name: get_eth1_vote#phase0
@@ -1871,6 +3314,20 @@
         )
     </spec>
 
+- name: get_execution_payload#bellatrix
+  sources: []
+  spec: |
+    <spec fn="get_execution_payload" fork="bellatrix" hash="abcc202e">
+    def get_execution_payload(
+        payload_id: Optional[PayloadId], execution_engine: ExecutionEngine
+    ) -> ExecutionPayload:
+        if payload_id is None:
+            # Pre-merge, empty payload
+            return ExecutionPayload()
+        else:
+            return execution_engine.get_payload(payload_id).execution_payload
+    </spec>
+
 - name: get_execution_payload_bid_signature#gloas
   sources: []
   spec: |
@@ -1895,7 +3352,7 @@
         return bls.Sign(privkey, signing_root)
     </spec>
 
-- name: get_execution_requests
+- name: get_execution_requests#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodec.java
       search: public ExecutionRequests decode(
@@ -1945,7 +3402,7 @@
         )
     </spec>
 
-- name: get_execution_requests_list
+- name: get_execution_requests_list#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodec.java
       search: public List<Bytes> encode(
@@ -2202,7 +3659,22 @@
         )
     </spec>
 
-- name: get_finality_delay
+- name: get_filtered_block_tree#phase0
+  sources: []
+  spec: |
+    <spec fn="get_filtered_block_tree" fork="phase0" hash="31b703b4">
+    def get_filtered_block_tree(store: Store) -> Dict[Root, BeaconBlock]:
+        """
+        Retrieve a filtered block tree from ``store``, only returning branches
+        whose leaf state's justified/finalized info agrees with that in ``store``.
+        """
+        base = store.justified_checkpoint.root
+        blocks: Dict[Root, BeaconBlock] = {}
+        filter_block_tree(store, base, blocks)
+        return blocks
+    </spec>
+
+- name: get_finality_delay#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getFinalityDelay(
@@ -2212,7 +3684,7 @@
         return get_previous_epoch(state) - state.finalized_checkpoint.epoch
     </spec>
 
-- name: get_flag_index_deltas
+- name: get_flag_index_deltas#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
       search: public void processFlagIndexDeltas(
@@ -2247,6 +3719,33 @@
         return rewards, penalties
     </spec>
 
+- name: get_forkchoice_store#phase0
+  sources: []
+  spec: |
+    <spec fn="get_forkchoice_store" fork="phase0" hash="aaa3553b">
+    def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
+        assert anchor_block.state_root == hash_tree_root(anchor_state)
+        anchor_root = hash_tree_root(anchor_block)
+        anchor_epoch = get_current_epoch(anchor_state)
+        justified_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
+        finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
+        proposer_boost_root = Root()
+        return Store(
+            time=uint64(anchor_state.genesis_time + SECONDS_PER_SLOT * anchor_state.slot),
+            genesis_time=anchor_state.genesis_time,
+            justified_checkpoint=justified_checkpoint,
+            finalized_checkpoint=finalized_checkpoint,
+            unrealized_justified_checkpoint=justified_checkpoint,
+            unrealized_finalized_checkpoint=finalized_checkpoint,
+            proposer_boost_root=proposer_boost_root,
+            equivocating_indices=set(),
+            blocks={anchor_root: copy(anchor_block)},
+            block_states={anchor_root: copy(anchor_state)},
+            checkpoint_states={justified_checkpoint: copy(anchor_state)},
+            unrealized_justifications={anchor_root: justified_checkpoint},
+        )
+    </spec>
+
 - name: get_forkchoice_store#gloas
   sources: []
   spec: |
@@ -2277,6 +3776,24 @@
         )
     </spec>
 
+- name: get_head#phase0
+  sources: []
+  spec: |
+    <spec fn="get_head" fork="phase0" hash="9fa2b1bd">
+    def get_head(store: Store) -> Root:
+        # Get filtered block tree that only includes viable branches
+        blocks = get_filtered_block_tree(store)
+        # Execute the LMD-GHOST fork choice
+        head = store.justified_checkpoint.root
+        while True:
+            children = [root for root in blocks.keys() if blocks[root].parent_root == head]
+            if len(children) == 0:
+                return head
+            # Sort by latest attesting balance with ties broken lexicographically
+            # Ties broken by favoring block with lexicographically higher root
+            head = max(children, key=lambda root: (get_weight(store, root), root))
+    </spec>
+
 - name: get_head#gloas
   sources: []
   spec: |
@@ -2305,7 +3822,7 @@
             )
     </spec>
 
-- name: get_head_deltas
+- name: get_head_deltas#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applyHeadDelta(
@@ -2317,6 +3834,39 @@
         """
         matching_head_attestations = get_matching_head_attestations(state, get_previous_epoch(state))
         return get_attestation_component_deltas(state, matching_head_attestations)
+    </spec>
+
+- name: get_inactivity_penalty_deltas#phase0
+  sources: []
+  spec: |
+    <spec fn="get_inactivity_penalty_deltas" fork="phase0" hash="11718f1b">
+    def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
+        """
+        Return inactivity reward/penalty deltas for each validator.
+        """
+        penalties = [Gwei(0) for _ in range(len(state.validators))]
+        if is_in_inactivity_leak(state):
+            matching_target_attestations = get_matching_target_attestations(
+                state, get_previous_epoch(state)
+            )
+            matching_target_attesting_indices = get_unslashed_attesting_indices(
+                state, matching_target_attestations
+            )
+            for index in get_eligible_validator_indices(state):
+                # If validator is performing optimally this cancels all rewards for a neutral balance
+                base_reward = get_base_reward(state, index)
+                penalties[index] += Gwei(
+                    BASE_REWARDS_PER_EPOCH * base_reward - get_proposer_reward(state, index)
+                )
+                if index not in matching_target_attesting_indices:
+                    effective_balance = state.validators[index].effective_balance
+                    penalties[index] += Gwei(
+                        effective_balance * get_finality_delay(state) // INACTIVITY_PENALTY_QUOTIENT
+                    )
+
+        # No rewards associated with inactivity penalties
+        rewards = [Gwei(0) for _ in range(len(state.validators))]
+        return rewards, penalties
     </spec>
 
 - name: get_inactivity_penalty_deltas#altair
@@ -2374,7 +3924,43 @@
         return rewards, penalties
     </spec>
 
-- name: get_indexed_attestation
+- name: get_inclusion_delay_deltas#phase0
+  sources: []
+  spec: |
+    <spec fn="get_inclusion_delay_deltas" fork="phase0" hash="aa690a2f">
+    def get_inclusion_delay_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
+        """
+        Return proposer and inclusion delay micro-rewards/penalties for each validator.
+        """
+        rewards = [Gwei(0) for _ in range(len(state.validators))]
+        matching_source_attestations = get_matching_source_attestations(
+            state, get_previous_epoch(state)
+        )
+        for index in get_unslashed_attesting_indices(state, matching_source_attestations):
+            attestation = min(
+                [a for a in matching_source_attestations if index in get_attesting_indices(state, a)],
+                key=lambda a: a.inclusion_delay,
+            )
+            rewards[attestation.proposer_index] += get_proposer_reward(state, index)
+            max_attester_reward = Gwei(
+                get_base_reward(state, index) - get_proposer_reward(state, index)
+            )
+            rewards[index] += Gwei(max_attester_reward // attestation.inclusion_delay)
+
+        # No penalties associated with inclusion delay
+        penalties = [Gwei(0) for _ in range(len(state.validators))]
+        return rewards, penalties
+    </spec>
+
+- name: get_index_for_new_validator#altair
+  sources: []
+  spec: |
+    <spec fn="get_index_for_new_validator" fork="altair" hash="e78e8714">
+    def get_index_for_new_validator(state: BeaconState) -> ValidatorIndex:
+        return ValidatorIndex(len(state.validators))
+    </spec>
+
+- name: get_indexed_attestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
       search: public IndexedAttestation getIndexedAttestation(
@@ -2416,7 +4002,140 @@
         )
     </spec>
 
-- name: get_max_effective_balance
+- name: get_lc_execution_root#capella
+  sources: []
+  spec: |
+    <spec fn="get_lc_execution_root" fork="capella" hash="1fe004a9">
+    def get_lc_execution_root(header: LightClientHeader) -> Root:
+        epoch = compute_epoch_at_slot(header.beacon.slot)
+
+        if epoch >= CAPELLA_FORK_EPOCH:
+            return hash_tree_root(header.execution)
+
+        return Root()
+    </spec>
+
+- name: get_lc_execution_root#deneb
+  sources: []
+  spec: |
+    <spec fn="get_lc_execution_root" fork="deneb" style="diff" hash="311e3c71">
+    --- capella
+    +++ deneb
+    @@ -1,7 +1,27 @@
+     def get_lc_execution_root(header: LightClientHeader) -> Root:
+         epoch = compute_epoch_at_slot(header.beacon.slot)
+
+    -    if epoch >= CAPELLA_FORK_EPOCH:
+    +    if epoch >= DENEB_FORK_EPOCH:
+             return hash_tree_root(header.execution)
+
+    +    if epoch >= CAPELLA_FORK_EPOCH:
+    +        execution_header = capella.ExecutionPayloadHeader(
+    +            parent_hash=header.execution.parent_hash,
+    +            fee_recipient=header.execution.fee_recipient,
+    +            state_root=header.execution.state_root,
+    +            receipts_root=header.execution.receipts_root,
+    +            logs_bloom=header.execution.logs_bloom,
+    +            prev_randao=header.execution.prev_randao,
+    +            block_number=header.execution.block_number,
+    +            gas_limit=header.execution.gas_limit,
+    +            gas_used=header.execution.gas_used,
+    +            timestamp=header.execution.timestamp,
+    +            extra_data=header.execution.extra_data,
+    +            base_fee_per_gas=header.execution.base_fee_per_gas,
+    +            block_hash=header.execution.block_hash,
+    +            transactions_root=header.execution.transactions_root,
+    +            withdrawals_root=header.execution.withdrawals_root,
+    +        )
+    +        return hash_tree_root(execution_header)
+    +
+         return Root()
+    </spec>
+
+- name: get_lc_execution_root#electra
+  sources: []
+  spec: |
+    <spec fn="get_lc_execution_root" fork="electra" style="diff" hash="939f89bd">
+    --- deneb
+    +++ electra
+    @@ -1,8 +1,30 @@
+     def get_lc_execution_root(header: LightClientHeader) -> Root:
+         epoch = compute_epoch_at_slot(header.beacon.slot)
+
+    +    if epoch >= ELECTRA_FORK_EPOCH:
+    +        return hash_tree_root(header.execution)
+    +
+         if epoch >= DENEB_FORK_EPOCH:
+    -        return hash_tree_root(header.execution)
+    +        execution_header = deneb.ExecutionPayloadHeader(
+    +            parent_hash=header.execution.parent_hash,
+    +            fee_recipient=header.execution.fee_recipient,
+    +            state_root=header.execution.state_root,
+    +            receipts_root=header.execution.receipts_root,
+    +            logs_bloom=header.execution.logs_bloom,
+    +            prev_randao=header.execution.prev_randao,
+    +            block_number=header.execution.block_number,
+    +            gas_limit=header.execution.gas_limit,
+    +            gas_used=header.execution.gas_used,
+    +            timestamp=header.execution.timestamp,
+    +            extra_data=header.execution.extra_data,
+    +            base_fee_per_gas=header.execution.base_fee_per_gas,
+    +            block_hash=header.execution.block_hash,
+    +            transactions_root=header.execution.transactions_root,
+    +            withdrawals_root=header.execution.withdrawals_root,
+    +            blob_gas_used=header.execution.blob_gas_used,
+    +            excess_blob_gas=header.execution.excess_blob_gas,
+    +        )
+    +        return hash_tree_root(execution_header)
+
+         if epoch >= CAPELLA_FORK_EPOCH:
+             execution_header = capella.ExecutionPayloadHeader(
+    </spec>
+
+- name: get_matching_head_attestations#phase0
+  sources: []
+  spec: |
+    <spec fn="get_matching_head_attestations" fork="phase0" hash="9e3ca171">
+    def get_matching_head_attestations(
+        state: BeaconState, epoch: Epoch
+    ) -> Sequence[PendingAttestation]:
+        return [
+            a
+            for a in get_matching_target_attestations(state, epoch)
+            if a.data.beacon_block_root == get_block_root_at_slot(state, a.data.slot)
+        ]
+    </spec>
+
+- name: get_matching_source_attestations#phase0
+  sources: []
+  spec: |
+    <spec fn="get_matching_source_attestations" fork="phase0" hash="4771b4df">
+    def get_matching_source_attestations(
+        state: BeaconState, epoch: Epoch
+    ) -> Sequence[PendingAttestation]:
+        assert epoch in (get_previous_epoch(state), get_current_epoch(state))
+        return (
+            state.current_epoch_attestations
+            if epoch == get_current_epoch(state)
+            else state.previous_epoch_attestations
+        )
+    </spec>
+
+- name: get_matching_target_attestations#phase0
+  sources: []
+  spec: |
+    <spec fn="get_matching_target_attestations" fork="phase0" hash="811f3459">
+    def get_matching_target_attestations(
+        state: BeaconState, epoch: Epoch
+    ) -> Sequence[PendingAttestation]:
+        return [
+            a
+            for a in get_matching_source_attestations(state, epoch)
+            if a.data.target.root == get_block_root(state, epoch)
+        ]
+    </spec>
+
+- name: get_max_effective_balance#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public UInt64 getMaxEffectiveBalance(
@@ -2432,7 +4151,7 @@
             return MIN_ACTIVATION_BALANCE
     </spec>
 
-- name: get_next_sync_committee
+- name: get_next_sync_committee#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public SyncCommittee getNextSyncCommittee(
@@ -2609,7 +4328,7 @@
                 return 2 if should_extend_payload(store, node.root) else 0
     </spec>
 
-- name: get_pending_balance_to_withdraw
+- name: get_pending_balance_to_withdraw#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public UInt64 getPendingBalanceToWithdraw(
@@ -2651,7 +4370,29 @@
         )
     </spec>
 
-- name: get_previous_epoch
+- name: get_pow_block_at_terminal_total_difficulty#bellatrix
+  sources: []
+  spec: |
+    <spec fn="get_pow_block_at_terminal_total_difficulty" fork="bellatrix" hash="7b6668d2">
+    def get_pow_block_at_terminal_total_difficulty(
+        pow_chain: Dict[Hash32, PowBlock],
+    ) -> Optional[PowBlock]:
+        # `pow_chain` abstractly represents all blocks in the PoW chain
+        for block in pow_chain.values():
+            block_reached_ttd = block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY
+            if block_reached_ttd:
+                # If genesis block, no parent exists so reaching TTD alone qualifies as valid terminal block
+                if block.parent_hash == Hash32():
+                    return block
+                parent = pow_chain[block.parent_hash]
+                parent_reached_ttd = parent.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY
+                if not parent_reached_ttd:
+                    return block
+
+        return None
+    </spec>
+
+- name: get_previous_epoch#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getPreviousEpoch(
@@ -2665,7 +4406,7 @@
         return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else Epoch(current_epoch - 1)
     </spec>
 
-- name: get_proposer_head
+- name: get_proposer_head#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
       search: public Bytes32 getProposerHead(
@@ -2733,7 +4474,7 @@
         return get_slot_component_duration_ms(PROPOSER_REORG_CUTOFF_BPS)
     </spec>
 
-- name: get_proposer_reward
+- name: get_proposer_reward#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
       search: long getProposerReward(
@@ -2743,7 +4484,7 @@
         return Gwei(get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT)
     </spec>
 
-- name: get_proposer_score
+- name: get_proposer_score#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getProposerBoostAmount(
@@ -2799,7 +4540,7 @@
         return None
     </spec>
 
-- name: get_randao_mix
+- name: get_randao_mix#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public Bytes32 getRandaoMix(
@@ -2812,7 +4553,21 @@
         return state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
     </spec>
 
-- name: get_seed
+- name: get_safety_threshold#altair
+  sources: []
+  spec: |
+    <spec fn="get_safety_threshold" fork="altair" hash="72f3d7ff">
+    def get_safety_threshold(store: LightClientStore) -> uint64:
+        return (
+            max(
+                store.previous_max_active_participants,
+                store.current_max_active_participants,
+            )
+            // 2
+        )
+    </spec>
+
+- name: get_seed#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public Bytes32 getSeed(
@@ -2841,7 +4596,7 @@
         return basis_points * SLOT_DURATION_MS // BASIS_POINTS
     </spec>
 
-- name: get_slot_signature
+- name: get_slot_signature#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
       search: public Bytes signingRootForSignAggregationSlot(
@@ -2853,7 +4608,15 @@
         return bls.Sign(privkey, signing_root)
     </spec>
 
-- name: get_source_deltas
+- name: get_slots_since_genesis#phase0
+  sources: []
+  spec: |
+    <spec fn="get_slots_since_genesis" fork="phase0" hash="3c697269">
+    def get_slots_since_genesis(store: Store) -> int:
+        return (store.time - store.genesis_time) // SECONDS_PER_SLOT
+    </spec>
+
+- name: get_source_deltas#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applySourceDelta(
@@ -2867,6 +4630,50 @@
             state, get_previous_epoch(state)
         )
         return get_attestation_component_deltas(state, matching_source_attestations)
+    </spec>
+
+- name: get_subtree_index#altair
+  sources: []
+  spec: |
+    <spec fn="get_subtree_index" fork="altair" hash="74962089">
+    def get_subtree_index(generalized_index: GeneralizedIndex) -> uint64:
+        return uint64(generalized_index % 2 ** (floorlog2(generalized_index)))
+    </spec>
+
+- name: get_sync_committee_message#altair
+  sources: []
+  spec: |
+    <spec fn="get_sync_committee_message" fork="altair" hash="f5ff7ff2">
+    def get_sync_committee_message(
+        state: BeaconState, block_root: Root, validator_index: ValidatorIndex, privkey: int
+    ) -> SyncCommitteeMessage:
+        epoch = get_current_epoch(state)
+        domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, epoch)
+        signing_root = compute_signing_root(block_root, domain)
+        signature = bls.Sign(privkey, signing_root)
+
+        return SyncCommitteeMessage(
+            slot=state.slot,
+            beacon_block_root=block_root,
+            validator_index=validator_index,
+            signature=signature,
+        )
+    </spec>
+
+- name: get_sync_committee_selection_proof#altair
+  sources: []
+  spec: |
+    <spec fn="get_sync_committee_selection_proof" fork="altair" hash="fa4e7704">
+    def get_sync_committee_selection_proof(
+        state: BeaconState, slot: Slot, subcommittee_index: uint64, privkey: int
+    ) -> BLSSignature:
+        domain = get_domain(state, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, compute_epoch_at_slot(slot))
+        signing_data = SyncAggregatorSelectionData(
+            slot=slot,
+            subcommittee_index=subcommittee_index,
+        )
+        signing_root = compute_signing_root(signing_data, domain)
+        return bls.Sign(privkey, signing_root)
     </spec>
 
 - name: get_sync_message_due_ms#altair
@@ -2892,7 +4699,30 @@
         return get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)
     </spec>
 
-- name: get_target_deltas
+- name: get_sync_subcommittee_pubkeys#altair
+  sources: []
+  spec: |
+    <spec fn="get_sync_subcommittee_pubkeys" fork="altair" hash="772addda">
+    def get_sync_subcommittee_pubkeys(
+        state: BeaconState, subcommittee_index: uint64
+    ) -> Sequence[BLSPubkey]:
+        # Committees assigned to `slot` sign for `slot - 1`
+        # This creates the exceptional logic below when transitioning between sync committee periods
+        next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
+        if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(
+            next_slot_epoch
+        ):
+            sync_committee = state.current_sync_committee
+        else:
+            sync_committee = state.next_sync_committee
+
+        # Return pubkeys for the subcommittee index
+        sync_subcommittee_size = SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT
+        i = subcommittee_index * sync_subcommittee_size
+        return sync_committee.pubkeys[i : i + sync_subcommittee_size]
+    </spec>
+
+- name: get_target_deltas#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applyTargetDelta(
@@ -2908,7 +4738,22 @@
         return get_attestation_component_deltas(state, matching_target_attestations)
     </spec>
 
-- name: get_total_active_balance
+- name: get_terminal_pow_block#bellatrix
+  sources: []
+  spec: |
+    <spec fn="get_terminal_pow_block" fork="bellatrix" hash="90e145ca">
+    def get_terminal_pow_block(pow_chain: Dict[Hash32, PowBlock]) -> Optional[PowBlock]:
+        if TERMINAL_BLOCK_HASH != Hash32():
+            # Terminal block hash override takes precedence over terminal total difficulty
+            if TERMINAL_BLOCK_HASH in pow_chain:
+                return pow_chain[TERMINAL_BLOCK_HASH]
+            else:
+                return None
+
+        return get_pow_block_at_terminal_total_difficulty(pow_chain)
+    </spec>
+
+- name: get_total_active_balance#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getTotalActiveBalance(
@@ -2924,7 +4769,7 @@
         )
     </spec>
 
-- name: get_total_balance
+- name: get_total_balance#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getTotalBalance(
@@ -2944,7 +4789,20 @@
         )
     </spec>
 
-- name: get_unslashed_participating_indices
+- name: get_unslashed_attesting_indices#phase0
+  sources: []
+  spec: |
+    <spec fn="get_unslashed_attesting_indices" fork="phase0" hash="21c7dd12">
+    def get_unslashed_attesting_indices(
+        state: BeaconState, attestations: Sequence[PendingAttestation]
+    ) -> Set[ValidatorIndex]:
+        output: Set[ValidatorIndex] = set()
+        for a in attestations:
+            output = output.union(get_attesting_indices(state, a))
+        return set(filter(lambda index: not state.validators[index].slashed, output))
+    </spec>
+
+- name: get_unslashed_participating_indices#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
       search: private boolean isUnslashedPrevEpochParticipatingIndex(
@@ -2968,7 +4826,7 @@
         return set(filter(lambda index: not state.validators[index].slashed, participating_indices))
     </spec>
 
-- name: get_validator_activation_churn_limit
+- name: get_validator_activation_churn_limit#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getValidatorActivationChurnLimit(
@@ -2981,7 +4839,7 @@
         return min(MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT, get_validator_churn_limit(state))
     </spec>
 
-- name: get_validator_churn_limit
+- name: get_validator_churn_limit#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getValidatorChurnLimit(final BeaconState state)
@@ -3049,7 +4907,7 @@
         return validator
     </spec>
 
-- name: get_validators_custody_requirement
+- name: get_validators_custody_requirement#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public UInt64 getValidatorsCustodyRequirement(
@@ -3065,7 +4923,27 @@
         return min(max(count, VALIDATOR_CUSTODY_REQUIREMENT), NUMBER_OF_CUSTODY_GROUPS)
     </spec>
 
-- name: get_weight
+- name: get_voting_source#phase0
+  sources: []
+  spec: |
+    <spec fn="get_voting_source" fork="phase0" hash="0af91bae">
+    def get_voting_source(store: Store, block_root: Root) -> Checkpoint:
+        """
+        Compute the voting source checkpoint in event that block with root ``block_root`` is the head block
+        """
+        block = store.blocks[block_root]
+        current_epoch = get_current_store_epoch(store)
+        block_epoch = compute_epoch_at_slot(block.slot)
+        if current_epoch > block_epoch:
+            # The block is from a prior epoch, the voting source will be pulled-up
+            return store.unrealized_justifications[block_root]
+        else:
+            # The block is not from a prior epoch, therefore the voting source is not pulled up
+            head_state = store.block_states[block_root]
+            return head_state.current_justified_checkpoint
+    </spec>
+
+- name: get_weight#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
       search: public Optional<UInt64> getWeight(
@@ -3164,7 +5042,7 @@
         return is_builder_withdrawal_credential(validator.withdrawal_credentials)
     </spec>
 
-- name: has_compounding_withdrawal_credential
+- name: has_compounding_withdrawal_credential#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
       search: public boolean hasCompoundingWithdrawalCredential(
@@ -3194,7 +5072,7 @@
         return False
     </spec>
 
-- name: has_eth1_withdrawal_credential
+- name: has_eth1_withdrawal_credential#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
       search: public boolean hasEth1WithdrawalCredential(
@@ -3207,7 +5085,7 @@
         return validator.withdrawal_credentials[:1] == ETH1_ADDRESS_WITHDRAWAL_PREFIX
     </spec>
 
-- name: has_execution_withdrawal_credential
+- name: has_execution_withdrawal_credential#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
       search: public boolean hasExecutionWithdrawalCredential(
@@ -3223,7 +5101,7 @@
         )
     </spec>
 
-- name: has_flag
+- name: has_flag#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/MiscHelpersAltair.java
       search: public boolean hasFlag(
@@ -3237,7 +5115,20 @@
         return flags & flag == flag
     </spec>
 
-- name: increase_balance
+- name: hash_to_bls_field#deneb
+  sources: []
+  spec: |
+    <spec fn="hash_to_bls_field" fork="deneb" hash="0856ac0c">
+    def hash_to_bls_field(data: bytes) -> BLSFieldElement:
+        """
+        Hash ``data`` and convert the output to a BLS scalar field element.
+        The output is not uniform over the BLS field.
+        """
+        hashed_data = hash(data)
+        return BLSFieldElement(int.from_bytes(hashed_data, KZG_ENDIANNESS) % BLS_MODULUS)
+    </spec>
+
+- name: increase_balance#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
       search: public void increaseBalance(
@@ -3250,7 +5141,7 @@
         state.balances[index] += delta
     </spec>
 
-- name: initialize_beacon_state_from_eth1
+- name: initialize_beacon_state_from_eth1#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
       search: public BeaconState initializeBeaconStateFromEth1(
@@ -3296,7 +5187,35 @@
         return state
     </spec>
 
-- name: initialize_proposer_lookahead
+- name: initialize_light_client_store#altair
+  sources: []
+  spec: |
+    <spec fn="initialize_light_client_store" fork="altair" hash="f3de55b9">
+    def initialize_light_client_store(
+        trusted_block_root: Root, bootstrap: LightClientBootstrap
+    ) -> LightClientStore:
+        assert is_valid_light_client_header(bootstrap.header)
+        assert hash_tree_root(bootstrap.header.beacon) == trusted_block_root
+
+        assert is_valid_normalized_merkle_branch(
+            leaf=hash_tree_root(bootstrap.current_sync_committee),
+            branch=bootstrap.current_sync_committee_branch,
+            gindex=current_sync_committee_gindex_at_slot(bootstrap.header.beacon.slot),
+            root=bootstrap.header.beacon.state_root,
+        )
+
+        return LightClientStore(
+            finalized_header=bootstrap.header,
+            current_sync_committee=bootstrap.current_sync_committee,
+            next_sync_committee=SyncCommittee(),
+            best_valid_update=None,
+            optimistic_header=bootstrap.header,
+            previous_max_active_participants=0,
+            current_max_active_participants=0,
+        )
+    </spec>
+
+- name: initialize_proposer_lookahead#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<UInt64> initializeProposerLookahead(
@@ -3366,7 +5285,7 @@
         validator.withdrawable_epoch = Epoch(validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
     </spec>
 
-- name: integer_squareroot
+- name: integer_squareroot#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
       search: public static UInt64 integerSquareRoot(
@@ -3386,7 +5305,33 @@
         return x
     </spec>
 
-- name: is_active_validator
+- name: interpolate_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="interpolate_polynomialcoeff" fork="fulu" hash="73875a16">
+    def interpolate_polynomialcoeff(
+        xs: Sequence[BLSFieldElement], ys: Sequence[BLSFieldElement]
+    ) -> PolynomialCoeff:
+        """
+        Lagrange interpolation: Finds the lowest degree polynomial that takes the value ``ys[i]`` at ``x[i]`` for all i.
+        Outputs a coefficient form polynomial. Leading coefficients may be zero.
+        """
+        assert len(xs) == len(ys)
+
+        r = PolynomialCoeff([BLSFieldElement(0)])
+        for i in range(len(xs)):
+            summand = PolynomialCoeff([ys[i]])
+            for j in range(len(ys)):
+                if j != i:
+                    weight_adjustment = (xs[i] - xs[j]).inverse()
+                    summand = multiply_polynomialcoeff(
+                        summand, PolynomialCoeff([-weight_adjustment * xs[j], weight_adjustment])
+                    )
+            r = add_polynomialcoeff(r, summand)
+        return r
+    </spec>
+
+- name: is_active_validator#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
       search: public boolean isActiveValidator(final Validator validator, final UInt64 epoch)
@@ -3399,7 +5344,7 @@
         return validator.activation_epoch <= epoch < validator.exit_epoch
     </spec>
 
-- name: is_aggregator
+- name: is_aggregator#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
       search: public boolean isAggregator(
@@ -3413,7 +5358,7 @@
         return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
     </spec>
 
-- name: is_assigned_to_sync_committee
+- name: is_assigned_to_sync_committee#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public SyncSubcommitteeAssignments getSubcommitteeAssignments(
@@ -3455,6 +5400,63 @@
         return blockroot == slot_blockroot and blockroot != prev_blockroot
     </spec>
 
+- name: is_better_update#altair
+  sources: []
+  spec: |
+    <spec fn="is_better_update" fork="altair" hash="b99582ff">
+    def is_better_update(new_update: LightClientUpdate, old_update: LightClientUpdate) -> bool:
+        # Compare supermajority (> 2/3) sync committee participation
+        max_active_participants = len(new_update.sync_aggregate.sync_committee_bits)
+        new_num_active_participants = sum(new_update.sync_aggregate.sync_committee_bits)
+        old_num_active_participants = sum(old_update.sync_aggregate.sync_committee_bits)
+        new_has_supermajority = new_num_active_participants * 3 >= max_active_participants * 2
+        old_has_supermajority = old_num_active_participants * 3 >= max_active_participants * 2
+        if new_has_supermajority != old_has_supermajority:
+            return new_has_supermajority
+        if not new_has_supermajority and new_num_active_participants != old_num_active_participants:
+            return new_num_active_participants > old_num_active_participants
+
+        # Compare presence of relevant sync committee
+        new_has_relevant_sync_committee = is_sync_committee_update(new_update) and (
+            compute_sync_committee_period_at_slot(new_update.attested_header.beacon.slot)
+            == compute_sync_committee_period_at_slot(new_update.signature_slot)
+        )
+        old_has_relevant_sync_committee = is_sync_committee_update(old_update) and (
+            compute_sync_committee_period_at_slot(old_update.attested_header.beacon.slot)
+            == compute_sync_committee_period_at_slot(old_update.signature_slot)
+        )
+        if new_has_relevant_sync_committee != old_has_relevant_sync_committee:
+            return new_has_relevant_sync_committee
+
+        # Compare indication of any finality
+        new_has_finality = is_finality_update(new_update)
+        old_has_finality = is_finality_update(old_update)
+        if new_has_finality != old_has_finality:
+            return new_has_finality
+
+        # Compare sync committee finality
+        if new_has_finality:
+            new_has_sync_committee_finality = compute_sync_committee_period_at_slot(
+                new_update.finalized_header.beacon.slot
+            ) == compute_sync_committee_period_at_slot(new_update.attested_header.beacon.slot)
+            old_has_sync_committee_finality = compute_sync_committee_period_at_slot(
+                old_update.finalized_header.beacon.slot
+            ) == compute_sync_committee_period_at_slot(old_update.attested_header.beacon.slot)
+            if new_has_sync_committee_finality != old_has_sync_committee_finality:
+                return new_has_sync_committee_finality
+
+        # Tiebreaker 1: Sync committee participation beyond supermajority
+        if new_num_active_participants != old_num_active_participants:
+            return new_num_active_participants > old_num_active_participants
+
+        # Tiebreaker 2: Prefer older data (fewer changes to best)
+        if new_update.attested_header.beacon.slot != old_update.attested_header.beacon.slot:
+            return new_update.attested_header.beacon.slot < old_update.attested_header.beacon.slot
+
+        # Tiebreaker 3: Prefer updates with earlier signature slots
+        return new_update.signature_slot < old_update.signature_slot
+    </spec>
+
 - name: is_builder_payment_withdrawable#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -3482,7 +5484,18 @@
         return withdrawal_credentials[:1] == BUILDER_WITHDRAWAL_PREFIX
     </spec>
 
-- name: is_compounding_withdrawal_credential
+- name: is_candidate_block#phase0
+  sources: []
+  spec: |
+    <spec fn="is_candidate_block" fork="phase0" hash="c588dc0a">
+    def is_candidate_block(block: Eth1Block, period_start: uint64) -> bool:
+        return (
+            block.timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE <= period_start
+            and block.timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE * 2 >= period_start
+        )
+    </spec>
+
+- name: is_compounding_withdrawal_credential#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
       search: public boolean isCompoundingWithdrawalCredential(
@@ -3528,7 +5541,7 @@
         )
     </spec>
 
-- name: is_eligible_for_activation
+- name: is_eligible_for_activation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
       search: public boolean isEligibleForActivation(
@@ -3579,7 +5592,15 @@
         )
     </spec>
 
-- name: is_execution_enabled
+- name: is_execution_block#bellatrix
+  sources: []
+  spec: |
+    <spec fn="is_execution_block" fork="bellatrix" hash="26be0b84">
+    def is_execution_block(block: BeaconBlock) -> bool:
+        return block.body.execution_payload != ExecutionPayload()
+    </spec>
+
+- name: is_execution_enabled#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/MiscHelpersBellatrix.java
       search: public boolean isExecutionEnabled(
@@ -3589,7 +5610,7 @@
         return is_merge_transition_block(state, body) or is_merge_transition_complete(state)
     </spec>
 
-- name: is_ffg_competitive
+- name: is_ffg_competitive#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
       search: public Optional<Boolean> isFfgCompetitive(
@@ -3599,6 +5620,23 @@
         return (
             store.unrealized_justifications[head_root] == store.unrealized_justifications[parent_root]
         )
+    </spec>
+
+- name: is_finality_update#altair
+  sources: []
+  spec: |
+    <spec fn="is_finality_update" fork="altair" hash="4d0080ac">
+    def is_finality_update(update: LightClientUpdate) -> bool:
+        return update.finality_branch != FinalityBranch()
+    </spec>
+
+- name: is_finalization_ok#phase0
+  sources: []
+  spec: |
+    <spec fn="is_finalization_ok" fork="phase0" hash="760ff77e">
+    def is_finalization_ok(store: Store, slot: Slot) -> bool:
+        epochs_since_finalization = compute_epoch_at_slot(slot) - store.finalized_checkpoint.epoch
+        return epochs_since_finalization <= REORG_MAX_EPOCHS_SINCE_FINALIZATION
     </spec>
 
 - name: is_fully_withdrawable_validator#capella
@@ -3636,7 +5674,7 @@
         )
     </spec>
 
-- name: is_head_late
+- name: is_head_late#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
       search: public boolean isBlockLate(
@@ -3646,7 +5684,7 @@
         return not store.block_timeliness[head_root]
     </spec>
 
-- name: is_head_weak
+- name: is_head_weak#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
       search: public boolean isHeadWeak(
@@ -3659,7 +5697,7 @@
         return head_weight < reorg_threshold
     </spec>
 
-- name: is_in_inactivity_leak
+- name: is_in_inactivity_leak#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public boolean isInactivityLeak(final BeaconState state)
@@ -3669,7 +5707,7 @@
         return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
     </spec>
 
-- name: is_merge_transition_block
+- name: is_merge_transition_block#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/MiscHelpersBellatrix.java
       search: private boolean isMergeTransitionBlock(
@@ -3679,7 +5717,7 @@
         return not is_merge_transition_complete(state) and body.execution_payload != ExecutionPayload()
     </spec>
 
-- name: is_merge_transition_complete
+- name: is_merge_transition_complete#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/MiscHelpersBellatrix.java
       search: public boolean isMergeTransitionComplete(
@@ -3701,7 +5739,15 @@
         return state.latest_execution_payload_bid != bid
     </spec>
 
-- name: is_optimistic
+- name: is_next_sync_committee_known#altair
+  sources: []
+  spec: |
+    <spec fn="is_next_sync_committee_known" fork="altair" hash="f5d3196e">
+    def is_next_sync_committee_known(store: LightClientStore) -> bool:
+        return store.next_sync_committee != SyncCommittee()
+    </spec>
+
+- name: is_optimistic#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
       search: public boolean isOptimistic(
@@ -3709,6 +5755,22 @@
     <spec fn="is_optimistic" fork="bellatrix" hash="d5afd615">
     def is_optimistic(opt_store: OptimisticStore, block: BeaconBlock) -> bool:
         return hash_tree_root(block) in opt_store.optimistic_roots
+    </spec>
+
+- name: is_optimistic_candidate_block#bellatrix
+  sources: []
+  spec: |
+    <spec fn="is_optimistic_candidate_block" fork="bellatrix" hash="fdb54007">
+    def is_optimistic_candidate_block(
+        opt_store: OptimisticStore, current_slot: Slot, block: BeaconBlock
+    ) -> bool:
+        if is_execution_block(opt_store.blocks[block.parent_root]):
+            return True
+
+        if block.slot + SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY <= current_slot:
+            return True
+
+        return False
     </spec>
 
 - name: is_parent_block_full#gloas
@@ -3729,7 +5791,7 @@
         return get_parent_payload_status(store, block) == PAYLOAD_STATUS_FULL
     </spec>
 
-- name: is_parent_strong
+- name: is_parent_strong#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
       search: boolean isParentStrong(
@@ -3804,7 +5866,26 @@
         return sum(store.ptc_vote[root]) > PAYLOAD_TIMELY_THRESHOLD
     </spec>
 
-- name: is_proposing_on_time
+- name: is_power_of_two#deneb
+  sources: []
+  spec: |
+    <spec fn="is_power_of_two" fork="deneb" hash="9a547510">
+    def is_power_of_two(value: int) -> bool:
+        """
+        Check if ``value`` is a power of two integer.
+        """
+        return (value > 0) and (value & (value - 1) == 0)
+    </spec>
+
+- name: is_proposer#phase0
+  sources: []
+  spec: |
+    <spec fn="is_proposer" fork="phase0" hash="d9e66d76">
+    def is_proposer(state: BeaconState, validator_index: ValidatorIndex) -> bool:
+        return get_beacon_proposer_index(state) == validator_index
+    </spec>
+
+- name: is_proposing_on_time#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
       search: public boolean isProposingOnTime(
@@ -3818,7 +5899,7 @@
         return time_into_slot_ms <= proposer_reorg_cutoff_ms
     </spec>
 
-- name: is_shuffling_stable
+- name: is_shuffling_stable#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public boolean isShufflingStable(
@@ -3828,7 +5909,7 @@
         return slot % SLOTS_PER_EPOCH != 0
     </spec>
 
-- name: is_slashable_attestation_data
+- name: is_slashable_attestation_data#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
       search: public boolean isSlashableAttestationData(
@@ -3847,7 +5928,7 @@
         )
     </spec>
 
-- name: is_slashable_validator
+- name: is_slashable_validator#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
       search: public boolean isSlashableValidator(
@@ -3890,7 +5971,7 @@
             )
     </spec>
 
-- name: is_sync_committee_aggregator
+- name: is_sync_committee_aggregator#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public boolean isSyncCommitteeAggregator(
@@ -3906,7 +5987,15 @@
         return bytes_to_uint64(hash(signature)[0:8]) % modulo == 0
     </spec>
 
-- name: is_valid_deposit_signature
+- name: is_sync_committee_update#altair
+  sources: []
+  spec: |
+    <spec fn="is_sync_committee_update" fork="altair" hash="af6f8cb0">
+    def is_sync_committee_update(update: LightClientUpdate) -> bool:
+        return update.next_sync_committee_branch != NextSyncCommitteeBranch()
+    </spec>
+
+- name: is_valid_deposit_signature#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public boolean isValidDepositSignature(
@@ -3926,7 +6015,7 @@
         return bls.Verify(pubkey, signing_root, signature)
     </spec>
 
-- name: is_valid_genesis_state
+- name: is_valid_genesis_state#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
       search: public boolean isValidGenesisState(
@@ -3940,7 +6029,7 @@
         return True
     </spec>
 
-- name: is_valid_indexed_attestation
+- name: is_valid_indexed_attestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
       search: public AttestationProcessingResult\s+isValidIndexedAttestation\s*\(\s*final\s+Fork\s+\w+\s*,\s*final\s+BeaconState\s+\w+\s*,\s*final\s+ValidatableAttestation\s+\w+\s*\)
@@ -3989,7 +6078,62 @@
         return bls.FastAggregateVerify(pubkeys, signing_root, indexed_payload_attestation.signature)
     </spec>
 
-- name: is_valid_merkle_branch
+- name: is_valid_light_client_header#altair
+  sources: []
+  spec: |
+    <spec fn="is_valid_light_client_header" fork="altair" hash="a4c4f0f3">
+    def is_valid_light_client_header(_header: LightClientHeader) -> bool:
+        return True
+    </spec>
+
+- name: is_valid_light_client_header#capella
+  sources: []
+  spec: |
+    <spec fn="is_valid_light_client_header" fork="capella" style="diff" hash="232ae1d9">
+    --- altair
+    +++ capella
+    @@ -1,2 +1,16 @@
+    -def is_valid_light_client_header(_header: LightClientHeader) -> bool:
+    -    return True
+    +def is_valid_light_client_header(header: LightClientHeader) -> bool:
+    +    epoch = compute_epoch_at_slot(header.beacon.slot)
+    +
+    +    if epoch < CAPELLA_FORK_EPOCH:
+    +        return (
+    +            header.execution == ExecutionPayloadHeader()
+    +            and header.execution_branch == ExecutionBranch()
+    +        )
+    +
+    +    return is_valid_merkle_branch(
+    +        leaf=get_lc_execution_root(header),
+    +        branch=header.execution_branch,
+    +        depth=floorlog2(EXECUTION_PAYLOAD_GINDEX),
+    +        index=get_subtree_index(EXECUTION_PAYLOAD_GINDEX),
+    +        root=header.beacon.body_root,
+    +    )
+    </spec>
+
+- name: is_valid_light_client_header#deneb
+  sources: []
+  spec: |
+    <spec fn="is_valid_light_client_header" fork="deneb" style="diff" hash="f458ba78">
+    --- capella
+    +++ deneb
+    @@ -1,5 +1,11 @@
+     def is_valid_light_client_header(header: LightClientHeader) -> bool:
+         epoch = compute_epoch_at_slot(header.beacon.slot)
+    +
+    +    if epoch < DENEB_FORK_EPOCH:
+    +        if header.execution.blob_gas_used != uint64(0):
+    +            return False
+    +        if header.execution.excess_blob_gas != uint64(0):
+    +            return False
+
+         if epoch < CAPELLA_FORK_EPOCH:
+             return (
+    </spec>
+
+- name: is_valid_merkle_branch#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
       search: public boolean isValidMerkleBranch(
@@ -4010,7 +6154,23 @@
         return value == root
     </spec>
 
-- name: is_valid_switch_to_compounding_request
+- name: is_valid_normalized_merkle_branch#altair
+  sources: []
+  spec: |
+    <spec fn="is_valid_normalized_merkle_branch" fork="altair" hash="ef32cdea">
+    def is_valid_normalized_merkle_branch(
+        leaf: Bytes32, branch: Sequence[Bytes32], gindex: GeneralizedIndex, root: Root
+    ) -> bool:
+        depth = floorlog2(gindex)
+        index = get_subtree_index(gindex)
+        num_extra = len(branch) - depth
+        for i in range(num_extra):
+            if branch[i] != Bytes32():
+                return False
+        return is_valid_merkle_branch(leaf, branch[num_extra:], depth, index, root)
+    </spec>
+
+- name: is_valid_switch_to_compounding_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public void switchToCompoundingValidator(
@@ -4051,6 +6211,16 @@
         return True
     </spec>
 
+- name: is_valid_terminal_pow_block#bellatrix
+  sources: []
+  spec: |
+    <spec fn="is_valid_terminal_pow_block" fork="bellatrix" hash="96a7d581">
+    def is_valid_terminal_pow_block(block: PowBlock, parent: PowBlock) -> bool:
+        is_total_difficulty_reached = block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY
+        is_parent_total_difficulty_valid = parent.total_difficulty < TERMINAL_TOTAL_DIFFICULTY
+        return is_total_difficulty_reached and is_parent_total_difficulty_valid
+    </spec>
+
 - name: is_within_weak_subjectivity_period#phase0
   sources:
     - file: ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -4070,7 +6240,14 @@
         return current_epoch <= ws_state_epoch + ws_period
     </spec>
 
-- name: kzg_commitment_to_versioned_hash
+- name: is_within_weak_subjectivity_period#electra
+  sources: []
+  spec: |
+    <spec fn="is_within_weak_subjectivity_period" fork="electra" style="diff" hash="d05d230d">
+
+    </spec>
+
+- name: kzg_commitment_to_versioned_hash#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
       search: public VersionedHash kzgCommitmentToVersionedHash(
@@ -4080,7 +6257,19 @@
         return VERSIONED_HASH_VERSION_KZG + hash(kzg_commitment)[1:]
     </spec>
 
-- name: max_compressed_len
+- name: latest_verified_ancestor#bellatrix
+  sources: []
+  spec: |
+    <spec fn="latest_verified_ancestor" fork="bellatrix" hash="c2ee2c55">
+    def latest_verified_ancestor(opt_store: OptimisticStore, block: BeaconBlock) -> BeaconBlock:
+        # It is assumed that the `block` parameter is never an INVALIDATED block.
+        while True:
+            if not is_optimistic(opt_store, block) or block.parent_root == Root():
+                return block
+            block = opt_store.blocks[block.parent_root]
+    </spec>
+
+- name: max_compressed_len#phase0
   sources:
     - file: networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
       search: private static int maxCompressedLength(
@@ -4092,7 +6281,7 @@
         return uint64(32 + n + n / 6)
     </spec>
 
-- name: max_message_size
+- name: max_message_size#phase0
   sources:
     - file: networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
       search: private static int maxMessageSize(
@@ -4101,6 +6290,66 @@
     def max_message_size() -> uint64:
         # Allow 1024 bytes for framing and encoding overhead but at least 1MiB in case MAX_PAYLOAD_SIZE is small.
         return max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1024 * 1024)
+    </spec>
+
+- name: multi_exp#deneb
+  sources: []
+  spec: |
+    <spec fn="multi_exp" fork="deneb" hash="3235b276">
+    def multi_exp(_points: Sequence[TPoint], _integers: Sequence[uint64]) -> Sequence[TPoint]: ...
+    </spec>
+
+- name: multiply_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="multiply_polynomialcoeff" fork="fulu" hash="c2ba13ea">
+    def multiply_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoeff:
+        """
+        Multiplies the coefficient form polynomials ``a`` and ``b``.
+        """
+        assert len(a) + len(b) <= FIELD_ELEMENTS_PER_EXT_BLOB
+
+        r = PolynomialCoeff([BLSFieldElement(0)])
+        for power, coef in enumerate(a):
+            summand = PolynomialCoeff([BLSFieldElement(0)] * power + [coef * x for x in b])
+            r = add_polynomialcoeff(r, summand)
+        return r
+    </spec>
+
+- name: next_sync_committee_gindex_at_slot#altair
+  sources: []
+  spec: |
+    <spec fn="next_sync_committee_gindex_at_slot" fork="altair" hash="129a53c6">
+    def next_sync_committee_gindex_at_slot(_slot: Slot) -> GeneralizedIndex:
+        return NEXT_SYNC_COMMITTEE_GINDEX
+    </spec>
+
+- name: next_sync_committee_gindex_at_slot#electra
+  sources: []
+  spec: |
+    <spec fn="next_sync_committee_gindex_at_slot" fork="electra" style="diff" hash="87d7c53a">
+    --- altair
+    +++ electra
+    @@ -1,2 +1,6 @@
+    -def next_sync_committee_gindex_at_slot(_slot: Slot) -> GeneralizedIndex:
+    +def next_sync_committee_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+    +    epoch = compute_epoch_at_slot(slot)
+    +
+    +    if epoch >= ELECTRA_FORK_EPOCH:
+    +        return NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
+         return NEXT_SYNC_COMMITTEE_GINDEX
+    </spec>
+
+- name: normalize_merkle_branch#electra
+  sources: []
+  spec: |
+    <spec fn="normalize_merkle_branch" fork="electra" hash="149d7b0c">
+    def normalize_merkle_branch(
+        branch: Sequence[Bytes32], gindex: GeneralizedIndex
+    ) -> Sequence[Bytes32]:
+        depth = floorlog2(gindex)
+        num_extra = depth - len(branch)
+        return [Bytes32()] * num_extra + [*branch]
     </spec>
 
 - name: notify_ptc_messages#gloas
@@ -4132,7 +6381,7 @@
                 )
     </spec>
 
-- name: on_attestation
+- name: on_attestation#phase0
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: public SafeFuture<AttestationProcessingResult> onAttestation(
@@ -4158,7 +6407,7 @@
         update_latest_messages(store, indexed_attestation.attesting_indices, attestation)
     </spec>
 
-- name: on_attester_slashing
+- name: on_attester_slashing#phase0
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: public void onAttesterSlashing(
@@ -4630,7 +6879,7 @@
         ptc_vote[ptc_index] = data.payload_present
     </spec>
 
-- name: on_tick
+- name: on_tick#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public void onTick(
@@ -4644,6 +6893,167 @@
             previous_time = store.genesis_time + (get_current_slot(store) + 1) * SECONDS_PER_SLOT
             on_tick_per_slot(store, previous_time)
         on_tick_per_slot(store, time)
+    </spec>
+
+- name: on_tick_per_slot#phase0
+  sources: []
+  spec: |
+    <spec fn="on_tick_per_slot" fork="phase0" hash="ae9ef172">
+    def on_tick_per_slot(store: Store, time: uint64) -> None:
+        previous_slot = get_current_slot(store)
+
+        # Update store time
+        store.time = time
+
+        current_slot = get_current_slot(store)
+
+        # If this is a new slot, reset store.proposer_boost_root
+        if current_slot > previous_slot:
+            store.proposer_boost_root = Root()
+
+        # If a new epoch, pull-up justification and finalization from previous epoch
+        if current_slot > previous_slot and compute_slots_since_epoch_start(current_slot) == 0:
+            update_checkpoints(
+                store, store.unrealized_justified_checkpoint, store.unrealized_finalized_checkpoint
+            )
+    </spec>
+
+- name: polynomial_eval_to_coeff#fulu
+  sources: []
+  spec: |
+    <spec fn="polynomial_eval_to_coeff" fork="fulu" hash="f13ead66">
+    def polynomial_eval_to_coeff(polynomial: Polynomial) -> PolynomialCoeff:
+        """
+        Interpolates a polynomial (given in evaluation form) to a polynomial in coefficient form.
+        """
+        roots_of_unity = compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB)
+        return PolynomialCoeff(
+            fft_field(bit_reversal_permutation(polynomial), roots_of_unity, inv=True)
+        )
+    </spec>
+
+- name: prepare_execution_payload#bellatrix
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="bellatrix" hash="6af4de76">
+    def prepare_execution_payload(
+        state: BeaconState,
+        safe_block_hash: Hash32,
+        finalized_block_hash: Hash32,
+        suggested_fee_recipient: ExecutionAddress,
+        execution_engine: ExecutionEngine,
+        pow_chain: Optional[Dict[Hash32, PowBlock]] = None,
+    ) -> Optional[PayloadId]:
+        if not is_merge_transition_complete(state):
+            assert pow_chain is not None
+            is_terminal_block_hash_set = TERMINAL_BLOCK_HASH != Hash32()
+            is_activation_epoch_reached = (
+                get_current_epoch(state) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
+            )
+            if is_terminal_block_hash_set and not is_activation_epoch_reached:
+                # Terminal block hash is set but activation epoch is not yet reached, no prepare payload call is needed
+                return None
+
+            terminal_pow_block = get_terminal_pow_block(pow_chain)
+            if terminal_pow_block is None:
+                # Pre-merge, no prepare payload call is needed
+                return None
+            # Signify merge via producing on top of the terminal PoW block
+            parent_hash = terminal_pow_block.block_hash
+        else:
+            # Post-merge, normal payload
+            parent_hash = state.latest_execution_payload_header.block_hash
+
+        # Set the forkchoice head and initiate the payload build process
+        payload_attributes = PayloadAttributes(
+            timestamp=compute_time_at_slot(state, state.slot),
+            prev_randao=get_randao_mix(state, get_current_epoch(state)),
+            suggested_fee_recipient=suggested_fee_recipient,
+        )
+        return execution_engine.notify_forkchoice_updated(
+            head_block_hash=parent_hash,
+            safe_block_hash=safe_block_hash,
+            finalized_block_hash=finalized_block_hash,
+            payload_attributes=payload_attributes,
+        )
+    </spec>
+
+- name: prepare_execution_payload#capella
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="capella" style="diff" hash="28db1590">
+    --- bellatrix
+    +++ capella
+    @@ -4,28 +4,14 @@
+         finalized_block_hash: Hash32,
+         suggested_fee_recipient: ExecutionAddress,
+         execution_engine: ExecutionEngine,
+    -    pow_chain: Optional[Dict[Hash32, PowBlock]] = None,
+     ) -> Optional[PayloadId]:
+    -    if not is_merge_transition_complete(state):
+    -        assert pow_chain is not None
+    -        is_terminal_block_hash_set = TERMINAL_BLOCK_HASH != Hash32()
+    -        is_activation_epoch_reached = (
+    -            get_current_epoch(state) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
+    -        )
+    -        if is_terminal_block_hash_set and not is_activation_epoch_reached:
+    -            return None
+    -
+    -        terminal_pow_block = get_terminal_pow_block(pow_chain)
+    -        if terminal_pow_block is None:
+    -            return None
+    -        parent_hash = terminal_pow_block.block_hash
+    -    else:
+    -        parent_hash = state.latest_execution_payload_header.block_hash
+    +    parent_hash = state.latest_execution_payload_header.block_hash
+
+         payload_attributes = PayloadAttributes(
+             timestamp=compute_time_at_slot(state, state.slot),
+             prev_randao=get_randao_mix(state, get_current_epoch(state)),
+             suggested_fee_recipient=suggested_fee_recipient,
+    +        withdrawals=get_expected_withdrawals(state),
+         )
+         return execution_engine.notify_forkchoice_updated(
+             head_block_hash=parent_hash,
+    </spec>
+
+- name: prepare_execution_payload#deneb
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="deneb" style="diff" hash="f3387ec6">
+    --- capella
+    +++ deneb
+    @@ -12,6 +12,7 @@
+             prev_randao=get_randao_mix(state, get_current_epoch(state)),
+             suggested_fee_recipient=suggested_fee_recipient,
+             withdrawals=get_expected_withdrawals(state),
+    +        parent_beacon_block_root=hash_tree_root(state.latest_block_header),
+         )
+         return execution_engine.notify_forkchoice_updated(
+             head_block_hash=parent_hash,
+    </spec>
+
+- name: prepare_execution_payload#electra
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="electra" style="diff" hash="567b3739">
+    --- deneb
+    +++ electra
+    @@ -7,11 +7,13 @@
+     ) -> Optional[PayloadId]:
+         parent_hash = state.latest_execution_payload_header.block_hash
+
+    +    withdrawals, _ = get_expected_withdrawals(state)
+    +
+         payload_attributes = PayloadAttributes(
+             timestamp=compute_time_at_slot(state, state.slot),
+             prev_randao=get_randao_mix(state, get_current_epoch(state)),
+             suggested_fee_recipient=suggested_fee_recipient,
+    -        withdrawals=get_expected_withdrawals(state),
+    +        withdrawals=withdrawals,
+             parent_beacon_block_root=hash_tree_root(state.latest_block_header),
+         )
+         return execution_engine.notify_forkchoice_updated(
     </spec>
 
 - name: prepare_execution_payload#gloas
@@ -4959,7 +7369,7 @@
             state.builder_pending_payments[data.slot % SLOTS_PER_EPOCH] = payment
     </spec>
 
-- name: process_attester_slashing
+- name: process_attester_slashing#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: public void processAttesterSlashings\s*\([^,]+,[^,]+\)\s*throws
@@ -5085,7 +7495,7 @@
         process_sync_aggregate(state, block.body.sync_aggregate)
     </spec>
 
-- name: process_block_header
+- name: process_block_header#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: public void processBlockHeader(
@@ -5114,7 +7524,7 @@
         assert not proposer.slashed
     </spec>
 
-- name: process_bls_to_execution_change
+- name: process_bls_to_execution_change#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processBlsToExecutionChangesNoValidation(
@@ -5168,7 +7578,7 @@
         state.builder_pending_payments = old_payments + new_payments
     </spec>
 
-- name: process_consolidation_request
+- name: process_consolidation_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processConsolidationRequests(
@@ -5308,7 +7718,7 @@
         )
     </spec>
 
-- name: process_deposit_request
+- name: process_deposit_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processDepositRequests(
@@ -5574,7 +7984,7 @@
         process_builder_pending_payments(state)
     </spec>
 
-- name: process_eth1_data
+- name: process_eth1_data#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: protected void processEth1Data(
@@ -5589,7 +7999,7 @@
             state.eth1_data = body.eth1_data
     </spec>
 
-- name: process_eth1_data_reset
+- name: process_eth1_data_reset#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processEth1DataReset(
@@ -5641,6 +8051,31 @@
             block_hash=payload.block_hash,
             transactions_root=hash_tree_root(payload.transactions),
         )
+    </spec>
+
+- name: process_execution_payload#capella
+  sources: []
+  spec: |
+    <spec fn="process_execution_payload" fork="capella" style="diff" hash="8da02dfc">
+    --- bellatrix
+    +++ capella
+    @@ -2,9 +2,7 @@
+         state: BeaconState, body: BeaconBlockBody, execution_engine: ExecutionEngine
+     ) -> None:
+         payload = body.execution_payload
+    -
+    -    if is_merge_transition_complete(state):
+    -        assert payload.parent_hash == state.latest_execution_payload_header.block_hash
+    +    assert payload.parent_hash == state.latest_execution_payload_header.block_hash
+         assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
+         assert payload.timestamp == compute_time_at_slot(state, state.slot)
+         assert execution_engine.verify_and_notify_new_payload(
+    @@ -25,4 +23,5 @@
+             base_fee_per_gas=payload.base_fee_per_gas,
+             block_hash=payload.block_hash,
+             transactions_root=hash_tree_root(payload.transactions),
+    +        withdrawals_root=hash_tree_root(payload.withdrawals),
+         )
     </spec>
 
 - name: process_execution_payload#deneb
@@ -5703,6 +8138,31 @@
             # [New in Deneb:EIP4844]
             excess_blob_gas=payload.excess_blob_gas,
         )
+    </spec>
+
+- name: process_execution_payload#electra
+  sources: []
+  spec: |
+    <spec fn="process_execution_payload" fork="electra" style="diff" hash="078e4a6c">
+    --- deneb
+    +++ electra
+    @@ -6,7 +6,7 @@
+         assert payload.parent_hash == state.latest_execution_payload_header.block_hash
+         assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
+         assert payload.timestamp == compute_time_at_slot(state, state.slot)
+    -    assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
+    +    assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK_ELECTRA
+
+         versioned_hashes = [
+             kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
+    @@ -17,6 +17,7 @@
+                 execution_payload=payload,
+                 versioned_hashes=versioned_hashes,
+                 parent_beacon_block_root=state.latest_block_header.parent_root,
+    +            execution_requests=body.execution_requests,
+             )
+         )
+
     </spec>
 
 - name: process_execution_payload#fulu
@@ -5931,7 +8391,7 @@
         state.latest_execution_payload_bid = bid
     </spec>
 
-- name: process_historical_roots_update
+- name: process_historical_roots_update#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processHistoricalRootsUpdate(
@@ -5947,7 +8407,7 @@
             state.historical_roots.append(hash_tree_root(historical_batch))
     </spec>
 
-- name: process_historical_summaries_update
+- name: process_historical_summaries_update#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/statetransition/epoch/EpochProcessorCapella.java
       search: public void processHistoricalSummariesUpdate(
@@ -5964,7 +8424,7 @@
             state.historical_summaries.append(historical_summary)
     </spec>
 
-- name: process_inactivity_updates
+- name: process_inactivity_updates#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
       search: public void processInactivityUpdates(
@@ -6009,6 +8469,150 @@
         weigh_justification_and_finalization(
             state, total_active_balance, previous_target_balance, current_target_balance
         )
+    </spec>
+
+- name: process_justification_and_finalization#altair
+  sources: []
+  spec: |
+    <spec fn="process_justification_and_finalization" fork="altair" style="diff" hash="863cfca6">
+    --- phase0
+    +++ altair
+    @@ -1,11 +1,15 @@
+     def process_justification_and_finalization(state: BeaconState) -> None:
+         if get_current_epoch(state) <= GENESIS_EPOCH + 1:
+             return
+    -    previous_attestations = get_matching_target_attestations(state, get_previous_epoch(state))
+    -    current_attestations = get_matching_target_attestations(state, get_current_epoch(state))
+    +    previous_indices = get_unslashed_participating_indices(
+    +        state, TIMELY_TARGET_FLAG_INDEX, get_previous_epoch(state)
+    +    )
+    +    current_indices = get_unslashed_participating_indices(
+    +        state, TIMELY_TARGET_FLAG_INDEX, get_current_epoch(state)
+    +    )
+         total_active_balance = get_total_active_balance(state)
+    -    previous_target_balance = get_attesting_balance(state, previous_attestations)
+    -    current_target_balance = get_attesting_balance(state, current_attestations)
+    +    previous_target_balance = get_total_balance(state, previous_indices)
+    +    current_target_balance = get_total_balance(state, current_indices)
+         weigh_justification_and_finalization(
+             state, total_active_balance, previous_target_balance, current_target_balance
+         )
+    </spec>
+
+- name: process_light_client_finality_update#altair
+  sources: []
+  spec: |
+    <spec fn="process_light_client_finality_update" fork="altair" hash="befaba5b">
+    def process_light_client_finality_update(
+        store: LightClientStore,
+        finality_update: LightClientFinalityUpdate,
+        current_slot: Slot,
+        genesis_validators_root: Root,
+    ) -> None:
+        update = LightClientUpdate(
+            attested_header=finality_update.attested_header,
+            next_sync_committee=SyncCommittee(),
+            next_sync_committee_branch=NextSyncCommitteeBranch(),
+            finalized_header=finality_update.finalized_header,
+            finality_branch=finality_update.finality_branch,
+            sync_aggregate=finality_update.sync_aggregate,
+            signature_slot=finality_update.signature_slot,
+        )
+        process_light_client_update(store, update, current_slot, genesis_validators_root)
+    </spec>
+
+- name: process_light_client_optimistic_update#altair
+  sources: []
+  spec: |
+    <spec fn="process_light_client_optimistic_update" fork="altair" hash="06c0365a">
+    def process_light_client_optimistic_update(
+        store: LightClientStore,
+        optimistic_update: LightClientOptimisticUpdate,
+        current_slot: Slot,
+        genesis_validators_root: Root,
+    ) -> None:
+        update = LightClientUpdate(
+            attested_header=optimistic_update.attested_header,
+            next_sync_committee=SyncCommittee(),
+            next_sync_committee_branch=NextSyncCommitteeBranch(),
+            finalized_header=LightClientHeader(),
+            finality_branch=FinalityBranch(),
+            sync_aggregate=optimistic_update.sync_aggregate,
+            signature_slot=optimistic_update.signature_slot,
+        )
+        process_light_client_update(store, update, current_slot, genesis_validators_root)
+    </spec>
+
+- name: process_light_client_store_force_update#altair
+  sources: []
+  spec: |
+    <spec fn="process_light_client_store_force_update" fork="altair" hash="fbb77069">
+    def process_light_client_store_force_update(store: LightClientStore, current_slot: Slot) -> None:
+        if (
+            current_slot > store.finalized_header.beacon.slot + UPDATE_TIMEOUT
+            and store.best_valid_update is not None
+        ):
+            # Forced best update when the update timeout has elapsed.
+            # Because the apply logic waits for `finalized_header.beacon.slot` to indicate sync committee finality,
+            # the `attested_header` may be treated as `finalized_header` in extended periods of non-finality
+            # to guarantee progression into later sync committee periods according to `is_better_update`.
+            if (
+                store.best_valid_update.finalized_header.beacon.slot
+                <= store.finalized_header.beacon.slot
+            ):
+                store.best_valid_update.finalized_header = store.best_valid_update.attested_header
+            apply_light_client_update(store, store.best_valid_update)
+            store.best_valid_update = None
+    </spec>
+
+- name: process_light_client_update#altair
+  sources: []
+  spec: |
+    <spec fn="process_light_client_update" fork="altair" hash="b64a67ff">
+    def process_light_client_update(
+        store: LightClientStore,
+        update: LightClientUpdate,
+        current_slot: Slot,
+        genesis_validators_root: Root,
+    ) -> None:
+        validate_light_client_update(store, update, current_slot, genesis_validators_root)
+
+        sync_committee_bits = update.sync_aggregate.sync_committee_bits
+
+        # Update the best update in case we have to force-update to it if the timeout elapses
+        if store.best_valid_update is None or is_better_update(update, store.best_valid_update):
+            store.best_valid_update = update
+
+        # Track the maximum number of active participants in the committee signatures
+        store.current_max_active_participants = max(
+            store.current_max_active_participants,
+            sum(sync_committee_bits),
+        )
+
+        # Update the optimistic header
+        if (
+            sum(sync_committee_bits) > get_safety_threshold(store)
+            and update.attested_header.beacon.slot > store.optimistic_header.beacon.slot
+        ):
+            store.optimistic_header = update.attested_header
+
+        # Update finalized header
+        update_has_finalized_next_sync_committee = (
+            not is_next_sync_committee_known(store)
+            and is_sync_committee_update(update)
+            and is_finality_update(update)
+            and (
+                compute_sync_committee_period_at_slot(update.finalized_header.beacon.slot)
+                == compute_sync_committee_period_at_slot(update.attested_header.beacon.slot)
+            )
+        )
+        if sum(sync_committee_bits) * 3 >= len(sync_committee_bits) * 2 and (
+            update.finalized_header.beacon.slot > store.finalized_header.beacon.slot
+            or update_has_finalized_next_sync_committee
+        ):
+            # Normal update through 2/3 threshold
+            apply_light_client_update(store, update)
+            store.best_valid_update = None
     </spec>
 
 - name: process_operations#phase0
@@ -6138,7 +8742,7 @@
         for_ops(body.payload_attestations, process_payload_attestation)
     </spec>
 
-- name: process_participation_flag_updates
+- name: process_participation_flag_updates#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
       search: public void processParticipationUpdates(
@@ -6151,7 +8755,7 @@
         ]
     </spec>
 
-- name: process_participation_record_updates
+- name: process_participation_record_updates#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
       search: public void processParticipationUpdates(
@@ -6185,7 +8789,7 @@
         assert is_valid_indexed_payload_attestation(state, indexed_payload_attestation)
     </spec>
 
-- name: process_pending_consolidations
+- name: process_pending_consolidations#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingConsolidations(
@@ -6215,7 +8819,7 @@
         state.pending_consolidations = state.pending_consolidations[next_pending_consolidation:]
     </spec>
 
-- name: process_pending_deposits
+- name: process_pending_deposits#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processPendingDeposits(
@@ -6288,7 +8892,7 @@
             state.deposit_balance_to_consume = Gwei(0)
     </spec>
 
-- name: process_proposer_lookahead
+- name: process_proposer_lookahead#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/statetransition/epoch/EpochProcessorFulu.java
       search: public void processProposerLookahead(
@@ -6305,7 +8909,7 @@
         state.proposer_lookahead[last_epoch_start:] = last_epoch_proposers
     </spec>
 
-- name: process_proposer_slashing
+- name: process_proposer_slashing#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: public void processProposerSlashings(
@@ -6375,7 +8979,7 @@
         slash_validator(state, header_1.proposer_index)
     </spec>
 
-- name: process_randao
+- name: process_randao#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: protected void processRandaoNoValidation(
@@ -6392,7 +8996,7 @@
         state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR] = mix
     </spec>
 
-- name: process_randao_mixes_reset
+- name: process_randao_mixes_reset#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processRandaoMixesReset(
@@ -6441,6 +9045,22 @@
             validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
     </spec>
 
+- name: process_registry_updates#deneb
+  sources: []
+  spec: |
+    <spec fn="process_registry_updates" fork="deneb" style="diff" hash="71a6a2d9">
+    --- phase0
+    +++ deneb
+    @@ -17,6 +17,6 @@
+             ],
+             key=lambda index: (state.validators[index].activation_eligibility_epoch, index),
+         )
+    -    for index in activation_queue[: get_validator_churn_limit(state)]:
+    +    for index in activation_queue[: get_validator_activation_churn_limit(state)]:
+             validator = state.validators[index]
+             validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
+    </spec>
+
 - name: process_registry_updates#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
@@ -6483,6 +9103,31 @@
             decrease_balance(state, ValidatorIndex(index), penalties[index])
     </spec>
 
+- name: process_rewards_and_penalties#altair
+  sources: []
+  spec: |
+    <spec fn="process_rewards_and_penalties" fork="altair" style="diff" hash="373af4c1">
+    --- phase0
+    +++ altair
+    @@ -2,7 +2,12 @@
+         if get_current_epoch(state) == GENESIS_EPOCH:
+             return
+
+    -    rewards, penalties = get_attestation_deltas(state)
+    -    for index in range(len(state.validators)):
+    -        increase_balance(state, ValidatorIndex(index), rewards[index])
+    -        decrease_balance(state, ValidatorIndex(index), penalties[index])
+    +    flag_deltas = [
+    +        get_flag_index_deltas(state, flag_index)
+    +        for flag_index in range(len(PARTICIPATION_FLAG_WEIGHTS))
+    +    ]
+    +    deltas = flag_deltas + [get_inactivity_penalty_deltas(state)]
+    +    for rewards, penalties in deltas:
+    +        for index in range(len(state.validators)):
+    +            increase_balance(state, ValidatorIndex(index), rewards[index])
+    +            decrease_balance(state, ValidatorIndex(index), penalties[index])
+    </spec>
+
 - name: process_slashings#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -6506,6 +9151,42 @@
                 )
                 penalty = penalty_numerator // total_balance * increment
                 decrease_balance(state, ValidatorIndex(index), penalty)
+    </spec>
+
+- name: process_slashings#altair
+  sources: []
+  spec: |
+    <spec fn="process_slashings" fork="altair" style="diff" hash="96cce87d">
+    --- phase0
+    +++ altair
+    @@ -2,7 +2,7 @@
+         epoch = get_current_epoch(state)
+         total_balance = get_total_active_balance(state)
+         adjusted_total_slashing_balance = min(
+    -        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER, total_balance
+    +        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance
+         )
+         for index, validator in enumerate(state.validators):
+             if (
+    </spec>
+
+- name: process_slashings#bellatrix
+  sources: []
+  spec: |
+    <spec fn="process_slashings" fork="bellatrix" style="diff" hash="0c8f6e6e">
+    --- altair
+    +++ bellatrix
+    @@ -2,7 +2,9 @@
+         epoch = get_current_epoch(state)
+         total_balance = get_total_active_balance(state)
+         adjusted_total_slashing_balance = min(
+    -        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance
+    +        sum(state.slashings)
+    +        * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX,
+    +        total_balance,
+         )
+         for index, validator in enumerate(state.validators):
+             if (
     </spec>
 
 - name: process_slashings#electra
@@ -6537,7 +9218,7 @@
                 decrease_balance(state, ValidatorIndex(index), penalty)
     </spec>
 
-- name: process_slashings_reset
+- name: process_slashings_reset#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashingsReset(
@@ -6549,7 +9230,7 @@
         state.slashings[next_epoch % EPOCHS_PER_SLASHINGS_VECTOR] = Gwei(0)
     </spec>
 
-- name: process_slot
+- name: process_slot#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
       search: private BeaconState processSlot(
@@ -6586,7 +9267,7 @@
         state.execution_payload_availability[(state.slot + 1) % SLOTS_PER_HISTORICAL_ROOT] = 0b0
     </spec>
 
-- name: process_slots
+- name: process_slots#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
       search: public BeaconState processSlots(
@@ -6602,7 +9283,7 @@
             state.slot = Slot(state.slot + 1)
     </spec>
 
-- name: process_sync_aggregate
+- name: process_sync_aggregate#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
       search: public void processSyncAggregate(
@@ -6671,7 +9352,31 @@
                 decrease_balance(state, participant_index, participant_reward)
     </spec>
 
-- name: process_sync_committee_updates
+- name: process_sync_committee_contributions#altair
+  sources: []
+  spec: |
+    <spec fn="process_sync_committee_contributions" fork="altair" hash="34e95c46">
+    def process_sync_committee_contributions(
+        block: BeaconBlock, contributions: Set[SyncCommitteeContribution]
+    ) -> None:
+        sync_aggregate = SyncAggregate()
+        signatures = []
+        sync_subcommittee_size = SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT
+
+        for contribution in contributions:
+            subcommittee_index = contribution.subcommittee_index
+            for index, participated in enumerate(contribution.aggregation_bits):
+                if participated:
+                    participant_index = sync_subcommittee_size * subcommittee_index + index
+                    sync_aggregate.sync_committee_bits[participant_index] = True
+            signatures.append(contribution.signature)
+
+        sync_aggregate.sync_committee_signature = bls.Aggregate(signatures)
+
+        block.body.sync_aggregate = sync_aggregate
+    </spec>
+
+- name: process_sync_committee_updates#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
       search: public void processSyncCommitteeUpdates(
@@ -6709,7 +9414,42 @@
         initiate_validator_exit(state, voluntary_exit.validator_index)
     </spec>
 
-- name: process_withdrawal_request
+- name: process_voluntary_exit#deneb
+  sources: []
+  spec: |
+    <spec fn="process_voluntary_exit" fork="deneb" style="diff" hash="f97fd167">
+    --- phase0
+    +++ deneb
+    @@ -5,7 +5,9 @@
+         assert validator.exit_epoch == FAR_FUTURE_EPOCH
+         assert get_current_epoch(state) >= voluntary_exit.epoch
+         assert get_current_epoch(state) >= validator.activation_epoch + SHARD_COMMITTEE_PERIOD
+    -    domain = get_domain(state, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch)
+    +    domain = compute_domain(
+    +        DOMAIN_VOLUNTARY_EXIT, CAPELLA_FORK_VERSION, state.genesis_validators_root
+    +    )
+         signing_root = compute_signing_root(voluntary_exit, domain)
+         assert bls.Verify(validator.pubkey, signing_root, signed_voluntary_exit.signature)
+         initiate_validator_exit(state, voluntary_exit.validator_index)
+    </spec>
+
+- name: process_voluntary_exit#electra
+  sources: []
+  spec: |
+    <spec fn="process_voluntary_exit" fork="electra" style="diff" hash="51b07d36">
+    --- deneb
+    +++ electra
+    @@ -5,6 +5,7 @@
+         assert validator.exit_epoch == FAR_FUTURE_EPOCH
+         assert get_current_epoch(state) >= voluntary_exit.epoch
+         assert get_current_epoch(state) >= validator.activation_epoch + SHARD_COMMITTEE_PERIOD
+    +    assert get_pending_balance_to_withdraw(state, voluntary_exit.validator_index) == 0
+         domain = compute_domain(
+             DOMAIN_VOLUNTARY_EXIT, CAPELLA_FORK_VERSION, state.genesis_validators_root
+         )
+    </spec>
+
+- name: process_withdrawal_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
       search: public void processWithdrawalRequests(
@@ -6914,7 +9654,7 @@
             state.next_withdrawal_validator_index = next_validator_index
     </spec>
 
-- name: queue_excess_active_balance
+- name: queue_excess_active_balance#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public void queueExcessActiveBalance(
@@ -6939,6 +9679,152 @@
             )
     </spec>
 
+- name: recover_cells_and_kzg_proofs#fulu
+  sources: []
+  spec: |
+    <spec fn="recover_cells_and_kzg_proofs" fork="fulu" hash="1a56b010">
+    def recover_cells_and_kzg_proofs(
+        cell_indices: Sequence[CellIndex], cells: Sequence[Cell]
+    ) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
+        """
+        Given at least 50% of cells for a blob, recover all the cells/proofs.
+        This algorithm uses FFTs to recover cells faster than using Lagrange
+        implementation, as can be seen here:
+        https://ethresear.ch/t/reed-solomon-erasure-code-recovery-in-n-log-2-n-time-with-ffts/3039
+
+        A faster version thanks to Qi Zhou can be found here:
+        https://github.com/ethereum/research/blob/51b530a53bd4147d123ab3e390a9d08605c2cdb8/polynomial_reconstruction/polynomial_reconstruction_danksharding.py
+
+        Public method.
+        """
+        # Check we have the same number of cells and indices
+        assert len(cell_indices) == len(cells)
+        # Check we have enough cells to be able to perform the reconstruction
+        assert CELLS_PER_EXT_BLOB // 2 <= len(cell_indices) <= CELLS_PER_EXT_BLOB
+        # Check for duplicates
+        assert len(cell_indices) == len(set(cell_indices))
+        # Check that indices are in ascending order
+        assert cell_indices == sorted(cell_indices)
+        # Check that the cell indices are within bounds
+        for cell_index in cell_indices:
+            assert cell_index < CELLS_PER_EXT_BLOB
+        # Check that each cell is the correct length
+        for cell in cells:
+            assert len(cell) == BYTES_PER_CELL
+
+        # Convert cells to coset evaluations
+        cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
+
+        # Given the coset evaluations, recover the polynomial in coefficient form
+        polynomial_coeff = recover_polynomialcoeff(cell_indices, cosets_evals)
+
+        # Recompute all cells/proofs
+        return compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff)
+    </spec>
+
+- name: recover_matrix#fulu
+  sources: []
+  spec: |
+    <spec fn="recover_matrix" fork="fulu" hash="9b01f005">
+    def recover_matrix(
+        partial_matrix: Sequence[MatrixEntry], blob_count: uint64
+    ) -> Sequence[MatrixEntry]:
+        """
+        Recover the full, flattened sequence of matrix entries.
+
+        This helper demonstrates how to apply ``recover_cells_and_kzg_proofs``.
+        The data structure for storing cells/proofs is implementation-dependent.
+        """
+        matrix = []
+        for blob_index in range(blob_count):
+            cell_indices = [e.column_index for e in partial_matrix if e.row_index == blob_index]
+            cells = [e.cell for e in partial_matrix if e.row_index == blob_index]
+            recovered_cells, recovered_proofs = recover_cells_and_kzg_proofs(cell_indices, cells)
+            for cell_index, (cell, proof) in enumerate(zip(recovered_cells, recovered_proofs)):
+                matrix.append(
+                    MatrixEntry(
+                        cell=cell,
+                        kzg_proof=proof,
+                        row_index=blob_index,
+                        column_index=cell_index,
+                    )
+                )
+        return matrix
+    </spec>
+
+- name: recover_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="recover_polynomialcoeff" fork="fulu" hash="48b30a8e">
+    def recover_polynomialcoeff(
+        cell_indices: Sequence[CellIndex], cosets_evals: Sequence[CosetEvals]
+    ) -> PolynomialCoeff:
+        """
+        Recover the polynomial in coefficient form that when evaluated at the roots of unity will give the extended blob.
+        """
+        # Get the extended domain. This will be referred to as the FFT domain.
+        roots_of_unity_extended = compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
+
+        # Flatten the cosets evaluations.
+        # If a cell is missing, then its evaluation is zero.
+        # We let E(x) be a polynomial of degree FIELD_ELEMENTS_PER_EXT_BLOB - 1
+        # that interpolates the evaluations including the zeros for missing ones.
+        extended_evaluation_rbo = [BLSFieldElement(0)] * FIELD_ELEMENTS_PER_EXT_BLOB
+        for cell_index, cell in zip(cell_indices, cosets_evals):
+            start = cell_index * FIELD_ELEMENTS_PER_CELL
+            end = (cell_index + 1) * FIELD_ELEMENTS_PER_CELL
+            extended_evaluation_rbo[start:end] = cell
+        extended_evaluation = bit_reversal_permutation(extended_evaluation_rbo)
+
+        # Compute the vanishing polynomial Z(x) in coefficient form.
+        # Z(x) is the polynomial which vanishes on all of the evaluations which are missing.
+        missing_cell_indices = [
+            CellIndex(cell_index)
+            for cell_index in range(CELLS_PER_EXT_BLOB)
+            if cell_index not in cell_indices
+        ]
+        zero_poly_coeff = construct_vanishing_polynomial(missing_cell_indices)
+
+        # Convert Z(x) to evaluation form over the FFT domain
+        zero_poly_eval = fft_field(zero_poly_coeff, roots_of_unity_extended)
+
+        # Compute (E*Z)(x) = E(x) * Z(x) in evaluation form over the FFT domain
+        # Note: over the FFT domain, the polynomials (E*Z)(x) and (P*Z)(x) agree, where
+        # P(x) is the polynomial we want to reconstruct (degree FIELD_ELEMENTS_PER_BLOB - 1).
+        extended_evaluation_times_zero = [a * b for a, b in zip(zero_poly_eval, extended_evaluation)]
+
+        # We know that (E*Z)(x) and (P*Z)(x) agree over the FFT domain,
+        # and we know that (P*Z)(x) has degree at most FIELD_ELEMENTS_PER_EXT_BLOB - 1.
+        # Thus, an inverse FFT of the evaluations of (E*Z)(x) (= evaluations of (P*Z)(x))
+        # yields the coefficient form of (P*Z)(x).
+        extended_evaluation_times_zero_coeffs = fft_field(
+            extended_evaluation_times_zero, roots_of_unity_extended, inv=True
+        )
+
+        # Next step is to divide the polynomial (P*Z)(x) by polynomial Z(x) to get P(x).
+        # We do this in evaluation form over a coset of the FFT domain to avoid division by 0.
+
+        # Convert (P*Z)(x) to evaluation form over a coset of the FFT domain
+        extended_evaluations_over_coset = coset_fft_field(
+            extended_evaluation_times_zero_coeffs, roots_of_unity_extended
+        )
+
+        # Convert Z(x) to evaluation form over a coset of the FFT domain
+        zero_poly_over_coset = coset_fft_field(zero_poly_coeff, roots_of_unity_extended)
+
+        # Compute P(x) = (P*Z)(x) / Z(x) in evaluation form over a coset of the FFT domain
+        reconstructed_poly_over_coset = [
+            a / b for a, b in zip(extended_evaluations_over_coset, zero_poly_over_coset)
+        ]
+
+        # Convert P(x) to coefficient form
+        reconstructed_poly_coeff = coset_fft_field(
+            reconstructed_poly_over_coset, roots_of_unity_extended, inv=True
+        )
+
+        return PolynomialCoeff(reconstructed_poly_coeff[:FIELD_ELEMENTS_PER_BLOB])
+    </spec>
+
 - name: remove_flag#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -6950,7 +9836,20 @@
         return flags & ~flag
     </spec>
 
-- name: saturating_sub
+- name: reverse_bits#deneb
+  sources: []
+  spec: |
+    <spec fn="reverse_bits" fork="deneb" hash="ea345856">
+    def reverse_bits(n: int, order: int) -> int:
+        """
+        Reverse the bit order of an integer ``n``.
+        """
+        assert is_power_of_two(order)
+        # Convert n to binary with the same number of bits as "order" - 1, then reverse its bit order
+        return int(("{:0" + str(order.bit_length() - 1) + "b}").format(n)[::-1], 2)
+    </spec>
+
+- name: saturating_sub#phase0
   sources:
     - file: infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
       search: public UInt64 minusMinZero(final UInt64 other)
@@ -6961,6 +9860,31 @@
         Computes a - b, saturating at numeric bounds.
         """
         return a - b if a > b else 0
+    </spec>
+
+- name: seconds_to_milliseconds#phase0
+  sources: []
+  spec: |
+    <spec fn="seconds_to_milliseconds" fork="phase0" hash="b2cc9743">
+    def seconds_to_milliseconds(seconds: uint64) -> uint64:
+        """
+        Convert seconds to milliseconds with overflow protection.
+        Returns ``UINT64_MAX`` if the result would overflow.
+        """
+        if seconds > UINT64_MAX // 1000:
+            return UINT64_MAX
+        return seconds * 1000
+    </spec>
+
+- name: set_or_append_list#altair
+  sources: []
+  spec: |
+    <spec fn="set_or_append_list" fork="altair" hash="a48f6f4c">
+    def set_or_append_list(list: List, index: ValidatorIndex, value: Any) -> None:
+        if index == len(list):
+            list.append(value)
+        else:
+            list[index] = value
     </spec>
 
 - name: should_extend_payload#gloas
@@ -6977,7 +9901,7 @@
         )
     </spec>
 
-- name: should_override_forkchoice_update
+- name: should_override_forkchoice_update#bellatrix
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
       search: public boolean shouldOverrideForkChoiceUpdate(
@@ -7187,7 +10111,7 @@
         increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
     </spec>
 
-- name: state_transition
+- name: state_transition#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
       search: public BeaconState processSlots(
@@ -7211,7 +10135,20 @@
             assert block.state_root == hash_tree_root(state)
     </spec>
 
-- name: switch_to_compounding_validator
+- name: store_target_checkpoint_state#phase0
+  sources: []
+  spec: |
+    <spec fn="store_target_checkpoint_state" fork="phase0" hash="2e4ff2b7">
+    def store_target_checkpoint_state(store: Store, target: Checkpoint) -> None:
+        # Store target checkpoint state if not yet seen
+        if target not in store.checkpoint_states:
+            base_state = copy(store.block_states[target.root])
+            if base_state.slot < compute_start_slot_at_epoch(target.epoch):
+                process_slots(base_state, compute_start_slot_at_epoch(target.epoch))
+            store.checkpoint_states[target] = base_state
+    </spec>
+
+- name: switch_to_compounding_validator#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
       search: public void switchToCompoundingValidator(
@@ -7225,7 +10162,7 @@
         queue_excess_active_balance(state, index)
     </spec>
 
-- name: translate_participation
+- name: translate_participation#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
       search: private void translateParticipation(
@@ -7249,7 +10186,7 @@
                     epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
     </spec>
 
-- name: update_checkpoints
+- name: update_checkpoints#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: private void updateCheckpoints(
@@ -7268,6 +10205,23 @@
         # Update finalized checkpoint
         if finalized_checkpoint.epoch > store.finalized_checkpoint.epoch:
             store.finalized_checkpoint = finalized_checkpoint
+    </spec>
+
+- name: update_latest_messages#phase0
+  sources: []
+  spec: |
+    <spec fn="update_latest_messages" fork="phase0" hash="3da3b413">
+    def update_latest_messages(
+        store: Store, attesting_indices: Sequence[ValidatorIndex], attestation: Attestation
+    ) -> None:
+        target = attestation.data.target
+        beacon_block_root = attestation.data.beacon_block_root
+        non_equivocating_attesting_indices = [
+            i for i in attesting_indices if i not in store.equivocating_indices
+        ]
+        for i in non_equivocating_attesting_indices:
+            if i not in store.latest_messages or target.epoch > store.latest_messages[i].epoch:
+                store.latest_messages[i] = LatestMessage(epoch=target.epoch, root=beacon_block_root)
     </spec>
 
 - name: update_latest_messages#gloas
@@ -7290,7 +10244,322 @@
                 )
     </spec>
 
-- name: upgrade_to_altair
+- name: update_unrealized_checkpoints#phase0
+  sources: []
+  spec: |
+    <spec fn="update_unrealized_checkpoints" fork="phase0" hash="8cee5d3b">
+    def update_unrealized_checkpoints(
+        store: Store,
+        unrealized_justified_checkpoint: Checkpoint,
+        unrealized_finalized_checkpoint: Checkpoint,
+    ) -> None:
+        """
+        Update unrealized checkpoints in store if necessary
+        """
+        # Update unrealized justified checkpoint
+        if unrealized_justified_checkpoint.epoch > store.unrealized_justified_checkpoint.epoch:
+            store.unrealized_justified_checkpoint = unrealized_justified_checkpoint
+
+        # Update unrealized finalized checkpoint
+        if unrealized_finalized_checkpoint.epoch > store.unrealized_finalized_checkpoint.epoch:
+            store.unrealized_finalized_checkpoint = unrealized_finalized_checkpoint
+    </spec>
+
+- name: upgrade_lc_bootstrap_to_capella#capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_bootstrap_to_capella" fork="capella" hash="d5f1203a">
+    def upgrade_lc_bootstrap_to_capella(pre: altair.LightClientBootstrap) -> LightClientBootstrap:
+        return LightClientBootstrap(
+            header=upgrade_lc_header_to_capella(pre.header),
+            current_sync_committee=pre.current_sync_committee,
+            current_sync_committee_branch=pre.current_sync_committee_branch,
+        )
+    </spec>
+
+- name: upgrade_lc_bootstrap_to_deneb#deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_bootstrap_to_deneb" fork="deneb" hash="f91baf71">
+    def upgrade_lc_bootstrap_to_deneb(pre: capella.LightClientBootstrap) -> LightClientBootstrap:
+        return LightClientBootstrap(
+            header=upgrade_lc_header_to_deneb(pre.header),
+            current_sync_committee=pre.current_sync_committee,
+            current_sync_committee_branch=pre.current_sync_committee_branch,
+        )
+    </spec>
+
+- name: upgrade_lc_bootstrap_to_electra#electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_bootstrap_to_electra" fork="electra" hash="93818ed1">
+    def upgrade_lc_bootstrap_to_electra(pre: deneb.LightClientBootstrap) -> LightClientBootstrap:
+        return LightClientBootstrap(
+            header=upgrade_lc_header_to_electra(pre.header),
+            current_sync_committee=pre.current_sync_committee,
+            current_sync_committee_branch=normalize_merkle_branch(
+                pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA
+            ),
+        )
+    </spec>
+
+- name: upgrade_lc_finality_update_to_capella#capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_finality_update_to_capella" fork="capella" hash="c314b172">
+    def upgrade_lc_finality_update_to_capella(
+        pre: altair.LightClientFinalityUpdate,
+    ) -> LightClientFinalityUpdate:
+        return LightClientFinalityUpdate(
+            attested_header=upgrade_lc_header_to_capella(pre.attested_header),
+            finalized_header=upgrade_lc_header_to_capella(pre.finalized_header),
+            finality_branch=pre.finality_branch,
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_finality_update_to_deneb#deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_finality_update_to_deneb" fork="deneb" hash="bfa53da6">
+    def upgrade_lc_finality_update_to_deneb(
+        pre: capella.LightClientFinalityUpdate,
+    ) -> LightClientFinalityUpdate:
+        return LightClientFinalityUpdate(
+            attested_header=upgrade_lc_header_to_deneb(pre.attested_header),
+            finalized_header=upgrade_lc_header_to_deneb(pre.finalized_header),
+            finality_branch=pre.finality_branch,
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_finality_update_to_electra#electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_finality_update_to_electra" fork="electra" hash="1bcc6b97">
+    def upgrade_lc_finality_update_to_electra(
+        pre: deneb.LightClientFinalityUpdate,
+    ) -> LightClientFinalityUpdate:
+        return LightClientFinalityUpdate(
+            attested_header=upgrade_lc_header_to_electra(pre.attested_header),
+            finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
+            finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_header_to_capella#capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_header_to_capella" fork="capella" hash="9f7a832d">
+    def upgrade_lc_header_to_capella(pre: altair.LightClientHeader) -> LightClientHeader:
+        return LightClientHeader(
+            beacon=pre.beacon,
+            execution=ExecutionPayloadHeader(),
+            execution_branch=ExecutionBranch(),
+        )
+    </spec>
+
+- name: upgrade_lc_header_to_deneb#deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_header_to_deneb" fork="deneb" hash="7dc12b61">
+    def upgrade_lc_header_to_deneb(pre: capella.LightClientHeader) -> LightClientHeader:
+        return LightClientHeader(
+            beacon=pre.beacon,
+            execution=ExecutionPayloadHeader(
+                parent_hash=pre.execution.parent_hash,
+                fee_recipient=pre.execution.fee_recipient,
+                state_root=pre.execution.state_root,
+                receipts_root=pre.execution.receipts_root,
+                logs_bloom=pre.execution.logs_bloom,
+                prev_randao=pre.execution.prev_randao,
+                block_number=pre.execution.block_number,
+                gas_limit=pre.execution.gas_limit,
+                gas_used=pre.execution.gas_used,
+                timestamp=pre.execution.timestamp,
+                extra_data=pre.execution.extra_data,
+                base_fee_per_gas=pre.execution.base_fee_per_gas,
+                block_hash=pre.execution.block_hash,
+                transactions_root=pre.execution.transactions_root,
+                withdrawals_root=pre.execution.withdrawals_root,
+                # [New in Deneb:EIP4844]
+                blob_gas_used=uint64(0),
+                # [New in Deneb:EIP4844]
+                excess_blob_gas=uint64(0),
+            ),
+            execution_branch=pre.execution_branch,
+        )
+    </spec>
+
+- name: upgrade_lc_header_to_electra#electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_header_to_electra" fork="electra" hash="90aa82aa">
+    def upgrade_lc_header_to_electra(pre: deneb.LightClientHeader) -> LightClientHeader:
+        return LightClientHeader(
+            beacon=pre.beacon,
+            execution=pre.execution,
+            execution_branch=pre.execution_branch,
+        )
+    </spec>
+
+- name: upgrade_lc_optimistic_update_to_capella#capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_optimistic_update_to_capella" fork="capella" hash="c4c29295">
+    def upgrade_lc_optimistic_update_to_capella(
+        pre: altair.LightClientOptimisticUpdate,
+    ) -> LightClientOptimisticUpdate:
+        return LightClientOptimisticUpdate(
+            attested_header=upgrade_lc_header_to_capella(pre.attested_header),
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_optimistic_update_to_deneb#deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_optimistic_update_to_deneb" fork="deneb" hash="66aa73ab">
+    def upgrade_lc_optimistic_update_to_deneb(
+        pre: capella.LightClientOptimisticUpdate,
+    ) -> LightClientOptimisticUpdate:
+        return LightClientOptimisticUpdate(
+            attested_header=upgrade_lc_header_to_deneb(pre.attested_header),
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_optimistic_update_to_electra#electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_optimistic_update_to_electra" fork="electra" hash="a6059e7d">
+    def upgrade_lc_optimistic_update_to_electra(
+        pre: deneb.LightClientOptimisticUpdate,
+    ) -> LightClientOptimisticUpdate:
+        return LightClientOptimisticUpdate(
+            attested_header=upgrade_lc_header_to_electra(pre.attested_header),
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_store_to_capella#capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_store_to_capella" fork="capella" hash="d02773ec">
+    def upgrade_lc_store_to_capella(pre: altair.LightClientStore) -> LightClientStore:
+        if pre.best_valid_update is None:
+            best_valid_update = None
+        else:
+            best_valid_update = upgrade_lc_update_to_capella(pre.best_valid_update)
+        return LightClientStore(
+            finalized_header=upgrade_lc_header_to_capella(pre.finalized_header),
+            current_sync_committee=pre.current_sync_committee,
+            next_sync_committee=pre.next_sync_committee,
+            best_valid_update=best_valid_update,
+            optimistic_header=upgrade_lc_header_to_capella(pre.optimistic_header),
+            previous_max_active_participants=pre.previous_max_active_participants,
+            current_max_active_participants=pre.current_max_active_participants,
+        )
+    </spec>
+
+- name: upgrade_lc_store_to_deneb#deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_store_to_deneb" fork="deneb" hash="29b26f52">
+    def upgrade_lc_store_to_deneb(pre: capella.LightClientStore) -> LightClientStore:
+        if pre.best_valid_update is None:
+            best_valid_update = None
+        else:
+            best_valid_update = upgrade_lc_update_to_deneb(pre.best_valid_update)
+        return LightClientStore(
+            finalized_header=upgrade_lc_header_to_deneb(pre.finalized_header),
+            current_sync_committee=pre.current_sync_committee,
+            next_sync_committee=pre.next_sync_committee,
+            best_valid_update=best_valid_update,
+            optimistic_header=upgrade_lc_header_to_deneb(pre.optimistic_header),
+            previous_max_active_participants=pre.previous_max_active_participants,
+            current_max_active_participants=pre.current_max_active_participants,
+        )
+    </spec>
+
+- name: upgrade_lc_store_to_electra#electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_store_to_electra" fork="electra" hash="e9096017">
+    def upgrade_lc_store_to_electra(pre: deneb.LightClientStore) -> LightClientStore:
+        if pre.best_valid_update is None:
+            best_valid_update = None
+        else:
+            best_valid_update = upgrade_lc_update_to_electra(pre.best_valid_update)
+        return LightClientStore(
+            finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
+            current_sync_committee=pre.current_sync_committee,
+            next_sync_committee=pre.next_sync_committee,
+            best_valid_update=best_valid_update,
+            optimistic_header=upgrade_lc_header_to_electra(pre.optimistic_header),
+            previous_max_active_participants=pre.previous_max_active_participants,
+            current_max_active_participants=pre.current_max_active_participants,
+        )
+    </spec>
+
+- name: upgrade_lc_update_to_capella#capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_update_to_capella" fork="capella" hash="ba863d2f">
+    def upgrade_lc_update_to_capella(pre: altair.LightClientUpdate) -> LightClientUpdate:
+        return LightClientUpdate(
+            attested_header=upgrade_lc_header_to_capella(pre.attested_header),
+            next_sync_committee=pre.next_sync_committee,
+            next_sync_committee_branch=pre.next_sync_committee_branch,
+            finalized_header=upgrade_lc_header_to_capella(pre.finalized_header),
+            finality_branch=pre.finality_branch,
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_update_to_deneb#deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_update_to_deneb" fork="deneb" hash="64adb1e0">
+    def upgrade_lc_update_to_deneb(pre: capella.LightClientUpdate) -> LightClientUpdate:
+        return LightClientUpdate(
+            attested_header=upgrade_lc_header_to_deneb(pre.attested_header),
+            next_sync_committee=pre.next_sync_committee,
+            next_sync_committee_branch=pre.next_sync_committee_branch,
+            finalized_header=upgrade_lc_header_to_deneb(pre.finalized_header),
+            finality_branch=pre.finality_branch,
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_lc_update_to_electra#electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_update_to_electra" fork="electra" hash="4d42b63e">
+    def upgrade_lc_update_to_electra(pre: deneb.LightClientUpdate) -> LightClientUpdate:
+        return LightClientUpdate(
+            attested_header=upgrade_lc_header_to_electra(pre.attested_header),
+            next_sync_committee=pre.next_sync_committee,
+            next_sync_committee_branch=normalize_merkle_branch(
+                pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
+            ),
+            finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
+            finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
+            sync_aggregate=pre.sync_aggregate,
+            signature_slot=pre.signature_slot,
+        )
+    </spec>
+
+- name: upgrade_to_altair#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
       search: public BeaconStateAltair upgrade(
@@ -7340,7 +10609,7 @@
         return post
     </spec>
 
-- name: upgrade_to_bellatrix
+- name: upgrade_to_bellatrix#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/forktransition/BellatrixStateUpgrade.java
       search: public BeaconStateBellatrix upgrade(
@@ -7385,7 +10654,7 @@
         return post
     </spec>
 
-- name: upgrade_to_capella
+- name: upgrade_to_capella#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/forktransition/CapellaStateUpgrade.java
       search: public BeaconStateCapella upgrade(
@@ -7452,7 +10721,7 @@
         return post
     </spec>
 
-- name: upgrade_to_deneb
+- name: upgrade_to_deneb#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/forktransition/DenebStateUpgrade.java
       search: public BeaconStateDeneb upgrade(
@@ -7521,7 +10790,7 @@
         return post
     </spec>
 
-- name: upgrade_to_electra
+- name: upgrade_to_electra#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
       search: public BeaconStateElectra upgrade(
@@ -7631,7 +10900,7 @@
         return post
     </spec>
 
-- name: upgrade_to_fulu
+- name: upgrade_to_fulu#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/forktransition/FuluStateUpgrade.java
       search: public BeaconStateFulu upgrade(
@@ -7689,7 +10958,7 @@
         return post
     </spec>
 
-- name: upgrade_to_gloas
+- name: upgrade_to_gloas#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: public BeaconStateGloas upgrade(
@@ -7760,7 +11029,108 @@
         return post
     </spec>
 
-- name: validate_merge_block
+- name: validate_kzg_g1#deneb
+  sources: []
+  spec: |
+    <spec fn="validate_kzg_g1" fork="deneb" hash="865bd0c2">
+    def validate_kzg_g1(b: Bytes48) -> None:
+        """
+        Perform BLS validation required by the types `KZGProof` and `KZGCommitment`.
+        """
+        if b == G1_POINT_AT_INFINITY:
+            return
+
+        assert bls.KeyValidate(b)
+    </spec>
+
+- name: validate_light_client_update#altair
+  sources: []
+  spec: |
+    <spec fn="validate_light_client_update" fork="altair" hash="eb5d169b">
+    def validate_light_client_update(
+        store: LightClientStore,
+        update: LightClientUpdate,
+        current_slot: Slot,
+        genesis_validators_root: Root,
+    ) -> None:
+        # Verify sync committee has sufficient participants
+        sync_aggregate = update.sync_aggregate
+        assert sum(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
+
+        # Verify update does not skip a sync committee period
+        assert is_valid_light_client_header(update.attested_header)
+        update_attested_slot = update.attested_header.beacon.slot
+        update_finalized_slot = update.finalized_header.beacon.slot
+        assert current_slot >= update.signature_slot > update_attested_slot >= update_finalized_slot
+        store_period = compute_sync_committee_period_at_slot(store.finalized_header.beacon.slot)
+        update_signature_period = compute_sync_committee_period_at_slot(update.signature_slot)
+        if is_next_sync_committee_known(store):
+            assert update_signature_period in (store_period, store_period + 1)
+        else:
+            assert update_signature_period == store_period
+
+        # Verify update is relevant
+        update_attested_period = compute_sync_committee_period_at_slot(update_attested_slot)
+        update_has_next_sync_committee = not is_next_sync_committee_known(store) and (
+            is_sync_committee_update(update) and update_attested_period == store_period
+        )
+        assert (
+            update_attested_slot > store.finalized_header.beacon.slot or update_has_next_sync_committee
+        )
+
+        # Verify that the `finality_branch`, if present, confirms `finalized_header`
+        # to match the finalized checkpoint root saved in the state of `attested_header`.
+        # Note that the genesis finalized checkpoint root is represented as a zero hash.
+        if not is_finality_update(update):
+            assert update.finalized_header == LightClientHeader()
+        else:
+            if update_finalized_slot == GENESIS_SLOT:
+                assert update.finalized_header == LightClientHeader()
+                finalized_root = Bytes32()
+            else:
+                assert is_valid_light_client_header(update.finalized_header)
+                finalized_root = hash_tree_root(update.finalized_header.beacon)
+            assert is_valid_normalized_merkle_branch(
+                leaf=finalized_root,
+                branch=update.finality_branch,
+                gindex=finalized_root_gindex_at_slot(update.attested_header.beacon.slot),
+                root=update.attested_header.beacon.state_root,
+            )
+
+        # Verify that the `next_sync_committee`, if present, actually is the next sync committee saved in the
+        # state of the `attested_header`
+        if not is_sync_committee_update(update):
+            assert update.next_sync_committee == SyncCommittee()
+        else:
+            if update_attested_period == store_period and is_next_sync_committee_known(store):
+                assert update.next_sync_committee == store.next_sync_committee
+            assert is_valid_normalized_merkle_branch(
+                leaf=hash_tree_root(update.next_sync_committee),
+                branch=update.next_sync_committee_branch,
+                gindex=next_sync_committee_gindex_at_slot(update.attested_header.beacon.slot),
+                root=update.attested_header.beacon.state_root,
+            )
+
+        # Verify sync committee aggregate signature
+        if update_signature_period == store_period:
+            sync_committee = store.current_sync_committee
+        else:
+            sync_committee = store.next_sync_committee
+        participant_pubkeys = [
+            pubkey
+            for (bit, pubkey) in zip(sync_aggregate.sync_committee_bits, sync_committee.pubkeys)
+            if bit
+        ]
+        fork_version_slot = max(update.signature_slot, Slot(1)) - Slot(1)
+        fork_version = compute_fork_version(compute_epoch_at_slot(fork_version_slot))
+        domain = compute_domain(DOMAIN_SYNC_COMMITTEE, fork_version, genesis_validators_root)
+        signing_root = compute_signing_root(update.attested_header.beacon, domain)
+        assert bls.FastAggregateVerify(
+            participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature
+        )
+    </spec>
+
+- name: validate_merge_block#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/BellatrixTransitionHelpers.java
       search: public SafeFuture<PayloadStatus> validateMergeBlock(
@@ -7820,7 +11190,7 @@
         assert is_valid_terminal_pow_block(pow_block, pow_parent)
     </spec>
 
-- name: validate_on_attestation
+- name: validate_on_attestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public AttestationProcessingResult validateOnAttestation(
@@ -7896,7 +11266,94 @@
         assert get_current_slot(store) >= attestation.data.slot + 1
     </spec>
 
-- name: verify_blob_sidecar_inclusion_proof
+- name: validate_target_epoch_against_current_time#phase0
+  sources: []
+  spec: |
+    <spec fn="validate_target_epoch_against_current_time" fork="phase0" hash="f7352056">
+    def validate_target_epoch_against_current_time(store: Store, attestation: Attestation) -> None:
+        target = attestation.data.target
+
+        # Attestations must be from the current or previous epoch
+        current_epoch = get_current_store_epoch(store)
+        # Use GENESIS_EPOCH for previous when genesis to avoid underflow
+        previous_epoch = current_epoch - 1 if current_epoch > GENESIS_EPOCH else GENESIS_EPOCH
+        # If attestation target is from a future epoch, delay consideration until the epoch arrives
+        assert target.epoch in [current_epoch, previous_epoch]
+    </spec>
+
+- name: vanishing_polynomialcoeff#fulu
+  sources: []
+  spec: |
+    <spec fn="vanishing_polynomialcoeff" fork="fulu" hash="e2c3fb1b">
+    def vanishing_polynomialcoeff(xs: Sequence[BLSFieldElement]) -> PolynomialCoeff:
+        """
+        Compute the vanishing polynomial on ``xs`` (in coefficient form).
+        """
+        p = PolynomialCoeff([BLSFieldElement(1)])
+        for x in xs:
+            p = multiply_polynomialcoeff(p, PolynomialCoeff([-x, BLSFieldElement(1)]))
+        return p
+    </spec>
+
+- name: verify_blob_kzg_proof#deneb
+  sources: []
+  spec: |
+    <spec fn="verify_blob_kzg_proof" fork="deneb" hash="1e0e92e6">
+    def verify_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes48, proof_bytes: Bytes48) -> bool:
+        """
+        Given a blob and a KZG proof, verify that the blob data corresponds to the provided commitment.
+
+        Public method.
+        """
+        assert len(blob) == BYTES_PER_BLOB
+        assert len(commitment_bytes) == BYTES_PER_COMMITMENT
+        assert len(proof_bytes) == BYTES_PER_PROOF
+
+        commitment = bytes_to_kzg_commitment(commitment_bytes)
+
+        polynomial = blob_to_polynomial(blob)
+        evaluation_challenge = compute_challenge(blob, commitment)
+
+        # Evaluate polynomial at `evaluation_challenge`
+        y = evaluate_polynomial_in_evaluation_form(polynomial, evaluation_challenge)
+
+        # Verify proof
+        proof = bytes_to_kzg_proof(proof_bytes)
+        return verify_kzg_proof_impl(commitment, evaluation_challenge, y, proof)
+    </spec>
+
+- name: verify_blob_kzg_proof_batch#deneb
+  sources: []
+  spec: |
+    <spec fn="verify_blob_kzg_proof_batch" fork="deneb" hash="f182e9ae">
+    def verify_blob_kzg_proof_batch(
+        blobs: Sequence[Blob], commitments_bytes: Sequence[Bytes48], proofs_bytes: Sequence[Bytes48]
+    ) -> bool:
+        """
+        Given a list of blobs and blob KZG proofs, verify that they correspond to the provided commitments.
+        Will return True if there are zero blobs/commitments/proofs.
+        Public method.
+        """
+
+        assert len(blobs) == len(commitments_bytes) == len(proofs_bytes)
+
+        commitments, evaluation_challenges, ys, proofs = [], [], [], []
+        for blob, commitment_bytes, proof_bytes in zip(blobs, commitments_bytes, proofs_bytes):
+            assert len(blob) == BYTES_PER_BLOB
+            assert len(commitment_bytes) == BYTES_PER_COMMITMENT
+            assert len(proof_bytes) == BYTES_PER_PROOF
+            commitment = bytes_to_kzg_commitment(commitment_bytes)
+            commitments.append(commitment)
+            polynomial = blob_to_polynomial(blob)
+            evaluation_challenge = compute_challenge(blob, commitment)
+            evaluation_challenges.append(evaluation_challenge)
+            ys.append(evaluate_polynomial_in_evaluation_form(polynomial, evaluation_challenge))
+            proofs.append(bytes_to_kzg_proof(proof_bytes))
+
+        return verify_kzg_proof_batch(commitments, evaluation_challenges, ys, proofs)
+    </spec>
+
+- name: verify_blob_sidecar_inclusion_proof#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
       search: public boolean verifyBlobKzgCommitmentInclusionProof(
@@ -7915,7 +11372,7 @@
         )
     </spec>
 
-- name: verify_block_signature
+- name: verify_block_signature#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: private BlockValidationResult verifyBlockSignature(
@@ -7929,7 +11386,171 @@
         return bls.Verify(proposer.pubkey, signing_root, signed_block.signature)
     </spec>
 
-- name: verify_data_column_sidecar
+- name: verify_cell_kzg_proof_batch#fulu
+  sources: []
+  spec: |
+    <spec fn="verify_cell_kzg_proof_batch" fork="fulu" hash="2005f095">
+    def verify_cell_kzg_proof_batch(
+        commitments_bytes: Sequence[Bytes48],
+        cell_indices: Sequence[CellIndex],
+        cells: Sequence[Cell],
+        proofs_bytes: Sequence[Bytes48],
+    ) -> bool:
+        """
+        Verify that a set of cells belong to their corresponding commitments.
+
+        Given four lists representing tuples of (``commitment``, ``cell_index``, ``cell``, ``proof``),
+        the function verifies ``proof`` which shows that ``cell`` are the evaluations of the polynomial
+        associated with ``commitment``, evaluated over the domain specified by ``cell_index``.
+
+        This function implements the universal verification equation that has been introduced here:
+        https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240
+
+        Public method.
+        """
+
+        assert len(commitments_bytes) == len(cells) == len(proofs_bytes) == len(cell_indices)
+        for commitment_bytes in commitments_bytes:
+            assert len(commitment_bytes) == BYTES_PER_COMMITMENT
+        for cell_index in cell_indices:
+            assert cell_index < CELLS_PER_EXT_BLOB
+        for cell in cells:
+            assert len(cell) == BYTES_PER_CELL
+        for proof_bytes in proofs_bytes:
+            assert len(proof_bytes) == BYTES_PER_PROOF
+
+        # Create the list of deduplicated commitments we are dealing with
+        deduplicated_commitments = [
+            bytes_to_kzg_commitment(commitment_bytes)
+            for index, commitment_bytes in enumerate(commitments_bytes)
+            if commitments_bytes.index(commitment_bytes) == index
+        ]
+        # Create indices list mapping initial commitments (that may contain duplicates) to the deduplicated commitments
+        commitment_indices = [
+            CommitmentIndex(deduplicated_commitments.index(commitment_bytes))
+            for commitment_bytes in commitments_bytes
+        ]
+
+        cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
+        proofs = [bytes_to_kzg_proof(proof_bytes) for proof_bytes in proofs_bytes]
+
+        # Do the actual verification
+        return verify_cell_kzg_proof_batch_impl(
+            deduplicated_commitments, commitment_indices, cell_indices, cosets_evals, proofs
+        )
+    </spec>
+
+- name: verify_cell_kzg_proof_batch_impl#fulu
+  sources: []
+  spec: |
+    <spec fn="verify_cell_kzg_proof_batch_impl" fork="fulu" hash="074e179a">
+    def verify_cell_kzg_proof_batch_impl(
+        commitments: Sequence[KZGCommitment],
+        commitment_indices: Sequence[CommitmentIndex],
+        cell_indices: Sequence[CellIndex],
+        cosets_evals: Sequence[CosetEvals],
+        proofs: Sequence[KZGProof],
+    ) -> bool:
+        """
+        Helper: Verify that a set of cells belong to their corresponding commitment.
+
+        Given a list of ``commitments`` (which contains no duplicates) and four lists representing
+        tuples of (``commitment_index``, ``cell_index``, ``evals``, ``proof``), the function
+        verifies ``proof`` which shows that ``evals`` are the evaluations of the polynomial associated
+        with ``commitments[commitment_index]``, evaluated over the domain specified by ``cell_index``.
+
+        This function is the internal implementation of ``verify_cell_kzg_proof_batch``.
+        """
+        assert len(commitment_indices) == len(cell_indices) == len(cosets_evals) == len(proofs)
+        assert len(commitments) == len(set(commitments))
+        for commitment_index in commitment_indices:
+            assert commitment_index < len(commitments)
+
+        # The verification equation that we will check is pairing (LL, LR) = pairing (RL, [1]), where
+        # LL = sum_k r^k proofs[k],
+        # LR = [s^n]
+        # RL = RLC - RLI + RLP, where
+        #   RLC = sum_i weights[i] commitments[i]
+        #   RLI = [sum_k r^k interpolation_poly_k(s)]
+        #   RLP = sum_k (r^k * h_k^n) proofs[k]
+        #
+        # Here, the variables have the following meaning:
+        # - k < len(cell_indices) is an index iterating over all cells in the input
+        # - r is a random coefficient, derived from hashing all data provided by the prover
+        # - s is the secret embedded in the KZG setup
+        # - n = FIELD_ELEMENTS_PER_CELL is the size of the evaluation domain
+        # - i ranges over all provided commitments
+        # - weights[i] is a weight computed for commitment i
+        #   - It depends on r and on which cells are associated with commitment i
+        # - interpolation_poly_k is the interpolation polynomial for the kth cell
+        # - h_k is the coset shift specifying the evaluation domain of the kth cell
+
+        # Preparation
+        num_cells = len(cell_indices)
+        n = FIELD_ELEMENTS_PER_CELL
+        num_commitments = len(commitments)
+
+        # Step 1: Compute a challenge r and its powers r^0, ..., r^{num_cells-1}
+        r = compute_verify_cell_kzg_proof_batch_challenge(
+            commitments, commitment_indices, cell_indices, cosets_evals, proofs
+        )
+        r_powers = compute_powers(r, num_cells)
+
+        # Step 2: Compute LL = sum_k r^k proofs[k]
+        ll = bls.bytes48_to_G1(g1_lincomb(proofs, r_powers))
+
+        # Step 3: Compute LR = [s^n]
+        lr = bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[n])
+
+        # Step 4: Compute RL = RLC - RLI + RLP
+        # Step 4.1: Compute RLC = sum_i weights[i] commitments[i]
+        # Step 4.1a: Compute weights[i]: the sum of all r^k for which cell k is associated with commitment i.
+        # Note: we do that by iterating over all k and updating the correct weights[i] accordingly
+        weights = [BLSFieldElement(0)] * num_commitments
+        for k in range(num_cells):
+            i = commitment_indices[k]
+            weights[i] += r_powers[k]
+        # Step 4.1b: Linearly combine the weights with the commitments to get RLC
+        rlc = bls.bytes48_to_G1(g1_lincomb(commitments, weights))
+
+        # Step 4.2: Compute RLI = [sum_k r^k interpolation_poly_k(s)]
+        # Note: an efficient implementation would use the IDFT based method explained in the blog post
+        sum_interp_polys_coeff = PolynomialCoeff([BLSFieldElement(0)] * n)
+        for k in range(num_cells):
+            interp_poly_coeff = interpolate_polynomialcoeff(
+                coset_for_cell(cell_indices[k]), cosets_evals[k]
+            )
+            interp_poly_scaled_coeff = multiply_polynomialcoeff(
+                PolynomialCoeff([r_powers[k]]), interp_poly_coeff
+            )
+            sum_interp_polys_coeff = add_polynomialcoeff(
+                sum_interp_polys_coeff, interp_poly_scaled_coeff
+            )
+        rli = bls.bytes48_to_G1(g1_lincomb(KZG_SETUP_G1_MONOMIAL[:n], sum_interp_polys_coeff))
+
+        # Step 4.3: Compute RLP = sum_k (r^k * h_k^n) proofs[k]
+        weighted_r_powers = []
+        for k in range(num_cells):
+            h_k = coset_shift_for_cell(cell_indices[k])
+            h_k_pow = h_k.pow(BLSFieldElement(n))
+            wrp = r_powers[k] * h_k_pow
+            weighted_r_powers.append(wrp)
+        rlp = bls.bytes48_to_G1(g1_lincomb(proofs, weighted_r_powers))
+
+        # Step 4.4: Compute RL = RLC - RLI + RLP
+        rl = bls.add(rlc, bls.neg(rli))
+        rl = bls.add(rl, rlp)
+
+        # Step 5: Check pairing (LL, LR) = pairing (RL, [1])
+        return bls.pairing_check(
+            [
+                [ll, lr],
+                [rl, bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[0]))],
+            ]
+        )
+    </spec>
+
+- name: verify_data_column_sidecar#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public boolean verifyDataColumnSidecar(
@@ -7992,7 +11613,7 @@
         return True
     </spec>
 
-- name: verify_data_column_sidecar_inclusion_proof
+- name: verify_data_column_sidecar_inclusion_proof#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public boolean verifyDataColumnSidecarInclusionProof(
@@ -8011,7 +11632,7 @@
         )
     </spec>
 
-- name: verify_data_column_sidecar_kzg_proofs
+- name: verify_data_column_sidecar_kzg_proofs#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public boolean verifyDataColumnSidecarKzgProofs(
@@ -8065,7 +11686,107 @@
         return bls.Verify(builder.pubkey, signing_root, signed_envelope.signature)
     </spec>
 
-- name: voting_period_start_time
+- name: verify_kzg_proof#deneb
+  sources: []
+  spec: |
+    <spec fn="verify_kzg_proof" fork="deneb" hash="900aa92d">
+    def verify_kzg_proof(
+        commitment_bytes: Bytes48, z_bytes: Bytes32, y_bytes: Bytes32, proof_bytes: Bytes48
+    ) -> bool:
+        """
+        Verify KZG proof that ``p(z) == y`` where ``p(z)`` is the polynomial represented by ``polynomial_kzg``.
+        Receives inputs as bytes.
+        Public method.
+        """
+        assert len(commitment_bytes) == BYTES_PER_COMMITMENT
+        assert len(z_bytes) == BYTES_PER_FIELD_ELEMENT
+        assert len(y_bytes) == BYTES_PER_FIELD_ELEMENT
+        assert len(proof_bytes) == BYTES_PER_PROOF
+
+        return verify_kzg_proof_impl(
+            bytes_to_kzg_commitment(commitment_bytes),
+            bytes_to_bls_field(z_bytes),
+            bytes_to_bls_field(y_bytes),
+            bytes_to_kzg_proof(proof_bytes),
+        )
+    </spec>
+
+- name: verify_kzg_proof_batch#deneb
+  sources: []
+  spec: |
+    <spec fn="verify_kzg_proof_batch" fork="deneb" hash="ee6b42c2">
+    def verify_kzg_proof_batch(
+        commitments: Sequence[KZGCommitment],
+        zs: Sequence[BLSFieldElement],
+        ys: Sequence[BLSFieldElement],
+        proofs: Sequence[KZGProof],
+    ) -> bool:
+        """
+        Verify multiple KZG proofs efficiently.
+        """
+
+        assert len(commitments) == len(zs) == len(ys) == len(proofs)
+
+        # Compute a random challenge. Note that it does not have to be computed from a hash,
+        # r just has to be random.
+        degree_poly = int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 8, KZG_ENDIANNESS)
+        num_commitments = int.to_bytes(len(commitments), 8, KZG_ENDIANNESS)
+        data = RANDOM_CHALLENGE_KZG_BATCH_DOMAIN + degree_poly + num_commitments
+
+        # Append all inputs to the transcript before we hash
+        for commitment, z, y, proof in zip(commitments, zs, ys, proofs):
+            data += commitment + bls_field_to_bytes(z) + bls_field_to_bytes(y) + proof
+
+        r = hash_to_bls_field(data)
+        r_powers = compute_powers(r, len(commitments))
+
+        # Verify: e(sum r^i proof_i, [s]) ==
+        # e(sum r^i (commitment_i - [y_i]) + sum r^i z_i proof_i, [1])
+        proof_lincomb = g1_lincomb(proofs, r_powers)
+        proof_z_lincomb = g1_lincomb(proofs, [z * r_power for z, r_power in zip(zs, r_powers)])
+        C_minus_ys = [
+            bls.add(bls.bytes48_to_G1(commitment), bls.multiply(bls.G1(), -y))
+            for commitment, y in zip(commitments, ys)
+        ]
+        C_minus_y_as_KZGCommitments = [KZGCommitment(bls.G1_to_bytes48(x)) for x in C_minus_ys]
+        C_minus_y_lincomb = g1_lincomb(C_minus_y_as_KZGCommitments, r_powers)
+
+        return bls.pairing_check(
+            [
+                [
+                    bls.bytes48_to_G1(proof_lincomb),
+                    bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[1])),
+                ],
+                [
+                    bls.add(bls.bytes48_to_G1(C_minus_y_lincomb), bls.bytes48_to_G1(proof_z_lincomb)),
+                    bls.G2(),
+                ],
+            ]
+        )
+    </spec>
+
+- name: verify_kzg_proof_impl#deneb
+  sources: []
+  spec: |
+    <spec fn="verify_kzg_proof_impl" fork="deneb" hash="7d2f5d17">
+    def verify_kzg_proof_impl(
+        commitment: KZGCommitment, z: BLSFieldElement, y: BLSFieldElement, proof: KZGProof
+    ) -> bool:
+        """
+        Verify KZG proof that ``p(z) == y`` where ``p(z)`` is the polynomial represented by ``polynomial_kzg``.
+        """
+        # Verify: P - y = Q * (X - z)
+        X_minus_z = bls.add(
+            bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[1]),
+            bls.multiply(bls.G2(), -z),
+        )
+        P_minus_y = bls.add(bls.bytes48_to_G1(commitment), bls.multiply(bls.G1(), -y))
+        return bls.pairing_check(
+            [[P_minus_y, bls.neg(bls.G2())], [bls.bytes48_to_G1(proof), X_minus_z]]
+        )
+    </spec>
+
+- name: voting_period_start_time#phase0
   sources:
     - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
       search: private UInt64 getVotingPeriodStartTime(
@@ -8078,7 +11799,7 @@
         return compute_time_at_slot(state, eth1_voting_period_start_slot)
     </spec>
 
-- name: weigh_justification_and_finalization
+- name: weigh_justification_and_finalization#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: private void weighJustificationAndFinalization(
@@ -8124,4 +11845,15 @@
         # The 1st/2nd most recent epochs are justified, the 1st using the 2nd as source
         if all(bits[0:2]) and old_current_justified_checkpoint.epoch + 1 == current_epoch:
             state.finalized_checkpoint = old_current_justified_checkpoint
+    </spec>
+
+- name: xor#phase0
+  sources: []
+  spec: |
+    <spec fn="xor" fork="phase0" hash="3b45f2e1">
+    def xor(bytes_1: Bytes32, bytes_2: Bytes32) -> Bytes32:
+        """
+        Return the exclusive-or of two 32-byte strings.
+        """
+        return Bytes32(a ^ b for a, b in zip(bytes_1, bytes_2))
     </spec>

--- a/specrefs/presets.yml
+++ b/specrefs/presets.yml
@@ -1,4 +1,4 @@
-- name: BASE_REWARD_FACTOR
+- name: BASE_REWARD_FACTOR#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "BASE_REWARD_FACTOR:"
@@ -7,7 +7,7 @@
     BASE_REWARD_FACTOR: uint64 = 64
     </spec>
 
-- name: BUILDER_PENDING_WITHDRAWALS_LIMIT
+- name: BUILDER_PENDING_WITHDRAWALS_LIMIT#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "BUILDER_PENDING_WITHDRAWALS_LIMIT:"
@@ -16,7 +16,7 @@
     BUILDER_PENDING_WITHDRAWALS_LIMIT: uint64 = 1048576
     </spec>
 
-- name: BYTES_PER_LOGS_BLOOM
+- name: BYTES_PER_LOGS_BLOOM#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "BYTES_PER_LOGS_BLOOM:"
@@ -25,7 +25,7 @@
     BYTES_PER_LOGS_BLOOM: uint64 = 256
     </spec>
 
-- name: CELLS_PER_EXT_BLOB
+- name: CELLS_PER_EXT_BLOB#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "CELLS_PER_EXT_BLOB:"
@@ -34,7 +34,7 @@
     CELLS_PER_EXT_BLOB = 128
     </spec>
 
-- name: EFFECTIVE_BALANCE_INCREMENT
+- name: EFFECTIVE_BALANCE_INCREMENT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "EFFECTIVE_BALANCE_INCREMENT:"
@@ -43,7 +43,7 @@
     EFFECTIVE_BALANCE_INCREMENT: Gwei = 1000000000
     </spec>
 
-- name: EPOCHS_PER_ETH1_VOTING_PERIOD
+- name: EPOCHS_PER_ETH1_VOTING_PERIOD#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "EPOCHS_PER_ETH1_VOTING_PERIOD:"
@@ -52,7 +52,7 @@
     EPOCHS_PER_ETH1_VOTING_PERIOD: uint64 = 64
     </spec>
 
-- name: EPOCHS_PER_HISTORICAL_VECTOR
+- name: EPOCHS_PER_HISTORICAL_VECTOR#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "EPOCHS_PER_HISTORICAL_VECTOR:"
@@ -61,7 +61,7 @@
     EPOCHS_PER_HISTORICAL_VECTOR: uint64 = 65536
     </spec>
 
-- name: EPOCHS_PER_SLASHINGS_VECTOR
+- name: EPOCHS_PER_SLASHINGS_VECTOR#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "EPOCHS_PER_SLASHINGS_VECTOR:"
@@ -70,7 +70,7 @@
     EPOCHS_PER_SLASHINGS_VECTOR: uint64 = 8192
     </spec>
 
-- name: EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+- name: EPOCHS_PER_SYNC_COMMITTEE_PERIOD#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "EPOCHS_PER_SYNC_COMMITTEE_PERIOD:"
@@ -79,7 +79,7 @@
     EPOCHS_PER_SYNC_COMMITTEE_PERIOD: uint64 = 256
     </spec>
 
-- name: FIELD_ELEMENTS_PER_BLOB
+- name: FIELD_ELEMENTS_PER_BLOB#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/deneb.yaml
       search: "FIELD_ELEMENTS_PER_BLOB:"
@@ -88,7 +88,7 @@
     FIELD_ELEMENTS_PER_BLOB: uint64 = 4096
     </spec>
 
-- name: FIELD_ELEMENTS_PER_CELL
+- name: FIELD_ELEMENTS_PER_CELL#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "FIELD_ELEMENTS_PER_CELL:"
@@ -97,7 +97,7 @@
     FIELD_ELEMENTS_PER_CELL: uint64 = 64
     </spec>
 
-- name: FIELD_ELEMENTS_PER_EXT_BLOB
+- name: FIELD_ELEMENTS_PER_EXT_BLOB#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "FIELD_ELEMENTS_PER_EXT_BLOB:"
@@ -106,7 +106,7 @@
     FIELD_ELEMENTS_PER_EXT_BLOB = 8192
     </spec>
 
-- name: HISTORICAL_ROOTS_LIMIT
+- name: HISTORICAL_ROOTS_LIMIT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HISTORICAL_ROOTS_LIMIT:"
@@ -115,7 +115,7 @@
     HISTORICAL_ROOTS_LIMIT: uint64 = 16777216
     </spec>
 
-- name: HYSTERESIS_DOWNWARD_MULTIPLIER
+- name: HYSTERESIS_DOWNWARD_MULTIPLIER#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HYSTERESIS_DOWNWARD_MULTIPLIER:"
@@ -124,7 +124,7 @@
     HYSTERESIS_DOWNWARD_MULTIPLIER: uint64 = 1
     </spec>
 
-- name: HYSTERESIS_QUOTIENT
+- name: HYSTERESIS_QUOTIENT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HYSTERESIS_QUOTIENT:"
@@ -133,7 +133,7 @@
     HYSTERESIS_QUOTIENT: uint64 = 4
     </spec>
 
-- name: HYSTERESIS_UPWARD_MULTIPLIER
+- name: HYSTERESIS_UPWARD_MULTIPLIER#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HYSTERESIS_UPWARD_MULTIPLIER:"
@@ -142,7 +142,7 @@
     HYSTERESIS_UPWARD_MULTIPLIER: uint64 = 5
     </spec>
 
-- name: INACTIVITY_PENALTY_QUOTIENT
+- name: INACTIVITY_PENALTY_QUOTIENT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "INACTIVITY_PENALTY_QUOTIENT:"
@@ -151,7 +151,7 @@
     INACTIVITY_PENALTY_QUOTIENT: uint64 = 67108864
     </spec>
 
-- name: INACTIVITY_PENALTY_QUOTIENT_ALTAIR
+- name: INACTIVITY_PENALTY_QUOTIENT_ALTAIR#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "INACTIVITY_PENALTY_QUOTIENT_ALTAIR:"
@@ -160,7 +160,7 @@
     INACTIVITY_PENALTY_QUOTIENT_ALTAIR: uint64 = 50331648
     </spec>
 
-- name: INACTIVITY_PENALTY_QUOTIENT_BELLATRIX
+- name: INACTIVITY_PENALTY_QUOTIENT_BELLATRIX#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "INACTIVITY_PENALTY_QUOTIENT_BELLATRIX:"
@@ -169,7 +169,7 @@
     INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: uint64 = 16777216
     </spec>
 
-- name: KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH
+- name: KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH:"
@@ -178,7 +178,7 @@
     KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH: uint64 = 4
     </spec>
 
-- name: KZG_COMMITMENT_INCLUSION_PROOF_DEPTH
+- name: KZG_COMMITMENT_INCLUSION_PROOF_DEPTH#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/deneb.yaml
       search: "KZG_COMMITMENT_INCLUSION_PROOF_DEPTH:"
@@ -187,7 +187,7 @@
     KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: uint64 = 17
     </spec>
 
-- name: MAX_ATTESTATIONS
+- name: MAX_ATTESTATIONS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_ATTESTATIONS:"
@@ -196,7 +196,7 @@
     MAX_ATTESTATIONS = 128
     </spec>
 
-- name: MAX_ATTESTATIONS_ELECTRA
+- name: MAX_ATTESTATIONS_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_ATTESTATIONS_ELECTRA:"
@@ -205,7 +205,7 @@
     MAX_ATTESTATIONS_ELECTRA = 8
     </spec>
 
-- name: MAX_ATTESTER_SLASHINGS
+- name: MAX_ATTESTER_SLASHINGS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_ATTESTER_SLASHINGS:"
@@ -214,7 +214,7 @@
     MAX_ATTESTER_SLASHINGS = 2
     </spec>
 
-- name: MAX_ATTESTER_SLASHINGS_ELECTRA
+- name: MAX_ATTESTER_SLASHINGS_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_ATTESTER_SLASHINGS_ELECTRA:"
@@ -223,7 +223,7 @@
     MAX_ATTESTER_SLASHINGS_ELECTRA = 1
     </spec>
 
-- name: MAX_BLOB_COMMITMENTS_PER_BLOCK
+- name: MAX_BLOB_COMMITMENTS_PER_BLOCK#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/deneb.yaml
       search: "MAX_BLOB_COMMITMENTS_PER_BLOCK:"
@@ -232,7 +232,7 @@
     MAX_BLOB_COMMITMENTS_PER_BLOCK: uint64 = 4096
     </spec>
 
-- name: MAX_BLS_TO_EXECUTION_CHANGES
+- name: MAX_BLS_TO_EXECUTION_CHANGES#capella
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
       search: "MAX_BLS_TO_EXECUTION_CHANGES:"
@@ -241,7 +241,7 @@
     MAX_BLS_TO_EXECUTION_CHANGES = 16
     </spec>
 
-- name: MAX_BYTES_PER_TRANSACTION
+- name: MAX_BYTES_PER_TRANSACTION#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MAX_BYTES_PER_TRANSACTION:"
@@ -250,7 +250,7 @@
     MAX_BYTES_PER_TRANSACTION: uint64 = 1073741824
     </spec>
 
-- name: MAX_COMMITTEES_PER_SLOT
+- name: MAX_COMMITTEES_PER_SLOT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_COMMITTEES_PER_SLOT:"
@@ -259,7 +259,7 @@
     MAX_COMMITTEES_PER_SLOT: uint64 = 64
     </spec>
 
-- name: MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
+- name: MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD:"
@@ -268,7 +268,7 @@
     MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: uint64 = 2
     </spec>
 
-- name: MAX_DEPOSITS
+- name: MAX_DEPOSITS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_DEPOSITS:"
@@ -277,7 +277,7 @@
     MAX_DEPOSITS = 16
     </spec>
 
-- name: MAX_DEPOSIT_REQUESTS_PER_PAYLOAD
+- name: MAX_DEPOSIT_REQUESTS_PER_PAYLOAD#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_DEPOSIT_REQUESTS_PER_PAYLOAD:"
@@ -286,7 +286,7 @@
     MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: uint64 = 8192
     </spec>
 
-- name: MAX_EFFECTIVE_BALANCE
+- name: MAX_EFFECTIVE_BALANCE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_EFFECTIVE_BALANCE:"
@@ -295,7 +295,7 @@
     MAX_EFFECTIVE_BALANCE: Gwei = 32000000000
     </spec>
 
-- name: MAX_EFFECTIVE_BALANCE_ELECTRA
+- name: MAX_EFFECTIVE_BALANCE_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_EFFECTIVE_BALANCE_ELECTRA:"
@@ -304,7 +304,7 @@
     MAX_EFFECTIVE_BALANCE_ELECTRA: Gwei = 2048000000000
     </spec>
 
-- name: MAX_EXTRA_DATA_BYTES
+- name: MAX_EXTRA_DATA_BYTES#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MAX_EXTRA_DATA_BYTES:"
@@ -313,7 +313,7 @@
     MAX_EXTRA_DATA_BYTES = 32
     </spec>
 
-- name: MAX_PAYLOAD_ATTESTATIONS
+- name: MAX_PAYLOAD_ATTESTATIONS#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "MAX_PAYLOAD_ATTESTATIONS:"
@@ -322,7 +322,7 @@
     MAX_PAYLOAD_ATTESTATIONS = 4
     </spec>
 
-- name: MAX_PENDING_DEPOSITS_PER_EPOCH
+- name: MAX_PENDING_DEPOSITS_PER_EPOCH#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_PENDING_DEPOSITS_PER_EPOCH:"
@@ -331,7 +331,7 @@
     MAX_PENDING_DEPOSITS_PER_EPOCH: uint64 = 16
     </spec>
 
-- name: MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+- name: MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP:"
@@ -340,7 +340,7 @@
     MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: uint64 = 8
     </spec>
 
-- name: MAX_PROPOSER_SLASHINGS
+- name: MAX_PROPOSER_SLASHINGS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_PROPOSER_SLASHINGS:"
@@ -349,7 +349,7 @@
     MAX_PROPOSER_SLASHINGS = 16
     </spec>
 
-- name: MAX_SEED_LOOKAHEAD
+- name: MAX_SEED_LOOKAHEAD#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_SEED_LOOKAHEAD:"
@@ -358,7 +358,7 @@
     MAX_SEED_LOOKAHEAD: uint64 = 4
     </spec>
 
-- name: MAX_TRANSACTIONS_PER_PAYLOAD
+- name: MAX_TRANSACTIONS_PER_PAYLOAD#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MAX_TRANSACTIONS_PER_PAYLOAD:"
@@ -367,7 +367,7 @@
     MAX_TRANSACTIONS_PER_PAYLOAD: uint64 = 1048576
     </spec>
 
-- name: MAX_VALIDATORS_PER_COMMITTEE
+- name: MAX_VALIDATORS_PER_COMMITTEE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_VALIDATORS_PER_COMMITTEE:"
@@ -376,7 +376,7 @@
     MAX_VALIDATORS_PER_COMMITTEE: uint64 = 2048
     </spec>
 
-- name: MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
+- name: MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP#capella
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
       search: "MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP:"
@@ -385,7 +385,7 @@
     MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP = 16384
     </spec>
 
-- name: MAX_VOLUNTARY_EXITS
+- name: MAX_VOLUNTARY_EXITS#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_VOLUNTARY_EXITS:"
@@ -394,7 +394,7 @@
     MAX_VOLUNTARY_EXITS = 16
     </spec>
 
-- name: MAX_WITHDRAWALS_PER_PAYLOAD
+- name: MAX_WITHDRAWALS_PER_PAYLOAD#capella
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
       search: "MAX_WITHDRAWALS_PER_PAYLOAD:"
@@ -403,7 +403,7 @@
     MAX_WITHDRAWALS_PER_PAYLOAD: uint64 = 16
     </spec>
 
-- name: MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
+- name: MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD:"
@@ -412,7 +412,7 @@
     MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: uint64 = 16
     </spec>
 
-- name: MIN_ACTIVATION_BALANCE
+- name: MIN_ACTIVATION_BALANCE#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MIN_ACTIVATION_BALANCE:"
@@ -421,7 +421,7 @@
     MIN_ACTIVATION_BALANCE: Gwei = 32000000000
     </spec>
 
-- name: MIN_ATTESTATION_INCLUSION_DELAY
+- name: MIN_ATTESTATION_INCLUSION_DELAY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_ATTESTATION_INCLUSION_DELAY:"
@@ -430,7 +430,7 @@
     MIN_ATTESTATION_INCLUSION_DELAY: uint64 = 1
     </spec>
 
-- name: MIN_DEPOSIT_AMOUNT
+- name: MIN_DEPOSIT_AMOUNT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_DEPOSIT_AMOUNT:"
@@ -439,7 +439,7 @@
     MIN_DEPOSIT_AMOUNT: Gwei = 1000000000
     </spec>
 
-- name: MIN_EPOCHS_TO_INACTIVITY_PENALTY
+- name: MIN_EPOCHS_TO_INACTIVITY_PENALTY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_EPOCHS_TO_INACTIVITY_PENALTY:"
@@ -448,7 +448,7 @@
     MIN_EPOCHS_TO_INACTIVITY_PENALTY: uint64 = 4
     </spec>
 
-- name: MIN_SEED_LOOKAHEAD
+- name: MIN_SEED_LOOKAHEAD#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_SEED_LOOKAHEAD:"
@@ -457,7 +457,7 @@
     MIN_SEED_LOOKAHEAD: uint64 = 1
     </spec>
 
-- name: MIN_SLASHING_PENALTY_QUOTIENT
+- name: MIN_SLASHING_PENALTY_QUOTIENT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT:"
@@ -466,7 +466,7 @@
     MIN_SLASHING_PENALTY_QUOTIENT: uint64 = 128
     </spec>
 
-- name: MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR
+- name: MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR:"
@@ -475,7 +475,7 @@
     MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: uint64 = 64
     </spec>
 
-- name: MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX
+- name: MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX:"
@@ -484,7 +484,7 @@
     MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: uint64 = 32
     </spec>
 
-- name: MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA
+- name: MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA:"
@@ -493,7 +493,7 @@
     MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: uint64 = 4096
     </spec>
 
-- name: MIN_SYNC_COMMITTEE_PARTICIPANTS
+- name: MIN_SYNC_COMMITTEE_PARTICIPANTS#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "MIN_SYNC_COMMITTEE_PARTICIPANTS:"
@@ -502,7 +502,7 @@
     MIN_SYNC_COMMITTEE_PARTICIPANTS = 1
     </spec>
 
-- name: NUMBER_OF_COLUMNS
+- name: NUMBER_OF_COLUMNS#fulu
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "NUMBER_OF_COLUMNS:"
@@ -511,7 +511,7 @@
     NUMBER_OF_COLUMNS: uint64 = 128
     </spec>
 
-- name: PENDING_CONSOLIDATIONS_LIMIT
+- name: PENDING_CONSOLIDATIONS_LIMIT#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "PENDING_CONSOLIDATIONS_LIMIT:"
@@ -520,7 +520,7 @@
     PENDING_CONSOLIDATIONS_LIMIT: uint64 = 262144
     </spec>
 
-- name: PENDING_DEPOSITS_LIMIT
+- name: PENDING_DEPOSITS_LIMIT#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "PENDING_DEPOSITS_LIMIT:"
@@ -529,7 +529,7 @@
     PENDING_DEPOSITS_LIMIT: uint64 = 134217728
     </spec>
 
-- name: PENDING_PARTIAL_WITHDRAWALS_LIMIT
+- name: PENDING_PARTIAL_WITHDRAWALS_LIMIT#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "PENDING_PARTIAL_WITHDRAWALS_LIMIT:"
@@ -538,7 +538,7 @@
     PENDING_PARTIAL_WITHDRAWALS_LIMIT: uint64 = 134217728
     </spec>
 
-- name: PROPORTIONAL_SLASHING_MULTIPLIER
+- name: PROPORTIONAL_SLASHING_MULTIPLIER#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "PROPORTIONAL_SLASHING_MULTIPLIER:"
@@ -547,7 +547,7 @@
     PROPORTIONAL_SLASHING_MULTIPLIER: uint64 = 1
     </spec>
 
-- name: PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR
+- name: PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR:"
@@ -556,7 +556,7 @@
     PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: uint64 = 2
     </spec>
 
-- name: PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX
+- name: PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX:"
@@ -565,7 +565,7 @@
     PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: uint64 = 3
     </spec>
 
-- name: PROPOSER_REWARD_QUOTIENT
+- name: PROPOSER_REWARD_QUOTIENT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "PROPOSER_REWARD_QUOTIENT:"
@@ -574,7 +574,7 @@
     PROPOSER_REWARD_QUOTIENT: uint64 = 8
     </spec>
 
-- name: PTC_SIZE
+- name: PTC_SIZE#gloas
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "PTC_SIZE:"
@@ -583,7 +583,7 @@
     PTC_SIZE: uint64 = 512
     </spec>
 
-- name: SHUFFLE_ROUND_COUNT
+- name: SHUFFLE_ROUND_COUNT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "SHUFFLE_ROUND_COUNT:"
@@ -592,7 +592,7 @@
     SHUFFLE_ROUND_COUNT: uint64 = 90
     </spec>
 
-- name: SLOTS_PER_EPOCH
+- name: SLOTS_PER_EPOCH#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "SLOTS_PER_EPOCH:"
@@ -601,7 +601,7 @@
     SLOTS_PER_EPOCH: uint64 = 32
     </spec>
 
-- name: SLOTS_PER_HISTORICAL_ROOT
+- name: SLOTS_PER_HISTORICAL_ROOT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "SLOTS_PER_HISTORICAL_ROOT:"
@@ -610,7 +610,7 @@
     SLOTS_PER_HISTORICAL_ROOT: uint64 = 8192
     </spec>
 
-- name: SYNC_COMMITTEE_SIZE
+- name: SYNC_COMMITTEE_SIZE#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "SYNC_COMMITTEE_SIZE:"
@@ -619,7 +619,7 @@
     SYNC_COMMITTEE_SIZE: uint64 = 512
     </spec>
 
-- name: TARGET_COMMITTEE_SIZE
+- name: TARGET_COMMITTEE_SIZE#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "TARGET_COMMITTEE_SIZE:"
@@ -628,7 +628,7 @@
     TARGET_COMMITTEE_SIZE: uint64 = 128
     </spec>
 
-- name: UPDATE_TIMEOUT
+- name: UPDATE_TIMEOUT#altair
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "UPDATE_TIMEOUT:"
@@ -637,7 +637,7 @@
     UPDATE_TIMEOUT = 8192
     </spec>
 
-- name: VALIDATOR_REGISTRY_LIMIT
+- name: VALIDATOR_REGISTRY_LIMIT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "VALIDATOR_REGISTRY_LIMIT:"
@@ -646,7 +646,7 @@
     VALIDATOR_REGISTRY_LIMIT: uint64 = 1099511627776
     </spec>
 
-- name: WHISTLEBLOWER_REWARD_QUOTIENT
+- name: WHISTLEBLOWER_REWARD_QUOTIENT#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "WHISTLEBLOWER_REWARD_QUOTIENT:"
@@ -655,7 +655,7 @@
     WHISTLEBLOWER_REWARD_QUOTIENT: uint64 = 512
     </spec>
 
-- name: WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA
+- name: WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA#electra
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA:"


### PR DESCRIPTION
## PR Description

More specification reference changes.

As of [`ethspecify==0.3.2`](https://pypi.org/project/ethspecify/0.3.2/), there are these configuration options:

* `auto_standardize_names` -- automatically rename yaml entries to be "<spec_item_name>#<fork>"
* `auto_add_missing_entries` -- automatically fill in missing specrefs (with empty sources)

This PR enables these two options & commits the changes.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable ethspecify auto-standardization and auto-fill, bulk-renaming specrefs to fork-qualified keys and adding numerous missing entries across configs, constants, containers, dataclasses, functions, and presets with an explicit exceptions list.
> 
> - **Config**:
>   - Enable `auto_standardize_names` and `auto_add_missing_entries` in `specrefs/.ethspecify.yml`.
>   - Add comprehensive `exceptions` for unsupported/externally-implemented items.
> - **Standardization**:
>   - Rename spec references to fork-qualified keys (e.g., ``NAME#fork``) across `configs.yml`, `constants.yml`, `containers.yml`, `dataclasses.yml`, `functions.yml`, and `presets.yml`.
> - **Coverage Expansion**:
>   - Auto-add numerous missing specrefs for multiple forks (`phase0`, `altair`, `bellatrix`, `capella`, `deneb`, `electra`, `fulu`, `gloas`), including KZG/light-client/EIP entries, often with empty sources.
> - **Outcome**:
>   - Consistent naming and broader, structured spec coverage without functional logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e00c787b0c39778693441b563d57f0dae20ae9d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->