### PR TITLE
Unify and RPC error handling and add QueueIsFullException case

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -18,8 +18,6 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
-import com.google.common.base.Throwables;
-import java.nio.channels.ClosedChannelException;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -40,7 +38,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandle
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.InvalidRpcMethodVersion;
-import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
@@ -155,21 +152,7 @@ public class BeaconBlocksByRangeMessageHandler
               }
               callback.completeSuccessfully();
             },
-            error -> {
-              final Throwable rootCause = Throwables.getRootCause(error);
-              if (rootCause instanceof RpcException) {
-                LOG.trace("Rejecting beacon blocks by range request", error); // Keep full context
-                callback.completeWithErrorResponse((RpcException) rootCause);
-              } else {
-                if (rootCause instanceof StreamClosedException
-                    || rootCause instanceof ClosedChannelException) {
-                  LOG.trace("Stream closed while sending requested blocks", error);
-                } else {
-                  LOG.error("Failed to process blocks by range request", error);
-                }
-                callback.completeWithUnexpectedError(error);
-              }
-            });
+            error -> handleError(error, callback, "blocks by range"));
   }
 
   private SafeFuture<RequestState> sendMatchingBlocks(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -16,9 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSortedMap;
-import java.nio.channels.ClosedChannelException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -39,7 +37,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandle
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ResourceUnavailableException;
-import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -213,7 +210,7 @@ public class BlobSidecarsByRangeMessageHandler
               LOG.trace("Sent {} blob sidecars to peer {}.", sentBlobSidecars, peer.getId());
               callback.completeSuccessfully();
             },
-            error -> handleProcessingRequestError(error, callback));
+            error -> handleError(error, callback, "blob sidecars by range"));
   }
 
   private int calculateRequestedCount(
@@ -246,23 +243,6 @@ public class BlobSidecarsByRangeMessageHandler
                 return sendBlobSidecars(requestState);
               }
             });
-  }
-
-  private void handleProcessingRequestError(
-      final Throwable error, final ResponseCallback<BlobSidecar> callback) {
-    final Throwable rootCause = Throwables.getRootCause(error);
-    if (rootCause instanceof RpcException) {
-      LOG.trace("Rejecting blob sidecars by range request", error);
-      callback.completeWithErrorResponse((RpcException) rootCause);
-    } else {
-      if (rootCause instanceof StreamClosedException
-          || rootCause instanceof ClosedChannelException) {
-        LOG.trace("Stream closed while sending requested blob sidecars", error);
-      } else {
-        LOG.error("Failed to process blob sidecars request", error);
-      }
-      callback.completeWithUnexpectedError(error);
-    }
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
-import com.google.common.base.Throwables;
-import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -32,7 +30,6 @@ import tech.pegasys.teku.networking.eth2.peers.RequestKey;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
-import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -145,7 +142,7 @@ public class BlobSidecarsByRootMessageHandler
           }
           callback.completeSuccessfully();
         },
-        err -> handleError(callback, err));
+        err -> handleError(err, callback, "blob sidecars by root"));
   }
 
   private int getMaxRequestBlobSidecars() {
@@ -203,21 +200,5 @@ public class BlobSidecarsByRootMessageHandler
   private SafeFuture<Optional<BlobSidecar>> retrieveBlobSidecar(final BlobIdentifier identifier) {
     return combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
         identifier.getBlockRoot(), identifier.getIndex());
-  }
-
-  private void handleError(final ResponseCallback<BlobSidecar> callback, final Throwable error) {
-    final Throwable rootCause = Throwables.getRootCause(error);
-    if (rootCause instanceof RpcException) {
-      LOG.trace("Rejecting blob sidecars by root request", error);
-      callback.completeWithErrorResponse((RpcException) rootCause);
-    } else {
-      if (rootCause instanceof StreamClosedException
-          || rootCause instanceof ClosedChannelException) {
-        LOG.trace("Stream closed while sending requested blob sidecars", error);
-      } else {
-        LOG.error("Failed to process blob sidecars by root request", error);
-      }
-      callback.completeWithUnexpectedError(error);
-    }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
@@ -55,8 +55,6 @@ public class DataColumnSidecarsByRangeMessageHandler
     extends PeerRequiredLocalMessageHandler<
         DataColumnSidecarsByRangeRequestMessage, DataColumnSidecar> {
 
-  private static final Logger LOG = LogManager.getLogger();
-
   private final SpecConfigFulu specConfigFulu;
   private final CombinedChainDataClient combinedChainDataClient;
   private final LabelledMetric<Counter> requestCounter;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -55,8 +55,6 @@ public class DataColumnSidecarsByRootMessageHandler
     extends PeerRequiredLocalMessageHandler<
         DataColumnSidecarsByRootRequestMessage, DataColumnSidecar> {
 
-  private static final Logger LOG = LogManager.getLogger();
-
   private final Spec spec;
   private final CombinedChainDataClient combinedChainDataClient;
   private final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier;
@@ -196,7 +194,6 @@ public class DataColumnSidecarsByRootMessageHandler
    *   <li>The block root references a block greater than or equal to the minimum_request_epoch
    * </ul>
    */
-  @SuppressWarnings("unused")
   private SafeFuture<Void> validateMinimumRequestEpoch(
       final DataColumnIdentifier identifier, final Optional<DataColumnSidecar> maybeSidecar) {
     return maybeSidecar

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
@@ -13,11 +13,15 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import com.google.common.base.Throwables;
+import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue.QueueIsFullException;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
+import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 
 public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMessageHandler<I, O> {
   private static final Logger LOG = LogManager.getLogger();
@@ -42,4 +46,30 @@ public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMess
       final Eth2Peer peer,
       final I message,
       final ResponseCallback<O> callback);
+
+  protected void handleError(
+      final Throwable error, final ResponseCallback<O> callback, final String type) {
+    final Throwable rootCause = Throwables.getRootCause(error);
+
+    if (rootCause instanceof RpcException rpcException) {
+      LOG.trace("Rejecting {} request", type, error);
+      callback.completeWithErrorResponse(rpcException);
+      return;
+    }
+
+    if (rootCause instanceof QueueIsFullException) {
+      LOG.trace("Storage queue full while processing {} request", type, error);
+      callback.completeWithUnexpectedError(error);
+      return;
+    }
+
+    if (rootCause instanceof StreamClosedException || rootCause instanceof ClosedChannelException) {
+      LOG.trace("Stream closed while sending requested {}", type, error);
+      callback.completeWithUnexpectedError(error);
+      return;
+    }
+
+    LOG.error("Failed to process {} request", type, error);
+    callback.completeWithUnexpectedError(error);
+  }
 }


### PR DESCRIPTION
fixes #10123

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes RPC error handling in `PeerRequiredLocalMessageHandler#handleError`, adds `QueueIsFullException` handling, and updates all beacon/blob/data column handlers to use it.
> 
> - **Core RPC**:
>   - Add unified `handleError` in `PeerRequiredLocalMessageHandler` handling `RpcException`, `QueueIsFullException`, and closed stream/channel cases with standardized logging and callbacks.
> - **Beacon/Blob/Data Column Handlers**:
>   - Replace per-class error handling with calls to `handleError(..., "<type>")` in:
>     - `BeaconBlocksByRangeMessageHandler`
>     - `BeaconBlocksByRootMessageHandler`
>     - `BlobSidecarsByRangeMessageHandler`
>     - `BlobSidecarsByRootMessageHandler`
>     - `DataColumnSidecarsByRangeMessageHandler`
>     - `DataColumnSidecarsByRootMessageHandler`
>   - Remove duplicated error-handling code and related imports/loggers; keep existing request validation and processing logic intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b9a8ca0e06d85065e2129cf4f9d051e02998e08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->