### PR TITLE
updated lightClientBootstrap for electra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
     resource_class: "medium+"
     working_directory: ~/project
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx2000m
+      JAVA_TOOL_OPTIONS: -Xmx1500m
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true
 
   large_executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
     resource_class: "medium+"
     working_directory: ~/project
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx1500m
+      JAVA_TOOL_OPTIONS: -Xmx2000m
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true
 
   large_executor:

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetLightClientBootstrapIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetLightClientBootstrapIntegrationTest.java
@@ -21,12 +21,14 @@ import java.io.IOException;
 import okhttp3.Response;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.lightclient.GetLightClientBootstrap;
 import tech.pegasys.teku.ethereum.json.types.SharedApiTypes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
@@ -36,27 +38,28 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
+@TestSpecContext(milestone = {SpecMilestone.ALTAIR, SpecMilestone.ELECTRA})
 public class GetLightClientBootstrapIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
 
   final Bytes32 blockRoot = Bytes32.random();
 
   @BeforeEach
-  void setup() {
-    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
+  void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    startRestAPIAtGenesis(specContext.getSpecMilestone());
   }
 
-  @Test
+  @TestTemplate
   void shouldReturnResultIfCreatedSuccessfully() throws IOException {
-    BeaconState state =
+    final BeaconState state =
         safeJoin(dataProvider.getChainDataProvider().getBeaconStateAtHead())
             .orElseThrow()
             .getData();
-    LightClientHeader expectedHeader =
+    final LightClientHeader expectedHeader =
         SchemaDefinitionsAltair.required(spec.getGenesisSchemaDefinitions())
             .getLightClientHeaderSchema()
             .create(BeaconBlockHeader.fromState(state));
-    SyncCommittee expectedSyncCommittee =
+    final SyncCommittee expectedSyncCommittee =
         BeaconStateAltair.required(state).getCurrentSyncCommittee();
 
     final Response response = get(expectedHeader.getBeacon().getRoot());
@@ -73,14 +76,14 @@ public class GetLightClientBootstrapIntegrationTest
     assertThat(parsedBootstrapResponse.getCurrentSyncCommittee()).isEqualTo(expectedSyncCommittee);
   }
 
-  @Test
+  @TestTemplate
   void shouldReturnBadRequestIfInvalidPath() throws IOException {
     final Response response =
         getResponse(GetLightClientBootstrap.ROUTE.replace("{block_root}", "foo"));
     assertBadRequest(response);
   }
 
-  @Test
+  @TestTemplate
   void shouldReturnNotFoundIfNoBlock() throws IOException {
     final Response response = get(blockRoot);
     assertNotFound(response);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetLightClientBootstrapIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetLightClientBootstrapIntegrationTest.java
@@ -21,14 +21,12 @@ import java.io.IOException;
 import okhttp3.Response;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.lightclient.GetLightClientBootstrap;
 import tech.pegasys.teku.ethereum.json.types.SharedApiTypes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecContext;
-import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
@@ -38,17 +36,17 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
-@TestSpecContext(allMilestones = true, ignoredMilestones = SpecMilestone.PHASE0)
 public class GetLightClientBootstrapIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
+
   final Bytes32 blockRoot = Bytes32.random();
 
   @BeforeEach
-  void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
-    startRestAPIAtGenesis(specContext.getSpecMilestone());
+  void setup() {
+    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
   }
 
-  @TestTemplate
+  @Test
   void shouldReturnResultIfCreatedSuccessfully() throws IOException {
     BeaconState state =
         safeJoin(dataProvider.getChainDataProvider().getBeaconStateAtHead())
@@ -62,16 +60,7 @@ public class GetLightClientBootstrapIntegrationTest
         BeaconStateAltair.required(state).getCurrentSyncCommittee();
 
     final Response response = get(expectedHeader.getBeacon().getRoot());
-    assertThat(response.code())
-        .withFailMessage(
-            () -> {
-              try {
-                return response.body().string();
-              } catch (IOException e) {
-                return "<NO RESPONSE BODY>";
-              }
-            })
-        .isEqualTo(SC_OK);
+    assertThat(response.code()).isEqualTo(SC_OK);
 
     final LightClientBootstrapSchema lightClientBootstrapSchema =
         SchemaDefinitionsAltair.required(spec.getGenesisSchemaDefinitions())
@@ -84,14 +73,14 @@ public class GetLightClientBootstrapIntegrationTest
     assertThat(parsedBootstrapResponse.getCurrentSyncCommittee()).isEqualTo(expectedSyncCommittee);
   }
 
-  @TestTemplate
+  @Test
   void shouldReturnBadRequestIfInvalidPath() throws IOException {
     final Response response =
         getResponse(GetLightClientBootstrap.ROUTE.replace("{block_root}", "foo"));
     assertBadRequest(response);
   }
 
-  @TestTemplate
+  @Test
   void shouldReturnNotFoundIfNoBlock() throws IOException {
     final Response response = get(blockRoot);
     assertNotFound(response);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetLightClientBootstrapIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetLightClientBootstrapIntegrationTest.java
@@ -21,12 +21,14 @@ import java.io.IOException;
 import okhttp3.Response;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.lightclient.GetLightClientBootstrap;
 import tech.pegasys.teku.ethereum.json.types.SharedApiTypes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
@@ -36,17 +38,17 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
+@TestSpecContext(allMilestones = true, ignoredMilestones = SpecMilestone.PHASE0)
 public class GetLightClientBootstrapIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
-
   final Bytes32 blockRoot = Bytes32.random();
 
   @BeforeEach
-  void setup() {
-    startRestAPIAtGenesis(SpecMilestone.ALTAIR);
+  void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    startRestAPIAtGenesis(specContext.getSpecMilestone());
   }
 
-  @Test
+  @TestTemplate
   void shouldReturnResultIfCreatedSuccessfully() throws IOException {
     BeaconState state =
         safeJoin(dataProvider.getChainDataProvider().getBeaconStateAtHead())
@@ -60,7 +62,16 @@ public class GetLightClientBootstrapIntegrationTest
         BeaconStateAltair.required(state).getCurrentSyncCommittee();
 
     final Response response = get(expectedHeader.getBeacon().getRoot());
-    assertThat(response.code()).isEqualTo(SC_OK);
+    assertThat(response.code())
+        .withFailMessage(
+            () -> {
+              try {
+                return response.body().string();
+              } catch (IOException e) {
+                return "<NO RESPONSE BODY>";
+              }
+            })
+        .isEqualTo(SC_OK);
 
     final LightClientBootstrapSchema lightClientBootstrapSchema =
         SchemaDefinitionsAltair.required(spec.getGenesisSchemaDefinitions())
@@ -73,14 +84,14 @@ public class GetLightClientBootstrapIntegrationTest
     assertThat(parsedBootstrapResponse.getCurrentSyncCommittee()).isEqualTo(expectedSyncCommittee);
   }
 
-  @Test
+  @TestTemplate
   void shouldReturnBadRequestIfInvalidPath() throws IOException {
     final Response response =
         getResponse(GetLightClientBootstrap.ROUTE.replace("{block_root}", "foo"));
     assertBadRequest(response);
   }
 
-  @Test
+  @TestTemplate
   void shouldReturnNotFoundIfNoBlock() throws IOException {
     final Response response = get(blockRoot);
     assertNotFound(response);

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_light_client_bootstrap_{block_root}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_light_client_bootstrap_{block_root}.json
@@ -11,8 +11,7 @@
       "schema" : {
         "type" : "string",
         "description" : "Block root. Hex encoded with 0x prefix.",
-        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-        "format" : "byte"
+        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
       }
     } ],
     "responses" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetLightClientBootstrapResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetLightClientBootstrapResponse.json
@@ -8,7 +8,11 @@
       "enum" : [ "phase0", "altair", "bellatrix", "capella", "deneb", "electra", "fulu", "gloas" ]
     },
     "data" : {
-      "$ref" : "#/components/schemas/LightClientBootstrap"
+      "title" : "LightClientBootstrap",
+      "type" : "object",
+      "oneOf" : [ {
+        "$ref" : "#/components/schemas/LightClientBootstrap"
+      } ]
     }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
@@ -104,9 +104,12 @@ public class BeaconRestApiTypes {
   public static final ParameterMetadata<String> PARAMETER_BLOCK_ID =
       new ParameterMetadata<>(PARAM_BLOCK_ID, CoreTypes.string(PARAM_BLOCK_ID_DESCRIPTION, "head"));
 
-  public static final ParameterMetadata<Bytes32> BLOCK_ROOT_PARAMETER =
+  public static final ParameterMetadata<String> BLOCK_ROOT_PARAMETER =
       new ParameterMetadata<>(
-          BLOCK_ROOT, BYTES32_TYPE.withDescription("Block root. Hex encoded with 0x prefix."));
+          BLOCK_ROOT,
+          CoreTypes.string(
+              "Block root. Hex encoded with 0x prefix.",
+              "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"));
 
   public static final ParameterMetadata<UInt64> SLOT_PARAMETER =
       new ParameterMetadata<>(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientBootstrap.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientBootstrap.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.lightclient;
 
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.BLOCK_ROOT_PARAMETER;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getMultipleSchemaDefinitionFromMilestone;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.sszResponseType;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
@@ -22,10 +23,13 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EXPERIMENTAL;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
@@ -36,7 +40,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
 public class GetLightClientBootstrap extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/beacon/light_client/bootstrap/{block_root}";
@@ -73,7 +76,7 @@ public class GetLightClientBootstrap extends RestApiEndpoint {
 
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
-    final Bytes32 blockRoot = request.getPathParameter(BLOCK_ROOT_PARAMETER);
+    final Bytes32 blockRoot = Bytes32.fromHexString(request.getPathParameter(BLOCK_ROOT_PARAMETER));
     final SafeFuture<Optional<ObjectAndMetaData<LightClientBootstrap>>> future =
         chainDataProvider.getLightClientBoostrap(blockRoot);
 
@@ -91,18 +94,52 @@ public class GetLightClientBootstrap extends RestApiEndpoint {
                     .orElseGet(AsyncApiResponse::respondNotFound)));
   }
 
-  private static SerializableTypeDefinition<ObjectAndMetaData<LightClientBootstrap>>
-      getResponseType(final SchemaDefinitionCache schemaDefinitionCache) {
+  static SerializableTypeDefinition<ObjectAndMetaData<LightClientBootstrap>> getResponseType(
+      final SchemaDefinitionCache schemaDefinitionCache) {
+
+    final List<MilestoneDependentTypesUtil.ConditionalSchemaGetter<LightClientBootstrap>>
+        schemaGetters = generateLightClientBootstrapSchemaGetters(schemaDefinitionCache);
     final SerializableTypeDefinition<LightClientBootstrap> lightClientBootstrapType =
-        SchemaDefinitionsAltair.required(
-                schemaDefinitionCache.getSchemaDefinition(SpecMilestone.ALTAIR))
-            .getLightClientBootstrapSchema()
-            .getJsonTypeDefinition();
+        getMultipleSchemaDefinitionFromMilestone(
+            schemaDefinitionCache, "LightClientBootstrap", schemaGetters);
 
     return SerializableTypeDefinition.<ObjectAndMetaData<LightClientBootstrap>>object()
         .name("GetLightClientBootstrapResponse")
         .withField("version", MILESTONE_TYPE, ObjectAndMetaData::getMilestone)
         .withField("data", lightClientBootstrapType, ObjectAndMetaData::getData)
         .build();
+  }
+
+  private static List<MilestoneDependentTypesUtil.ConditionalSchemaGetter<LightClientBootstrap>>
+      generateLightClientBootstrapSchemaGetters(final SchemaDefinitionCache schemaDefinitionCache) {
+    final List<MilestoneDependentTypesUtil.ConditionalSchemaGetter<LightClientBootstrap>>
+        schemaGetterList = new ArrayList<>();
+
+    schemaGetterList.add(
+        new MilestoneDependentTypesUtil.ConditionalSchemaGetter<LightClientBootstrap>(
+            (bootstrap, milestone) ->
+                schemaDefinitionCache
+                        .milestoneAtSlot(bootstrap.getLightClientHeader().getBeacon().getSlot())
+                        .equals(milestone)
+                    && milestone.isGreaterThan(SpecMilestone.PHASE0)
+                    && milestone.isLessThan(SpecMilestone.ELECTRA),
+            SpecMilestone.ALTAIR,
+            schemaDefinitions ->
+                schemaDefinitions.toVersionAltair().orElseThrow().getLightClientBootstrapSchema()));
+    schemaGetterList.add(
+        new MilestoneDependentTypesUtil.ConditionalSchemaGetter<>(
+            (bootstrap, milestone) ->
+                schemaDefinitionCache
+                        .milestoneAtSlot(bootstrap.getLightClientHeader().getBeacon().getSlot())
+                        .equals(milestone)
+                    && milestone.isGreaterThan(SpecMilestone.DENEB),
+            SpecMilestone.ELECTRA,
+            schemaDefinitions ->
+                schemaDefinitions
+                    .toVersionElectra()
+                    .orElseThrow()
+                    .getLightClientBootstrapSchema()));
+
+    return schemaGetterList;
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
@@ -75,6 +75,12 @@ public abstract class AbstractMigratedBeaconHandlerTest {
         UInt64.valueOf(highestSlot));
   }
 
+  protected void setSpec(final Spec spec) {
+    this.spec = spec;
+    this.dataStructureUtil = new DataStructureUtil(this.spec);
+    schemaDefinitionCache = new SchemaDefinitionCache(this.spec);
+  }
+
   protected <T> ObjectAndMetaData<T> withMetaData(final T value) {
     return new ObjectAndMetaData<>(value, spec.getGenesisSpec().getMilestone(), false, true, false);
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractPostBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractPostBlockTest.java
@@ -35,8 +35,6 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
 public abstract class AbstractPostBlockTest extends AbstractMigratedBeaconHandlerTest {
@@ -46,9 +44,7 @@ public abstract class AbstractPostBlockTest extends AbstractMigratedBeaconHandle
   public abstract boolean isBlinded();
 
   protected void setupDeneb() {
-    spec = TestSpecFactory.createMinimalDeneb();
-    schemaDefinitionCache = new SchemaDefinitionCache(spec);
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(TestSpecFactory.createMinimalDeneb());
     setup();
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlobSidecarsAtSlotTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlobSidecarsAtSlotTest.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetAllBlobSidecarsAtSlotTest extends AbstractMigratedBeaconHandlerTest {
 
@@ -51,8 +50,7 @@ public class GetAllBlobSidecarsAtSlotTest extends AbstractMigratedBeaconHandlerT
 
   @BeforeEach
   void setup() {
-    spec = TestSpecFactory.createMinimalDeneb();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(TestSpecFactory.createMinimalDeneb());
     setHandler(new GetAllBlobSidecarsAtSlot(chainDataProvider, schemaDefinitionCache));
     request.setPathParameter(SLOT, "1");
     request.setListQueryParameters(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlsToExecutionChangesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlsToExecutionChangesTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class GetBlsToExecutionChangesTest extends AbstractMigratedBeaconHandlerTest {
 
@@ -41,8 +40,7 @@ class GetBlsToExecutionChangesTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setUp() {
-    spec = TestSpecFactory.createMinimalCapella();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(TestSpecFactory.createMinimalCapella());
     setHandler(new GetBlsToExecutionChanges(nodeDataProvider, schemaDefinitionCache));
 
     responseData =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlsToExecutionChangesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlsToExecutionChangesTest.java
@@ -42,15 +42,13 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
 class PostBlsToExecutionChangesTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   public void setup() {
-    spec = TestSpecFactory.createMinimalCapella();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(TestSpecFactory.createMinimalCapella());
     setHandler(new PostBlsToExecutionChanges(nodeDataProvider, schemaDefinitionCache));
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommitteesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommitteesTest.java
@@ -38,15 +38,13 @@ import tech.pegasys.teku.beaconrestapi.schema.ErrorListBadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
 public class PostSyncCommitteesTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setup() {
-    spec = TestSpecFactory.createMinimalAltair();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(TestSpecFactory.createMinimalAltair());
     setHandler(new PostSyncCommittees(validatorDataProvider));
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientBootstrapTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientBootstrapTest.java
@@ -40,7 +40,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetLightClientBootstrapTest extends AbstractMigratedBeaconHandlerTest {
 
@@ -49,8 +48,9 @@ public class GetLightClientBootstrapTest extends AbstractMigratedBeaconHandlerTe
 
   @BeforeEach
   void setup() {
+    // we need altair minimum, so update spec
+    setSpec(TestSpecFactory.createMinimalAltair());
     setHandler(new GetLightClientBootstrap(chainDataProvider, schemaDefinitionCache));
-    dataStructureUtil = new DataStructureUtil(TestSpecFactory.createMinimalAltair());
     request.setPathParameter("block_root", blockRoot.toHexString());
   }
 
@@ -72,9 +72,9 @@ public class GetLightClientBootstrapTest extends AbstractMigratedBeaconHandlerTe
 
   @Test
   void metadata_shouldHandle200() throws IOException {
-    LightClientBootstrap lightClientBootstrap =
+    final LightClientBootstrap lightClientBootstrap =
         dataStructureUtil.randomLightClientBoostrap(UInt64.ONE);
-    ObjectAndMetaData<LightClientBootstrap> responseData =
+    final ObjectAndMetaData<LightClientBootstrap> responseData =
         new ObjectAndMetaData<>(lightClientBootstrap, SpecMilestone.ALTAIR, false, true, false);
 
     final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetSyncCommitteeRewardsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetSyncCommitteeRewardsTest.java
@@ -40,7 +40,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetSyncCommitteeRewardsTest
     extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
@@ -48,8 +47,7 @@ public class GetSyncCommitteeRewardsTest
 
   @BeforeEach
   void setup() {
-    spec = TestSpecFactory.createMinimalAltair();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(TestSpecFactory.createMinimalAltair());
     initialise(SpecMilestone.ALTAIR);
     genesis();
     final SyncAggregate syncAggregate =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetAttestationsV2Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetAttestationsV2Test.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @TestSpecContext(milestone = {PHASE0, ELECTRA})
 public class GetAttestationsV2Test extends AbstractMigratedBeaconHandlerTest {
@@ -51,8 +50,7 @@ public class GetAttestationsV2Test extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
-    spec = specContext.getSpec();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
     setHandler(new GetAttestationsV2(nodeDataProvider, new SchemaDefinitionCache(spec)));
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetAttesterSlashingsV2Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetAttesterSlashingsV2Test.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @TestSpecContext(milestone = {PHASE0, ELECTRA})
 class GetAttesterSlashingsV2Test extends AbstractMigratedBeaconHandlerTest {
@@ -50,8 +49,7 @@ class GetAttesterSlashingsV2Test extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
-    spec = specContext.getSpec();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
     setHandler(new GetAttesterSlashingsV2(nodeDataProvider, new SchemaDefinitionCache(spec)));
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostAttestationsV2Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostAttestationsV2Test.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
 @TestSpecContext(milestone = {PHASE0, ELECTRA})
@@ -58,9 +57,8 @@ public class PostAttestationsV2Test extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
-    spec = specContext.getSpec();
+    setSpec(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
-    schemaDefinitionCache = new SchemaDefinitionCache(spec);
     setHandler(new PostAttestationsV2(validatorDataProvider, spec, schemaDefinitionCache));
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostAttesterSlashingV2Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostAttesterSlashingV2Test.java
@@ -40,7 +40,6 @@ import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 @TestSpecContext(milestone = {PHASE0, ELECTRA})
@@ -50,8 +49,7 @@ class PostAttesterSlashingV2Test extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
-    spec = specContext.getSpec();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
     setHandler(new PostAttesterSlashingV2(nodeDataProvider, new SchemaDefinitionCache(spec)));
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/PostAggregateAndProofsV2Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/PostAggregateAndProofsV2Test.java
@@ -47,7 +47,6 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.electra.AttestationElectra;
 import tech.pegasys.teku.spec.datastructures.operations.versions.phase0.AttestationPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
 @TestSpecContext(milestone = {PHASE0, ELECTRA})
@@ -57,8 +56,7 @@ public class PostAggregateAndProofsV2Test extends AbstractMigratedBeaconHandlerT
 
   @BeforeEach
   public void beforeEach(final TestSpecInvocationContextProvider.SpecContext specContext) {
-    spec = specContext.getSpec();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
     setHandler(
         new PostAggregateAndProofsV2(validatorDataProvider, spec, new SchemaDefinitionCache(spec)));

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
@@ -49,7 +49,6 @@ import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @TestSpecContext(allMilestones = true)
 public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
@@ -59,8 +58,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   public void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
-    spec = specContext.getSpec();
-    dataStructureUtil = new DataStructureUtil(spec);
+    setSpec(specContext.getSpec());
     specMilestone = specContext.getSpecMilestone();
     setHandler(new GetNewBlockV3(validatorDataProvider, schemaDefinitionCache));
     request.setPathParameter(SLOT, "1");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientBootstrapSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientBootstrapSchema.java
@@ -26,8 +26,8 @@ import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers;
 public class LightClientBootstrapSchema
     extends ContainerSchema3<
         LightClientBootstrap, LightClientHeader, SyncCommittee, SszBytes32Vector> {
-
-  public LightClientBootstrapSchema(final SpecConfigAltair specConfigAltair) {
+  protected LightClientBootstrapSchema(
+      final SpecConfigAltair specConfigAltair, final int syncCommitteeGindex) {
     super(
         "LightClientBootstrap",
         namedSchema("header", new LightClientHeaderSchema()),
@@ -35,7 +35,11 @@ public class LightClientBootstrapSchema
             "current_sync_committee", new SyncCommittee.SyncCommitteeSchema(specConfigAltair)),
         namedSchema(
             "current_sync_committee_branch",
-            SszBytes32VectorSchema.create(MathHelpers.floorLog2(CURRENT_SYNC_COMMITTEE_GINDEX))));
+            SszBytes32VectorSchema.create(MathHelpers.floorLog2(syncCommitteeGindex))));
+  }
+
+  public LightClientBootstrapSchema(final SpecConfigAltair specConfigAltair) {
+    this(specConfigAltair, CURRENT_SYNC_COMMITTEE_GINDEX);
   }
 
   public LightClientBootstrap create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/versions/electra/LightClientBootstrapSchemaElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/versions/electra/LightClientBootstrapSchemaElectra.java
@@ -11,12 +11,15 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.constants;
+package tech.pegasys.teku.spec.datastructures.lightclient.versions.electra;
 
-public class LightClientConstants {
-  // Altair
-  public static final int FINALIZED_ROOT_GINDEX = 105;
-  public static final int CURRENT_SYNC_COMMITTEE_GINDEX = 54;
-  public static final int CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA = 86;
-  public static final int NEXT_SYNC_COMMITTEE_GINDEX = 55;
+import static tech.pegasys.teku.spec.constants.LightClientConstants.CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA;
+
+import tech.pegasys.teku.spec.config.SpecConfigElectra;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
+
+public class LightClientBootstrapSchemaElectra extends LightClientBootstrapSchema {
+  public LightClientBootstrapSchemaElectra(final SpecConfigElectra specConfigElectra) {
+    super(specConfigElectra, CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA);
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.AGGREGATE_AND_
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_BODY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_STATE_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.LIGHT_CLIENT_BOOTSTRAP_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.METADATA_MESSAGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_AGGREGATE_AND_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BEACON_BLOCK_SCHEMA;
@@ -91,6 +92,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     this.beaconBlockBodySchema = schemaRegistry.get(BEACON_BLOCK_BODY_SCHEMA);
     this.beaconBlockSchema = schemaRegistry.get(BEACON_BLOCK_SCHEMA);
     this.signedBeaconBlockSchema = schemaRegistry.get(SIGNED_BEACON_BLOCK_SCHEMA);
+
     this.syncCommitteeContributionSchema = SyncCommitteeContributionSchema.create(specConfig);
     this.contributionAndProofSchema =
         ContributionAndProofSchema.create(syncCommitteeContributionSchema);
@@ -99,7 +101,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     this.metadataMessageSchema = schemaRegistry.get(METADATA_MESSAGE_SCHEMA);
     this.statusMessageSchema = schemaRegistry.get(STATUS_MESSAGE_SCHEMA);
     this.lightClientHeaderSchema = new LightClientHeaderSchema();
-    this.lightClientBootstrapSchema = new LightClientBootstrapSchema(specConfig);
+    this.lightClientBootstrapSchema = schemaRegistry.get(LIGHT_CLIENT_BOOTSTRAP_SCHEMA);
     this.lightClientUpdateSchema = new LightClientUpdateSchema(specConfig);
     this.lightClientUpdateResponseSchema = new LightClientUpdateResponseSchema(specConfig);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.CONSOLIDATION_
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.DEPOSIT_REQUEST_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PROOF_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQUESTS_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.LIGHT_CLIENT_BOOTSTRAP_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_CONSOLIDATIONS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_DEPOSITS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PENDING_PARTIAL_WITHDRAWALS_SCHEMA;
@@ -34,6 +35,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SingleAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation.PendingConsolidationSchema;
@@ -56,6 +58,7 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   private final PendingDepositSchema pendingDepositSchema;
   private final PendingPartialWithdrawalSchema pendingPartialWithdrawalSchema;
   private final PendingConsolidationSchema pendingConsolidationSchema;
+  private final LightClientBootstrapSchema lightClientBootstrapSchema;
 
   private final SingleAttestationSchema singleAttestationSchema;
 
@@ -81,6 +84,7 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
     this.pendingConsolidationSchema =
         (PendingConsolidationSchema)
             schemaRegistry.get(PENDING_CONSOLIDATIONS_SCHEMA).getElementSchema();
+    this.lightClientBootstrapSchema = schemaRegistry.get(LIGHT_CLIENT_BOOTSTRAP_SCHEMA);
 
     this.executionProofSchema = schemaRegistry.get(EXECUTION_PROOF_SCHEMA);
   }
@@ -154,6 +158,11 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   @Override
   long getMaxValidatorsPerAttestation(final SpecConfig specConfig) {
     return (long) specConfig.getMaxValidatorsPerCommittee() * specConfig.getMaxCommitteesPerSlot();
+  }
+
+  @Override
+  public LightClientBootstrapSchema getLightClientBootstrapSchema() {
+    return lightClientBootstrapSchema;
   }
 
   public ExecutionProofSchema getExecutionProofSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -67,6 +67,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_BAT
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.HISTORICAL_SUMMARIES_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.INDEXED_ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.INDEXED_PAYLOAD_ATTESTATION_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.LIGHT_CLIENT_BOOTSTRAP_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.MATRIX_ENTRY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.METADATA_MESSAGE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PAYLOAD_ATTESTATION_DATA_SCHEMA;
@@ -99,6 +100,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchem
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64VectorSchema;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
@@ -161,6 +163,8 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
+import tech.pegasys.teku.spec.datastructures.lightclient.versions.electra.LightClientBootstrapSchemaElectra;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage.BeaconBlocksByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRangeRequestMessage;
@@ -221,6 +225,7 @@ public class SchemaRegistryBuilder {
         .addProvider(createBeaconStateSchemaProvider())
         .addProvider(createMetadataMessageSchemaProvider())
         .addProvider(createStatusMessageSchemaProvider())
+        .addProvider(createLightClientBootstrapSchemaProvider())
 
         // BELLATRIX
         .addProvider(createExecutionPayloadSchemaProvider())
@@ -765,6 +770,19 @@ public class SchemaRegistryBuilder {
         .withCreator(
             ELECTRA,
             (registry, specConfig, schemaName) -> new AggregateAndProofSchema(schemaName, registry))
+        .build();
+  }
+
+  private static SchemaProvider<?> createLightClientBootstrapSchemaProvider() {
+    return providerBuilder(LIGHT_CLIENT_BOOTSTRAP_SCHEMA)
+        .withCreator(
+            ALTAIR,
+            (registry, specConfig, schemaName) ->
+                new LightClientBootstrapSchema(SpecConfigAltair.required(specConfig)))
+        .withCreator(
+            ELECTRA,
+            (registry, specConfig, schemaName) ->
+                new LightClientBootstrapSchemaElectra(SpecConfigElectra.required(specConfig)))
         .build();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaTypes.java
@@ -69,6 +69,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage.BeaconBlocksByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRangeRequestMessage;
@@ -205,6 +206,8 @@ public class SchemaTypes {
   // Move this when we decide which fork this schema should be under
   public static final SchemaId<ExecutionProofSchema> EXECUTION_PROOF_SCHEMA =
       create("EXECUTION_PROOF_SCHEMA");
+  public static final SchemaId<LightClientBootstrapSchema> LIGHT_CLIENT_BOOTSTRAP_SCHEMA =
+      create("LIGHT_CLIENT_BOOTSTRAP_SCHEMA");
 
   // Fulu
   public static final SchemaId<CellSchema> CELL_SCHEMA = create("CELL_SCHEMA");

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtilTest.java
@@ -15,10 +15,13 @@ package tech.pegasys.teku.spec.logic.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientHeader;
@@ -27,17 +30,25 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
+@TestSpecContext(allMilestones = true, ignoredMilestones = SpecMilestone.PHASE0)
 public class LightClientUtilTest {
-  private final Spec spec = TestSpecFactory.createMinimalAltair();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final LightClientUtil lightClientUtil = spec.getLightClientUtilRequired(UInt64.ZERO);
+  private Spec spec;
+  private DataStructureUtil dataStructureUtil;
+  private LightClientUtil lightClientUtil;
 
-  @Test
+  @BeforeEach
+  void setup(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    spec = specContext.getSpec();
+    dataStructureUtil = specContext.getDataStructureUtil();
+    lightClientUtil = spec.getLightClientUtilRequired(UInt64.ZERO);
+  }
+
+  @TestTemplate
   public void getBoostrap_shouldReturnValidBootstrap() {
-    BeaconState state = dataStructureUtil.stateBuilderAltair().build();
-    LightClientHeader expectedHeader =
+    final BeaconState state = dataStructureUtil.randomBeaconState();
+    final LightClientHeader expectedHeader =
         new LightClientHeaderSchema().create(BeaconBlockHeader.fromState(state));
-    LightClientBootstrap bootstrap = lightClientUtil.getLightClientBootstrap(state);
+    final LightClientBootstrap bootstrap = lightClientUtil.getLightClientBootstrap(state);
 
     assertThat(bootstrap.getLightClientHeader()).isEqualTo(expectedHeader);
     assertThat(bootstrap.getCurrentSyncCommittee())


### PR DESCRIPTION
Still very much experimental but the bootstrap successfully renders now.

I checked the other endpoint we've exposed but it's returning not implemented.

fixes #9870

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Electra LightClientBootstrap support with milestone-dependent schemas wired through the registry and updates the REST endpoint and tests accordingly.
> 
> - **Spec/Core (Light client)**:
>   - Introduce `CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA` and new `LightClientBootstrapSchemaElectra`.
>   - Refactor `LightClientBootstrapSchema` to accept a gindex; add Electra constructor.
>   - Register `LIGHT_CLIENT_BOOTSTRAP_SCHEMA` in `SchemaTypes` and `SchemaRegistryBuilder` with providers for Altair and Electra.
>   - Update `SchemaDefinitionsAltair`/`SchemaDefinitionsElectra` to source `getLightClientBootstrapSchema()` from the registry.
> - **REST API**:
>   - Make `block_root` a `string` path param and parse to `Bytes32` in `GetLightClientBootstrap`.
>   - Build response with milestone-dependent schema selection (Altair vs Electra) based on header slot.
>   - Adjust OpenAPI test resources for `block_root` and `GetLightClientBootstrapResponse`.
> - **Tests**:
>   - Parameterize light client bootstrap integration/unit tests across Altair and Electra; use `@TestTemplate` and `@TestSpecContext`.
>   - Add/adjust tests to use `setSpec` helper; broaden `LightClientUtilTest` to all milestones (except Phase0).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5a093ac062f9c436f2bccc915efbbaad589d037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->