### PR TITLE
refactor attestation validator

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -24,6 +24,7 @@ import java.util.OptionalInt;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.beacon.sync.fetch.DefaultFetchTaskFactory;
 import tech.pegasys.teku.beacon.sync.fetch.FetchTaskFactory;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
@@ -117,6 +118,8 @@ public class SyncingNodeManager {
     final MergeTransitionBlockValidator transitionBlockValidator =
         new MergeTransitionBlockValidator(spec, recentChainData);
 
+    final MetricsSystem metricsSystem = new StubMetricsSystem();
+
     final ForkChoice forkChoice =
         new ForkChoice(
             spec,
@@ -124,7 +127,7 @@ public class SyncingNodeManager {
             recentChainData,
             new NoopForkChoiceNotifier(),
             transitionBlockValidator,
-            new StubMetricsSystem());
+            metricsSystem);
 
     final ReceivedBlockEventsChannel receivedBlockEventsChannelPublisher =
         eventChannels.getPublisher(ReceivedBlockEventsChannel.class);
@@ -132,7 +135,7 @@ public class SyncingNodeManager {
     final BlockGossipValidator blockGossipValidator =
         new BlockGossipValidator(
             spec,
-            new GossipValidationHelper(spec, recentChainData),
+            new GossipValidationHelper(spec, recentChainData, metricsSystem),
             receivedBlockEventsChannelPublisher);
     final BlockValidator blockValidator = new BlockValidator(blockGossipValidator);
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubDataColumnSidecarManager.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubDataColumnSidecarManager.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -91,13 +92,14 @@ public class StubDataColumnSidecarManager implements AvailabilityCheckerFactory<
           default -> {
             final MiscHelpersFulu helpers =
                 spec.forMilestone(SpecMilestone.FULU).miscHelpers().toVersionFulu().orElseThrow();
+            final MetricsSystem metricsSystem = new StubMetricsSystem();
             validator =
                 DataColumnSidecarGossipValidator.create(
                     spec,
                     new ConcurrentHashMap<>(),
-                    new GossipValidationHelper(spec, recentChainData),
+                    new GossipValidationHelper(spec, recentChainData, metricsSystem),
                     helpers,
-                    new StubMetricsSystem(),
+                    metricsSystem,
                     recentChainData.getStore());
             validationResult.complete(validateDataColumnSidecar());
           }

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.statetransition.validation.signatures.SimpleSignatureVerificationService;
@@ -100,9 +101,10 @@ class AttestationManagerIntegrationTest {
           "attestations");
   private final SignatureVerificationService signatureVerificationService =
       new SimpleSignatureVerificationService();
+  private final GossipValidationHelper gossipValidationHelper =
+      new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem());
   private final AttestationValidator attestationValidator =
-      new AttestationValidator(
-          spec, recentChainData, signatureVerificationService, storageSystem.getMetricsSystem());
+      new AttestationValidator(spec, signatureVerificationService, gossipValidationHelper);
   private final ActiveValidatorChannel activeValidatorChannel = mock(ActiveValidatorChannel.class);
 
   private final AttestationManager attestationManager =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractAttestationValidatorTest.java
@@ -89,9 +89,10 @@ abstract class AbstractAttestationValidatorTest {
       new AttestationGenerator(spec, chainBuilder.getValidatorKeys());
   protected final AsyncBLSSignatureVerifier signatureVerifier =
       AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.SIMPLE);
-
+  protected final GossipValidationHelper gossipValidationHelper =
+      new GossipValidationHelper(spec, recentChainData, new StubMetricsSystem());
   protected final AttestationValidator validator =
-      new AttestationValidator(spec, recentChainData, signatureVerifier, new StubMetricsSystem());
+      new AttestationValidator(spec, signatureVerifier, gossipValidationHelper);
 
   @BeforeEach
   public void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -70,7 +70,7 @@ public class BlockGossipValidatorTest {
     blockGossipValidator =
         new BlockGossipValidator(
             spec,
-            new GossipValidationHelper(spec, recentChainData),
+            new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem()),
             receivedBlockEventsChannelPublisher);
   }
 
@@ -226,7 +226,8 @@ public class BlockGossipValidatorTest {
     final BlockGossipValidator blockValidator =
         new BlockGossipValidator(
             spec,
-            new GossipValidationHelper(spec, localRecentChainData),
+            new GossipValidationHelper(
+                spec, localRecentChainData, storageSystem.getMetricsSystem()),
             receivedBlockEventsChannelPublisher);
     chainUpdater.initializeGenesis();
 
@@ -263,7 +264,7 @@ public class BlockGossipValidatorTest {
     blockGossipValidator =
         new BlockGossipValidator(
             spec,
-            new GossipValidationHelper(spec, recentChainData),
+            new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem()),
             receivedBlockEventsChannelPublisher);
 
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
@@ -287,7 +288,7 @@ public class BlockGossipValidatorTest {
     blockGossipValidator =
         new BlockGossipValidator(
             spec,
-            new GossipValidationHelper(spec, recentChainData),
+            new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem()),
             receivedBlockEventsChannelPublisher);
 
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
@@ -347,7 +348,7 @@ public class BlockGossipValidatorTest {
     blockGossipValidator =
         new BlockGossipValidator(
             spec,
-            new GossipValidationHelper(spec, recentChainData),
+            new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem()),
             receivedBlockEventsChannelPublisher);
 
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -68,7 +68,8 @@ public class GossipValidationHelperTest {
     storageSystem.chainUpdater().initializeGenesis(false);
     recentChainData = storageSystem.recentChainData();
 
-    gossipValidationHelper = new GossipValidationHelper(spec, recentChainData);
+    gossipValidationHelper =
+        new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem());
   }
 
   @TestTemplate
@@ -279,7 +280,7 @@ public class GossipValidationHelperTest {
     final ChainUpdater chainUpdater = new ChainUpdater(localRecentChainData, chainBuilder, spec);
 
     final GossipValidationHelper gossipValidationHelper =
-        new GossipValidationHelper(spec, localRecentChainData);
+        new GossipValidationHelper(spec, localRecentChainData, storageSystem.getMetricsSystem());
     chainUpdater.initializeGenesis();
 
     chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(1));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
@@ -30,7 +30,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -292,7 +291,7 @@ public class Phase0AttestationValidatorTest extends AbstractAttestationValidator
     final Attestation attestation = attestationGenerator.validAttestation(blockAndState);
     final AsyncBLSSignatureVerifier signatureVerifier = mock(AsyncBLSSignatureVerifier.class);
     final AttestationValidator validator =
-        new AttestationValidator(spec, recentChainData, signatureVerifier, new StubMetricsSystem());
+        new AttestationValidator(spec, signatureVerifier, gossipValidationHelper);
     final AttestationData data = attestation.getData();
     final Checkpoint checkpoint =
         new Checkpoint(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1189,7 +1189,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   protected void initGossipValidationHelper() {
     LOG.debug("BeaconChainController.initGossipValidationHelper()");
-    gossipValidationHelper = new GossipValidationHelper(spec, recentChainData);
+    gossipValidationHelper = new GossipValidationHelper(spec, recentChainData, metricsSystem);
   }
 
   protected void initPerformanceTracker() {
@@ -1681,8 +1681,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             futureItemsMetric,
             "attestations");
     AttestationValidator attestationValidator =
-        new AttestationValidator(
-            spec, recentChainData, signatureVerificationService, metricsSystem);
+        new AttestationValidator(spec, signatureVerificationService, gossipValidationHelper);
     AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(spec, attestationValidator, signatureVerificationService);
     blockImporter.subscribeToVerifiedBlockAttestations(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Refactor `AttestationValidator` to use the `GossipValidationHelper` and remove the `RecentChainData` dependency 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors AttestationValidator to use a metrics-aware GossipValidationHelper for chain/state lookups, updating wiring and tests across the codebase.
> 
> - **Validation**:
>   - `AttestationValidator` now depends on `GossipValidationHelper` (drops direct `RecentChainData`/`MetricsSystem` params) and routes slot inclusion, payload status, state selection, block availability, and fork-choice queries through it.
> - **`GossipValidationHelper`**:
>   - Requires `MetricsSystem`; integrates `AttestationStateSelector`.
>   - Adds `getStateForAttestationValidation`, `getGenesisTime`, `getCurrentTimeMillis`, `getForkChoiceStrategy`.
> - **Wiring**:
>   - Instantiate helper with metrics in `BeaconChainController.initGossipValidationHelper` and propagate to `AttestationValidator`, `BlockGossipValidator`, and data column sidecar validators.
>   - Update test fixtures/utilities (e.g., `SyncingNodeManager`, `StubDataColumnSidecarManager`) to pass `MetricsSystem` and new helper.
> - **Tests**:
>   - Update unit/integration tests to new constructors and helper usage (`AttestationManagerIntegrationTest`, `Abstract/Phase0AttestationValidatorTest`, `BlockGossipValidatorTest`, `GossipValidationHelperTest`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07eb2968eaeca0689d5cc44f7139e7e31dd0e4f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->