### PR TITLE
Outgoing rpc metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@
 ### Bug Fixes
  - Fixed NPE in DasPreSampler (#10110).
  - Added connection direction to `beacon_peer_count` metric.
+ - Added metrics for outgoing LibP2P RPC requests (`rpc_requests_total`, `rpc_requests_sent` and
+  `rpc_requests_failed`)

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueueTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueueTest.java
@@ -272,28 +272,28 @@ class CachingTaskQueueTest {
 
   private void assertCacheHitCount(final int expectedCount) {
     final double value =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.STORAGE, METRICS_PREFIX + "_tasks_total", "cached");
     assertThat(value).isEqualTo(expectedCount);
   }
 
   private void assertNewTaskCount(final int expectedCount) {
     final double value =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.STORAGE, METRICS_PREFIX + "_tasks_total", "new");
     assertThat(value).isEqualTo(expectedCount);
   }
 
   private void assertDuplicateTaskCount(final int expectedCount) {
     final double value =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.STORAGE, METRICS_PREFIX + "_tasks_total", "duplicate");
     assertThat(value).isEqualTo(expectedCount);
   }
 
   private void assertRebasedTaskCount(final int expectedCount) {
     final double value =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.STORAGE, METRICS_PREFIX + "_tasks_total", "rebase");
     assertThat(value).isEqualTo(expectedCount);
   }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -638,7 +638,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
   private void verifySourceCounter(final Source source, final FallbackReason reason) {
     final long actualCount =
-        stubMetricsSystem.getCounterValue(
+        stubMetricsSystem.getLabelledCounterValue(
             TekuMetricCategory.BEACON,
             "execution_payload_source_total",
             source.toString(),

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -1133,7 +1133,7 @@ class ExecutionLayerManagerImplTest {
 
   private void verifySourceCounter(final Source source, final FallbackReason reason) {
     final long actualCount =
-        stubMetricsSystem.getCounterValue(
+        stubMetricsSystem.getLabelledCounterValue(
             TekuMetricCategory.BEACON,
             "execution_payload_source_total",
             source.toString(),
@@ -1143,7 +1143,7 @@ class ExecutionLayerManagerImplTest {
 
   private void verifySourceCounterIsZero(final Source source, final FallbackReason reason) {
     final long actualCount =
-        stubMetricsSystem.getCounterValue(
+        stubMetricsSystem.getLabelledCounterValue(
             TekuMetricCategory.BEACON,
             "execution_payload_source_total",
             source.toString(),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
@@ -247,15 +247,15 @@ public class SidecarRetrieverTest {
   private void verifyMetrics(
       final int cancelledCount, final int downloadedCount, final int recoveredCount) {
     assertThat(
-            metricsSystem.getCounterValue(
+            metricsSystem.getLabelledCounterValue(
                 TekuMetricCategory.BEACON, RECOVERY_METRIC_NAME, CANCELLED))
         .isEqualTo(cancelledCount);
     assertThat(
-            metricsSystem.getCounterValue(
+            metricsSystem.getLabelledCounterValue(
                 TekuMetricCategory.BEACON, RECOVERY_METRIC_NAME, DOWNLOADED))
         .isEqualTo(downloadedCount);
     assertThat(
-            metricsSystem.getCounterValue(
+            metricsSystem.getLabelledCounterValue(
                 TekuMetricCategory.BEACON, RECOVERY_METRIC_NAME, RECOVERED))
         .isEqualTo(recoveredCount);
   }

--- a/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubMetricsSystem.java
+++ b/infrastructure/metrics/src/testFixtures/java/tech/pegasys/teku/infrastructure/metrics/StubMetricsSystem.java
@@ -89,7 +89,11 @@ public class StubMetricsSystem implements MetricsSystem {
         .computeIfAbsent(name, __ -> new StubLabelledGauge(category, name, help));
   }
 
-  public long getCounterValue(
+  public long getCounterValue(final MetricCategory category, final String name) {
+    return getLabelledCounterValue(category, name);
+  }
+
+  public long getLabelledCounterValue(
       final MetricCategory category, final String name, final String... labels) {
     final Map<String, StubLabelledCounter> counters = this.counters.get(category);
     final StubLabelledCounter labelledCounter = counters.get(name);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManagerTest.java
@@ -236,12 +236,12 @@ public class AttestationGossipManagerTest {
   }
 
   private long getPublishSuccessCounterValue() {
-    return metricsSystem.getCounterValue(
+    return metricsSystem.getLabelledCounterValue(
         TekuMetricCategory.BEACON, "published_attestation_total", "success");
   }
 
   private long getPublishFailureCounterValue() {
-    return metricsSystem.getCounterValue(
+    return metricsSystem.getLabelledCounterValue(
         TekuMetricCategory.BEACON, "published_attestation_total", "failure");
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -166,7 +166,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
                     maxRequestBlobSidecars)));
 
     final long countTooBigCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_blob_sidecars_by_range_requests_total",
             "count_too_big");
@@ -196,7 +196,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
                     maxRequestBlobSidecars)));
 
     final long countTooBigCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_blob_sidecars_by_range_requests_total",
             "count_too_big");
@@ -227,7 +227,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
                     maxRequestBlobSidecars)));
 
     final long countTooBigCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_blob_sidecars_by_range_requests_total",
             "count_too_big");
@@ -252,7 +252,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
     final long rateLimitedCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_blob_sidecars_by_range_requests_total",
             "rate_limited");

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -169,7 +169,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
             });
 
     final long countTooBigCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_blob_sidecars_by_root_requests_total",
             "count_too_big");
@@ -194,7 +194,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
     verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
     final long rateLimitedCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK, "rpc_blob_sidecars_by_root_requests_total", "rate_limited");
 
     assertThat(rateLimitedCount).isOne();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandlerTest.java
@@ -158,7 +158,7 @@ public class DataColumnSidecarsByRangeMessageHandlerTest {
                     "Only a maximum of %s data column sidecars can be requested per request",
                     maxRequestDataColumnSidecars)));
     final long countTooBigCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_data_column_sidecars_by_range_requests_total",
             "count_too_big");
@@ -180,7 +180,7 @@ public class DataColumnSidecarsByRangeMessageHandlerTest {
                     "Only a maximum of %s data column sidecars can be requested per request",
                     maxRequestDataColumnSidecars)));
     final long countTooBigCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_data_column_sidecars_by_range_requests_total",
             "count_too_big");
@@ -206,7 +206,7 @@ public class DataColumnSidecarsByRangeMessageHandlerTest {
                     "Only a maximum of %s data column sidecars can be requested per request",
                     maxRequestDataColumnSidecars)));
     final long countTooBigCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_data_column_sidecars_by_range_requests_total",
             "count_too_big");
@@ -228,7 +228,7 @@ public class DataColumnSidecarsByRangeMessageHandlerTest {
     // No adjustment
     verify(peer, never()).adjustDataColumnSidecarsRequest(any(), anyLong());
     final long rateLimitedCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_data_column_sidecars_by_range_requests_total",
             "rate_limited");

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -178,7 +178,7 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     verify(peer, never()).adjustDataColumnSidecarsRequest(any(), anyLong());
 
     final long rateLimitedCount =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.NETWORK,
             "rpc_data_column_sidecars_by_root_requests_total",
             "rate_limited");

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -152,7 +152,7 @@ public class LibP2PNetworkBuilder {
   }
 
   protected List<? extends RpcHandler<?, ?, ?>> createRpcHandlers() {
-    return rpcMethods.stream().map(m -> new RpcHandler<>(asyncRunner, m)).toList();
+    return rpcMethods.stream().map(m -> new RpcHandler<>(asyncRunner, m, metricsSystem)).toList();
   }
 
   protected LibP2PGossipNetwork createGossipNetwork() {

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandlerTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler.Controller;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
@@ -55,8 +57,9 @@ public class RpcHandlerTest {
 
   StubAsyncRunner asyncRunner = new StubAsyncRunner();
   RpcMethod<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> rpcMethod = mock(RpcMethod.class);
+  StubMetricsSystem metricsSystem = new StubMetricsSystem();
   RpcHandler<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> rpcHandler =
-      new RpcHandler<>(asyncRunner, rpcMethod);
+      new RpcHandler<>(asyncRunner, rpcMethod, metricsSystem);
 
   Connection connection = mock(Connection.class);
   Session session = mock(Session.class);
@@ -71,6 +74,7 @@ public class RpcHandlerTest {
   RpcStream rpcStream = mock(RpcStream.class);
   final RpcResponseHandler<?> responseHandler = mock(RpcResponseHandler.class);
   final RpcRequest request = mock(RpcRequest.class);
+  final String protocolId = "test";
 
   @BeforeEach
   void init() {
@@ -96,7 +100,7 @@ public class RpcHandlerTest {
     streamPromise.getController().complete(controller);
 
     assertThat(future).isNotDone();
-    stream.getProtocol().complete("test");
+    stream.getProtocol().complete(protocolId);
 
     assertThat(future).isNotDone();
     writeFuture.complete(null);
@@ -113,6 +117,10 @@ public class RpcHandlerTest {
     verify(controller, never()).closeAbruptly();
     assertThat(future).isCompletedWithValue(controller);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 1);
+    assertRequestsFailedCounterValue(0);
   }
 
   @Test
@@ -127,14 +135,17 @@ public class RpcHandlerTest {
     streamPromise.getController().complete(controller);
 
     assertThat(future).isNotDone();
-    stream.getProtocol().complete("test");
+    stream.getProtocol().complete(protocolId);
 
     assertThat(future).isCompletedExceptionally();
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @Test
   void sendRequestWithBodySelector_positiveCase() {
-    final String protocolId = "test";
     final VersionBasedRpcRequestBodySelector<RpcRequest> bodySelector =
         new VersionBasedRpcRequestBodySelector<>(Map.of(protocolId, request));
 
@@ -165,6 +176,10 @@ public class RpcHandlerTest {
     verify(controller, never()).closeAbruptly();
     assertThat(future).isCompletedWithValue(controller);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 1);
+    assertRequestsFailedCounterValue(0);
   }
 
   @Test
@@ -181,9 +196,13 @@ public class RpcHandlerTest {
     streamPromise.getController().complete(controller);
 
     assertThat(future).isNotDone();
-    stream.getProtocol().complete("test");
+    stream.getProtocol().complete(protocolId);
 
     assertThat(future).isCompletedExceptionally();
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @Test
@@ -195,6 +214,10 @@ public class RpcHandlerTest {
         rpcHandler.sendRequest(connection, request, responseHandler);
 
     assertThatSafeFuture(future).isCompletedExceptionallyWith(PeerDisconnectedException.class);
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @Test
@@ -207,6 +230,10 @@ public class RpcHandlerTest {
     verify(connection, never()).muxerSession();
     assertThatThrownBy(future::get).hasRootCauseInstanceOf(PeerDisconnectedException.class);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @ParameterizedTest(name = "closeStream={0}, exceedTimeout={1}")
@@ -227,6 +254,10 @@ public class RpcHandlerTest {
 
     assertThatThrownBy(future::get).hasRootCauseInstanceOf(expectedException);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @ParameterizedTest(name = "closeStream={0}, exceedTimeout={1}")
@@ -249,6 +280,10 @@ public class RpcHandlerTest {
     assertThatThrownBy(future::get).hasRootCauseInstanceOf(expectedException);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
     verify(stream).close();
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @ParameterizedTest(name = "closeStream={0}, exceedTimeout={1}")
@@ -272,6 +307,10 @@ public class RpcHandlerTest {
     assertThatThrownBy(future::get).hasRootCauseInstanceOf(expectedException);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
     verify(stream).close();
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @ParameterizedTest(name = "closeStream={0}, exceedTimeout={1}")
@@ -282,7 +321,7 @@ public class RpcHandlerTest {
         rpcHandler.sendRequest(connection, request, responseHandler);
 
     streamPromise.getStream().complete(stream);
-    stream.getProtocol().complete("test");
+    stream.getProtocol().complete(protocolId);
     assertThat(future).isNotDone();
 
     final Class<? extends Exception> expectedException =
@@ -295,6 +334,10 @@ public class RpcHandlerTest {
     assertThatThrownBy(future::get).hasRootCauseInstanceOf(expectedException);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
     verify(stream).close();
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @ParameterizedTest(name = "closeStream={0}, exceedTimeout={1}")
@@ -306,7 +349,7 @@ public class RpcHandlerTest {
 
     streamPromise.getStream().complete(stream);
     streamPromise.getController().complete(controller);
-    stream.getProtocol().complete("test");
+    stream.getProtocol().complete(protocolId);
     assertThat(future).isNotDone();
 
     final Class<? extends Exception> expectedException =
@@ -319,6 +362,10 @@ public class RpcHandlerTest {
     assertThatThrownBy(future::get).hasRootCauseInstanceOf(expectedException);
     assertThat(closeFuture.getNumberOfDependents()).isEqualTo(0);
     verify(stream).close();
+
+    assertRequestsTotalCounterValue(1);
+    assertRequestsSentCounterValue(protocolId, 0);
+    assertRequestsFailedCounterValue(1);
   }
 
   @SuppressWarnings("UnnecessaryAsync")
@@ -341,5 +388,22 @@ public class RpcHandlerTest {
   public static java.util.stream.Stream<Arguments> getInterruptParams() {
     return java.util.stream.Stream.of(
         Arguments.of(true, false), Arguments.of(false, true), Arguments.of(true, true));
+  }
+
+  private void assertRequestsSentCounterValue(final String protocolId, final long expectedValue) {
+    assertThat(
+            metricsSystem.getLabelledCounterValue(
+                TekuMetricCategory.LIBP2P, "rpc_requests_sent", protocolId))
+        .isEqualTo(expectedValue);
+  }
+
+  private void assertRequestsTotalCounterValue(final long expectedValue) {
+    assertThat(metricsSystem.getCounterValue(TekuMetricCategory.LIBP2P, "rpc_requests_total"))
+        .isEqualTo(expectedValue);
+  }
+
+  private void assertRequestsFailedCounterValue(final long expectedValue) {
+    assertThat(metricsSystem.getCounterValue(TekuMetricCategory.LIBP2P, "rpc_requests_failed"))
+        .isEqualTo(expectedValue);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -1240,6 +1240,6 @@ class RecentChainDataTest {
   private long getReorgCountMetric(final StorageSystem storageSystem) {
     return storageSystem
         .getMetricsSystem()
-        .getCounterValue(TekuMetricCategory.BEACON, "reorgs_total");
+        .getLabelledCounterValue(TekuMetricCategory.BEACON, "reorgs_total");
   }
 }

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -280,7 +280,7 @@ class MetricRecordingValidatorApiChannelTest {
   }
 
   private long getCounterValue(final String methodLabel, final RequestOutcome outcome) {
-    return metricsSystem.getCounterValue(
+    return metricsSystem.getLabelledCounterValue(
         TekuMetricCategory.VALIDATOR,
         MetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME,
         methodLabel,

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerTestUtil.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerTestUtil.java
@@ -54,15 +54,15 @@ class ExternalSignerTestUtil {
       final long timeoutCount) {
 
     assertThat(
-            metricsSystem.getCounterValue(
+            metricsSystem.getLabelledCounterValue(
                 TekuMetricCategory.VALIDATOR, "external_signer_requests_total", "success"))
         .isEqualTo(successCount);
     assertThat(
-            metricsSystem.getCounterValue(
+            metricsSystem.getLabelledCounterValue(
                 TekuMetricCategory.VALIDATOR, "external_signer_requests_total", "failed"))
         .isEqualTo(failCount);
     assertThat(
-            metricsSystem.getCounterValue(
+            metricsSystem.getLabelledCounterValue(
                 TekuMetricCategory.VALIDATOR, "external_signer_requests_total", "timeout"))
         .isEqualTo(timeoutCount);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/PendingDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/PendingDutiesTest.java
@@ -244,10 +244,10 @@ class PendingDutiesTest {
 
   private void validateMetrics(final String duty, final long successCount, final long failCount) {
     final long labelledCounterSuccess =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.VALIDATOR, "duties_performed_total", duty, "success");
     final long labelledCounterFailed =
-        metricsSystem.getCounterValue(
+        metricsSystem.getLabelledCounterValue(
             TekuMetricCategory.VALIDATOR, "duties_performed_total", duty, "failed");
     assertThat(labelledCounterSuccess).isEqualTo(successCount);
     assertThat(labelledCounterFailed).isEqualTo(failCount);

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -934,7 +934,7 @@ class FailoverValidatorApiHandlerTest {
       final RemoteValidatorApiChannel apiChannel,
       final String methodLabel,
       final RequestOutcome outcome) {
-    return stubMetricsSystem.getCounterValue(
+    return stubMetricsSystem.getLabelledCounterValue(
         TekuMetricCategory.VALIDATOR,
         FailoverValidatorApiHandler.REMOTE_BEACON_NODES_REQUESTS_COUNTER_NAME,
         apiChannel.getEndpoint().toString(),


### PR DESCRIPTION
## PR Description
Added three new metrics to track our outgoing peer RPC requests (req/resp domain).

Most of the changes are related to a renamed method `getCounterValue` to `getLabelledCounterValue` on `StubMetricSystem`.

## Fixed Issue(s)
N/A
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds metrics for outgoing LibP2P RPC requests (total, sent-by-protocol, failed) and updates tests to use labelled counters.
> 
> - **Networking/P2P**:
>   - `RpcHandler` now records outgoing RPC metrics: `rpc_requests_total`, `rpc_requests_sent{protocolId}` and `rpc_requests_failed`.
>   - `LibP2PNetworkBuilder` wires `metricsSystem` into `RpcHandler`.
> - **Metrics/Test Infrastructure**:
>   - `StubMetricsSystem`: adds `getCounterValue(category, name)` overload and centralizes reads via `getLabelledCounterValue(...)`.
>   - Tests updated to use `getLabelledCounterValue(...)` and assert new RPC metrics; minor metric label assertions added across RPC handlers.
> - **Changelog**:
>   - Documents new outgoing LibP2P RPC metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d513c50a1c79277169f8f470c4bc53d85ec7406c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->