### PR TITLE
Fxed typo in info log output message

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -780,7 +780,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
 
     final boolean isLocallyCreated = isLocallyCreatedBlock(maybeBlindedBlockContainer);
 
-    LOG.info("stating to publish block at slot {}", maybeBlindedBlockContainer.getSlot());
+    LOG.info("starting to publish block at slot {}", maybeBlindedBlockContainer.getSlot());
 
     return blockPublisher
         .sendSignedBlock(


### PR DESCRIPTION
## PR Description

## Fixed Issue(s)
Typo in `INFO` logging fixed when "starting" block production

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects a typo in the INFO log when starting to publish a block ("stating" -> "starting").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fed90e5ca881159303957b840bb98da81bd2f2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->