### PR TITLE
Change behavior of `--Xdas-extra-custody-group-count` 

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasSyncAcceptanceTest.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
 public class DasSyncAcceptanceTest extends AcceptanceTestBase {
 
   private final int subnetCount = 128;
-  private final int defaultCustodySubnetCount = 4;
   private final int fuluEpoch = 1;
 
   @Test
@@ -41,7 +40,7 @@ public class DasSyncAcceptanceTest extends AcceptanceTestBase {
         createTekuBeaconNode(
             createConfigBuilder()
                 .withRealNetwork()
-                .withDasExtraCustodyGroupCount(subnetCount - defaultCustodySubnetCount)
+                .withCustodyGroupCountOverride(subnetCount)
                 .build());
 
     primaryNode.start();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -636,9 +636,9 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
-  public TekuNodeConfigBuilder withDasExtraCustodyGroupCount(final int extraCustodySubnetCount) {
-    LOG.debug("Xdas-extra-custody-group-count: {}", extraCustodySubnetCount);
-    configMap.put("Xdas-extra-custody-group-count", extraCustodySubnetCount);
+  public TekuNodeConfigBuilder withCustodyGroupCountOverride(final int custodyGroupCount) {
+    LOG.debug("Xcustody-group-count-override: {}", custodyGroupCount);
+    configMap.put("Xcustody-group-count-override", custodyGroupCount);
     return this;
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -516,12 +516,15 @@ public class P2POptions {
       GossipConfig.DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
 
   @Option(
-      names = {"--Xdas-extra-custody-group-count"},
+      names = {"--Xcustody-group-count-override"},
       paramLabel = "<NUMBER>",
-      description = "Number of extra custody groups",
+      description =
+          "Override the number of custody groups. If it's lower than node configuration requirement, "
+              + "the value is ignored. If it's higher than maximum number of custody groups, the value is set to "
+              + "allowed maximum.",
       arity = "1",
       hidden = true)
-  private int dasExtraCustodyGroupCount = P2PConfig.DEFAULT_DAS_EXTRA_CUSTODY_GROUP_COUNT;
+  private int custodyGroupCountOverride = P2PConfig.DEFAULT_CUSTODY_GROUP_COUNT_OVERRIDE;
 
   @Option(
       names = {"--Xp2p-historical-data-max-concurrent-queries"},
@@ -630,7 +633,7 @@ public class P2POptions {
                   .peerRequestLimit(peerRequestLimit)
                   .floodPublishMaxMessageSizeThreshold(floodPublishMaxMessageSizeThreshold)
                   .gossipBlobsAfterBlockEnabled(gossipBlobsAfterBlockEnabled)
-                  .dasExtraCustodyGroupCount(dasExtraCustodyGroupCount)
+                  .custodyGroupCountOverride(custodyGroupCountOverride)
                   .historicalDataMaxConcurrentQueries(historicalDataMaxConcurrentQueries)
                   .historicalDataMaxQueryQueueSize(historicalDataMaxQueryQueueSize)
                   .executionProofTopicEnabled(executionProofTopicEnabled)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -57,6 +57,11 @@ import tech.pegasys.teku.networking.p2p.network.config.GeneratingFilePrivateKeyS
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.network.config.PrivateKeySource;
 import tech.pegasys.teku.networking.p2p.network.config.TypedFilePrivateKeySource;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigFulu;
 
 public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
 
@@ -741,5 +746,73 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     } catch (Exception e) {
       fail("Test setup failed: " + e.getMessage(), e);
     }
+  }
+
+  @Test
+  public void allCustodySubnetsIsDisabled() {
+    final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
+
+    final Spec mainnetFulu = TestSpecFactory.createMainnetFulu();
+    final SpecVersion specVersionFulu = mainnetFulu.forMilestone(SpecMilestone.FULU);
+
+    assertThat(tekuConfiguration.p2p().getTotalCustodyGroupCount(specVersionFulu))
+        .isEqualTo(SpecConfigFulu.required(specVersionFulu.getConfig()).getCustodyRequirement());
+  }
+
+  @Test
+  public void allCustodySubnetsEnabled() {
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--p2p-subscribe-all-custody-subnets-enabled", "true");
+
+    final Spec mainnetFulu = TestSpecFactory.createMainnetFulu();
+    final SpecVersion specVersionFulu = mainnetFulu.forMilestone(SpecMilestone.FULU);
+
+    assertThat(tekuConfiguration.p2p().getTotalCustodyGroupCount(specVersionFulu))
+        .isEqualTo(SpecConfigFulu.required(specVersionFulu.getConfig()).getNumberOfCustodyGroups());
+  }
+
+  @Test
+  public void custodyGroupCountOverrideCorrectly() {
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xcustody-group-count-override", "20");
+
+    final Spec mainnetFulu = TestSpecFactory.createMainnetFulu();
+    final SpecVersion specVersionFulu = mainnetFulu.forMilestone(SpecMilestone.FULU);
+
+    assertThat(tekuConfiguration.p2p().getTotalCustodyGroupCount(specVersionFulu)).isEqualTo(20);
+  }
+
+  @Test
+  public void custodyGroupCountOverrideMin() {
+    final int overrideMin = 2;
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments(
+            "--Xcustody-group-count-override", String.valueOf(overrideMin));
+
+    final Spec mainnetFulu = TestSpecFactory.createMainnetFulu();
+    final SpecVersion specVersionFulu = mainnetFulu.forMilestone(SpecMilestone.FULU);
+    final int expectedCustodyRequirement =
+        SpecConfigFulu.required(specVersionFulu.getConfig()).getCustodyRequirement();
+
+    assertThat(overrideMin).isLessThan(expectedCustodyRequirement);
+    assertThat(tekuConfiguration.p2p().getTotalCustodyGroupCount(specVersionFulu))
+        .isEqualTo(expectedCustodyRequirement);
+  }
+
+  @Test
+  public void custodyGroupCountOverrideMax() {
+    final int overrideMax = 256;
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments(
+            "--Xcustody-group-count-override", String.valueOf(overrideMax));
+
+    final Spec mainnetFulu = TestSpecFactory.createMainnetFulu();
+    final SpecVersion specVersionFulu = mainnetFulu.forMilestone(SpecMilestone.FULU);
+    final int expectedCustodyRequirement =
+        SpecConfigFulu.required(specVersionFulu.getConfig()).getNumberOfCustodyGroups();
+
+    assertThat(overrideMax).isGreaterThan(expectedCustodyRequirement);
+    assertThat(tekuConfiguration.p2p().getTotalCustodyGroupCount(specVersionFulu))
+        .isEqualTo(expectedCustodyRequirement);
   }
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Change behavior of `--Xdas-extra-custody-group-count` to `--Xcustody-group-count-override`
Current behavior is to add configured value to the requirement which is not predictable and non-transparent. Changing this to full override instead. If, say it's set to 20 with 18 validators and 4 validators are added later, it will be successfully overrided to 22, it's only initial value and it couldn't decrease the value required by the spec.

The feature is still in hidden command flags space, I'd stick to keep it hidden.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `--Xdas-extra-custody-group-count` to `--Xcustody-group-count-override` and switches to a bounded override of custody group count; updates config, builder, CLI, and tests.
> 
> - **P2P/Config**:
>   - Replace `dasExtraCustodyGroupCount` with `custodyGroupCountOverride` in `P2PConfig` and builder; add `DEFAULT_CUSTODY_GROUP_COUNT_OVERRIDE`.
>   - Update `getTotalCustodyGroupCount` to use `min(maxGroups, max(requirement, custodyGroupCountOverride))`.
>   - When `subscribeAllCustodySubnetsEnabled`, set override to `Integer.MAX_VALUE`.
> - **CLI**:
>   - Rename hidden flag `--Xdas-extra-custody-group-count` to `--Xcustody-group-count-override` with bounded override semantics.
>   - Wire through in `P2POptions` to builder.
> - **Acceptance/DSL**:
>   - Replace `.withDasExtraCustodyGroupCount(...)` with `.withCustodyGroupCountOverride(...)` in `TekuNodeConfigBuilder` and `DasSyncAcceptanceTest`.
> - **Tests**:
>   - Add cases validating default, all-custody-subnets enabled, and override min/exact/max in `P2POptionsTest`.
>   - Adjust imports/usages accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c69c831888b2a9bf5ba73c34e3797416c39d72c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->