### PR TITLE
Gloas changes for `v1.6.1`

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -598,11 +598,13 @@ public abstract class AbstractBlockFactoryTest {
                           executionPayload.getParentHash(),
                           state.getLatestBlockHeader().getRoot(),
                           executionPayload.getBlockHash(),
+                          executionPayload.getPrevRandao(),
                           executionPayload.getFeeRecipient(),
                           executionPayload.getGasLimit(),
                           // self-built for simplification
                           UInt64.valueOf(spec.getBeaconProposerIndex(state, slot)),
                           slot,
+                          ZERO,
                           ZERO,
                           blobsBundle
                               .map(blobKzgCommitmentsSchema::createFromBlobsBundle)

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloasTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloasTest.java
@@ -156,7 +156,6 @@ class ExecutionPayloadFactoryGloasTest {
     final BeaconState state = blockAndState.getState();
     final SpecVersion specVersion = spec.atSlot(state.getSlot());
     final MiscHelpers miscHelpers = specVersion.miscHelpers();
-    final BeaconStateAccessors beaconStateAccessors = specVersion.beaconStateAccessors();
     final ExecutionPayloadBid bid = getBidFromBlock(blockAndState.getBlock());
     final ExecutionPayload executionPayload =
         dataStructureUtil.randomExecutionPayload(
@@ -166,9 +165,7 @@ class ExecutionPayloadFactoryGloasTest {
                     .parentHash(BeaconStateGloas.required(state).getLatestBlockHash())
                     .gasLimit(bid.getGasLimit())
                     .blockHash(bid.getBlockHash())
-                    .prevRandao(
-                        beaconStateAccessors.getRandaoMix(
-                            state, beaconStateAccessors.getCurrentEpoch(state)))
+                    .prevRandao(bid.getPrevRandao())
                     .timestamp(
                         miscHelpers.computeTimeAtSlot(state.getGenesisTime(), state.getSlot()))
                     .withdrawals(Collections::emptyList));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloasTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ExecutionPayloadFactoryGloasTest.java
@@ -46,7 +46,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.Be
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;

--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.6.0"
+def refTestVersion = nightly ? "nightly" : "v1.6.1"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadBid.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadBid.json
@@ -1,61 +1,85 @@
 {
-  "title" : "ExecutionPayloadBid",
-  "type" : "object",
-  "required" : [ "parent_block_hash", "parent_block_root", "block_hash", "fee_recipient", "gas_limit", "builder_index", "slot", "value", "blob_kzg_commitments_root" ],
-  "properties" : {
-    "parent_block_hash" : {
-      "type" : "string",
-      "description" : "Bytes32 hexadecimal",
-      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-      "format" : "byte"
+  "title": "ExecutionPayloadBid",
+  "type": "object",
+  "required": [
+    "parent_block_hash",
+    "parent_block_root",
+    "block_hash",
+    "prev_randao",
+    "fee_recipient",
+    "gas_limit",
+    "builder_index",
+    "slot",
+    "value",
+    "execution_payment",
+    "blob_kzg_commitments_root"
+  ],
+  "properties": {
+    "parent_block_hash": {
+      "type": "string",
+      "description": "Bytes32 hexadecimal",
+      "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format": "byte"
     },
-    "parent_block_root" : {
-      "type" : "string",
-      "description" : "Bytes32 hexadecimal",
-      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-      "format" : "byte"
+    "parent_block_root": {
+      "type": "string",
+      "description": "Bytes32 hexadecimal",
+      "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format": "byte"
     },
-    "block_hash" : {
-      "type" : "string",
-      "description" : "Bytes32 hexadecimal",
-      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-      "format" : "byte"
+    "block_hash": {
+      "type": "string",
+      "description": "Bytes32 hexadecimal",
+      "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format": "byte"
     },
-    "fee_recipient" : {
-      "type" : "string",
-      "pattern" : "^0x[a-fA-F0-9]{2,}$",
-      "description" : "SSZ hexadecimal",
-      "format" : "bytes"
+    "prev_randao": {
+      "type": "string",
+      "description": "Bytes32 hexadecimal",
+      "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format": "byte"
     },
-    "gas_limit" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
+    "fee_recipient": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]{2,}$",
+      "description": "SSZ hexadecimal",
+      "format": "bytes"
     },
-    "builder_index" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
+    "gas_limit": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
     },
-    "slot" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
+    "builder_index": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
     },
-    "value" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
+    "slot": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
     },
-    "blob_kzg_commitments_root" : {
-      "type" : "string",
-      "description" : "Bytes32 hexadecimal",
-      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-      "format" : "byte"
+    "value": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
+    },
+    "execution_payment": {
+      "type": "string",
+      "description": "unsigned 64 bit integer",
+      "example": "1",
+      "format": "uint64"
+    },
+    "blob_kzg_commitments_root": {
+      "type": "string",
+      "description": "Bytes32 hexadecimal",
+      "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format": "byte"
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockGLOAS.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockGLOAS.json
@@ -1,13 +1,13 @@
 {
   "version": "gloas",
   "execution_payload_blinded": false,
-  "execution_payload_value": "76713209214131783738529880011383082433585760875758578793839191401534955940321",
-  "consensus_block_value": "85365417869794681440511947829803128359273241077382340157256470204531202859372",
+  "execution_payload_value": "59408791875951349144595766734490198143801819883755800247510973018900591999947",
+  "consensus_block_value": "68061000558468473059772155448695499422945973210558489479576378279868340613718",
   "data": {
     "slot": "1",
-    "proposer_index": "4770780334617103279",
-    "parent_root": "0x36d44642cfa8a73b4c27b317e2d9bff5469b1cbe5c05d35f4b2286f9dd9a1da1",
-    "state_root": "0x49f540426ff48680416a1a43b562d4c24d9e1b5012cefb1979a3c9c1b8fbd42b",
+    "proposer_index": "4774085296755504239",
+    "parent_root": "0xa99a23428f6ee3d80bb91e1cd80e3bc46cad162aa2b9c7bc5e291babfcdf69e1",
+    "state_root": "0xbcbb1d422fbac21d01fc8547ab974f9172b015bc5882f0768caa5e73d640216c",
     "body": {
       "randao_reveal": "0x896972a61590fa3df074e8b86d9229c800e16b2c69c92b424c42947efb2c5c9badf3dea0289f088c86cf45ef8add162d1764bfe82b05fa69da6969f8a5ef4a5d70422b2d6568164b0f34de00e4592a05ab90c757c76b2edfc512fef7937c5a5a",
       "eth1_data": {
@@ -335,55 +335,57 @@
           "parent_block_hash": "0x0c15f142b0175c6e8491002de9596cba91433934b44834491c80e04920a257ea",
           "parent_block_root": "0xd3b10243d034be9fa5c8caaa6ebf2e537e3a3c7e91eeb91a93fc15f1917f314a",
           "block_hash": "0xe6d2fc4270809de49a0b32d641484320853d3b1047b7e2d4c07d59b96ce0e8d4",
-          "fee_recipient": "0x4678df4290faf93c645a36af63f4a921a44c36ea",
-          "gas_limit": "4817049881864128048",
+          "prev_randao": "0x4678df4290faf93c645a36af63f4a921a44c36ead7a2ae77a503aba2afc47d8a",
+          "fee_recipient": "0x5999d9423046d981599d9dda377dbeeeaa4f357c",
+          "gas_limit": "4822007335809147728",
           "builder_index": "740284",
           "slot": "1310451960",
-          "value": "4822007335809147728",
-          "blob_kzg_commitments_root": "0x3357e542f0ae1af86f17cf83906b95549e49375821da85bd778267dad563c6ff"
+          "value": "4820354852592463600",
+          "execution_payment": "4759212943510379790",
+          "blob_kzg_commitments_root": "0x08400642aee83f31d60723f5fabaa1c58bbc110432a5935f43af6c943fc4fe96"
         },
-        "signature": "0x9590d1d0c5216aeacaa19bb58a4a66a6430e554a0b020e2977be2421bcd089fb47bccbe10f2baac88dee33fc625dd5441217042918ac793c0aa2aba45a379decdb018b7bdd277f2a66b122a95aa1974cb05208e00801ed52f7f86b671c372e2f"
+        "signature": "0xb58eaaba3ba51d7098d65fbec3829ace78576a2276fd9c97c293aabdb634a2c50f52611f48088da5d4a5b5fa2c5f4c0513d8dd91c8534b50a7b8ae0072583612610ada0c81a261641c66ac542428cedf20f1b954ad03505fc058b40ce0bf4182"
       },
       "payload_attestations": [
         {
-          "aggregation_bits": "0x00",
+          "aggregation_bits": "0x02",
           "data": {
-            "beacon_block_root": "0xcfdc1742cf05a262f63eed727f20645e78b3144e0f4b1931b92ba23bb0a1d8f6",
-            "slot": "9363531959",
+            "beacon_block_root": "0x42a3f4418ecbddffb5d058777555df2c9ec50eba55ff0d8ecc3237edcfe62437",
+            "slot": "31713479575",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0x8e4e43252f668d04559aa2ecf1ae7605a054c1fc2d5b0a9b77f9b091b8fd851ef5a02d54ed31a66053144d0319d8f4ac11185d05cd68099841cc554c99de314a291e83c4bd166b924240d4851d8ff63a05c62def40f8b839f087a60db6ef5172"
+          "signature": "0xb851b39a32955a7f05acd7707c6859df4ee2b1472996d6a805a61e14415db550a92a7eaaff14a67e858a9d3633306efb12a62ed84f76387a84deefe726afcf2fb744f616f67d144411689343e6e0dea7a88b57449b2cdecb43cf0b5a80887550"
+        },
+        {
+          "aggregation_bits": "0x00",
+          "data": {
+            "beacon_block_root": "0x68e5e841ce629c89a05627ce1c6708c7aacb0cdec1905f022835be7d83a8934c",
+            "slot": "26349311799",
+            "payload_present": false,
+            "blob_data_available": false
+          },
+          "signature": "0xb99cdab802f2f2683fabc52c8ea095386730c43694a9a5f7a42033e6dea53f4896092b207f56b1402c5c69937a3e2fb41958e001895bb43c2ee1e360da601e1ac56ffa8bd5371b1dcfe85518f297f94c02cd4981a5961201d2c2fb4d2a15c888"
         },
         {
           "aggregation_bits": "0x02",
           "data": {
-            "beacon_block_root": "0x8e27dd410efa5a138adcf524c3783161b7d10a022e22b1768337450e386a0262",
-            "slot": "23132627671",
+            "beacon_block_root": "0xc40d6a420fe36b9e8d954713eca44427218922521651de02391bf147bf55d160",
+            "slot": "6322771799",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xa31249a2500d0428a2b38100b6db1191f1014087af8e58cdc025e28fc9e2aa5f08c74036c1c99b5e6b9f96c250700e2505201e2d4657bff1de53e01ac3c28f2f6624da4e953c9d08b0011e547902197fc5317daa051526f68684f16e1608ff33"
+          "signature": "0x917311e1a5f7a689ceee1af61f06519a3e4c6d68a4af6f4d24da0f57a2246c963c964d0e576607222856258c0e34b0b1014b68dfe481454ceaf521bc6f87c15e6a21f6db1c303b2042d5857ad4506f00dcfdfc5e65bbaf1b4ee9fe7ddf7b738e"
         },
         {
-          "aggregation_bits": "0x00",
+          "aggregation_bits": "0x02",
           "data": {
-            "beacon_block_root": "0xb469d1414e91199d7562c47b6a8a5afbc3d708269bb302ebdf39cc9eed2b7177",
-            "slot": "17768459895",
+            "beacon_block_root": "0xea4f5e424f7a2a28771b166a93b66dc12d8f207683e22f77941d78d874174076",
+            "slot": "3106087671",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xa29e82672b9b023ec4496bc5ba26cd0e12ae4e168591a2412dc2c62cfbf0466710810999921e34e7249e3a4700c837ec115bb6bee111a50c55a1af9d2f996bb6600a4767e23781cf4eb177845372b39df6156906f9e24c5b908920161a44d8fa"
-        },
-        {
-          "aggregation_bits": "0x00",
-          "data": {
-            "beacon_block_root": "0x109252428f11e9b162a1e4c03bc8965b3a951e9aef7381ebf01fff6828d9ae8b",
-            "slot": "29741919895",
-            "payload_present": false,
-            "blob_data_available": false
-          },
-          "signature": "0xa34048285c5a03bac9edfcf306e845a8cc0f8e7f7b4c5590dce0146b30b5a4d6340855b4384b53cc72b4ac5bb9b372590a7f7eca40e78ef3ae9b0e9dfe020abc94d161627ff642df1386143f221aee8ba432f4e7affa7736c65a01e6f342cd4d"
+          "signature": "0xb875609f4aa01bb03c08b4f13459fa7696b969fc5e8440c89f690478820b8b5b4ad75e7fbf03c4b0e919cdc80b07857604bd81f75128f2bbc61861d0b5a7744e21eb4ad008f05b46be2c2780900a7913abc2cd3591390f29e05e2d5b2dba570b"
         }
       ]
     }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -300,7 +300,6 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
                   schemas ->
                       SchemaDefinitionsGloas.required(schemas)
                           .getSignedExecutionPayloadEnvelopeSchema()))
-          .put("ssz_static/ForkChoiceNode", IGNORE_TESTS)
 
           // Legacy Schemas (Not yet migrated to SchemaDefinitions)
           .put(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -300,6 +300,7 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
                   schemas ->
                       SchemaDefinitionsGloas.required(schemas)
                           .getSignedExecutionPayloadEnvelopeSchema()))
+          .put("ssz_static/ForkChoiceNode", IGNORE_TESTS)
 
           // Legacy Schemas (Not yet migrated to SchemaDefinitions)
           .put(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
@@ -17,7 +17,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container9;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container11;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -25,12 +25,14 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.SlotAndBuilderIndex;
 
 public class ExecutionPayloadBid
-    extends Container9<
+    extends Container11<
         ExecutionPayloadBid,
         SszBytes32,
         SszBytes32,
         SszBytes32,
+        SszBytes32,
         SszByteVector,
+        SszUInt64,
         SszUInt64,
         SszUInt64,
         SszUInt64,
@@ -42,22 +44,26 @@ public class ExecutionPayloadBid
       final Bytes32 parentBlockHash,
       final Bytes32 parentBlockRoot,
       final Bytes32 blockHash,
+      final Bytes32 prevRandao,
       final Bytes20 feeRecipient,
       final UInt64 gasLimit,
       final UInt64 builderIndex,
       final UInt64 slot,
       final UInt64 value,
+      final UInt64 executionPayment,
       final Bytes32 blobKzgCommitmentsRoot) {
     super(
         schema,
         SszBytes32.of(parentBlockHash),
         SszBytes32.of(parentBlockRoot),
         SszBytes32.of(blockHash),
+        SszBytes32.of(prevRandao),
         SszByteVector.fromBytes(feeRecipient.getWrappedBytes()),
         SszUInt64.of(gasLimit),
         SszUInt64.of(builderIndex),
         SszUInt64.of(slot),
         SszUInt64.of(value),
+        SszUInt64.of(executionPayment),
         SszBytes32.of(blobKzgCommitmentsRoot));
   }
 
@@ -78,28 +84,36 @@ public class ExecutionPayloadBid
     return getField2().get();
   }
 
+  public Bytes32 getPrevRandao() {
+    return getField3().get();
+  }
+
   public Eth1Address getFeeRecipient() {
-    return Eth1Address.fromBytes(getField3().getBytes());
+    return Eth1Address.fromBytes(getField4().getBytes());
   }
 
   public UInt64 getGasLimit() {
-    return getField4().get();
-  }
-
-  public UInt64 getBuilderIndex() {
     return getField5().get();
   }
 
-  public UInt64 getSlot() {
+  public UInt64 getBuilderIndex() {
     return getField6().get();
   }
 
-  public UInt64 getValue() {
+  public UInt64 getSlot() {
     return getField7().get();
   }
 
-  public Bytes32 getBlobKzgCommitmentsRoot() {
+  public UInt64 getValue() {
     return getField8().get();
+  }
+
+  public UInt64 getExecutionPayment() {
+    return getField9().get();
+  }
+
+  public Bytes32 getBlobKzgCommitmentsRoot() {
+    return getField10().get();
   }
 
   public SlotAndBuilderIndex getSlotAndBuilderIndex() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
@@ -17,17 +17,19 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOB_KZG_COMMITMENTS_ROOT;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_HASH;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BUILDER_INDEX;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.EXECUTION_PAYMENT;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.FEE_RECIPIENT;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.GAS_LIMIT;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.PARENT_BLOCK_HASH;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.PARENT_BLOCK_ROOT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.PREV_RANDAO;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.SLOT;
 import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.VALUE;
 
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema9;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema11;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
@@ -39,12 +41,14 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 
 public class ExecutionPayloadBidSchema
-    extends ContainerSchema9<
+    extends ContainerSchema11<
         ExecutionPayloadBid,
         SszBytes32,
         SszBytes32,
         SszBytes32,
+        SszBytes32,
         SszByteVector,
+        SszUInt64,
         SszUInt64,
         SszUInt64,
         SszUInt64,
@@ -57,11 +61,13 @@ public class ExecutionPayloadBidSchema
         namedSchema(PARENT_BLOCK_HASH, SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema(PARENT_BLOCK_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema(BLOCK_HASH, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(PREV_RANDAO, SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema(FEE_RECIPIENT, SszByteVectorSchema.create(Bytes20.SIZE)),
         namedSchema(GAS_LIMIT, SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema(BUILDER_INDEX, SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema(SLOT, SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema(VALUE, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(EXECUTION_PAYMENT, SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema(BLOB_KZG_COMMITMENTS_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA));
   }
 
@@ -69,22 +75,26 @@ public class ExecutionPayloadBidSchema
       final Bytes32 parentBlockHash,
       final Bytes32 parentBlockRoot,
       final Bytes32 blockHash,
+      final Bytes32 prevRandao,
       final Bytes20 feeRecipient,
       final UInt64 gasLimit,
       final UInt64 builderIndex,
       final UInt64 slot,
       final UInt64 value,
+      final UInt64 executionPayment,
       final Bytes32 blobKzgCommitmentsRoot) {
     return new ExecutionPayloadBid(
         this,
         parentBlockHash,
         parentBlockRoot,
         blockHash,
+        prevRandao,
         feeRecipient,
         gasLimit,
         builderIndex,
         slot,
         value,
+        executionPayment,
         blobKzgCommitmentsRoot);
   }
 
@@ -104,11 +114,13 @@ public class ExecutionPayloadBidSchema
         BeaconStateGloas.required(state).getLatestBlockHash(),
         state.getLatestBlockHeader().getRoot(),
         executionPayload.getBlockHash(),
+        executionPayload.getPrevRandao(),
         executionPayload.getFeeRecipient(),
         executionPayload.getGasLimit(),
         builderIndex,
         slot,
-        // amount must be zero for self-build blocks
+        // amount and execution_payment must be zero for self-build blocks
+        ZERO,
         ZERO,
         blobKzgCommitmentsRoot);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadFields.java
@@ -42,6 +42,7 @@ public enum ExecutionPayloadFields implements SszFieldName {
   BUILDER_INDEX,
   SLOT,
   VALUE,
+  EXECUTION_PAYMENT,
   BLOB_KZG_COMMITMENTS_ROOT;
 
   private final String sszFieldName;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -134,6 +134,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     }
 
     processPendingConsolidations(state);
+    processBuilderPendingPayments(state);
     processEffectiveBalanceUpdates(state, validatorStatuses.getStatuses());
     processSlashingsReset(state);
     processRandaoMixesReset(state);
@@ -142,7 +143,6 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     processParticipationUpdates(state);
     processSyncCommitteeUpdates(state);
     processProposerLookahead(state);
-    processBuilderPendingPayments(state);
 
     if (beaconStateAccessors.isInactivityLeak(state)) {
       loggerThrottler.invoke(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -211,6 +211,12 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
         || !bid.getParentBlockRoot().equals(beaconBlock.getParentRoot())) {
       throw new BlockProcessingException("Bid is not for the right parent block");
     }
+    if (!bid.getPrevRandao()
+        .equals(
+            beaconStateAccessors.getRandaoMix(
+                state, beaconStateAccessors.getCurrentEpoch(state)))) {
+      throw new BlockProcessingException("Prev randao of the bid is not as expected");
+    }
 
     // Record the pending payment if there is some payment
     if (amount.isGreaterThan(UInt64.ZERO)) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
@@ -150,6 +150,10 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
       throw new ExecutionPayloadProcessingException(
           "The hash tree root of the blob kzg commitments in the envelope are not consistent with the blob kzg commitments root of the committed bid");
     }
+    if (!envelope.getPayload().getPrevRandao().equals(committedBid.getPrevRandao())) {
+      throw new ExecutionPayloadProcessingException(
+          "Prev randao of the envelope is not consistent with the prev randao of the committed bid");
+    }
     // Verify the withdrawals root
     if (!ExecutionPayloadCapella.required(payload)
         .getWithdrawals()
@@ -173,12 +177,6 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
       throw new ExecutionPayloadProcessingException(
           "Parent hash of the payload is not consistent with the previous execution payload");
     }
-    // Verify prev_randao
-    final UInt64 currentEpoch = beaconStateAccessors.getCurrentEpoch(state);
-    if (!payload.getPrevRandao().equals(beaconStateAccessors.getRandaoMix(state, currentEpoch))) {
-      throw new ExecutionPayloadProcessingException(
-          "Prev randao of the payload is not as expected");
-    }
     // Verify timestamp
     if (!payload
         .getTimestamp()
@@ -187,7 +185,9 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
     }
     // Verify commitments are under limit
     if (envelope.getBlobKzgCommitments().size()
-        > miscHelpers.getBlobParameters(currentEpoch).maxBlobsPerBlock()) {
+        > miscHelpers
+            .getBlobParameters(beaconStateAccessors.getCurrentEpoch(state))
+            .maxBlobsPerBlock()) {
       throw new ExecutionPayloadProcessingException(
           "Number of kzg commitments in the envelope exceeds max blobs per block");
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
@@ -68,8 +69,23 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
               state.setNextSyncCommittee(preStateFulu.getNextSyncCommittee());
 
               // New in Gloas
+              final Bytes32 latestBlockHash =
+                  preStateFulu.getLatestExecutionPayloadHeaderRequired().getBlockHash();
               state.setLatestExecutionPayloadBid(
-                  schemaDefinitions.getExecutionPayloadBidSchema().getDefault());
+                  schemaDefinitions
+                      .getExecutionPayloadBidSchema()
+                      .create(
+                          Bytes32.ZERO,
+                          Bytes32.ZERO,
+                          latestBlockHash,
+                          Bytes32.ZERO,
+                          Bytes20.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          Bytes32.ZERO));
 
               state.setNextWithdrawalIndex(preStateFulu.getNextWithdrawalIndex());
               state.setNextWithdrawalValidatorIndex(preStateFulu.getNextWithdrawalValidatorIndex());
@@ -102,8 +118,7 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                       .createFromElements(builderPendingPayments));
               state.setBuilderPendingWithdrawals(
                   schemaDefinitions.getBuilderPendingWithdrawalsSchema().getDefault());
-              state.setLatestBlockHash(
-                  preStateFulu.getLatestExecutionPayloadHeaderRequired().getBlockHash());
+              state.setLatestBlockHash(latestBlockHash);
               state.setLatestWithdrawalsRoot(Bytes32.ZERO);
             });
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -80,11 +80,6 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
         .toList();
   }
 
-  public byte removeFlag(final byte participationFlags, final int flagIndex) {
-    final byte flag = (byte) (1 << flagIndex);
-    return (byte) (participationFlags & ~flag);
-  }
-
   /**
    * compute_balance_weighted_selection
    *

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -225,7 +225,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "pToYn303XI2b3xhMp9gnkHdWYTISbpMUYns6iy3BL+n5YBt/zrsS6I1tAJ67Aw0sBhc2NIyt2BH8va1gc9pMhFTUwM068fTEHiGBy9rlOv2xMsKwkH01Jjz0ukS7bgDw"));
+                "jKXnVjb5vBjxXDb3SDaoU0nXkfZEvbHjtUlR5X4YQxpjECxhGCbuWDU736kvV5C2BUD7aGjk6iHMPv3qyr/YNcbnoyZczx5c9hKy5nLZAxbkQLIhsVUElFDn0TfolUy2"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadBid(bid, fork);
     asyncRunner.executeQueuedActions();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -505,10 +505,12 @@ public class BlockProposalTestUtil {
                 executionPayload.getParentHash(),
                 state.getLatestBlockHeader().getRoot(),
                 executionPayload.getBlockHash(),
+                executionPayload.getPrevRandao(),
                 executionPayload.getFeeRecipient(),
                 executionPayload.getGasLimit(),
                 UInt64.valueOf(proposerIndex),
                 newSlot,
+                UInt64.ZERO,
                 UInt64.ZERO,
                 executionPayloadProposalData.kzgCommitments().hashTreeRoot());
     return schemaDefinitions

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -679,8 +679,7 @@ public class ChainBuilder {
   private SignedBlockAndState appendNewBlockToChain(final UInt64 slot, final BlockOptions options) {
     final SignedBlockAndState latestBlockAndState = getLatestBlockAndState();
     final BeaconState preState =
-        // use the execution payload state if it has been processed to allow for correct block
-        // appending
+        // build on top of the execution payload state if an execution payload has been processed
         Optional.ofNullable(getExecutionPayloadStateAtSlot(latestBlockAndState.getSlot()))
             .orElse(latestBlockAndState.getState());
     final Bytes32 parentRoot = latestBlockAndState.getBlock().getMessage().hashTreeRoot();
@@ -1149,9 +1148,7 @@ public class ChainBuilder {
     private boolean storeDataColumnSidecars = true;
     private boolean skipStateTransition = false;
     private boolean wrongProposer = false;
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10071 temporarily not produce execution
-    // payloads until we have a fully working ChainBuilder + ChainUpdater design
-    private boolean withholdExecutionPayload = true;
+    private boolean withholdExecutionPayload = false;
 
     private BlockOptions() {}
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -3130,10 +3130,12 @@ public final class DataStructureUtil {
             randomBytes32(),
             randomBytes32(),
             randomBytes32(),
+            randomBytes32(),
             randomEth1Address(),
             randomUInt64(),
             builderIndex,
             slot,
+            randomUInt64(),
             randomUInt64(),
             randomBytes32());
   }

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.6.0
+version: v1.6.1
 style: full
 
 specrefs:

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -953,16 +953,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="175bc24b">
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="aa04e425">
     class ExecutionPayloadBid(Container):
         parent_block_hash: Hash32
         parent_block_root: Root
         block_hash: Hash32
+        prev_randao: Bytes32
         fee_recipient: ExecutionAddress
         gas_limit: uint64
         builder_index: ValidatorIndex
         slot: Slot
         value: Gwei
+        execution_payment: Gwei
         blob_kzg_commitments_root: Root
     </spec>
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -4522,13 +4522,14 @@
 - name: get_ptc_assignment#gloas
   sources: []
   spec: |
-    <spec fn="get_ptc_assignment" fork="gloas" hash="6db8c274">
+    <spec fn="get_ptc_assignment" fork="gloas" hash="817acb90">
     def get_ptc_assignment(
         state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
     ) -> Optional[Slot]:
         """
-        Returns the slot during the requested epoch in which the validator with index `validator_index`
-        is a member of the PTC. Returns None if no assignment is found.
+        Returns the slot during the requested epoch in which the validator with
+        index `validator_index` is a member of the PTC. Returns None if no
+        assignment is found.
         """
         next_epoch = Epoch(get_current_epoch(state) + 1)
         assert epoch <= next_epoch
@@ -5730,13 +5731,9 @@
 - name: is_merge_transition_complete#gloas
   sources: []
   spec: |
-    <spec fn="is_merge_transition_complete" fork="gloas" hash="38872f35">
+    <spec fn="is_merge_transition_complete" fork="gloas" hash="b13c98c6">
     def is_merge_transition_complete(state: BeaconState) -> bool:
-        bid = ExecutionPayloadBid()
-        kzgs = List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]()
-        bid.blob_kzg_commitments_root = kzgs.hash_tree_root()
-
-        return state.latest_execution_payload_bid != bid
+        return state.latest_execution_payload_header != ExecutionPayloadHeader()
     </spec>
 
 - name: is_next_sync_committee_known#altair
@@ -7963,7 +7960,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public BeaconState processEpoch(
   spec: |
-    <spec fn="process_epoch" fork="gloas" hash="32184972">
+    <spec fn="process_epoch" fork="gloas" hash="393b69ef">
     def process_epoch(state: BeaconState) -> None:
         process_justification_and_finalization(state)
         process_inactivity_updates(state)
@@ -7973,6 +7970,8 @@
         process_eth1_data_reset(state)
         process_pending_deposits(state)
         process_pending_consolidations(state)
+        # [New in Gloas:EIP7732]
+        process_builder_pending_payments(state)
         process_effective_balance_updates(state)
         process_slashings_reset(state)
         process_randao_mixes_reset(state)
@@ -7980,8 +7979,6 @@
         process_participation_flag_updates(state)
         process_sync_committee_updates(state)
         process_proposer_lookahead(state)
-        # [New in Gloas:EIP7732]
-        process_builder_pending_payments(state)
     </spec>
 
 - name: process_eth1_data#phase0
@@ -8230,7 +8227,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
       search: public void processUnsignedExecutionPayload(
   spec: |
-    <spec fn="process_execution_payload" fork="gloas" hash="200702e3">
+    <spec fn="process_execution_payload" fork="gloas" hash="b1cc7efc">
     def process_execution_payload(
         state: BeaconState,
         # [Modified in Gloas:EIP7732]
@@ -8261,6 +8258,7 @@
         committed_bid = state.latest_execution_payload_bid
         assert envelope.builder_index == committed_bid.builder_index
         assert committed_bid.blob_kzg_commitments_root == hash_tree_root(envelope.blob_kzg_commitments)
+        assert committed_bid.prev_randao == payload.prev_randao
 
         # Verify the withdrawals root
         assert hash_tree_root(payload.withdrawals) == state.latest_withdrawals_root
@@ -8271,8 +8269,6 @@
         assert committed_bid.block_hash == payload.block_hash
         # Verify consistency of the parent hash with respect to the previous execution payload
         assert payload.parent_hash == state.latest_block_hash
-        # Verify prev_randao
-        assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
         # Verify timestamp
         assert payload.timestamp == compute_time_at_slot(state, state.slot)
         # Verify commitments are under limit
@@ -8329,7 +8325,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void processExecutionPayloadBid(
   spec: |
-    <spec fn="process_execution_payload_bid" fork="gloas" hash="bfc45bf8">
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="d8bba25d">
     def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> None:
         signed_bid = block.body.signed_execution_payload_bid
         bid = signed_bid.message
@@ -8371,6 +8367,7 @@
         # Verify that the bid is for the right parent block
         assert bid.parent_block_hash == state.latest_block_hash
         assert bid.parent_block_root == block.parent_root
+        assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 
         # Record the pending payment if there is some payment
         if amount > 0:
@@ -9825,17 +9822,6 @@
         return PolynomialCoeff(reconstructed_poly_coeff[:FIELD_ELEMENTS_PER_BLOB])
     </spec>
 
-- name: remove_flag#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
-      search: public byte removeFlag(
-  spec: |
-    <spec fn="remove_flag" fork="gloas" hash="2566cb90">
-    def remove_flag(flags: ParticipationFlags, flag_index: int) -> ParticipationFlags:
-        flag = ParticipationFlags(2**flag_index)
-        return flags & ~flag
-    </spec>
-
 - name: reverse_bits#deneb
   sources: []
   spec: |
@@ -10963,7 +10949,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: public BeaconStateGloas upgrade(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="e147526b">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="d2c34d52">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -11000,7 +10986,9 @@
             # [Modified in Gloas:EIP7732]
             # Removed `latest_execution_payload_header`
             # [New in Gloas:EIP7732]
-            latest_execution_payload_bid=ExecutionPayloadBid(),
+            latest_execution_payload_bid=ExecutionPayloadBid(
+                block_hash=pre.latest_execution_payload_header.block_hash,
+            ),
             next_withdrawal_index=pre.next_withdrawal_index,
             next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
             historical_summaries=pre.historical_summaries,

--- a/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockGLOAS.json
+++ b/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockGLOAS.json
@@ -5,9 +5,9 @@
   "consensus_block_value": "123000000000",
   "data": {
     "slot": "1",
-    "proposer_index": "4770780334617103279",
-    "parent_root": "0x36d44642cfa8a73b4c27b317e2d9bff5469b1cbe5c05d35f4b2286f9dd9a1da1",
-    "state_root": "0x49f540426ff48680416a1a43b562d4c24d9e1b5012cefb1979a3c9c1b8fbd42b",
+    "proposer_index": "4774085296755504239",
+    "parent_root": "0xa99a23428f6ee3d80bb91e1cd80e3bc46cad162aa2b9c7bc5e291babfcdf69e1",
+    "state_root": "0xbcbb1d422fbac21d01fc8547ab974f9172b015bc5882f0768caa5e73d640216c",
     "body": {
       "randao_reveal": "0x896972a61590fa3df074e8b86d9229c800e16b2c69c92b424c42947efb2c5c9badf3dea0289f088c86cf45ef8add162d1764bfe82b05fa69da6969f8a5ef4a5d70422b2d6568164b0f34de00e4592a05ab90c757c76b2edfc512fef7937c5a5a",
       "eth1_data": {
@@ -335,55 +335,57 @@
           "parent_block_hash": "0x0c15f142b0175c6e8491002de9596cba91433934b44834491c80e04920a257ea",
           "parent_block_root": "0xd3b10243d034be9fa5c8caaa6ebf2e537e3a3c7e91eeb91a93fc15f1917f314a",
           "block_hash": "0xe6d2fc4270809de49a0b32d641484320853d3b1047b7e2d4c07d59b96ce0e8d4",
-          "fee_recipient": "0x4678df4290faf93c645a36af63f4a921a44c36ea",
-          "gas_limit": "4817049881864128048",
+          "prev_randao": "0x4678df4290faf93c645a36af63f4a921a44c36ead7a2ae77a503aba2afc47d8a",
+          "fee_recipient": "0x5999d9423046d981599d9dda377dbeeeaa4f357c",
+          "gas_limit": "4822007335809147728",
           "builder_index": "740284",
           "slot": "1310451960",
-          "value": "4822007335809147728",
-          "blob_kzg_commitments_root": "0x3357e542f0ae1af86f17cf83906b95549e49375821da85bd778267dad563c6ff"
+          "value": "4820354852592463600",
+          "execution_payment": "4759212943510379790",
+          "blob_kzg_commitments_root": "0x08400642aee83f31d60723f5fabaa1c58bbc110432a5935f43af6c943fc4fe96"
         },
-        "signature": "0x9590d1d0c5216aeacaa19bb58a4a66a6430e554a0b020e2977be2421bcd089fb47bccbe10f2baac88dee33fc625dd5441217042918ac793c0aa2aba45a379decdb018b7bdd277f2a66b122a95aa1974cb05208e00801ed52f7f86b671c372e2f"
+        "signature": "0xb58eaaba3ba51d7098d65fbec3829ace78576a2276fd9c97c293aabdb634a2c50f52611f48088da5d4a5b5fa2c5f4c0513d8dd91c8534b50a7b8ae0072583612610ada0c81a261641c66ac542428cedf20f1b954ad03505fc058b40ce0bf4182"
       },
       "payload_attestations": [
         {
-          "aggregation_bits": "0x00",
+          "aggregation_bits": "0x02",
           "data": {
-            "beacon_block_root": "0xcfdc1742cf05a262f63eed727f20645e78b3144e0f4b1931b92ba23bb0a1d8f6",
-            "slot": "9363531959",
+            "beacon_block_root": "0x42a3f4418ecbddffb5d058777555df2c9ec50eba55ff0d8ecc3237edcfe62437",
+            "slot": "31713479575",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0x8e4e43252f668d04559aa2ecf1ae7605a054c1fc2d5b0a9b77f9b091b8fd851ef5a02d54ed31a66053144d0319d8f4ac11185d05cd68099841cc554c99de314a291e83c4bd166b924240d4851d8ff63a05c62def40f8b839f087a60db6ef5172"
+          "signature": "0xb851b39a32955a7f05acd7707c6859df4ee2b1472996d6a805a61e14415db550a92a7eaaff14a67e858a9d3633306efb12a62ed84f76387a84deefe726afcf2fb744f616f67d144411689343e6e0dea7a88b57449b2cdecb43cf0b5a80887550"
+        },
+        {
+          "aggregation_bits": "0x00",
+          "data": {
+            "beacon_block_root": "0x68e5e841ce629c89a05627ce1c6708c7aacb0cdec1905f022835be7d83a8934c",
+            "slot": "26349311799",
+            "payload_present": false,
+            "blob_data_available": false
+          },
+          "signature": "0xb99cdab802f2f2683fabc52c8ea095386730c43694a9a5f7a42033e6dea53f4896092b207f56b1402c5c69937a3e2fb41958e001895bb43c2ee1e360da601e1ac56ffa8bd5371b1dcfe85518f297f94c02cd4981a5961201d2c2fb4d2a15c888"
         },
         {
           "aggregation_bits": "0x02",
           "data": {
-            "beacon_block_root": "0x8e27dd410efa5a138adcf524c3783161b7d10a022e22b1768337450e386a0262",
-            "slot": "23132627671",
+            "beacon_block_root": "0xc40d6a420fe36b9e8d954713eca44427218922521651de02391bf147bf55d160",
+            "slot": "6322771799",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xa31249a2500d0428a2b38100b6db1191f1014087af8e58cdc025e28fc9e2aa5f08c74036c1c99b5e6b9f96c250700e2505201e2d4657bff1de53e01ac3c28f2f6624da4e953c9d08b0011e547902197fc5317daa051526f68684f16e1608ff33"
+          "signature": "0x917311e1a5f7a689ceee1af61f06519a3e4c6d68a4af6f4d24da0f57a2246c963c964d0e576607222856258c0e34b0b1014b68dfe481454ceaf521bc6f87c15e6a21f6db1c303b2042d5857ad4506f00dcfdfc5e65bbaf1b4ee9fe7ddf7b738e"
         },
         {
-          "aggregation_bits": "0x00",
+          "aggregation_bits": "0x02",
           "data": {
-            "beacon_block_root": "0xb469d1414e91199d7562c47b6a8a5afbc3d708269bb302ebdf39cc9eed2b7177",
-            "slot": "17768459895",
+            "beacon_block_root": "0xea4f5e424f7a2a28771b166a93b66dc12d8f207683e22f77941d78d874174076",
+            "slot": "3106087671",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xa29e82672b9b023ec4496bc5ba26cd0e12ae4e168591a2412dc2c62cfbf0466710810999921e34e7249e3a4700c837ec115bb6bee111a50c55a1af9d2f996bb6600a4767e23781cf4eb177845372b39df6156906f9e24c5b908920161a44d8fa"
-        },
-        {
-          "aggregation_bits": "0x00",
-          "data": {
-            "beacon_block_root": "0x109252428f11e9b162a1e4c03bc8965b3a951e9aef7381ebf01fff6828d9ae8b",
-            "slot": "29741919895",
-            "payload_present": false,
-            "blob_data_available": false
-          },
-          "signature": "0xa34048285c5a03bac9edfcf306e845a8cc0f8e7f7b4c5590dce0146b30b5a4d6340855b4384b53cc72b4ac5bb9b372590a7f7eca40e78ef3ae9b0e9dfe020abc94d161627ff642df1386143f221aee8ba432f4e7affa7736c65a01e6f342cd4d"
+          "signature": "0xb875609f4aa01bb03c08b4f13459fa7696b969fc5e8440c89f690478820b8b5b4ad75e7fbf03c4b0e919cdc80b07857604bd81f75128f2bbc61861d0b5a7744e21eb4ad008f05b46be2c2780900a7913abc2cd3591390f29e05e2d5b2dba570b"
         }
       ]
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/releases/tag/v1.6.1

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends Gloas ExecutionPayloadBid with prev_randao and execution_payment, adds corresponding validation/state upgrades, reorders epoch processing, enables payload production in tests, and bumps refs to spec v1.6.1.
> 
> - **Gloas data model**:
>   - Extend `ExecutionPayloadBid` to include `prev_randao` and `execution_payment` (schema/container updates, getters, `ExecutionPayloadFields.EXECUTION_PAYMENT`).
>   - Initialize new fields during Gloas state upgrade and local self-built bids.
> - **Validation/processing**:
>   - Enforce bid `prev_randao` against state in `BlockProcessorGloas`; ensure envelope `prev_randao` matches committed bid in `ExecutionPayloadProcessorGloas` (and drop redundant state check).
>   - Use current epoch for blob-commitments limit check; reorder epoch processing to call `processBuilderPendingPayments` earlier.
> - **Builders and utilities**:
>   - `ChainBuilder`: build on execution-payload state and enable payload production by default.
> - **API/fixtures/tests**:
>   - Update REST schemas/fixtures (`ExecutionPayloadBid.json`, `newBlockGLOAS.json`) to new fields/values; adjust validator remote fixture.
>   - Update tests to construct/verify bids with new fields and adjust expected signatures.
> - **Spec/version refs**:
>   - Bump consensus spec references to `v1.6.1` (build and `specrefs`); tidy spec function entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c7e7f3fe75137ecaaaba746bf5d6f1349050e42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->