### PR TITLE
[SPIKE] Initial database changes for Gloas

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlockProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlockProvider.java
@@ -44,14 +44,6 @@ public interface BlockProvider {
                 .collect(Collectors.toMap(Function.identity(), blockMap::get)));
   }
 
-  static BlockProvider fromList(final List<SignedBeaconBlock> blockAndStates) {
-    final Map<Bytes32, SignedBeaconBlock> blocks =
-        blockAndStates.stream()
-            .collect(Collectors.toMap(SignedBeaconBlock::getRoot, Function.identity()));
-
-    return fromMap(blocks);
-  }
-
   static BlockProvider withKnownBlocks(
       final BlockProvider blockProvider, final Map<Bytes32, SignedBeaconBlock> knownBlocks) {
     return combined(fromMap(knownBlocks), blockProvider);

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/ExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/ExecutionPayloadProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.dataproviders.lookup;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+@FunctionalInterface
+public interface ExecutionPayloadProvider {
+
+  ExecutionPayloadProvider NOOP = beaconBlockRoot -> SafeFuture.completedFuture(Optional.empty());
+
+  SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getExecutionPayload(Bytes32 beaconBlockRoot);
+}

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/ExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/ExecutionPayloadProvider.java
@@ -24,4 +24,19 @@ public interface ExecutionPayloadProvider {
   ExecutionPayloadProvider NOOP = beaconBlockRoot -> SafeFuture.completedFuture(Optional.empty());
 
   SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getExecutionPayload(Bytes32 beaconBlockRoot);
+
+  static ExecutionPayloadProvider combined(
+      final ExecutionPayloadProvider primaryProvider,
+      final ExecutionPayloadProvider secondaryProvider) {
+    return beaconBlockRoot ->
+        primaryProvider
+            .getExecutionPayload(beaconBlockRoot)
+            .thenCompose(
+                executionPayload -> {
+                  if (executionPayload.isPresent()) {
+                    return SafeFuture.completedFuture(executionPayload);
+                  }
+                  return secondaryProvider.getExecutionPayload(beaconBlockRoot);
+                });
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -79,6 +79,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.epbs.ExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
@@ -125,6 +126,7 @@ import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.ForkChoiceUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistryBuilder;
 
 public class Spec {
@@ -470,6 +472,17 @@ public class Spec {
     return schemaDefinition
         .getSignedBlindedBlockContainerSchema()
         .sszDeserialize(serializedSignedBlindedBlockContainer);
+  }
+
+  /**
+   * TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 this works for devnet-0 but we need
+   * a generic solution similar to {@link BeaconBlockInvariants}
+   */
+  public SignedExecutionPayloadEnvelope deserializeSignedExecutionPayload(
+      final Bytes serializedSignedExecutionPayload) {
+    return SchemaDefinitionsGloas.required(forMilestone(GLOAS).getSchemaDefinitions())
+        .getSignedExecutionPayloadEnvelopeSchema()
+        .sszDeserialize(serializedSignedExecutionPayload);
   }
 
   private Optional<SchemaDefinitions> getSchemaDefinitionsForMilestone(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.epbs;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -24,5 +25,9 @@ public record SignedExecutionPayloadAndState(
     SignedExecutionPayloadEnvelope executionPayload, BeaconState state) {
   public UInt64 getSlot() {
     return executionPayload.getMessage().getSlot();
+  }
+
+  public Bytes32 getBeaconBlockRoot() {
+    return executionPayload.getMessage().getBeaconBlockRoot();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.epbs.versions.gloas;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
@@ -51,6 +52,10 @@ public class SignedExecutionPayloadEnvelope
 
   public UInt64 getSlot() {
     return getMessage().getSlot();
+  }
+
+  public Bytes32 getBeaconBlockRoot() {
+    return getMessage().getBeaconBlockRoot();
   }
 
   public SlotAndBlockRoot getSlotAndBlockRoot() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -66,6 +67,15 @@ public interface MutableStore extends ReadOnlyStore {
         Optional.of(blobSidecars),
         Optional.empty());
   }
+
+  /**
+   * Stores the corresponding data for this execution payload
+   *
+   * @param executionPayload Execution payload
+   * @param state Corresponding state
+   */
+  void putExecutionPayloadAndState(
+      SignedExecutionPayloadEnvelope executionPayload, BeaconState state);
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -139,6 +140,17 @@ public interface ReadOnlyStore extends TimeProvider {
 
   void computeBalanceThresholds(BeaconState justifiedState);
 
-  // implements is_ffg_competitive from Consensus Spec
+  // implements is_ffg_competitive from consensus-specs
   Optional<Boolean> isFfgCompetitive(Bytes32 headRoot, Bytes32 parentRoot);
+
+  /**
+   * Returns an execution payload only if it is immediately available (not pruned).
+   *
+   * @param beaconBlockRoot The beacon block root of the execution payload to retrieve
+   * @return The execution payload if available.
+   */
+  Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(Bytes32 beaconBlockRoot);
+
+  SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayloadEnvelope(
+      Bytes32 beaconBlockRoot);
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -77,7 +78,9 @@ public class TestStoreFactory {
         new HashMap<>(),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        new HashMap<>(),
+        new HashMap<>());
   }
 
   private AnchorPoint createAnchorForGenesis() {
@@ -99,6 +102,8 @@ public class TestStoreFactory {
     Map<Checkpoint, BeaconState> checkpointStates = new HashMap<>();
     Map<UInt64, VoteTracker> votes = new HashMap<>();
     Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars = new HashMap<>();
+    Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads = new HashMap<>();
+    Map<Bytes32, BeaconState> executionPayloadStates = new HashMap<>();
 
     blocks.put(anchorRoot, anchor.getSignedBeaconBlock().orElseThrow());
     blockStates.put(anchorRoot, anchorState);
@@ -124,7 +129,9 @@ public class TestStoreFactory {
         blobSidecars,
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        executionPayloads,
+        executionPayloadStates);
   }
 
   private BeaconState createRandomGenesisState() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -331,7 +331,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public void putExecutionPayloadAndState(
       final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
-    final Bytes32 beaconBlockRoot = executionPayload.getMessage().getBeaconBlockRoot();
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
     executionPayloads.put(beaconBlockRoot, executionPayload);
     executionPayloadStates.put(beaconBlockRoot, state);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -56,7 +57,10 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Optional<UInt64> earliestBlobSidecarSlot;
   protected Optional<Bytes32> latestCanonicalBlockRoot;
   protected Optional<UInt64> custodyGroupCount;
+  protected Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads;
+  protected Map<Bytes32, BeaconState> executionPayloadStates;
   protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
+
   protected final TestReadOnlyForkChoiceStrategy forkChoiceStrategy =
       new TestReadOnlyForkChoiceStrategy();
 
@@ -76,7 +80,9 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot,
       final Optional<Bytes32> maybeLatestCanonicalBlockRoot,
-      final Optional<UInt64> maybeCustodyGroupCount) {
+      final Optional<UInt64> maybeCustodyGroupCount,
+      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads,
+      final Map<Bytes32, BeaconState> executionPayloadStates) {
     this.spec = spec;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
@@ -93,6 +99,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     this.earliestBlobSidecarSlot = maybeEarliestBlobSidecarSlot;
     this.latestCanonicalBlockRoot = maybeLatestCanonicalBlockRoot;
     this.custodyGroupCount = maybeCustodyGroupCount;
+    this.executionPayloads = executionPayloads;
+    this.executionPayloadStates = executionPayloadStates;
   }
 
   // Readonly methods
@@ -160,6 +168,10 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
 
   private SignedBeaconBlock getSignedBlock(final Bytes32 blockRoot) {
     return blocks.get(blockRoot);
+  }
+
+  private SignedExecutionPayloadEnvelope getSignedExecutionPayload(final Bytes32 beaconBlockRoot) {
+    return executionPayloads.get(beaconBlockRoot);
   }
 
   private Optional<SignedBlockAndState> getBlockAndState(final Bytes32 blockRoot) {
@@ -276,6 +288,18 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
+  public Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(
+      final Bytes32 beaconBlockRoot) {
+    return Optional.ofNullable(getSignedExecutionPayload(beaconBlockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>>
+      retrieveSignedExecutionPayloadEnvelope(final Bytes32 beaconBlockRoot) {
+    return SafeFuture.completedFuture(getExecutionPayloadIfAvailable(beaconBlockRoot));
+  }
+
+  @Override
   public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot));
@@ -302,6 +326,14 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     if (earliestBlobSidecarSlot.isEmpty()) {
       earliestBlobSidecarSlot = maybeEarliestBlobSidecarSlot;
     }
+  }
+
+  @Override
+  public void putExecutionPayloadAndState(
+      final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
+    final Bytes32 beaconBlockRoot = executionPayload.getMessage().getBeaconBlockRoot();
+    executionPayloads.put(beaconBlockRoot, executionPayload);
+    executionPayloadStates.put(beaconBlockRoot, state);
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -194,6 +194,10 @@ public class ChainBuilder {
     return Optional.ofNullable(executionPayloadsByHash.get(beaconBlockRoot));
   }
 
+  public Optional<BeaconState> getExecutionPayloadState(final Bytes32 beaconBlockRoot) {
+    return getExecutionPayloadAndState(beaconBlockRoot).map(SignedExecutionPayloadAndState::state);
+  }
+
   public Optional<SignedExecutionPayloadEnvelope> getExecutionPayload(
       final Bytes32 beaconBlockRoot) {
     return getExecutionPayloadAndState(beaconBlockRoot)
@@ -377,10 +381,6 @@ public class ChainBuilder {
 
   public SignedExecutionPayloadAndState getExecutionPayloadAndStateAtSlot(final UInt64 slot) {
     return executionPayloads.get(slot);
-  }
-
-  public BeaconState getExecutionPayloadStateAtSlot(final UInt64 slot) {
-    return resultToState(getExecutionPayloadAndStateAtSlot(slot));
   }
 
   public SignedBlockAndState getLatestBlockAndStateAtSlot(final long slot) {
@@ -692,8 +692,7 @@ public class ChainBuilder {
     final Bytes32 parentRoot = latestBlockAndState.getBlock().getRoot();
     final BeaconState preState =
         // build on top of the execution payload state if an execution payload has been processed
-        Optional.ofNullable(getExecutionPayloadStateAtSlot(latestBlockAndState.getSlot()))
-            .orElse(latestBlockAndState.getState());
+        getExecutionPayloadState(parentRoot).orElse(latestBlockAndState.getState());
 
     int proposerIndex = blockProposalTestUtil.getProposerIndexForSlot(preState, slot);
     if (options.isWrongProposerEnabled()) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -315,11 +315,6 @@ public class ChainBuilder {
   }
 
   public Stream<SignedExecutionPayloadAndState> streamExecutionPayloadsAndStates(
-      final UInt64 fromSlot) {
-    return streamExecutionPayloadsAndStates(fromSlot, getLatestSlot());
-  }
-
-  public Stream<SignedExecutionPayloadAndState> streamExecutionPayloadsAndStates(
       final long fromSlot, final long toSlot) {
     return streamExecutionPayloadsAndStates(UInt64.valueOf(fromSlot), UInt64.valueOf(toSlot));
   }
@@ -1025,10 +1020,6 @@ public class ChainBuilder {
 
   private SignedBeaconBlock resultToBlock(final SignedBlockAndState result) {
     return Optional.ofNullable(result).map(SignedBlockAndState::getBlock).orElse(null);
-  }
-
-  private BeaconState resultToState(final SignedExecutionPayloadAndState result) {
-    return Optional.ofNullable(result).map(SignedExecutionPayloadAndState::state).orElse(null);
   }
 
   public SignedContributionAndProofTestBuilder createValidSignedContributionAndProofBuilder() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -163,10 +163,7 @@ public class ChainBuilder {
     executionPayloads.putAll(existingExecutionPayloads);
     existingExecutionPayloads
         .values()
-        .forEach(
-            e ->
-                executionPayloadsByHash.put(
-                    e.executionPayload().getMessage().getBeaconBlockRoot(), e));
+        .forEach(e -> executionPayloadsByHash.put(e.executionPayload().getBeaconBlockRoot(), e));
   }
 
   public static ChainBuilder create(final Spec spec) {
@@ -307,6 +304,10 @@ public class ChainBuilder {
   public Stream<Map.Entry<SlotAndBlockRoot, List<DataColumnSidecar>>> streamDataColumnSidecars(
       final long fromSlot, final long toSlot, final List<UInt64> columns) {
     return streamDataColumnSidecars(UInt64.valueOf(fromSlot), UInt64.valueOf(toSlot), columns);
+  }
+
+  public Stream<SignedExecutionPayloadAndState> streamExecutionPayloadsAndStates() {
+    return executionPayloads.values().stream();
   }
 
   public Stream<SignedExecutionPayloadAndState> streamExecutionPayloadsAndStates(
@@ -681,10 +682,9 @@ public class ChainBuilder {
   }
 
   private void trackExecutionPayload(final SignedExecutionPayloadAndState executionPayload) {
-    executionPayloads.put(
-        executionPayload.executionPayload().getMessage().getSlot(), executionPayload);
+    executionPayloads.put(executionPayload.executionPayload().getSlot(), executionPayload);
     executionPayloadsByHash.put(
-        executionPayload.executionPayload().getMessage().getBeaconBlockRoot(), executionPayload);
+        executionPayload.executionPayload().getBeaconBlockRoot(), executionPayload);
   }
 
   private SignedBlockAndState appendNewBlockToChain(final UInt64 slot, final BlockOptions options) {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
@@ -62,16 +63,18 @@ public interface StorageQueryChannel extends ChannelInterface {
       Bytes32 blockRoot);
 
   /**
-   * Returns "hot" blocks - the latest finalized block or blocks that descend from the latest
-   * finalized block
+   * Returns "hot" blocks - the latest block or blocks that descend from the latest finalized block
    *
    * @param blockRoots The roots of blocks to look up
-   * @return A map from root too block of any found blocks
+   * @return A map from root to block of any found blocks
    */
   SafeFuture<Map<Bytes32, SignedBeaconBlock>> getHotBlocksByRoot(Set<Bytes32> blockRoots);
 
   SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
       SlotAndBlockRoot slotAndBlockRoot);
+
+  SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getHotExecutionPayloadByRoot(
+      Bytes32 beaconBlockRoot);
 
   SafeFuture<Optional<SlotAndBlockRoot>> getSlotAndBlockRootByStateRoot(Bytes32 stateRoot);
 

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -63,7 +63,8 @@ public interface StorageQueryChannel extends ChannelInterface {
       Bytes32 blockRoot);
 
   /**
-   * Returns "hot" blocks - the latest block or blocks that descend from the latest finalized block
+   * Returns "hot" blocks - the latest finalized block or blocks that descend from the latest
+   * finalized block
    *
    * @param blockRoots The roots of blocks to look up
    * @return A map from root to block of any found blocks

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -48,6 +49,7 @@ public class StorageUpdate {
   private final Optional<Bytes32> optimisticTransitionBlockRoot;
   private final Optional<Bytes32> latestCanonicalBlockRoot;
   private final Optional<UInt64> custodyGroupCount;
+  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
   private final boolean blobSidecarsEnabled;
   private final boolean sidecarsEnabled;
   private final boolean isEmpty;
@@ -67,6 +69,7 @@ public class StorageUpdate {
       final Optional<Bytes32> optimisticTransitionBlockRoot,
       final Optional<Bytes32> latestCanonicalBlockRoot,
       final Optional<UInt64> custodyGroupCount,
+      final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates,
       @NonUpdating final boolean blobSidecarsEnabled,
       @NonUpdating final boolean sidecarsEnabled) {
     this.genesisTime = genesisTime;
@@ -83,6 +86,7 @@ public class StorageUpdate {
     this.optimisticTransitionBlockRoot = optimisticTransitionBlockRoot;
     this.latestCanonicalBlockRoot = latestCanonicalBlockRoot;
     this.custodyGroupCount = custodyGroupCount;
+    this.hotExecutionPayloadAndStates = hotExecutionPayloadAndStates;
     this.blobSidecarsEnabled = blobSidecarsEnabled;
     this.sidecarsEnabled = sidecarsEnabled;
     checkArgument(
@@ -102,6 +106,7 @@ public class StorageUpdate {
             && maybeEarliestBlobSidecarSlot.isEmpty()
             && latestCanonicalBlockRoot.isEmpty()
             && custodyGroupCount.isEmpty()
+            && hotExecutionPayloadAndStates.isEmpty()
             && !optimisticTransitionBlockRootSet;
   }
 
@@ -143,6 +148,10 @@ public class StorageUpdate {
 
   public Map<Bytes32, UInt64> getDeletedHotBlocks() {
     return deletedHotBlocks;
+  }
+
+  public Map<Bytes32, SignedExecutionPayloadAndState> getHotExecutionPayloadAndStates() {
+    return hotExecutionPayloadAndStates;
   }
 
   public Map<Bytes32, Bytes32> getFinalizedChildToParentMap() {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
@@ -115,6 +116,12 @@ public class ThrottlingStorageQueryChannel implements StorageQueryChannel {
   public SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return taskQueue.queueTask(() -> delegate.getBlobSidecarsBySlotAndBlockRoot(slotAndBlockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getHotExecutionPayloadByRoot(
+      final Bytes32 beaconBlockRoot) {
+    return taskQueue.queueTask(() -> delegate.getHotExecutionPayloadByRoot(beaconBlockRoot));
   }
 
   @Override

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
@@ -258,6 +259,7 @@ public class DatabaseTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Map.of(),
             true,
             false));
     database.update(
@@ -276,6 +278,7 @@ public class DatabaseTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Map.of(),
             true,
             false));
     // Will not be overridden from Database interface, only initial set
@@ -424,6 +427,7 @@ public class DatabaseTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Map.of(),
             true,
             false));
     database.update(
@@ -442,6 +446,7 @@ public class DatabaseTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Map.of(),
             true,
             false));
 
@@ -1656,6 +1661,7 @@ public class DatabaseTest {
             .blockProvider(mock(BlockProvider.class))
             .stateProvider(mock(StateAndBlockSummaryProvider.class))
             .latestCanonicalBlockRoot(Optional.empty())
+            .executionPayloadProvider(mock(ExecutionPayloadProvider.class))
             .build();
 
     assertThat(store.getTimeSeconds()).isEqualTo(genesisTime);

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -2344,25 +2344,6 @@ public class DatabaseTest {
   }
 
   @TestTemplate
-  public void shouldGetHotExecutionPayloadByBeaconBlockRoot(final DatabaseContext context)
-      throws IOException {
-    setupWithSpec(TestSpecFactory.createMinimalGloas());
-    initialize(context);
-
-    final SignedBlockAndState block = chainBuilder.generateBlockAtSlot(12);
-
-    assertThat(database.getHotExecutionPayload(block.getRoot())).isEmpty();
-
-    final SignedExecutionPayloadAndState executionPayloadAndState =
-        chainBuilder.getExecutionPayloadAndStateAtSlot(block.getSlot());
-
-    addExecutionPayloads(executionPayloadAndState);
-
-    assertThat(database.getHotExecutionPayload(block.getRoot()))
-        .hasValue(executionPayloadAndState.executionPayload());
-  }
-
-  @TestTemplate
   public void setFirstCustodyIncompleteSlot_isOperational(final DatabaseContext context)
       throws IOException {
     setupWithSpec(TestSpecFactory.createMinimalFulu());
@@ -2679,6 +2660,25 @@ public class DatabaseTest {
 
     assertThat(database.getLastDataColumnSidecarsProofsSlot()).isEmpty();
     assertThat(database.getDataColumnSidecarsProofs(header.getMessage().getSlot())).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldGetHotExecutionPayloadByBeaconBlockRoot(final DatabaseContext context)
+      throws IOException {
+    setupWithSpec(TestSpecFactory.createMinimalGloas());
+    initialize(context);
+
+    final SignedBlockAndState block = chainBuilder.generateBlockAtSlot(12);
+
+    assertThat(database.getHotExecutionPayload(block.getRoot())).isEmpty();
+
+    final SignedExecutionPayloadAndState executionPayloadAndState =
+        chainBuilder.getExecutionPayloadAndStateAtSlot(block.getSlot());
+
+    addExecutionPayloads(executionPayloadAndState);
+
+    assertThat(database.getHotExecutionPayload(block.getRoot()))
+        .hasValue(executionPayloadAndState.executionPayload());
   }
 
   private List<Map.Entry<Bytes32, UInt64>> getFinalizedStateRootsList() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlobSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -109,6 +110,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
 
   private final SingleBlockProvider validatedBlockProvider;
   private final SingleBlobSidecarProvider validatedBlobSidecarProvider;
+  private final ExecutionPayloadProvider executionPayloadProvider;
 
   private final LateBlockReorgLogic lateBlockReorgLogic;
 
@@ -123,6 +125,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
       final SingleBlobSidecarProvider validatedBlobSidecarProvider,
       final StateAndBlockSummaryProvider stateProvider,
       final EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider,
+      final ExecutionPayloadProvider executionPayloadProvider,
       final StorageUpdateChannel storageUpdateChannel,
       final VoteUpdateChannel voteUpdateChannel,
       final FinalizedCheckpointChannel finalizedCheckpointChannel,
@@ -137,6 +140,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
     this.validatedBlockProvider = validatedBlockProvider;
     this.validatedBlobSidecarProvider = validatedBlobSidecarProvider;
     this.earliestBlobSidecarSlotProvider = earliestBlobSidecarSlotProvider;
+    this.executionPayloadProvider = executionPayloadProvider;
     this.voteUpdateChannel = voteUpdateChannel;
     this.chainHeadChannel = chainHeadChannel;
     this.storageUpdateChannel = storageUpdateChannel;
@@ -174,6 +178,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
             .blockProvider(blockProvider)
             .stateProvider(stateProvider)
             .earliestBlobSidecarSlotProvider(earliestBlobSidecarSlotProvider)
+            .executionPayloadProvider(executionPayloadProvider)
             .storeConfig(storeConfig)
             .build();
 
@@ -393,11 +398,6 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
           optionalReorgContext);
     }
     bestBlockInitialized.complete(null);
-  }
-
-  public Optional<SlotAndBlockRoot> findCommonAncestor(
-      final Bytes32 blockRoot1, final Bytes32 blockRoot2) {
-    return store.getForkChoiceStrategy().findCommonAncestor(blockRoot1, blockRoot2);
   }
 
   private Optional<ReorgContext> computeReorgContext(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlobSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -44,6 +45,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
   private static final Logger LOG = LogManager.getLogger();
   private final BlockProvider blockProvider;
   private final StateAndBlockSummaryProvider stateProvider;
+  private final ExecutionPayloadProvider executionPayloadProvider;
   private final StorageQueryChannel storageQueryChannel;
   private final StoreConfig storeConfig;
 
@@ -69,6 +71,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
         validatedBlobSidecarProvider,
         storageQueryChannel::getHotStateAndBlockSummaryByBlockRoot,
         storageQueryChannel::getEarliestAvailableBlobSidecarSlot,
+        storageQueryChannel::getHotExecutionPayloadByRoot,
         storageUpdateChannel,
         voteUpdateChannel,
         finalizedCheckpointChannel,
@@ -79,6 +82,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
     this.storageQueryChannel = storageQueryChannel;
     this.blockProvider = storageQueryChannel::getHotBlocksByRoot;
     this.stateProvider = storageQueryChannel::getHotStateAndBlockSummaryByBlockRoot;
+    this.executionPayloadProvider = storageQueryChannel::getHotExecutionPayloadByRoot;
   }
 
   public static SafeFuture<RecentChainData> create(
@@ -174,6 +178,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
                   .asyncRunner(asyncRunner)
                   .blockProvider(blockProvider)
                   .stateProvider(stateProvider)
+                  .executionPayloadProvider(executionPayloadProvider)
                   .storeConfig(storeConfig)
                   .build();
           setStore(store);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -239,6 +240,12 @@ public class ChainStorage
             return blobSidecarStream.toList();
           }
         });
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getHotExecutionPayloadByRoot(
+      final Bytes32 beaconBlockRoot) {
+    return SafeFuture.of(() -> database.getHotExecutionPayload(beaconBlockRoot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -162,6 +163,12 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
       final SlotAndBlockRoot slotAndBlockRoot) {
     return asyncRunner.runAsync(
         () -> queryDelegate.getBlobSidecarsBySlotAndBlockRoot(slotAndBlockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getHotExecutionPayloadByRoot(
+      final Bytes32 beaconBlockRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getHotExecutionPayloadByRoot(beaconBlockRoot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -167,9 +168,11 @@ public interface Database extends AutoCloseable {
    * @param blockRoots The roots of blocks to look up
    * @return A map from root too block of any found blocks
    */
-  Map<Bytes32, SignedBeaconBlock> getHotBlocks(final Set<Bytes32> blockRoots);
+  Map<Bytes32, SignedBeaconBlock> getHotBlocks(Set<Bytes32> blockRoots);
 
-  Optional<SignedBeaconBlock> getHotBlock(final Bytes32 blockRoot);
+  Optional<SignedBeaconBlock> getHotBlock(Bytes32 blockRoot);
+
+  Optional<SignedExecutionPayloadEnvelope> getHotExecutionPayload(Bytes32 beaconBlockRoot);
 
   @MustBeClosed
   Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -166,7 +166,7 @@ public interface Database extends AutoCloseable {
    * Returns latest finalized block or any known blocks that descend from the latest finalized block
    *
    * @param blockRoots The roots of blocks to look up
-   * @return A map from root too block of any found blocks
+   * @return A map from root to block of any found blocks
    */
   Map<Bytes32, SignedBeaconBlock> getHotBlocks(Set<Bytes32> blockRoots);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -599,6 +599,7 @@ public class KvStoreDatabase implements Database {
     deletedHotBlockRoots.forEach(updater::deleteHotBlock);
   }
 
+  @SuppressWarnings("unused")
   protected void updateHotExecutionPayloads(
       final HotUpdater updater,
       final Map<Bytes32, SignedExecutionPayloadEnvelope> addedExecutionPayloads,

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -125,6 +126,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   @MustBeClosed
   public Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz() {
     return db.streamRaw(schema.getColumnHotBlocksByRoot()).map(entry -> entry);
+  }
+
+  @Override
+  public Optional<SignedExecutionPayloadEnvelope> getHotExecutionPayload(final Bytes32 blockRoot) {
+    return db.get(schema.getColumnHotExecutionPayloadsByRoot(), blockRoot);
   }
 
   @Override
@@ -786,6 +792,12 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     @Override
     public void deleteHotBlockOnly(final Bytes32 blockRoot) {
       transaction.delete(schema.getColumnHotBlocksByRoot(), blockRoot);
+    }
+
+    @Override
+    public void addHotExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+      final Bytes32 blockRoot = executionPayload.getMessage().getBeaconBlockRoot();
+      transaction.put(schema.getColumnHotExecutionPayloadsByRoot(), blockRoot, executionPayload);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -796,7 +796,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
     @Override
     public void addHotExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
-      final Bytes32 blockRoot = executionPayload.getMessage().getBeaconBlockRoot();
+      final Bytes32 blockRoot = executionPayload.getBeaconBlockRoot();
       transaction.put(schema.getColumnHotExecutionPayloadsByRoot(), blockRoot, executionPayload);
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -61,6 +62,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
   Stream<SignedBeaconBlock> streamHotBlocks();
 
   Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz();
+
+  Optional<SignedExecutionPayloadEnvelope> getHotExecutionPayload(Bytes32 blockRoot);
 
   Optional<SignedBeaconBlock> getFinalizedBlock(final Bytes32 root);
 
@@ -207,6 +210,13 @@ public interface KvStoreCombinedDao extends AutoCloseable {
     void deleteHotBlock(Bytes32 blockRoot);
 
     void deleteHotBlockOnly(Bytes32 blockRoot);
+
+    void addHotExecutionPayload(SignedExecutionPayloadEnvelope executionPayload);
+
+    default void addHotExecutionPayloads(
+        final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads) {
+      executionPayloads.values().forEach(this::addHotExecutionPayload);
+    }
 
     void setGenesisTime(UInt64 genesisTime);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -131,6 +132,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   @MustBeClosed
   public Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz() {
     return hotDao.streamHotBlocksAsSsz();
+  }
+
+  @Override
+  public Optional<SignedExecutionPayloadEnvelope> getHotExecutionPayload(final Bytes32 blockRoot) {
+    return hotDao.getHotExecutionPayload(blockRoot);
   }
 
   @Override
@@ -597,6 +603,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     @Override
     public void deleteHotBlockOnly(final Bytes32 blockRoot) {
       hotUpdater.deleteHotBlockOnly(blockRoot);
+    }
+
+    @Override
+    public void addHotExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+      hotUpdater.addHotExecutionPayload(executionPayload);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -103,6 +104,10 @@ public class V4HotKvStoreDao {
   @MustBeClosed
   public Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz() {
     return streamRawColumn(schema.getColumnHotBlocksByRoot()).map(entry -> entry);
+  }
+
+  public Optional<SignedExecutionPayloadEnvelope> getHotExecutionPayload(final Bytes32 blockRoot) {
+    return db.get(schema.getColumnHotExecutionPayloadsByRoot(), blockRoot);
   }
 
   public Optional<BeaconState> getLatestFinalizedState() {
@@ -304,6 +309,12 @@ public class V4HotKvStoreDao {
     @Override
     public void deleteHotBlockOnly(final Bytes32 blockRoot) {
       transaction.delete(schema.getColumnHotBlocksByRoot(), blockRoot);
+    }
+
+    @Override
+    public void addHotExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
+      final Bytes32 blockRoot = executionPayload.getMessage().getBeaconBlockRoot();
+      transaction.put(schema.getColumnHotExecutionPayloadsByRoot(), blockRoot, executionPayload);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -313,7 +313,7 @@ public class V4HotKvStoreDao {
 
     @Override
     public void addHotExecutionPayload(final SignedExecutionPayloadEnvelope executionPayload) {
-      final Bytes32 blockRoot = executionPayload.getMessage().getBeaconBlockRoot();
+      final Bytes32 blockRoot = executionPayload.getBeaconBlockRoot();
       transaction.put(schema.getColumnHotExecutionPayloadsByRoot(), blockRoot, executionPayload);
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -71,6 +72,8 @@ public interface SchemaCombined extends Schema {
       getColumnNonCanonicalSidecarByColumnSlotAndIdentifier();
 
   KvStoreColumn<UInt64, List<List<KZGProof>>> getColumnDataColumnSidecarsProofsBySlot();
+
+  KvStoreColumn<Bytes32, SignedExecutionPayloadEnvelope> getColumnHotExecutionPayloadsByRoot();
 
   // Variables
   KvStoreVariable<UInt64> getVariableGenesisTime();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaHotAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaHotAdapter.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -69,6 +70,11 @@ public class SchemaHotAdapter implements Schema {
   public KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
       getColumnBlobSidecarBySlotRootBlobIndex() {
     return delegate.getColumnBlobSidecarBySlotRootBlobIndex();
+  }
+
+  public KvStoreColumn<Bytes32, SignedExecutionPayloadEnvelope>
+      getColumnHotExecutionPayloadsByRoot() {
+    return delegate.getColumnHotExecutionPayloadsByRoot();
   }
 
   public KvStoreVariable<UInt64> getVariableGenesisTime() {
@@ -127,6 +133,7 @@ public class SchemaHotAdapter implements Schema {
         .put(
             "BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX",
             getColumnBlobSidecarBySlotRootBlobIndex())
+        .put("HOT_EXECUTION_PAYLOADS_BY_ROOT", getColumnHotExecutionPayloadsByRoot())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
@@ -206,6 +206,7 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
             "NON_CANONICAL_SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER",
             getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
         .put("DATA_COLUMN_SIDECARS_PROOFS_BY_SLOT", getColumnDataColumnSidecarsProofsBySlot())
+        .put("HOT_EXECUTION_PAYLOADS_BY_ROOT", getColumnHotExecutionPayloadsByRoot())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -234,6 +234,7 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
             "NON_CANONICAL_SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER",
             getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
         .put("DATA_COLUMN_SIDECARS_PROOFS_BY_SLOT", getColumnDataColumnSidecarsProofsBySlot())
+        .put("HOT_EXECUTION_PAYLOADS_BY_ROOT", getColumnHotExecutionPayloadsByRoot())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/KvStoreSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/KvStoreSerializer.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -70,6 +71,11 @@ public interface KvStoreSerializer<T> {
 
   static KvStoreSerializer<SignedBeaconBlock> createSignedBlockSerializer(final Spec spec) {
     return new SignedBeaconBlockSerializer(spec);
+  }
+
+  static KvStoreSerializer<SignedExecutionPayloadEnvelope> createSignedExecutionPayloadSerializer(
+      final Spec spec) {
+    return new SignedExecutionPayloadSerializer(spec);
   }
 
   T deserialize(final byte[] data);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SignedExecutionPayloadSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SignedExecutionPayloadSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+class SignedExecutionPayloadSerializer
+    implements KvStoreSerializer<SignedExecutionPayloadEnvelope> {
+
+  private final Spec spec;
+
+  SignedExecutionPayloadSerializer(final Spec spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public SignedExecutionPayloadEnvelope deserialize(final byte[] data) {
+    return spec.deserializeSignedExecutionPayload(Bytes.wrap(data));
+  }
+
+  @Override
+  public byte[] serialize(final SignedExecutionPayloadEnvelope value) {
+    return value.sszSerialize().toArrayUnsafe();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SignedExecutionPayloadSerializer that = (SignedExecutionPayloadSerializer) o;
+    return Objects.equals(spec, that.spec);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(spec);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -158,6 +159,12 @@ public class NoOpDatabase implements Database {
 
   @Override
   public Optional<SignedBeaconBlock> getHotBlock(final Bytes32 blockRoot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<SignedExecutionPayloadEnvelope> getHotExecutionPayload(
+      final Bytes32 beaconBlockRoot) {
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 
@@ -40,7 +40,7 @@ public abstract class CacheableStore implements UpdatableStore {
   abstract void cacheBlocks(Collection<BlockAndCheckpoints> blockAndCheckpoints);
 
   abstract void cacheExecutionPayloads(
-      Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads);
+      Collection<SignedExecutionPayloadAndState> executionPayloads);
 
   abstract void cacheStates(Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 
@@ -37,6 +38,9 @@ public abstract class CacheableStore implements UpdatableStore {
   abstract void cacheProposerBoostRoot(Optional<Bytes32> proposerBoostRoot);
 
   abstract void cacheBlocks(Collection<BlockAndCheckpoints> blockAndCheckpoints);
+
+  abstract void cacheExecutionPayloads(
+      Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads);
 
   abstract void cacheStates(Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public abstract class EmptyStoreResults {
@@ -41,4 +42,7 @@ public abstract class EmptyStoreResults {
 
   public static final SafeFuture<Optional<UInt64>> NO_EARLIEST_BLOB_SIDECAR_SLOT_FUTURE =
       SafeFuture.completedFuture(Optional.empty());
+
+  public static final SafeFuture<Optional<SignedExecutionPayloadEnvelope>>
+      EMPTY_SIGNED_EXECUTION_PAYLOAD_ENVELOPE_FUTURE = SafeFuture.completedFuture(Optional.empty());
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -202,7 +202,7 @@ class Store extends CacheableStore {
     this.custodyGroupCount = custodyGroupCount;
 
     this.executionPayloads = executionPayloads;
-    // Set up execution payload provider to draw from in-memory blocks
+    // Set up execution payload provider to draw from in-memory execution payloads
     this.executionPayloadProvider =
         ExecutionPayloadProvider.combined(
             createExecutionPayloadProviderFromMapWhileLocked(this.executionPayloads),

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -58,6 +59,7 @@ public class StoreBuilder {
       Optional.empty();
   private ForkChoiceStrategy forkChoiceStrategy = null;
   private Optional<UInt64> custodyGroupCount = Optional.empty();
+  private ExecutionPayloadProvider executionPayloadProvider;
 
   private StoreBuilder() {}
 
@@ -129,11 +131,11 @@ public class StoreBuilder {
           finalizedOptimisticTransitionPayload,
           justifiedCheckpoint,
           bestJustifiedCheckpoint,
-          blockInfoByRoot,
           votes,
           storeConfig,
           forkChoiceStrategy,
-          custodyGroupCount);
+          custodyGroupCount,
+          executionPayloadProvider);
     }
     return Store.create(
         asyncRunner,
@@ -153,7 +155,8 @@ public class StoreBuilder {
         latestCanonicalBlockRoot,
         votes,
         storeConfig,
-        custodyGroupCount);
+        custodyGroupCount,
+        executionPayloadProvider);
   }
 
   private void assertValid() {
@@ -169,6 +172,7 @@ public class StoreBuilder {
     checkState(latestFinalized != null, "Latest finalized anchor must be defined");
     checkState(votes != null, "Votes must be defined");
     checkState(!blockInfoByRoot.isEmpty(), "Block data must be supplied");
+    checkState(executionPayloadProvider != null, "Execution payload provider must be defined");
   }
 
   public StoreBuilder asyncRunner(final AsyncRunner asyncRunner) {
@@ -287,6 +291,13 @@ public class StoreBuilder {
   public StoreBuilder votes(final Map<UInt64, VoteTracker> votes) {
     checkNotNull(votes);
     this.votes = votes;
+    return this;
+  }
+
+  public StoreBuilder executionPayloadProvider(
+      final ExecutionPayloadProvider executionPayloadProvider) {
+    checkNotNull(executionPayloadProvider);
+    this.executionPayloadProvider = executionPayloadProvider;
     return this;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -114,7 +114,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   public void putExecutionPayloadAndState(
       final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
     executionPayloads.put(
-        executionPayload.getMessage().getBeaconBlockRoot(),
+        executionPayload.getBeaconBlockRoot(),
         new SignedExecutionPayloadAndState(executionPayload, state));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -160,9 +160,7 @@ class StoreTransactionUpdates {
             prunedHotBlockRoots,
             store.getFinalizedCheckpoint());
 
-    store.cacheExecutionPayloads(
-        Maps.transformValues(
-            hotExecutionPayloadAndStates, SignedExecutionPayloadAndState::executionPayload));
+    store.cacheExecutionPayloads(hotExecutionPayloadAndStates.values());
   }
 
   private StateAndBlockSummary blockAndStateAsSummary(final SignedBlockAndState blockAndState) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.api.FinalizedChainData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
@@ -47,6 +48,8 @@ class StoreTransactionUpdates {
   private final Optional<Bytes32> optimisticTransitionBlockRoot;
   private final Optional<Bytes32> latestCanonicalBlockRoot;
   private final Optional<UInt64> custodyGroupCount;
+  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
+
   private final boolean blobSidecarsEnabled;
   private final boolean dataColumnSidecarsEnabled;
 
@@ -64,6 +67,7 @@ class StoreTransactionUpdates {
       final Optional<Bytes32> optimisticTransitionBlockRoot,
       final Optional<Bytes32> latestCanonicalBlockRoot,
       final Optional<UInt64> custodyGroupCount,
+      final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates,
       final boolean blobSidecarsEnabled,
       final boolean dataColumnSidecarsEnabled) {
     checkNotNull(tx, "Transaction is required");
@@ -78,6 +82,7 @@ class StoreTransactionUpdates {
     checkNotNull(optimisticTransitionBlockRoot, "Optimistic transition block root is required");
     checkNotNull(latestCanonicalBlockRoot, "Latest canonical block root is required");
     checkNotNull(custodyGroupCount, "Current custody group count is required");
+    checkNotNull(hotExecutionPayloadAndStates, "Hot execution payload and states are required");
 
     this.tx = tx;
     this.finalizedChainData = finalizedChainData;
@@ -92,6 +97,7 @@ class StoreTransactionUpdates {
     this.optimisticTransitionBlockRoot = optimisticTransitionBlockRoot;
     this.latestCanonicalBlockRoot = latestCanonicalBlockRoot;
     this.custodyGroupCount = custodyGroupCount;
+    this.hotExecutionPayloadAndStates = hotExecutionPayloadAndStates;
     this.blobSidecarsEnabled = blobSidecarsEnabled;
     this.dataColumnSidecarsEnabled = dataColumnSidecarsEnabled;
   }
@@ -112,6 +118,7 @@ class StoreTransactionUpdates {
         optimisticTransitionBlockRoot,
         latestCanonicalBlockRoot,
         custodyGroupCount,
+        hotExecutionPayloadAndStates,
         blobSidecarsEnabled,
         dataColumnSidecarsEnabled);
   }
@@ -152,6 +159,10 @@ class StoreTransactionUpdates {
             tx.pulledUpBlockCheckpoints,
             prunedHotBlockRoots,
             store.getFinalizedCheckpoint());
+
+    store.cacheExecutionPayloads(
+        Maps.transformValues(
+            hotExecutionPayloadAndStates, SignedExecutionPayloadAndState::executionPayload));
   }
 
   private StateAndBlockSummary blockAndStateAsSummary(final SignedBlockAndState blockAndState) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -54,6 +55,7 @@ class StoreTransactionUpdatesFactory {
   private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
   private final AnchorPoint latestFinalized;
   private final Map<Bytes32, UInt64> prunedHotBlockRoots = new ConcurrentHashMap<>();
+  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
 
   public StoreTransactionUpdatesFactory(
       final Spec spec,
@@ -76,6 +78,7 @@ class StoreTransactionUpdatesFactory {
     maybeEarliestBlobSidecarSlot = tx.maybeEarliestBlobSidecarTransactionSlot;
     maybeLatestCanonicalBlockRoot = tx.maybeLatestCanonicalBlockRoot;
     maybeCustodyGroupCount = tx.maybeCustodyGroupCount;
+    hotExecutionPayloadAndStates = new ConcurrentHashMap<>(tx.executionPayloads);
   }
 
   public static StoreTransactionUpdates create(
@@ -263,6 +266,7 @@ class StoreTransactionUpdatesFactory {
         optimisticTransitionBlockRoot,
         maybeLatestCanonicalBlockRoot,
         maybeCustodyGroupCount,
+        hotExecutionPayloadAndStates,
         spec.isMilestoneSupported(SpecMilestone.DENEB),
         spec.isMilestoneSupported(SpecMilestone.FULU));
   }

--- a/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SignedExecutionPayloadSerializerPropertyTest.java
+++ b/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SignedExecutionPayloadSerializerPropertyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.createSignedExecutionPayloadSerializer;
+
+import java.util.Objects;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.Positive;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.propertytest.suppliers.SpecSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedExecutionPayloadSerializerPropertyTest {
+
+  private final Spec spec =
+      Objects.requireNonNull(new SpecSupplier(SpecMilestone.GLOAS).get()).sample();
+  private final KvStoreSerializer<SignedExecutionPayloadEnvelope> serializer =
+      createSignedExecutionPayloadSerializer(spec);
+
+  @Property
+  public boolean roundTrip(@ForAll final int seed, @ForAll @Positive final long slotNum) {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final SignedExecutionPayloadEnvelope value =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(slotNum);
+    final byte[] serialized = serializer.serialize(value);
+    final SignedExecutionPayloadEnvelope deserialized = serializer.deserialize(serialized);
+    return deserialized.equals(value);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlobSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -113,6 +114,7 @@ public class StorageBackedRecentChainDataTest {
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
             .stateProvider(StateAndBlockSummaryProvider.NOOP)
+            .executionPayloadProvider(ExecutionPayloadProvider.NOOP)
             .storeConfig(storeConfig)
             .build();
     StoreAssertions.assertStoresMatch(client.get().getStore(), expectedStore);
@@ -163,6 +165,7 @@ public class StorageBackedRecentChainDataTest {
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
             .stateProvider(StateAndBlockSummaryProvider.NOOP)
+            .executionPayloadProvider(ExecutionPayloadProvider.NOOP)
             .storeConfig(storeConfig)
             .build();
     client.get().initializeFromGenesis(initialState, UInt64.ZERO);
@@ -213,7 +216,8 @@ public class StorageBackedRecentChainDataTest {
             .metricsSystem(new StubMetricsSystem())
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
-            .stateProvider(StateAndBlockSummaryProvider.NOOP);
+            .stateProvider(StateAndBlockSummaryProvider.NOOP)
+            .executionPayloadProvider(ExecutionPayloadProvider.NOOP);
     storeRequestFuture.complete(Optional.of(storeData));
     assertThat(client).isCompleted();
     assertStoreInitialized(client.get());

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
@@ -218,7 +219,8 @@ public abstract class AbstractStoreTest {
                     Optional.of(spec.calculateBlockCheckpoints(genesis.getState())))))
         .storeConfig(pruningOptions)
         .votes(emptyMap())
-        .latestCanonicalBlockRoot(Optional.empty());
+        .latestCanonicalBlockRoot(Optional.empty())
+        .executionPayloadProvider(executionPayloadProviderFromChainBuilder());
   }
 
   protected UpdatableStore createGenesisStoreWithMockForkChoiceStrategy(
@@ -237,5 +239,10 @@ public abstract class AbstractStoreTest {
 
   protected EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProviderFromChainBuilder() {
     return () -> SafeFuture.completedFuture(chainBuilder.getEarliestBlobSidecarSlot());
+  }
+
+  protected ExecutionPayloadProvider executionPayloadProviderFromChainBuilder() {
+    return beaconBlockRoot ->
+        SafeFuture.completedFuture(chainBuilder.getExecutionPayload(beaconBlockRoot));
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -706,14 +706,8 @@ class StoreTest extends AbstractStoreTest {
     chainBuilder.generateBlocksUpToSlot(startSlot);
 
     // Add blocks
-    final StoreTransaction tx = store.startTransaction(new StubStorageUpdateChannel());
-    chainBuilder
-        .streamBlocksAndStates()
-        .forEach(
-            blockAndState ->
-                tx.putBlockAndState(
-                    blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState())));
-    safeJoin(tx.commit());
+    addBlocks(store, chainBuilder.streamBlocksAndStates().toList());
+
     final List<SignedBlockAndState> last32 =
         chainBuilder
             .streamBlocksAndStates()
@@ -727,6 +721,7 @@ class StoreTest extends AbstractStoreTest {
                                 .getSlot()
                                 .minus(defaultStoreConfig.getBlockCacheSize())))
             .toList();
+    assertThat(last32).hasSize(32);
     for (final SignedBlockAndState signedBlockAndState : last32) {
       assertThat(store.getBlockIfAvailable(signedBlockAndState.getRoot())).isPresent();
     }
@@ -742,14 +737,8 @@ class StoreTest extends AbstractStoreTest {
     chainBuilder.generateBlocksUpToSlot(startSlot);
 
     // Add execution payloads
-    final StoreTransaction tx = store.startTransaction(new StubStorageUpdateChannel());
-    chainBuilder
-        .streamExecutionPayloadsAndStates()
-        .forEach(
-            executionPayloadAndState ->
-                tx.putExecutionPayloadAndState(
-                    executionPayloadAndState.executionPayload(), executionPayloadAndState.state()));
-    safeJoin(tx.commit());
+    addExecutionPayloads(store, chainBuilder.streamExecutionPayloadsAndStates().toList());
+
     final List<SignedExecutionPayloadAndState> last32 =
         chainBuilder
             .streamExecutionPayloadsAndStates()

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -83,7 +83,8 @@ class StoreTest extends AbstractStoreTest {
                     Optional.empty(),
                     Collections.emptyMap(),
                     defaultStoreConfig,
-                    Optional.empty()))
+                    Optional.empty(),
+                    executionPayloadProviderFromChainBuilder()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Time must be greater than or equal to genesisTime");
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
@@ -199,6 +200,12 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   public SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return SafeFuture.completedFuture(Collections.emptyList());
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getHotExecutionPayloadByRoot(
+      final Bytes32 beaconBlockRoot) {
+    return SafeFuture.completedFuture(Optional.empty());
   }
 
   @Override

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlobSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.SingleBlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -56,6 +57,7 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
         SingleBlobSidecarProvider.NOOP,
         StateAndBlockSummaryProvider.NOOP,
         EarliestBlobSidecarSlotProvider.NOOP,
+        ExecutionPayloadProvider.NOOP,
         storageUpdateChannel,
         voteUpdateChannel,
         finalizedCheckpointChannel,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -58,7 +58,8 @@ public class StoreAssertions {
             "maybeEpochStates",
             "epochStatesCountGauge",
             "blobSidecars",
-            "blobSidecarsBlocksCountGauge")
+            "blobSidecarsBlocksCountGauge",
+            "executionPayloadProvider")
         .isEqualTo(expectedState);
     assertThat(actualState.getOrderedBlockRoots())
         .containsExactlyElementsOf(expectedState.getOrderedBlockRoots());

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
 import tech.pegasys.teku.cli.options.BeaconNodeDataOptions;
 import tech.pegasys.teku.cli.options.Eth2NetworkOptions;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
+import tech.pegasys.teku.dataproviders.lookup.ExecutionPayloadProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
@@ -299,6 +300,7 @@ public class DebugDbCommand implements Runnable {
                           .specProvider(eth2NetworkOptions.getNetworkConfiguration().getSpec())
                           .blockProvider(BlockProvider.NOOP)
                           .stateProvider(StateAndBlockSummaryProvider.NOOP)
+                          .executionPayloadProvider(ExecutionPayloadProvider.NOOP)
                           .build())
               .map(UpdatableStore::getLatestFinalized);
       int result = writeState(outputFile, finalizedAnchor.map(AnchorPoint::getState));

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
+// TODO-GLOAS: https://github.com/Consensys/teku/issues/10053
 public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
   private static final Logger LOG = LogManager.getLogger();
 
@@ -84,7 +85,6 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
           millisPerSlot,
           this::onContributionCreationDue);
     }
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10018
     if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
       taskScheduler.scheduleRepeatingEventInMillis(
           nextSlotStartTimeMillis.plus(spec.getPayloadAttestationDueMillis(nextSlot)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Some initial code to make ChainBuilder + ChainUpdater work with `RecentChainData`.

Essentially implementing this in the Store:

```java
Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(Bytes32 beaconBlockRoot);

SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayloadEnvelope(
      Bytes32 beaconBlockRoot);
```

And new column in DB:
```
.put("HOT_EXECUTION_PAYLOADS_BY_ROOT", getColumnHotExecutionPayloadsByRoot())
final KvStoreSerializer<SignedExecutionPayloadEnvelope> signedExecutionPayloadSerializer =
        KvStoreSerializer.createSignedExecutionPayloadSerializer(spec);
hotExecutionPayloadsByRoot =
        KvStoreColumn.create(8, BYTES32_SERIALIZER, signedExecutionPayloadSerializer);
```




## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/10098
fixes #10071 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce hot execution payload support (ePBS/Gloas) with DB column and serializer, new APIs, and full integration across Store/RecentChainData/Storage layers.
> 
> - **Storage/DB**:
>   - Add `HOT_EXECUTION_PAYLOADS_BY_ROOT` column and serializer for `SignedExecutionPayloadEnvelope`.
>   - DAO/Database methods to put/get hot execution payloads; included in updates (`StorageUpdate`).
> - **APIs**:
>   - `StorageQueryChannel`/throttling/chain storage: `getHotExecutionPayloadByRoot`.
>   - `ReadOnlyStore` adds `getExecutionPayloadIfAvailable` and async retrieval; `MutableStore.putExecutionPayloadAndState`.
>   - New `ExecutionPayloadProvider` and composition util.
> - **Store/Client**:
>   - Wire `ExecutionPayloadProvider` through `StoreBuilder`, `Store`, `StoreTransaction(Updates)`, `RecentChainData`, `StorageBackedRecentChainData`.
>   - Cache/prune hot execution payloads alongside blocks; expose retrieval.
> - **Spec/Util**:
>   - `Spec.deserializeSignedExecutionPayload` (Gloas);
>   - `ChainBuilder` tracks and exposes execution payloads/states by beacon block root.
> - **Tests**:
>   - Property test for payload serializer; integration/unit tests for hot payload retrieval and cache behavior; minor test name fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e58929a666b0838f289eefb63097f7e13f27b4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->