### PR TITLE
Fix aggregating signatures when creating PayloadAttestation(s)

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/MatchingDataPayloadAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/MatchingDataPayloadAttestationGroup.java
@@ -15,15 +15,15 @@ package tech.pegasys.teku.statetransition.payloadattestation;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.IntStream;
+import java.util.ArrayList;
+import java.util.List;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
@@ -37,8 +37,8 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
  */
 class MatchingDataPayloadAttestationGroup {
 
-  private final Set<PayloadAttestationMessage> payloadAttestationMessages =
-      ConcurrentHashMap.newKeySet();
+  private final Int2ObjectMap<PayloadAttestationMessage> payloadAttestationMessages =
+      new Int2ObjectOpenHashMap<>();
 
   private final Spec spec;
   private final PayloadAttestationData data;
@@ -60,38 +60,38 @@ class MatchingDataPayloadAttestationGroup {
    * Adds a payload attestation message to this group. This payload attestation message will
    * eventually be aggregated with others.
    */
-  boolean add(final PayloadAttestationMessage payloadAttestationMessage) {
-    if (!payloadAttestationMessage.getData().equals(data)) {
-      // ignore payload attestation messages with a different data
+  synchronized boolean add(final PayloadAttestationMessage payloadAttestationMessage) {
+    final int validatorIndex = payloadAttestationMessage.getValidatorIndex().intValue();
+    if (!payloadAttestationMessage.getData().equals(data)
+        || payloadAttestationMessages.containsKey(validatorIndex)) {
+      // ignore payload attestation messages with a different data or a validator index which has
+      // already been added
       return false;
     }
-    return payloadAttestationMessages.add(payloadAttestationMessage);
+    payloadAttestationMessages.put(validatorIndex, payloadAttestationMessage);
+    return true;
   }
 
   PayloadAttestation createAggregatedPayloadAttestation(final IntList ptc) {
     checkArgument(!payloadAttestationMessages.isEmpty(), "Nothing to aggregate");
     // use a snapshot to avoid any concurrent additions
-    final Set<PayloadAttestationMessage> payloadAttestationMessagesSnapshot =
-        new HashSet<>(payloadAttestationMessages);
-    final UInt64 slot = data.getSlot();
-    final int[] setBitIndices =
-        payloadAttestationMessagesSnapshot.stream()
-            .flatMapToInt(
-                message ->
-                    // relative position(s) of the validator index with respect to the PTC
-                    IntStream.range(0, ptc.size())
-                        .filter(i -> ptc.getInt(i) == message.getValidatorIndex().intValue()))
-            .toArray();
+    final Int2ObjectMap<PayloadAttestationMessage> payloadAttestationMessagesSnapshot =
+        new Int2ObjectOpenHashMap<>(payloadAttestationMessages);
+    // relative positions of the validator indices with respect to the PTC
+    final IntList setBitIndices = new IntArrayList();
+    final List<BLSSignature> signatures = new ArrayList<>();
+    for (int ptcPosition = 0; ptcPosition < ptc.size(); ptcPosition++) {
+      final int validatorIndex = ptc.getInt(ptcPosition);
+      if (payloadAttestationMessagesSnapshot.containsKey(validatorIndex)) {
+        setBitIndices.add(ptcPosition);
+        signatures.add(payloadAttestationMessagesSnapshot.get(validatorIndex).getSignature());
+      }
+    }
     final PayloadAttestationSchema payloadAttestationSchema =
-        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
+        SchemaDefinitionsGloas.required(spec.atSlot(data.getSlot()).getSchemaDefinitions())
             .getPayloadAttestationSchema();
     final SszBitvector aggregationBits =
         payloadAttestationSchema.getAggregationBitsSchema().ofBits(setBitIndices);
-    final BLSSignature signature =
-        BLS.aggregate(
-            payloadAttestationMessagesSnapshot.stream()
-                .map(PayloadAttestationMessage::getSignature)
-                .toList());
-    return payloadAttestationSchema.create(aggregationBits, data, signature);
+    return payloadAttestationSchema.create(aggregationBits, data, BLS.aggregate(signatures));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/MatchingDataPayloadAttestationGroup.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/MatchingDataPayloadAttestationGroup.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.statetransition.payloadattestation;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
@@ -74,17 +72,17 @@ class MatchingDataPayloadAttestationGroup {
 
   PayloadAttestation createAggregatedPayloadAttestation(final IntList ptc) {
     checkArgument(!payloadAttestationMessages.isEmpty(), "Nothing to aggregate");
-    // use a snapshot to avoid any concurrent additions
-    final Int2ObjectMap<PayloadAttestationMessage> payloadAttestationMessagesSnapshot =
-        new Int2ObjectOpenHashMap<>(payloadAttestationMessages);
     // relative positions of the validator indices with respect to the PTC
     final IntList setBitIndices = new IntArrayList();
     final List<BLSSignature> signatures = new ArrayList<>();
     for (int ptcPosition = 0; ptcPosition < ptc.size(); ptcPosition++) {
       final int validatorIndex = ptc.getInt(ptcPosition);
-      if (payloadAttestationMessagesSnapshot.containsKey(validatorIndex)) {
+      // check if we have received a payload attestation message for the validator in the PTC
+      final PayloadAttestationMessage payloadAttestationMessage =
+          payloadAttestationMessages.get(validatorIndex);
+      if (payloadAttestationMessage != null) {
         setBitIndices.add(ptcPosition);
-        signatures.add(payloadAttestationMessagesSnapshot.get(validatorIndex).getSignature());
+        signatures.add(payloadAttestationMessage.getSignature());
       }
     }
     final PayloadAttestationSchema payloadAttestationSchema =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
@@ -99,28 +99,37 @@ class AggregatingPayloadAttestationPoolTest {
   @Test
   public void getsAggregatedPayloadAttestationsForBlock() {
     final UInt64 blockSlot = dataStructureUtil.randomSlot();
-    final int validatorCount = 32;
+    final int validatorCount = 8192;
     final BeaconState state =
         dataStructureUtil.randomBeaconStateWithActiveValidators(validatorCount, blockSlot);
     final Bytes32 parentRoot = dataStructureUtil.randomBytes32();
     final UInt64 slot = blockSlot.minusMinZero(1);
+
+    final IntList ptc = spec.getPtc(state, slot);
 
     final PayloadAttestationData payloadPresentData =
         createPayloadAttestationData(parentRoot, slot, true);
     final PayloadAttestationData payloadAbsentData =
         createPayloadAttestationData(parentRoot, slot, false);
 
-    // Validators (0-28) vote for payload to be present
-    // Validators (29-31) vote for payload to be absent
-    UInt64.range(UInt64.ZERO, UInt64.valueOf(validatorCount))
+    // 80% vote for payload to be present
+    // 20% vote for payload to be absent
+    final List<Integer> payloadPresentVoters = new ArrayList<>();
+    final List<Integer> payloadAbsentVoters = new ArrayList<>();
+    ptc.intStream()
+        .distinct()
         .forEach(
             validatorIndex -> {
+              final boolean voteForPayloadPresent = Math.random() < 0.8;
               final PayloadAttestationMessage payloadAttestationMessage =
                   createPayloadAttestationMessage(
-                      validatorIndex,
-                      validatorIndex.isLessThanOrEqualTo(28)
-                          ? payloadPresentData
-                          : payloadAbsentData);
+                      UInt64.valueOf(validatorIndex),
+                      voteForPayloadPresent ? payloadPresentData : payloadAbsentData);
+              if (voteForPayloadPresent) {
+                payloadPresentVoters.add(validatorIndex);
+              } else {
+                payloadAbsentVoters.add(validatorIndex);
+              }
               SafeFutureAssert.safeJoin(
                   payloadAttestationPool.addRemote(payloadAttestationMessage, Optional.empty()));
             });
@@ -138,23 +147,34 @@ class AggregatingPayloadAttestationPoolTest {
             createPayloadAttestationMessage(UInt64.valueOf(1), differentBeaconBlockRootData),
             Optional.empty()));
 
-    assertThat(getPoolSizeFromMetric()).isEqualTo(34);
+    assertThat(getPoolSizeFromMetric())
+        .isEqualTo(payloadPresentVoters.size() + payloadAbsentVoters.size() + 2);
 
     final SszList<PayloadAttestation> payloadAttestations =
         payloadAttestationPool.getPayloadAttestationsForBlock(state, parentRoot);
 
     assertThat(payloadAttestations).hasSize(2);
 
-    final IntList ptc = spec.getPtc(state, slot);
-
     // more validators voted, so it should be first in the list
     assertThat(payloadAttestations.get(0).getData()).isEqualTo(payloadPresentData);
-    assertThat(payloadAttestations.get(0).getAggregationBits().streamAllSetBits())
-        .allMatch(i -> ptc.getInt(i) <= 28);
+    assertThat(
+            payloadAttestations
+                .get(0)
+                .getAggregationBits()
+                .streamAllSetBits()
+                .map(ptc::getInt)
+                .distinct())
+        .containsExactlyInAnyOrderElementsOf(payloadPresentVoters);
 
     assertThat(payloadAttestations.get(1).getData()).isEqualTo(payloadAbsentData);
-    assertThat(payloadAttestations.get(1).getAggregationBits().streamAllSetBits())
-        .allMatch(i -> ptc.getInt(i) > 28);
+    assertThat(
+            payloadAttestations
+                .get(1)
+                .getAggregationBits()
+                .streamAllSetBits()
+                .map(ptc::getInt)
+                .distinct())
+        .containsExactlyInAnyOrderElementsOf(payloadAbsentVoters);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/AggregatingPayloadAttestationPoolTest.java
@@ -112,8 +112,8 @@ class AggregatingPayloadAttestationPoolTest {
     final PayloadAttestationData payloadAbsentData =
         createPayloadAttestationData(parentRoot, slot, false);
 
-    // 80% vote for payload to be present
-    // 20% vote for payload to be absent
+    // ~80% vote for payload to be present
+    // ~20% vote for payload to be absent
     final List<Integer> payloadPresentVoters = new ArrayList<>();
     final List<Integer> payloadAbsentVoters = new ArrayList<>();
     ptc.intStream()
@@ -136,7 +136,7 @@ class AggregatingPayloadAttestationPoolTest {
 
     // Not applicable votes
     final PayloadAttestationData differentSlotData =
-        createPayloadAttestationData(parentRoot, slot.plus(42), true);
+        createPayloadAttestationData(parentRoot, slot.minus(1), true);
     final PayloadAttestationData differentBeaconBlockRootData =
         createPayloadAttestationData(dataStructureUtil.randomBytes32(), slot, true);
     SafeFutureAssert.safeJoin(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
After some testing and discussions, if one validator appears more than once in a PTC, we need the signature to be added multiple times when aggregating. Tested on local interop successfully block being processed with multiple attestations.

Also one of the tests wasn't really working since when number of validators is 32, then exactly one validator would be chosen for PTC (since 32 slots in an epoch) and then the `allMatch()` assertion was just asserting on empty bits but was passing.

## Fixed Issue(s)
related to #10041 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix payload attestation aggregation to align with PTC (including repeated validators) and de-duplicate messages by validator; update tests accordingly.
> 
> - **State transition / payload attestation**:
>   - `MatchingDataPayloadAttestationGroup`
>     - De-duplicates by validator using `Map<Integer, PayloadAttestationMessage>` and rejects repeats in `add(...)`.
>     - Aggregates by iterating PTC positions, setting aggregation bits per PTC index and collecting signatures; supports repeated validators in PTC (signature included per occurrence).
>     - Uses `spec.atSlot(data.getSlot())` when building schemas; simplifies with `IntArrayList` and explicit loops.
> - **Tests**:
>   - `AggregatingPayloadAttestationPoolTest`
>     - Scales to `8192` validators; derives voters from `ptc` (80/20 split); fixes assertions by mapping set bits back through `ptc`; adjusts "not applicable" slot and metric expectations.
>   - `MatchingDataPayloadAttestationGroupTest`
>     - Adds test rejecting duplicate validator index.
>     - Adds test verifying multiple PTC occurrences set multiple bits; retains multi-attestation aggregation test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 652ac430b6fbe3fcb2c987d219a4b5c80722d793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->