### PR TITLE
PTC scheduled duty on VC

### DIFF
--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -68,9 +68,11 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
+import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.storage.client.ChainUpdater;
@@ -116,6 +118,8 @@ public class ValidatorApiHandlerIntegrationTest {
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
+  private final ExecutionPayloadManager executionPayloadManager =
+      mock(ExecutionPayloadManager.class);
   private final ExecutionPayloadFactory executionPayloadFactory =
       mock(ExecutionPayloadFactory.class);
   private final ExecutionPayloadPublisher executionPayloadPublisher =
@@ -128,6 +132,7 @@ public class ValidatorApiHandlerIntegrationTest {
       mock(SyncCommitteeContributionPool.class);
   private final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager =
       mock(SyncCommitteeSubscriptionManager.class);
+  private final PayloadAttestationPool payloadAttestationPool = mock(PayloadAttestationPool.class);
 
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
 
@@ -210,6 +215,8 @@ public class ValidatorApiHandlerIntegrationTest {
                 dataColumnSidecarGossipChannel,
                 dutyMetrics,
                 P2PConfig.DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED),
+            payloadAttestationPool,
+            executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,
             ExecutionProofManager.NOOP);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -1407,12 +1407,11 @@ class ValidatorApiHandlerTest {
   @Test
   public void createPayloadAttestationData_shouldCreatePayloadAttestationData() {
     final UInt64 newSlot = UInt64.valueOf(25);
-    final BeaconBlockAndState blockAndState = dataStructureUtil.randomBlockAndState(newSlot);
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(newSlot);
 
-    when(chainDataClient.getBlockAndStateInEffectAtSlot(eq(newSlot)))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(blockAndState)));
-    when(executionPayloadManager.isExecutionPayloadRecentlySeen(blockAndState.getRoot()))
-        .thenReturn(true);
+    when(chainDataClient.getBlockInEffectAtSlot(eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(executionPayloadManager.isExecutionPayloadRecentlySeen(block.getRoot())).thenReturn(true);
 
     final Optional<PayloadAttestationData> result =
         SafeFutureAssert.safeJoin(validatorApiHandler.createPayloadAttestationData(newSlot));
@@ -1420,8 +1419,7 @@ class ValidatorApiHandlerTest {
     assertThat(result)
         .hasValueSatisfying(
             payloadAttestationData -> {
-              assertThat(payloadAttestationData.getBeaconBlockRoot())
-                  .isEqualTo(blockAndState.getRoot());
+              assertThat(payloadAttestationData.getBeaconBlockRoot()).isEqualTo(block.getRoot());
               assertThat(payloadAttestationData.getSlot()).isEqualTo(newSlot);
               assertThat(payloadAttestationData.isPayloadPresent()).isTrue();
               assertThat(payloadAttestationData.isBlobDataAvailable()).isFalse();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -74,6 +74,7 @@ import tech.pegasys.teku.ethereum.json.types.validator.SyncCommitteeSubnetSubscr
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionAndPublishingPerformanceFactory;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricUtils;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -94,6 +95,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
@@ -111,9 +114,11 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
+import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -150,6 +155,9 @@ class ValidatorApiHandlerTest {
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
+  private final PayloadAttestationPool payloadAttestationPool = mock(PayloadAttestationPool.class);
+  private final ExecutionPayloadManager executionPayloadManager =
+      mock(ExecutionPayloadManager.class);
   private final ExecutionPayloadFactory executionPayloadFactory =
       mock(ExecutionPayloadFactory.class);
   private final ExecutionPayloadPublisher executionPayloadPublisher =
@@ -203,6 +211,8 @@ class ValidatorApiHandlerTest {
             syncCommitteeSubscriptionManager,
             blockProductionPerformanceFactory,
             blockPublisher,
+            payloadAttestationPool,
+            executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,
             executionProofManager);
@@ -458,6 +468,8 @@ class ValidatorApiHandlerTest {
             syncCommitteeSubscriptionManager,
             blockProductionPerformanceFactory,
             blockPublisher,
+            payloadAttestationPool,
+            executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,
             executionProofManager);
@@ -1380,6 +1392,52 @@ class ValidatorApiHandlerTest {
                 state.getValidators().get(8).getPublicKey(),
                 UInt64.valueOf(8),
                 UInt64.valueOf(108)));
+  }
+
+  @Test
+  public void createPayloadAttestationData_shouldFailWhenNodeIsSyncing() {
+    nodeIsSyncing();
+    final SafeFuture<Optional<PayloadAttestationData>> result =
+        validatorApiHandler.createPayloadAttestationData(ONE);
+
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
+  }
+
+  @Test
+  public void createPayloadAttestationData_shouldCreatePayloadAttestationData() {
+    final UInt64 newSlot = UInt64.valueOf(25);
+    final BeaconBlockAndState blockAndState = dataStructureUtil.randomBlockAndState(newSlot);
+
+    when(chainDataClient.getBlockAndStateInEffectAtSlot(eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blockAndState)));
+    when(executionPayloadManager.isExecutionPayloadRecentlySeen(blockAndState.getRoot()))
+        .thenReturn(true);
+
+    final Optional<PayloadAttestationData> result =
+        SafeFutureAssert.safeJoin(validatorApiHandler.createPayloadAttestationData(newSlot));
+
+    assertThat(result)
+        .hasValueSatisfying(
+            payloadAttestationData -> {
+              assertThat(payloadAttestationData.getBeaconBlockRoot())
+                  .isEqualTo(blockAndState.getRoot());
+              assertThat(payloadAttestationData.getSlot()).isEqualTo(newSlot);
+              assertThat(payloadAttestationData.isPayloadPresent()).isTrue();
+              assertThat(payloadAttestationData.isBlobDataAvailable()).isFalse();
+            });
+  }
+
+  @Test
+  void sendPayloadAttestationMessages_shouldAddPayloadAttestationsToPool() {
+    final PayloadAttestationMessage payloadAttestationMessage =
+        dataStructureUtil.randomPayloadAttestationMessage();
+    when(payloadAttestationPool.addLocal(any()))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+
+    final SafeFuture<List<SubmitDataError>> result =
+        validatorApiHandler.sendPayloadAttestationMessages(List.of(payloadAttestationMessage));
+    assertThat(result).isCompletedWithValue(List.of());
   }
 
   private boolean validatorIsLive(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -59,7 +59,6 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
     final List<BLSPublicKey> pubKeys =
         indices.stream()
             .map(index -> state.getValidators().get(index.intValue()).getPublicKey())
-            .distinct()
             .toList();
     final Bytes32 domain =
         beaconStateAccessors.getDomain(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -59,6 +59,7 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
     final List<BLSPublicKey> pubKeys =
         indices.stream()
             .map(index -> state.getValidators().get(index.intValue()).getPublicKey())
+            .distinct()
             .toList();
     final Bytes32 domain =
         beaconStateAccessors.getDomain(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -3047,6 +3047,12 @@ public final class DataStructureUtil {
         .create(randomBytes32(), randomSlot(), true, true);
   }
 
+  public PayloadAttestationData randomPayloadAttestationData(final UInt64 slot) {
+    return getGloasSchemaDefinitions()
+        .getPayloadAttestationDataSchema()
+        .create(randomBytes32(), slot, true, true);
+  }
+
   public PayloadAttestation randomPayloadAttestation() {
     return getGloasSchemaDefinitions()
         .getPayloadAttestationSchema()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -14,10 +14,13 @@
 package tech.pegasys.teku.statetransition.execution;
 
 import java.util.Optional;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
@@ -29,6 +32,13 @@ import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
 
   private static final Logger LOG = LogManager.getLogger();
+
+  // The cache is currently only used for the `payload_present` voting, so no need for a long term
+  // caching
+  private static final int RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE = 32;
+
+  private final Set<Bytes32> recentSeenExecutionPayloads =
+      LimitedSet.createSynchronized(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
   private final AsyncRunner asyncRunner;
   private final ExecutionPayloadGossipValidator executionPayloadGossipValidator;
@@ -44,6 +54,11 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
     this.executionPayloadGossipValidator = executionPayloadGossipValidator;
     this.forkChoice = forkChoice;
     this.executionLayer = executionLayer;
+  }
+
+  @Override
+  public boolean isExecutionPayloadRecentlySeen(final Bytes32 beaconBlockRoot) {
+    return recentSeenExecutionPayloads.contains(beaconBlockRoot);
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -81,6 +96,8 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
 
   private SafeFuture<ExecutionPayloadImportResult> doImportExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    // cache the seen `beacon_block_root`
+    recentSeenExecutionPayloads.add(signedExecutionPayload.getMessage().getBeaconBlockRoot());
     return asyncRunner
         .runAsync(() -> forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
         .thenPeek(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.execution;
 
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
@@ -24,6 +25,11 @@ public interface ExecutionPayloadManager {
 
   ExecutionPayloadManager NOOP =
       new ExecutionPayloadManager() {
+        @Override
+        public boolean isExecutionPayloadRecentlySeen(Bytes32 beaconBlockRoot) {
+          return false;
+        }
+
         @Override
         public SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
             final SignedExecutionPayloadEnvelope signedExecutionPayload,
@@ -38,6 +44,12 @@ public interface ExecutionPayloadManager {
               ExecutionPayloadImportResult.successful(signedExecutionPayload));
         }
       };
+
+  /**
+   * {@link SignedExecutionPayloadEnvelope} has been recently seen referencing the block. This
+   * method is used for the `payload_present` vote.
+   */
+  boolean isExecutionPayloadRecentlySeen(final Bytes32 beaconBlockRoot);
 
   SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
       SignedExecutionPayloadEnvelope signedExecutionPayload, Optional<UInt64> arrivalTimestamp);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPool.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.payloadattestation;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -29,7 +30,8 @@ import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 // TODO-GLOAS: https://github.com/Consensys/teku/issues/10041 implementation + test
-public class AggregatingPayloadAttestationPool implements PayloadAttestationPool {
+public class AggregatingPayloadAttestationPool
+    implements PayloadAttestationPool, SlotEventsChannel {
 
   private final Subscribers<OperationAddedSubscriber<PayloadAttestationMessage>> subscribers =
       Subscribers.create(true);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationPool.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.payloadattestation;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -25,16 +24,13 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
-public interface PayloadAttestationPool extends SlotEventsChannel {
+public interface PayloadAttestationPool {
 
   PayloadAttestationPool NOOP =
       new PayloadAttestationPool() {
         @Override
         public void subscribeOperationAdded(
             final OperationAddedSubscriber<PayloadAttestationMessage> subscriber) {}
-
-        @Override
-        public void onSlot(final UInt64 slot) {}
 
         @Override
         public SafeFuture<InternalValidationResult> addLocal(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -67,6 +67,12 @@ class DefaultExecutionPayloadManagerTest {
     asyncRunner.executeDueActions();
 
     assertThat(resultFuture).isCompletedWithValue(successfulImportResult);
+
+    // verify the `beacon_block_root` is cached
+    assertThat(
+            executionPayloadManager.isExecutionPayloadRecentlySeen(
+                signedExecutionPayload.getMessage().getBeaconBlockRoot()))
+        .isTrue();
   }
 
   @Test
@@ -105,5 +111,11 @@ class DefaultExecutionPayloadManagerTest {
     assertThat(resultFuture).isCompletedWithValue(InternalValidationResult.ACCEPT);
 
     verify(forkChoice).onExecutionPayload(signedExecutionPayload, executionLayer);
+
+    // verify the `beacon_block_root` is cached
+    assertThat(
+            executionPayloadManager.isExecutionPayloadRecentlySeen(
+                signedExecutionPayload.getMessage().getBeaconBlockRoot()))
+        .isTrue();
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -30,7 +30,7 @@ public class ValidatorLogger {
   private static final int VALIDATOR_KEY_LIMIT = 20;
   public static final ValidatorLogger VALIDATOR_LOGGER =
       new ValidatorLogger(LoggingConfigurator.VALIDATOR_LOGGER_NAME);
-  public static final int LONGEST_TYPE_LENGTH = "sync_contribution".length();
+  public static final int LONGEST_TYPE_LENGTH = "payload_attestation".length();
   private static final String PREFIX = "Validator   *** ";
   private static final String BUILDER_PREFIX = "Builder     *** ";
 

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/Validator/DutyType.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/Validator/DutyType.java
@@ -16,7 +16,8 @@ package tech.pegasys.teku.infrastructure.metrics.Validator;
 public enum DutyType {
   ATTESTATION_AGGREGATION("attestation_aggregation"),
   ATTESTATION_PRODUCTION("attestation_production"),
-  BLOCK_PRODUCTION("block_production");
+  BLOCK_PRODUCTION("block_production"),
+  PAYLOAD_ATTESTATION_PRODUCTION("payload_attestation_production");
 
   private final String name;
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1300,8 +1300,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.debug("BeaconChainController.initPayloadAttestationPool()");
     if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
       final PayloadAttestationMessageValidator validator = new PayloadAttestationMessageValidator();
-      payloadAttestationPool = new AggregatingPayloadAttestationPool(spec, validator);
-      eventChannels.subscribe(SlotEventsChannel.class, payloadAttestationPool);
+      final AggregatingPayloadAttestationPool aggregatingPayloadAttestationPool =
+              new AggregatingPayloadAttestationPool(spec, validator);
+      payloadAttestationPool = aggregatingPayloadAttestationPool;
+      eventChannels.subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool);
     } else {
       payloadAttestationPool = PayloadAttestationPool.NOOP;
     }
@@ -1623,6 +1625,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             syncCommitteeSubscriptionManager,
             blockProductionPerformanceFactory,
             blockPublisher,
+            payloadAttestationPool,
+            executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,
             executionProofManager);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1301,7 +1301,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
       final PayloadAttestationMessageValidator validator = new PayloadAttestationMessageValidator();
       final AggregatingPayloadAttestationPool aggregatingPayloadAttestationPool =
-              new AggregatingPayloadAttestationPool(spec, validator);
+          new AggregatingPayloadAttestationPool(spec, validator);
       payloadAttestationPool = aggregatingPayloadAttestationPool;
       eventChannels.subscribe(SlotEventsChannel.class, aggregatingPayloadAttestationPool);
     } else {

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -84,6 +84,7 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
           millisPerSlot,
           this::onContributionCreationDue);
     }
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10018
     if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
       taskScheduler.scheduleRepeatingEventInMillis(
           nextSlotStartTimeMillis.plus(spec.getPayloadAttestationDueMillis(nextSlot)),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyLoader.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.json.types.validator.PtcDuties;
+import tech.pegasys.teku.ethereum.json.types.validator.PtcDuty;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.duties.Duty;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+import tech.pegasys.teku.validator.client.duties.payloadattestations.PayloadAttestationProductionDuty;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+public class PtcDutyLoader extends AbstractDutyLoader<PtcDuties, SlotBasedScheduledDuties<?, ?>> {
+
+  private final ValidatorApiChannel validatorApiChannel;
+  private final Function<Bytes32, SlotBasedScheduledDuties<PayloadAttestationProductionDuty, Duty>>
+      scheduledDutiesFactory;
+
+  public PtcDutyLoader(
+      final ValidatorApiChannel validatorApiChannel,
+      final Function<Bytes32, SlotBasedScheduledDuties<PayloadAttestationProductionDuty, Duty>>
+          scheduledDutiesFactory,
+      final OwnedValidators validators,
+      final ValidatorIndexProvider validatorIndexProvider) {
+    super(validators, validatorIndexProvider);
+    this.validatorApiChannel = validatorApiChannel;
+    this.scheduledDutiesFactory = scheduledDutiesFactory;
+  }
+
+  @Override
+  protected SafeFuture<Optional<PtcDuties>> requestDuties(
+      final UInt64 epoch, final IntCollection validatorIndices) {
+    if (validatorIndices.isEmpty()) {
+      return SafeFuture.completedFuture(Optional.empty());
+    }
+    return validatorApiChannel.getPtcDuties(epoch, validatorIndices);
+  }
+
+  @Override
+  protected SafeFuture<SlotBasedScheduledDuties<?, ?>> scheduleAllDuties(
+      final UInt64 epoch, final PtcDuties duties) {
+    final SlotBasedScheduledDuties<PayloadAttestationProductionDuty, Duty> scheduledDuties =
+        scheduledDutiesFactory.apply(duties.dependentRoot());
+
+    duties.duties().forEach(duty -> scheduleDuty(scheduledDuties, duty));
+
+    return SafeFuture.completedFuture(scheduledDuties);
+  }
+
+  private void scheduleDuty(
+      final SlotBasedScheduledDuties<PayloadAttestationProductionDuty, Duty> scheduledDuties,
+      final PtcDuty duty) {
+    validators
+        .getValidator(duty.publicKey())
+        .ifPresent(
+            validator ->
+                scheduledDuties.scheduleProduction(
+                    duty.slot(),
+                    validator,
+                    d -> {
+                      d.addValidator(validator, duty.validatorIndex());
+                      return null;
+                    }));
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyScheduler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.api.response.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+
+public class PtcDutyScheduler extends AbstractDutyScheduler {
+
+  private static final Logger LOG = LogManager.getLogger();
+  static final int LOOKAHEAD_EPOCHS = 1;
+
+  public PtcDutyScheduler(
+      final MetricsSystem metricsSystem, final DutyLoader<?> dutyLoader, final Spec spec) {
+    super(metricsSystem, "payload_attestation", dutyLoader, LOOKAHEAD_EPOCHS, spec);
+
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.VALIDATOR,
+        "scheduled_payload_attestation_duties_current",
+        "Current number of pending payload attestation duties that have been scheduled",
+        () -> dutiesByEpoch.values().stream().mapToInt(PendingDuties::countDuties).sum());
+  }
+
+  @Override
+  public void onSyncCommitteeCreationDue(final UInt64 slot) {}
+
+  @Override
+  public void onContributionCreationDue(final UInt64 slot) {}
+
+  @Override
+  public void onPayloadAttestationCreationDue(final UInt64 slot) {
+    onProductionDue(slot);
+  }
+
+  @Override
+  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
+
+  @Override
+  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
+
+  @Override
+  public void onUpdatedValidatorStatuses(
+      final Map<BLSPublicKey, ValidatorStatus> newValidatorStatuses,
+      final boolean possibleMissingEvents) {}
+
+  @Override
+  protected Bytes32 getExpectedDependentRoot(
+      final Bytes32 headBlockRoot,
+      final Bytes32 previousDutyDependentRoot,
+      final Bytes32 currentDutyDependentRoot,
+      final UInt64 headEpoch,
+      final UInt64 dutyEpoch) {
+    checkArgument(
+        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
+        "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
+        dutyEpoch,
+        headEpoch);
+    if (headEpoch.equals(dutyEpoch)) {
+      LOG.debug("headEpoch {} - returning previousDutyDependentRoot", () -> headEpoch);
+      return previousDutyDependentRoot;
+    } else if (headEpoch.increment().equals(dutyEpoch)) {
+      LOG.debug("dutyEpoch (next epoch) {} - returning currentDutyDependentRoot", () -> dutyEpoch);
+      return currentDutyDependentRoot;
+    } else {
+      LOG.debug(
+          "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () -> headEpoch);
+      return headBlockRoot;
+    }
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationDutyFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.payloadattestations;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.ForkProvider;
+import tech.pegasys.teku.validator.client.Validator;
+import tech.pegasys.teku.validator.client.duties.Duty;
+import tech.pegasys.teku.validator.client.duties.DutyFactory;
+import tech.pegasys.teku.validator.client.duties.ValidatorDutyMetrics;
+import tech.pegasys.teku.validator.client.duties.attestations.AggregationDuty;
+import tech.pegasys.teku.validator.client.duties.attestations.BatchAttestationSendingStrategy;
+
+public class PayloadAttestationDutyFactory
+    implements DutyFactory<PayloadAttestationProductionDuty, Duty> {
+
+  private final Spec spec;
+  private final ForkProvider forkProvider;
+  private final ValidatorApiChannel validatorApiChannel;
+
+  private final ValidatorDutyMetrics validatorDutyMetrics;
+
+  public PayloadAttestationDutyFactory(
+      final Spec spec,
+      final ForkProvider forkProvider,
+      final ValidatorApiChannel validatorApiChannel,
+      final ValidatorDutyMetrics validatorDutyMetrics) {
+    this.spec = spec;
+    this.forkProvider = forkProvider;
+    this.validatorApiChannel = validatorApiChannel;
+    this.validatorDutyMetrics = validatorDutyMetrics;
+  }
+
+  @Override
+  public PayloadAttestationProductionDuty createProductionDuty(
+      final UInt64 slot, final Validator validator) {
+    return new PayloadAttestationProductionDuty(
+        spec,
+        slot,
+        forkProvider,
+        validatorApiChannel,
+        new BatchAttestationSendingStrategy<>(validatorApiChannel::sendPayloadAttestationMessages),
+        validatorDutyMetrics);
+  }
+
+  @Override
+  public AggregationDuty createAggregationDuty(final UInt64 slot, final Validator validator) {
+    throw new UnsupportedOperationException(
+        "Aggregation for payload attestations is performed by the block proposer");
+  }
+
+  @Override
+  public String getProductionType() {
+    return "payload_attestation";
+  }
+
+  @Override
+  public String getAggregationType() {
+    // not used
+    return "";
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationProductionDuty.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.payloadattestations;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricsSteps.CREATE_TOTAL;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.Validator.DutyType;
+import tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricsSteps;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessageSchema;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.ForkProvider;
+import tech.pegasys.teku.validator.client.Validator;
+import tech.pegasys.teku.validator.client.duties.Duty;
+import tech.pegasys.teku.validator.client.duties.DutyResult;
+import tech.pegasys.teku.validator.client.duties.ProductionResult;
+import tech.pegasys.teku.validator.client.duties.ValidatorDutyMetrics;
+import tech.pegasys.teku.validator.client.duties.attestations.SendingStrategy;
+
+public class PayloadAttestationProductionDuty implements Duty {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+  private final UInt64 slot;
+  private final ForkProvider forkProvider;
+  private final ValidatorApiChannel validatorApiChannel;
+  private final SendingStrategy<PayloadAttestationMessage> sendingStrategy;
+  private final ValidatorDutyMetrics validatorDutyMetrics;
+
+  private final List<ValidatorWithIndex> validators = new ArrayList<>();
+
+  public PayloadAttestationProductionDuty(
+      final Spec spec,
+      final UInt64 slot,
+      final ForkProvider forkProvider,
+      final ValidatorApiChannel validatorApiChannel,
+      final SendingStrategy<PayloadAttestationMessage> sendingStrategy,
+      final ValidatorDutyMetrics validatorDutyMetrics) {
+    this.spec = spec;
+    this.slot = slot;
+    this.forkProvider = forkProvider;
+    this.validatorApiChannel = validatorApiChannel;
+    this.sendingStrategy = sendingStrategy;
+    this.validatorDutyMetrics = validatorDutyMetrics;
+  }
+
+  @Override
+  public DutyType getType() {
+    return DutyType.PAYLOAD_ATTESTATION_PRODUCTION;
+  }
+
+  public void addValidator(final Validator validator, final UInt64 index) {
+    validators.add(new ValidatorWithIndex(validator, index));
+  }
+
+  @Override
+  public SafeFuture<DutyResult> performDuty() {
+    LOG.trace("Creating payload attestations at slot {}", slot);
+
+    if (validators.isEmpty()) {
+      return SafeFuture.completedFuture(DutyResult.NO_OP);
+    }
+
+    return forkProvider
+        .getForkInfo(slot)
+        .thenCompose(
+            forkInfo ->
+                sendingStrategy.send(produceAllPayloadAttestations(slot, forkInfo, validators)));
+  }
+
+  private Stream<SafeFuture<ProductionResult<PayloadAttestationMessage>>>
+      produceAllPayloadAttestations(
+          final UInt64 slot,
+          final ForkInfo forkInfo,
+          final List<ValidatorWithIndex> validatorsWithIndex) {
+
+    final SafeFuture<Optional<PayloadAttestationData>> unsignedPayloadAttestationDataFuture =
+        validatorDutyMetrics.record(
+            () -> validatorApiChannel.createPayloadAttestationData(slot), this, CREATE_TOTAL);
+
+    return validatorsWithIndex.stream()
+        .map(
+            validatorWithIndex ->
+                signPayloadAttestationForValidator(
+                    slot, forkInfo, validatorWithIndex, unsignedPayloadAttestationDataFuture));
+  }
+
+  private SafeFuture<ProductionResult<PayloadAttestationMessage>>
+      signPayloadAttestationForValidator(
+          final UInt64 slot,
+          final ForkInfo forkInfo,
+          final ValidatorWithIndex validatorWithIndex,
+          final SafeFuture<Optional<PayloadAttestationData>> unsignedPayloadAttestationDataFuture) {
+    return unsignedPayloadAttestationDataFuture
+        .thenCompose(
+            maybeUnsignedPayloadAttestationData ->
+                maybeUnsignedPayloadAttestationData
+                    .map(
+                        payloadAttestationData -> {
+                          validatePayloadAttestationData(slot, payloadAttestationData);
+                          return validatorDutyMetrics.record(
+                              () ->
+                                  signPayloadAttestationForValidator(
+                                      forkInfo, payloadAttestationData, validatorWithIndex),
+                              this,
+                              ValidatorDutyMetricsSteps.SIGN);
+                        })
+                    .orElseGet(
+                        () ->
+                            SafeFuture.completedFuture(
+                                ProductionResult.failure(
+                                    validatorWithIndex.validator.getPublicKey(),
+                                    new IllegalStateException(
+                                        "Unable to produce payload attestation for slot "
+                                            + slot
+                                            + " because chain data was unavailable")))))
+        .exceptionally(
+            error -> ProductionResult.failure(validatorWithIndex.validator.getPublicKey(), error));
+  }
+
+  private static void validatePayloadAttestationData(
+      final UInt64 slot, final PayloadAttestationData payloadAttestationData) {
+    checkArgument(
+        payloadAttestationData.getSlot().equals(slot),
+        "Unsigned payload attestation slot (%s) does not match expected slot %s",
+        payloadAttestationData.getSlot(),
+        slot);
+  }
+
+  private SafeFuture<ProductionResult<PayloadAttestationMessage>>
+      signPayloadAttestationForValidator(
+          final ForkInfo forkInfo,
+          final PayloadAttestationData payloadAttestationData,
+          final ValidatorWithIndex validatorWithIndex) {
+    return validatorWithIndex
+        .validator
+        .getSigner()
+        .signPayloadAttestationData(payloadAttestationData, forkInfo)
+        .thenApply(
+            signature ->
+                createSignedPayloadAttestation(
+                    payloadAttestationData, validatorWithIndex, signature))
+        .thenApply(
+            attestation ->
+                ProductionResult.success(
+                    validatorWithIndex.validator.getPublicKey(),
+                    payloadAttestationData.getBeaconBlockRoot(),
+                    attestation));
+  }
+
+  private PayloadAttestationMessage createSignedPayloadAttestation(
+      final PayloadAttestationData data,
+      final ValidatorWithIndex validatorWithIndex,
+      final BLSSignature signature) {
+    final PayloadAttestationMessageSchema payloadAttestationMessageSchema =
+        SchemaDefinitionsGloas.required(spec.atSlot(data.getSlot()).getSchemaDefinitions())
+            .getPayloadAttestationMessageSchema();
+
+    return payloadAttestationMessageSchema.create(validatorWithIndex.index, data, signature);
+  }
+
+  private record ValidatorWithIndex(Validator validator, UInt64 index) {}
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/PtcDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/PtcDutyLoaderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.json.types.validator.PtcDuties;
+import tech.pegasys.teku.ethereum.json.types.validator.PtcDuty;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.duties.Duty;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+import tech.pegasys.teku.validator.client.duties.payloadattestations.PayloadAttestationProductionDuty;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+class PtcDutyLoaderTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final Validator validator1 =
+      new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  private final Validator validator2 =
+      new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  private final int validator1Index = 19;
+  private final int validator2Index = 23;
+  private final IntSet validatorIndices = IntSet.of(validator1Index, validator2Index);
+  private final OwnedValidators validators =
+      new OwnedValidators(
+          Map.of(validator1.getPublicKey(), validator1, validator2.getPublicKey(), validator2));
+  private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+
+  @SuppressWarnings("unchecked")
+  private final SlotBasedScheduledDuties<PayloadAttestationProductionDuty, Duty>
+      slotBasedScheduledDuties = mock(SlotBasedScheduledDuties.class);
+
+  private final PtcDutyLoader dutyLoader =
+      new PtcDutyLoader(
+          validatorApiChannel, __ -> slotBasedScheduledDuties, validators, validatorIndexProvider);
+
+  @BeforeEach
+  void setUp() {
+    when(validatorIndexProvider.getValidatorIndices())
+        .thenReturn(SafeFuture.completedFuture(validatorIndices));
+  }
+
+  @Test
+  void shouldLoadPtcDuties() {
+    final UInt64 epoch = UInt64.valueOf(1);
+    final Bytes32 dependentRoot = dataStructureUtil.randomBytes32();
+
+    when(validatorApiChannel.getPtcDuties(epoch, validatorIndices))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(
+                    new PtcDuties(
+                        false,
+                        dependentRoot,
+                        List.of(
+                            new PtcDuty(
+                                validator1.getPublicKey(),
+                                UInt64.valueOf(validator1Index),
+                                UInt64.valueOf(9)),
+                            new PtcDuty(
+                                validator2.getPublicKey(),
+                                UInt64.valueOf(validator2Index),
+                                UInt64.valueOf(10)))))));
+
+    loadDuties(epoch);
+
+    verify(slotBasedScheduledDuties)
+        .scheduleProduction(eq(UInt64.valueOf(9)), eq(validator1), any());
+    verify(slotBasedScheduledDuties)
+        .scheduleProduction(eq(UInt64.valueOf(10)), eq(validator2), any());
+  }
+
+  private void loadDuties(final UInt64 epoch) {
+    final SafeFuture<Optional<SlotBasedScheduledDuties<?, ?>>> result =
+        dutyLoader.loadDutiesForEpoch(epoch);
+    assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/PtcDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/PtcDutySchedulerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
+
+class PtcDutySchedulerTest {
+
+  private static final UInt64 SLOT = UInt64.valueOf(42);
+
+  private final Map<UInt64, SafeFuture<Optional<SlotBasedScheduledDuties<?, ?>>>>
+      requestedDutiesByEpoch = new HashMap<>();
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+  private final DutyLoader<?> dutyLoader = mock(DutyLoader.class);
+
+  private final SlotBasedScheduledDuties<?, ?> duties = createScheduledDuties();
+
+  private final PtcDutyScheduler dutyScheduler =
+      new PtcDutyScheduler(metricsSystem, dutyLoader, spec);
+
+  @BeforeEach
+  public void setUp() {
+    when(dutyLoader.loadDutiesForEpoch(any()))
+        .thenAnswer(
+            invocation -> {
+              final UInt64 epoch = invocation.getArgument(0);
+              return requestedDutiesByEpoch.computeIfAbsent(epoch, __ -> new SafeFuture<>());
+            });
+  }
+
+  @Test
+  void shouldPerformProductionWhenPayloadAttestationCreationDue() {
+    final UInt64 epoch = spec.computeEpochAtSlot(SLOT);
+    // calculate pending duties
+    dutyScheduler.onSlot(SLOT);
+
+    requestedDutiesByEpoch.get(epoch).complete(Optional.of(duties));
+
+    dutyScheduler.onPayloadAttestationCreationDue(SLOT);
+
+    verify(duties).performProductionDuty(SLOT);
+  }
+
+  private SlotBasedScheduledDuties<?, ?> createScheduledDuties() {
+    final SlotBasedScheduledDuties<?, ?> duties = mock(SlotBasedScheduledDuties.class);
+    when(duties.performProductionDuty(any())).thenReturn(new SafeFuture<>());
+    return duties;
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationProductionDutyTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.payloadattestations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.ForkProvider;
+import tech.pegasys.teku.validator.client.Validator;
+import tech.pegasys.teku.validator.client.duties.DutyResult;
+import tech.pegasys.teku.validator.client.duties.ValidatorDutyMetrics;
+import tech.pegasys.teku.validator.client.duties.attestations.BatchAttestationSendingStrategy;
+
+@TestSpecContext(milestone = {GLOAS})
+class PayloadAttestationProductionDutyTest {
+
+  private static final String TYPE = "payload_attestation";
+  private static final UInt64 SLOT = UInt64.valueOf(42);
+
+  private Spec spec;
+  private DataStructureUtil dataStructureUtil;
+  private ForkInfo fork;
+
+  private final ForkProvider forkProvider = mock(ForkProvider.class);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
+  private final ValidatorDutyMetrics validatorDutyMetrics =
+      spy(ValidatorDutyMetrics.create(new StubMetricsSystem()));
+
+  private PayloadAttestationProductionDuty duty;
+
+  @BeforeEach
+  public void setUp(final SpecContext specContext) {
+    spec = specContext.getSpec();
+    dataStructureUtil = specContext.getDataStructureUtil();
+    fork = dataStructureUtil.randomForkInfo();
+
+    duty =
+        new PayloadAttestationProductionDuty(
+            spec,
+            SLOT,
+            forkProvider,
+            validatorApiChannel,
+            new BatchAttestationSendingStrategy<>(
+                validatorApiChannel::sendPayloadAttestationMessages),
+            validatorDutyMetrics);
+
+    when(forkProvider.getForkInfo(any())).thenReturn(completedFuture(fork));
+    when(validatorApiChannel.sendPayloadAttestationMessages(any()))
+        .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
+  }
+
+  @TestTemplate
+  public void shouldNotProduceAnyPayloadAttestationsWhenNoValidatorsAdded() {
+    performAndReportDuty();
+
+    verifyNoInteractions(validatorApiChannel, validatorLogger, validatorDutyMetrics);
+  }
+
+  @TestTemplate
+  void shouldProducePayloadAttestationMessage() {
+    final Validator validator = createValidator();
+    final UInt64 validatorIndex = UInt64.valueOf(23);
+    final PayloadAttestationData data = dataStructureUtil.randomPayloadAttestationData(SLOT);
+    final BLSSignature signature = dataStructureUtil.randomSignature();
+
+    duty.addValidator(validator, validatorIndex);
+
+    when(validatorApiChannel.createPayloadAttestationData(SLOT))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(data)));
+    when(validator.getSigner().signPayloadAttestationData(data, fork))
+        .thenReturn(SafeFuture.completedFuture(signature));
+
+    performAndReportDuty();
+
+    verify(validatorApiChannel)
+        .sendPayloadAttestationMessages(
+            List.of(createExpectedMessage(data, validatorIndex, signature)));
+    verify(validatorLogger)
+        .dutyCompleted(TYPE, SLOT, 1, Set.of(data.getBeaconBlockRoot()), Optional.empty());
+  }
+
+  @TestTemplate
+  void shouldProduceOnePayloadAttestationMessageForEachValidator() {
+    final UInt64 validatorIndex1 = UInt64.valueOf(11);
+    final UInt64 validatorIndex2 = UInt64.valueOf(22);
+    final Validator validator1 = createValidator();
+    final Validator validator2 = createValidator();
+    final PayloadAttestationData data = dataStructureUtil.randomPayloadAttestationData(SLOT);
+    final BLSSignature signature1 = dataStructureUtil.randomSignature();
+    final BLSSignature signature2 = dataStructureUtil.randomSignature();
+
+    duty.addValidator(validator1, validatorIndex1);
+    duty.addValidator(validator2, validatorIndex2);
+
+    when(validatorApiChannel.createPayloadAttestationData(SLOT))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(data)));
+    when(validator1.getSigner().signPayloadAttestationData(data, fork))
+        .thenReturn(SafeFuture.completedFuture(signature1));
+    when(validator2.getSigner().signPayloadAttestationData(data, fork))
+        .thenReturn(SafeFuture.completedFuture(signature2));
+
+    performAndReportDuty();
+
+    verify(validatorApiChannel)
+        .sendPayloadAttestationMessages(
+            List.of(
+                createExpectedMessage(data, validatorIndex1, signature1),
+                createExpectedMessage(data, validatorIndex2, signature2)));
+    verify(validatorLogger)
+        .dutyCompleted(TYPE, SLOT, 2, Set.of(data.getBeaconBlockRoot()), Optional.empty());
+  }
+
+  @TestTemplate
+  void shouldReportPartialFailureWhenBeaconNodeRejectsSomePayloadAttestationMessages() {
+    final UInt64 validatorIndex1 = UInt64.valueOf(11);
+    final UInt64 validatorIndex2 = UInt64.valueOf(22);
+    final Validator validator1 = createValidator();
+    final Validator validator2 = createValidator();
+    final PayloadAttestationData data = dataStructureUtil.randomPayloadAttestationData(SLOT);
+    final BLSSignature signature1 = dataStructureUtil.randomSignature();
+    final BLSSignature signature2 = dataStructureUtil.randomSignature();
+
+    duty.addValidator(validator1, validatorIndex1);
+    duty.addValidator(validator2, validatorIndex2);
+
+    when(validatorApiChannel.createPayloadAttestationData(SLOT))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(data)));
+    when(validator1.getSigner().signPayloadAttestationData(data, fork))
+        .thenReturn(SafeFuture.completedFuture(signature1));
+    when(validator2.getSigner().signPayloadAttestationData(data, fork))
+        .thenReturn(SafeFuture.completedFuture(signature2));
+
+    when(validatorApiChannel.sendPayloadAttestationMessages(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(List.of(new SubmitDataError(UInt64.ZERO, "API Rejected"))));
+
+    performAndReportDuty();
+
+    verify(validatorApiChannel)
+        .sendPayloadAttestationMessages(
+            List.of(
+                createExpectedMessage(data, validatorIndex1, signature1),
+                createExpectedMessage(data, validatorIndex2, signature2)));
+    verify(validatorLogger)
+        .dutyCompleted(TYPE, SLOT, 1, Set.of(data.getBeaconBlockRoot()), Optional.empty());
+    verify(validatorLogger)
+        .dutyFailed(
+            eq(TYPE),
+            eq(SLOT),
+            eq(Set.of(validator1.getPublicKey().toAbbreviatedString())),
+            argThat(error -> error.getMessage().equals("API Rejected")));
+  }
+
+  private void performAndReportDuty() {
+    final SafeFuture<DutyResult> result = duty.performDuty();
+    assertThat(result).isCompleted();
+    safeJoin(result).report(TYPE, SLOT, validatorLogger);
+  }
+
+  private Validator createValidator() {
+    final Signer signer = mock(Signer.class);
+    return new Validator(
+        dataStructureUtil.randomPublicKey(), signer, new FileBackedGraffitiProvider());
+  }
+
+  private PayloadAttestationMessage createExpectedMessage(
+      final PayloadAttestationData data,
+      final UInt64 validatorIndex,
+      final BLSSignature signature) {
+    return SchemaDefinitionsGloas.required(spec.atSlot(data.getSlot()).getSchemaDefinitions())
+        .getPayloadAttestationMessageSchema()
+        .create(validatorIndex, data, signature);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Create new `PayloadAttestationProductionDuty` to be performed at `getPayloadAttestationDueMillis`

**Logs from interop:**
<img width="2276" height="193" alt="image" src="https://github.com/user-attachments/assets/ed8dfe20-0df9-4557-ac8d-f1bcb0b51e87" />

## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/10041

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements payload attestation (PTC) production on the validator client, adds BN APIs to create/send payload attestation data, and caches seen execution payloads for payload_present voting.
> 
> - **Validator Client (VC)**:
>   - **New duty pipeline**: Add `PtcDutyLoader`, `PtcDutyScheduler`, and `PayloadAttestationProductionDuty` with `PayloadAttestationDutyFactory` to produce and submit payload attestation messages at `getPayloadAttestationDueMillis`.
>   - **Scheduling**: Hook into `TimeBasedEventAdapter` for per-slot PTC production.
> - **Beacon Node (BN) / Validator API**:
>   - Implement `createPayloadAttestationData(slot)` in `ValidatorApiHandler` using `SchemaDefinitionsGloas` and `ExecutionPayloadManager.isExecutionPayloadRecentlySeen`.
>   - Implement `sendPayloadAttestationMessages(...)` to add to `PayloadAttestationPool` and return errors.
>   - Wire `PayloadAttestationPool` and `ExecutionPayloadManager` into `ValidatorApiHandler` and `BeaconChainController`.
> - **Execution Payload Manager**:
>   - Add recent `beacon_block_root` cache and `isExecutionPayloadRecentlySeen(...)` for `payload_present` voting; populate cache on import/validate+import.
> - **Pools/APIs**:
>   - Update `PayloadAttestationPool` API (remove SlotEvents from interface); `AggregatingPayloadAttestationPool` now implements `SlotEventsChannel` and basic add/notify.
> - **Metrics/Logging**:
>   - Add new duty type `payload_attestation_production`; adjust validator log formatting width.
> - **Tests/Fixtures**:
>   - Add comprehensive tests for VC duties/scheduling, BN handler methods, and execution payload manager caching; extend `DataStructureUtil` helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 217326d9394506674ec0c5175157a6b976ceb367. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->