### PR TITLE
added integrationTest for GetProposerDuties

### DIFF
--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     integrationTestImplementation project(':ethereum:weaksubjectivity')
 
     integrationTestImplementation project(':networking:p2p')
+    integrationTestImplementation project(':ethereum:performance-trackers')
     integrationTestImplementation 'com.squareup.okhttp3:okhttp'
     integrationTestImplementation 'org.jsoup:jsoup'
     integrationTestImplementation testFixtures(project(':ethereum:statetransition'))

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -39,12 +39,17 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.NetworkDataProvider;
+import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.api.RewardCalculator;
 import tech.pegasys.teku.beacon.sync.SyncService;
+import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionAndPublishingPerformanceFactory;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -53,6 +58,8 @@ import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.networking.eth2.gossip.subnets.AttestationTopicSubscriber;
+import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubscriptionManager;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -71,12 +78,17 @@ import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
+import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.validation.SignedBlsToExecutionChangeValidator;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
@@ -88,7 +100,15 @@ import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.coordinator.ActiveValidatorTracker;
+import tech.pegasys.teku.validator.coordinator.BlockFactory;
+import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 import tech.pegasys.teku.validator.coordinator.Eth1DataProvider;
+import tech.pegasys.teku.validator.coordinator.ExecutionPayloadFactory;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
+import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
+import tech.pegasys.teku.validator.coordinator.publisher.BlockPublisher;
+import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisher;
 
 @SuppressWarnings("unchecked")
 public abstract class AbstractDataBackedRestAPIIntegrationTest {
@@ -119,7 +139,8 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   // Mocks
   protected final Eth2P2PNetwork eth2P2PNetwork = mock(Eth2P2PNetwork.class);
   protected final SyncService syncService = mock(SyncService.class);
-  protected final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  protected ValidatorApiHandler validatorApiHandler = mock(ValidatorApiHandler.class);
+  protected ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
   protected final EventChannels eventChannels = mock(EventChannels.class);
   protected final AggregatingAttestationPool attestationPool =
       mock(AggregatingAttestationPool.class);
@@ -128,6 +149,34 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
   protected final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
 
+  protected final BlockProductionAndPublishingPerformanceFactory
+      blockProductionAndPublishingFactory =
+          mock(BlockProductionAndPublishingPerformanceFactory.class);
+  protected final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
+  protected final NodeDataProvider nodeDataProvider = mock(NodeDataProvider.class);
+  protected final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
+  protected final SyncStateProvider syncStateProvider = mock(SyncStateProvider.class);
+  protected final BlockFactory blockFactory = mock(BlockFactory.class);
+  protected final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
+  protected final SyncCommitteeMessagePool syncCommitteeMessagePool =
+      mock(SyncCommitteeMessagePool.class);
+  protected final BlockPublisher blockPublisher = mock(BlockPublisher.class);
+  protected final AttestationTopicSubscriber attestationTopicSubscriber =
+      mock(AttestationTopicSubscriber.class);
+  protected final ActiveValidatorTracker activeValidatorTracker =
+      mock(ActiveValidatorTracker.class);
+  protected final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
+  protected final PerformanceTracker performanceTracker = mock(PerformanceTracker.class);
+  protected final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager =
+      mock(SyncCommitteeSubscriptionManager.class);
+  protected final PayloadAttestationPool payloadAttestationPool = PayloadAttestationPool.NOOP;
+  protected final ExecutionPayloadManager executionPayloadManager =
+      mock(ExecutionPayloadManager.class);
+  protected final ExecutionPayloadFactory executionPayloadFactory =
+      mock(ExecutionPayloadFactory.class);
+  protected final ExecutionPayloadPublisher executionPayloadPublisher =
+      mock(ExecutionPayloadPublisher.class);
+  protected final ExecutionProofManager executionProofManager = mock(ExecutionProofManager.class);
   protected RewardCalculator rewardCalculator = mock(RewardCalculator.class);
 
   protected OperationPool<SignedBlsToExecutionChange> blsToExecutionChangePool;
@@ -258,6 +307,41 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
     setupStorage(StateStorageMode.ARCHIVE, false, SpecMilestone.PHASE0);
     // Start API
     setupAndStartRestAPI(config);
+  }
+
+  protected void startRestApiAtGenesisWithValidatorApiHandler(final SpecMilestone specMilestone) {
+
+    setupStorage(StateStorageMode.ARCHIVE, false, specMilestone, true);
+    validatorApiHandler =
+        new ValidatorApiHandler(
+            chainDataProvider,
+            nodeDataProvider,
+            networkDataProvider,
+            storageSystem.combinedChainDataClient(),
+            syncStateProvider,
+            blockFactory,
+            attestationPool,
+            attestationManager,
+            attestationTopicSubscriber,
+            activeValidatorTracker,
+            dutyMetrics,
+            performanceTracker,
+            spec,
+            forkChoiceTrigger,
+            proposersDataManager,
+            syncCommitteeMessagePool,
+            syncCommitteeContributionPool,
+            syncCommitteeSubscriptionManager,
+            blockProductionAndPublishingFactory,
+            blockPublisher,
+            payloadAttestationPool,
+            executionPayloadManager,
+            executionPayloadFactory,
+            executionPayloadPublisher,
+            executionProofManager);
+    validatorApiChannel = validatorApiHandler;
+    chainUpdater.initializeGenesis();
+    setupAndStartRestAPI();
   }
 
   protected void startRestAPIAtGenesis(final SpecMilestone specMilestone) {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import okhttp3.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beacon.sync.events.SyncState;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetProposerDuties;
+import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+
+public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
+
+  // epoch | 0                   | 1
+  // slot  | 1  2  3  4  5  6  7 | 8
+  // query |                     | ^
+  // dep   |                   D |
+  // EXPECT epoch 1 duties with dependent root slot 7
+  private static final Logger LOG = LogManager.getLogger();
+
+  @Test
+  void shouldReturnCorrectDependentRootPreFulu() throws IOException {
+    startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.ALTAIR);
+    final List<SignedBlockAndState> chain = createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7, 8);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    final Response response = getProposerDuties("1");
+    final String responseBody = response.body().string();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
+  }
+
+  // epoch | 0                   | 1
+  // slot  | 1  2  3  4  5  6  7 |
+  // query |                   ^ |
+  // dep   |                   D |
+  // EXPECT - should be able to query for the next epoch, may not be stable if its too early.
+  @Test
+  void shouldReturnNextEpochDutiesBeforeEpochTransition() throws IOException {
+    startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.ALTAIR);
+    final List<SignedBlockAndState> chain = createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    final Response response = getProposerDuties("1");
+    final String responseBody = response.body().string();
+    logChainData(chain);
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getRoot());
+  }
+
+  // epoch | 0                   | 1                      | 2
+  // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
+  // query |                     |                        |  ^
+  // dep   |                     |                      D |
+  // EXPECT - expect epoch 2 duties with dependent root slot 15
+  @Test
+  void shouldReturnCorrectDependentRootPreFuluExtraSlots() throws IOException {
+    startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.BELLATRIX);
+    final List<SignedBlockAndState> chain =
+        createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+
+    logChainData(chain);
+    final Response response = getProposerDuties("2");
+    final String responseBody = response.body().string();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
+  }
+
+  // epoch | 0                   | 1                      | 2
+  // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
+  // query |                     |                        |  ^
+  // dep   |                     |                      D |
+  // EXPECT - expect epoch 2 duties with dependent root slot 15
+  @Test
+  void shouldReturnCorrectDependentRootPostFulu() throws IOException {
+    startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
+    final List<SignedBlockAndState> chain = createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7, 8);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    final Response response = getProposerDuties("1");
+    final String responseBody = response.body().string();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
+  }
+
+  @Test
+  void shouldReturnCorrectDependentRootPostFuluExtraSlots() throws IOException {
+    startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
+    final List<SignedBlockAndState> chain =
+        createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    logChainData(chain);
+    final Response response = getProposerDuties("1");
+    final String responseBody = response.body().string();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.get(6).getRoot());
+  }
+
+  // epoch | 0                   | 1                      | 2
+  // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 |
+  // query |                     |                      ^ |
+  // dep   |                     |                      D |
+  // EXPECT - expect epoch 2 duties with dependent root slot 15
+  @Test
+  void shouldReturnCorrectDependentRootPostFuluExtraSlots2() throws IOException {
+    startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
+    final List<SignedBlockAndState> chain =
+        createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+
+    logChainData(chain);
+    final Response response = getProposerDuties("2");
+    final String responseBody = response.body().string();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getRoot());
+  }
+
+  // epoch | 0                   | 1                      | 2
+  // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
+  // query |                     |                        |  ^
+  // dep   |                     |                      D |
+  // EXPECT - expect epoch 2 duties with dependent root slot 15
+  @Test
+  void shouldReturnCorrectDependentRootSecondEpoch() throws IOException {
+    startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
+    final List<SignedBlockAndState> chain =
+        createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    logChainData(chain);
+    final Response response = getProposerDuties("2");
+    final String responseBody = response.body().string();
+    assertThat(response.code()).isEqualTo(200);
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
+  }
+
+  final Bytes32 dependentRoot(final String responseBody) {
+    try {
+      final JsonNode jsonNode = JsonTestUtil.parseAsJsonNode(responseBody);
+      return Bytes32.fromHexString(jsonNode.get("dependent_root").asText());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Response getProposerDuties(final String epoch) throws IOException {
+    return getResponse(GetProposerDuties.ROUTE.replace("{epoch}", epoch));
+  }
+
+  private void logChainData(final List<SignedBlockAndState> chain) {
+    chain.forEach(
+        signedBlockAndState ->
+            LOG.info(
+                "SLOT: {}, root: {}, ROOT: {}",
+                signedBlockAndState.getSlot(),
+                signedBlockAndState.getRoot(),
+                signedBlockAndState.getBlock().getRoot()));
+  }
+}


### PR DESCRIPTION
This was from the proposers change I had reverted, going to import bit by bit.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds integration tests for `v1/validator/proposer_duties` and updates the integration test harness to instantiate `ValidatorApiHandler` with required mocks.
> 
> - **Tests**:
>   - Add `GetProposerDutiesIntegrationTest` verifying `dependent_root` across epochs and milestones (`ALTAIR`, `BELLATRIX`, `FULU`).
> - **Test Infrastructure**:
>   - Extend `AbstractDataBackedRestAPIIntegrationTest` to construct and use `ValidatorApiHandler` (`startRestApiAtGenesisWithValidatorApiHandler`) with new mocks (`ChainDataProvider`, `SyncStateProvider`, `BlockFactory`, `ForkChoiceTrigger`, publishing/performance components, execution payload/proof managers, etc.).
>   - Enable storing non-canonical blocks in setup where needed.
> - **Build**:
>   - Add `integrationTestImplementation` dependency on `:ethereum:performance-trackers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43ce6d858276151ed3ca1e3bd9b8984b106f16e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->