### PR TITLE
`ExecutionPayloadEnvelopesByRoot` implementation

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/EarliestBlobSidecarSlotProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/EarliestBlobSidecarSlotProvider.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
+@FunctionalInterface
 public interface EarliestBlobSidecarSlotProvider {
   EarliestBlobSidecarSlotProvider NOOP = () -> SafeFuture.completedFuture(Optional.empty());
 

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/SingleBlobSidecarProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/SingleBlobSidecarProvider.java
@@ -18,6 +18,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 
+@FunctionalInterface
 public interface SingleBlobSidecarProvider {
   SingleBlobSidecarProvider NOOP = (blockRoot, index) -> Optional.empty();
 

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/StateAndBlockSummaryProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/StateAndBlockSummaryProvider.java
@@ -18,6 +18,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 
+@FunctionalInterface
 public interface StateAndBlockSummaryProvider {
   StateAndBlockSummaryProvider NOOP = (root) -> SafeFuture.completedFuture(Optional.empty());
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -304,6 +304,11 @@ public class ChainBuilder {
   }
 
   public Stream<SignedExecutionPayloadAndState> streamExecutionPayloadsAndStates(
+      final UInt64 fromSlot) {
+    return streamExecutionPayloadsAndStates(fromSlot, getLatestSlot());
+  }
+
+  public Stream<SignedExecutionPayloadAndState> streamExecutionPayloadsAndStates(
       final long fromSlot, final long toSlot) {
     return streamExecutionPayloadsAndStates(UInt64.valueOf(fromSlot), UInt64.valueOf(toSlot));
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -86,7 +86,7 @@ public class Eth2PeerFactory {
             "data_column_sidecars"),
         RateTracker.create(
             peerBlocksRateLimit, TIME_OUT, timeProvider, "execution_payload_envelopes"),
-        RateTracker.create(peerRequestLimit, TIME_OUT, timeProvider, "requestTracker"),
+        RateTracker.create(peerRequestLimit, TIME_OUT, timeProvider, "request_tracker"),
         metricsSystem,
         timeProvider);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIds.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIds.java
@@ -72,6 +72,11 @@ public class BeaconChainMethodIds {
     return getMethodId(DATA_COLUMN_SIDECARS_BY_RANGE, version, encoding);
   }
 
+  public static String getExecutionPayloadEnvelopesByRootMethodId(
+      final int version, final RpcEncoding encoding) {
+    return getMethodId(EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT, version, encoding);
+  }
+
   public static String getStatusMethodId(final int version, final RpcEncoding encoding) {
     return getMethodId(STATUS, version, encoding);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -572,8 +572,7 @@ public class BeaconChainMethods {
 
     final ExecutionPayloadEnvelopesByRootMessageHandler
         executionPayloadEnvelopesByRootMessageHandler =
-            new ExecutionPayloadEnvelopesByRootMessageHandler(
-                getSpecConfigGloas(spec), metricsSystem);
+            new ExecutionPayloadEnvelopesByRootMessageHandler(recentChainData, metricsSystem);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandler.java
@@ -13,28 +13,30 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
-
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.RequestKey;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
-import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
-import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
+import tech.pegasys.teku.storage.client.RecentChainData;
 
-// TODO-GLOAS: https://github.com/Consensys/teku/issues/9974
 /**
  * <a
  * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#executionpayloadenvelopesbyroot-v1">ExecutionPayloadEnvelopesByRoot</a>
+ *
+ * <p>Count validation is done as part of {@link ExecutionPayloadEnvelopesByRootRequestMessage}
+ * schema limits
  */
 public class ExecutionPayloadEnvelopesByRootMessageHandler
     extends PeerRequiredLocalMessageHandler<
@@ -42,13 +44,13 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private final SpecConfigGloas config;
+  private final RecentChainData recentChainData;
   private final LabelledMetric<Counter> requestCounter;
   private final Counter totalExecutionPayloadEnvelopesRequestedCounter;
 
   public ExecutionPayloadEnvelopesByRootMessageHandler(
-      final SpecConfigGloas config, final MetricsSystem metricsSystem) {
-    this.config = config;
+      final RecentChainData recentChainData, final MetricsSystem metricsSystem) {
+    this.recentChainData = recentChainData;
     requestCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.NETWORK,
@@ -60,21 +62,6 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
             TekuMetricCategory.NETWORK,
             "rpc_execution_payload_envelopes_by_root_requested_envelopes_total",
             "Total number of execution payload envelopes requested in accepted execution payload envelopes by root requests from peers");
-  }
-
-  @Override
-  public Optional<RpcException> validateRequest(
-      final String protocolId, final ExecutionPayloadEnvelopesByRootRequestMessage request) {
-    if (request.size() > config.getMaxRequestPayloads()) {
-      requestCounter.labels("count_too_big").inc();
-      return Optional.of(
-          new RpcException(
-              INVALID_REQUEST_CODE,
-              String.format(
-                  "Only a maximum of %s execution payload envelopes can be requested per request",
-                  config.getMaxRequestPayloads())));
-    }
-    return Optional.empty();
   }
 
   @Override
@@ -100,6 +87,36 @@ public class ExecutionPayloadEnvelopesByRootMessageHandler
     requestCounter.labels("ok").inc();
     totalExecutionPayloadEnvelopesRequestedCounter.inc(message.size());
 
-    throw new UnsupportedOperationException("Not yet implemented");
+    final AtomicInteger sentExecutionPayloadEnvelopes = new AtomicInteger(0);
+
+    SafeFuture<Void> future = SafeFuture.COMPLETE;
+
+    for (final SszBytes32 beaconBlockRoot : message) {
+      future =
+          future.thenCompose(
+              __ ->
+                  recentChainData
+                      .retrieveSignedExecutionPayloadEnvelopeByBlockRoot(beaconBlockRoot.get())
+                      .thenCompose(
+                          maybeExecutionPayloadEnvelope ->
+                              maybeExecutionPayloadEnvelope
+                                  .map(
+                                      executionPayloadEnvelope ->
+                                          callback
+                                              .respond(executionPayloadEnvelope)
+                                              .thenRun(
+                                                  sentExecutionPayloadEnvelopes::incrementAndGet))
+                                  .orElse(SafeFuture.COMPLETE)));
+    }
+
+    future.finish(
+        () -> {
+          if (sentExecutionPayloadEnvelopes.get() != message.size()) {
+            peer.adjustExecutionPayloadEnvelopesRequest(
+                maybeRequestKey.get(), sentExecutionPayloadEnvelopes.get());
+          }
+          callback.completeSuccessfully();
+        },
+        err -> handleError(err, callback, "execution payload envelopes by root"));
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -53,7 +53,6 @@ import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
-import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class BeaconBlocksByRootMessageHandlerTest {
   private static final RpcEncoding RPC_ENCODING =
@@ -68,7 +67,6 @@ public class BeaconBlocksByRootMessageHandlerTest {
   private final UInt64 altairForkSlot = spec.computeStartSlotAtEpoch(altairForkEpoch);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
   private final ChainUpdater chainUpdater = storageSystem.chainUpdater();
-  final UpdatableStore store = mock(UpdatableStore.class);
   final RecentChainData recentChainData = mock(RecentChainData.class);
   final BeaconBlocksByRootMessageHandler handler =
       new BeaconBlocksByRootMessageHandler(spec, storageSystem.getMetricsSystem(), recentChainData);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRootMessageHandlerTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.peers.RequestKey;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
+import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
+import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRootRequestMessage;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+class ExecutionPayloadEnvelopesByRootMessageHandlerTest {
+
+  private static final RpcEncoding RPC_ENCODING =
+      RpcEncoding.createSszSnappyEncoding(
+          TestSpecFactory.createDefault().getNetworkingConfig().getMaxPayloadSize());
+
+  private static final String V2_PROTOCOL_ID =
+      BeaconChainMethodIds.getExecutionPayloadEnvelopesByRootMethodId(1, RPC_ENCODING);
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+  final ExecutionPayloadEnvelopesByRootMessageHandler handler =
+      new ExecutionPayloadEnvelopesByRootMessageHandler(recentChainData, metricsSystem);
+
+  final Eth2Peer peer = mock(Eth2Peer.class);
+
+  @SuppressWarnings("unchecked")
+  final ResponseCallback<SignedExecutionPayloadEnvelope> callback = mock(ResponseCallback.class);
+
+  @BeforeEach
+  public void setup() {
+    chainBuilder.generateGenesis();
+    when(peer.approveRequest()).thenReturn(true);
+    when(peer.approveExecutionPayloadEnvelopesRequest(any(), anyLong()))
+        .thenReturn(Optional.of(new RequestKey(ZERO, 42)));
+    // Forward execution payload envelope requests from the mock to the ChainBuilder
+    when(recentChainData.retrieveSignedExecutionPayloadEnvelopeByBlockRoot(any()))
+        .thenAnswer(
+            i -> SafeFuture.completedFuture(chainBuilder.getExecutionPayload(i.getArgument(0))));
+    when(callback.respond(any())).thenReturn(SafeFuture.COMPLETE);
+  }
+
+  @Test
+  public void checkPeerIsRateLimited_requestNotApproved() {
+    when(peer.approveRequest()).thenReturn(false);
+
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = buildChain(2);
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromExecutionPayloadEnvelopes(executionPayloadEnvelopes);
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    // Requesting 2 execution payload envelopes
+    verify(peer).approveExecutionPayloadEnvelopesRequest(any(), eq(2L));
+
+    verify(callback, never()).completeSuccessfully();
+    verify(callback, never()).respond(any());
+
+    // verify counters
+    assertThat(getRequestCounterValueForLabel("rate_limited")).isOne();
+    assertThat(getRequestCounterValueForLabel("ok")).isZero();
+  }
+
+  @Test
+  public void checkPeerIsRateLimited_noRequestKey() {
+    when(peer.approveExecutionPayloadEnvelopesRequest(eq(callback), eq(2L)))
+        .thenReturn(Optional.empty());
+
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = buildChain(2);
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromExecutionPayloadEnvelopes(executionPayloadEnvelopes);
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    verify(callback, never()).completeSuccessfully();
+    verify(callback, never()).respond(any());
+
+    // verify counters
+    assertThat(getRequestCounterValueForLabel("rate_limited")).isOne();
+    assertThat(getRequestCounterValueForLabel("ok")).isZero();
+  }
+
+  @Test
+  public void onIncomingMessage_respondsWithAllExecutionPayloadEnvelopes() {
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = buildChain(5);
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromExecutionPayloadEnvelopes(executionPayloadEnvelopes);
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    // Requesting 5 execution payload envelopes
+    verify(peer)
+        .approveExecutionPayloadEnvelopesRequest(
+            any(), eq(Long.valueOf(executionPayloadEnvelopes.size())));
+    // Sending 5 execution payload envelopes: No rate limiter adjustment required
+    verify(peer, never()).adjustExecutionPayloadEnvelopesRequest(any(), anyLong());
+
+    verify(callback, times(5)).respond(any());
+
+    for (final SignedExecutionPayloadEnvelope executionPayloadEnvelope :
+        executionPayloadEnvelopes) {
+      verify(callback).respond(executionPayloadEnvelope);
+    }
+
+    verify(callback).completeSuccessfully();
+
+    // verify counters
+    assertThat(getRequestCounterValueForLabel("ok")).isOne();
+    assertThat(getExecutionPayloadEnvelopesRequestedCounterValue()).isEqualTo(5);
+  }
+
+  @Test
+  public void onIncomingMessage_respondsWithSomeOfTheExecutionPayloadEnvelopes() {
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = buildChain(4);
+
+    final List<Bytes32> beaconBlockRoots =
+        new ArrayList<>(
+            executionPayloadEnvelopes.stream()
+                .map(SignedExecutionPayloadEnvelope::getMessage)
+                .map(ExecutionPayloadEnvelope::getBeaconBlockRoot)
+                .toList());
+
+    beaconBlockRoots.add(Bytes32.random());
+
+    final ExecutionPayloadEnvelopesByRootRequestMessage message =
+        createRequestFromBeaconBlockRoots(beaconBlockRoots);
+    handler.onIncomingMessage(V2_PROTOCOL_ID, peer, message, callback);
+
+    // Requesting 5 execution payload envelopes
+    verify(peer).approveExecutionPayloadEnvelopesRequest(any(), eq(5L));
+    // Sending 4 execution payload envelopes: Rate limiter adjustment required
+    verify(peer).adjustExecutionPayloadEnvelopesRequest(any(), eq(4L));
+
+    verify(callback, times(4)).respond(any());
+
+    for (final SignedExecutionPayloadEnvelope executionPayloadEnvelope :
+        executionPayloadEnvelopes) {
+      verify(callback).respond(executionPayloadEnvelope);
+    }
+
+    verify(callback).completeSuccessfully();
+
+    // verify counters
+    assertThat(getRequestCounterValueForLabel("ok")).isOne();
+    assertThat(getExecutionPayloadEnvelopesRequestedCounterValue()).isEqualTo(5);
+  }
+
+  private ExecutionPayloadEnvelopesByRootRequestMessage createRequestFromExecutionPayloadEnvelopes(
+      final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes) {
+    final List<Bytes32> beaconBlockRoots =
+        executionPayloadEnvelopes.stream()
+            .map(SignedExecutionPayloadEnvelope::getMessage)
+            .map(ExecutionPayloadEnvelope::getBeaconBlockRoot)
+            .toList();
+    return createRequestFromBeaconBlockRoots(beaconBlockRoots);
+  }
+
+  private ExecutionPayloadEnvelopesByRootRequestMessage createRequestFromBeaconBlockRoots(
+      final List<Bytes32> beaconBlockRoots) {
+    return new ExecutionPayloadEnvelopesByRootRequestMessage(
+        SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
+            .getExecutionPayloadEnvelopesByRootRequestMessageSchema(),
+        beaconBlockRoots);
+  }
+
+  private List<SignedExecutionPayloadEnvelope> buildChain(final int chainSize) {
+    // Create some blocks to request
+    final UInt64 latestSlot = chainBuilder.getLatestSlot();
+    chainBuilder.generateBlocksUpToSlot(latestSlot.plus(chainSize));
+
+    return chainBuilder
+        .streamExecutionPayloadsAndStates(latestSlot.plus(1))
+        .map(SignedExecutionPayloadAndState::executionPayload)
+        .toList();
+  }
+
+  private long getRequestCounterValueForLabel(final String label) {
+    return metricsSystem.getLabelledCounterValue(
+        TekuMetricCategory.NETWORK,
+        "rpc_execution_payload_envelopes_by_root_requests_total",
+        label);
+  }
+
+  private long getExecutionPayloadEnvelopesRequestedCounterValue() {
+    return metricsSystem.getCounterValue(
+        TekuMetricCategory.NETWORK,
+        "rpc_execution_payload_envelopes_by_root_requested_envelopes_total");
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -651,6 +652,15 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
 
   public Optional<SignedBeaconBlock> getRecentlyValidatedSignedBlockByRoot(final Bytes32 root) {
     return validatedBlockProvider.getBlock(root);
+  }
+
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>>
+      retrieveSignedExecutionPayloadEnvelopeByBlockRoot(final Bytes32 beaconBlockRoot) {
+    if (store == null) {
+      return EmptyStoreResults.EMPTY_SIGNED_EXECUTION_PAYLOAD_ENVELOPE_FUTURE;
+    }
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
   }
 
   public SafeFuture<Optional<BeaconState>> retrieveBlockState(final Bytes32 blockRoot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public abstract class EmptyStoreResults {
@@ -41,4 +42,7 @@ public abstract class EmptyStoreResults {
 
   public static final SafeFuture<Optional<UInt64>> NO_EARLIEST_BLOB_SIDECAR_SLOT_FUTURE =
       SafeFuture.completedFuture(Optional.empty());
+
+  public static final SafeFuture<Optional<SignedExecutionPayloadEnvelope>>
+      EMPTY_SIGNED_EXECUTION_PAYLOAD_ENVELOPE_FUTURE = SafeFuture.completedFuture(Optional.empty());
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#executionpayloadenvelopesbyroot-v1

Integration test can be only done after the storage changes. It is captured in #9974 as a task.

## Fixed Issue(s)
related to #9974 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements the `execution_payload_envelopes_by_root` RPC, wiring it through method IDs and BeaconChainMethods with a new message handler, metrics, rate-limiting, tests, and a storage stub retrieval API.
> 
> - **Networking/RPC**:
>   - **New RPC**: Implements `EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT` handler `ExecutionPayloadEnvelopesByRootMessageHandler` that retrieves envelopes via `RecentChainData`, streams responses, adjusts rate limits, and records metrics.
>   - **Wiring**: Adds method ID helper `getExecutionPayloadEnvelopesByRootMethodId` and registers the method in `BeaconChainMethods` using fork-digest context; handler now constructed with `recentChainData`.
>   - **Refactor**: Simplifies response flow in `BeaconBlocksByRootMessageHandler` (no behavior change).
>   - **Metrics**: Renames peer request tracker label to `request_tracker` in `Eth2PeerFactory`.
> - **Storage**:
>   - Adds `RecentChainData.retrieveSignedExecutionPayloadEnvelopeByBlockRoot(...)` (currently unimplemented TODO) and corresponding empty future in `EmptyStoreResults`.
> - **Testing**:
>   - Adds `ExecutionPayloadEnvelopesByRootMessageHandlerTest` covering rate-limiting, full/partial responses.
>   - Updates `ChainBuilder` with `streamExecutionPayloadsAndStates(UInt64 fromSlot)` to support tests.
> - **Misc**:
>   - Marks provider interfaces as `@FunctionalInterface`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac46244bd07086b8591c67629fcb24afe115d876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->