### PR TITLE
Pass data config to the StorageConfiguration

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
+import tech.pegasys.teku.service.serviceutils.layout.DataConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -972,14 +973,15 @@ public class DebugDbCommand implements Runnable {
     final Eth2NetworkConfiguration networkConfiguration =
         eth2NetworkOptions.getNetworkConfiguration();
     final Spec spec = networkConfiguration.getSpec();
+    final DataConfig dataConfig = beaconNodeDataOptions.getDataConfig();
     final VersionedDatabaseFactory databaseFactory =
         new VersionedDatabaseFactory(
             new NoOpMetricsSystem(),
-            DataDirLayout.createFrom(beaconNodeDataOptions.getDataConfig())
-                .getBeaconDataDirectory(),
+            DataDirLayout.createFrom(dataConfig).getBeaconDataDirectory(),
             StorageConfiguration.builder()
                 .eth1DepositContract(networkConfiguration.getEth1DepositContractAddress())
                 .specProvider(spec)
+                .dataConfig(dataConfig)
                 .build(),
             Optional.empty());
     return databaseFactory.createDatabase();


### PR DESCRIPTION
StorageConfiguration was overriding database parameters when using debug-tools, this will ensure it's reading from current configuration files.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure debug DB initialization uses current DataConfig for both data dir layout and StorageConfiguration.
> 
> - **Debug tools**:
>   - In `DebugDbCommand#createDatabase`, propagate `DataConfig` from `BeaconNodeDataOptions` to:
>     - `DataDirLayout.createFrom(dataConfig).getBeaconDataDirectory()`
>     - `StorageConfiguration.builder().dataConfig(dataConfig)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22bb301479f72832beed94e7fb90635deae39a4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->