### PR TITLE
Return a result object instead of void when publishing execution payload

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -115,6 +115,7 @@ import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -987,9 +988,16 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   }
 
   @Override
-  public SafeFuture<Void> publishSignedExecutionPayload(
+  public SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
-    return executionPayloadPublisher.publishSignedExecutionPayload(signedExecutionPayload);
+    return executionPayloadPublisher
+        .publishSignedExecutionPayload(signedExecutionPayload)
+        .exceptionally(
+            ex -> {
+              final String reason = getRootCauseMessage(ex);
+              return PublishSignedExecutionPayloadResult.rejected(
+                  signedExecutionPayload.getBeaconBlockRoot(), reason);
+            });
   }
 
   private Optional<SubmitDataError> fromInternalValidationResult(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisher.java
@@ -15,19 +15,17 @@ package tech.pegasys.teku.validator.coordinator.publisher;
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 
 /** Used to publish execution payload and data column sidecars */
 public interface ExecutionPayloadPublisher {
 
   ExecutionPayloadPublisher NOOP =
-      new ExecutionPayloadPublisher() {
-        @Override
-        public SafeFuture<Void> publishSignedExecutionPayload(
-            final SignedExecutionPayloadEnvelope signedExecutionPayload) {
-          return SafeFuture.COMPLETE;
-        }
-      };
+      signedExecutionPayload ->
+          SafeFuture.completedFuture(
+              PublishSignedExecutionPayloadResult.success(
+                  signedExecutionPayload.getBeaconBlockRoot()));
 
-  SafeFuture<Void> publishSignedExecutionPayload(
+  SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
       SignedExecutionPayloadEnvelope signedExecutionPayload);
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -123,6 +123,7 @@ import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
@@ -1340,12 +1341,29 @@ class ValidatorApiHandlerTest {
   public void publishSignedExecutionPayload_shouldPublish() {
     final SignedExecutionPayloadEnvelope signedExecutionPayload =
         dataStructureUtil.randomSignedExecutionPayloadEnvelope(5);
+    final PublishSignedExecutionPayloadResult publishResult =
+        PublishSignedExecutionPayloadResult.success(signedExecutionPayload.getBeaconBlockRoot());
     when(executionPayloadPublisher.publishSignedExecutionPayload(eq(signedExecutionPayload)))
-        .thenReturn(SafeFuture.COMPLETE);
-    final SafeFuture<Void> result =
-        validatorApiHandler.publishSignedExecutionPayload(signedExecutionPayload);
+        .thenReturn(SafeFuture.completedFuture(publishResult));
 
-    assertThat(result).isCompleted();
+    assertThat(validatorApiHandler.publishSignedExecutionPayload(signedExecutionPayload))
+        .isCompletedWithValue(publishResult);
+
+    verify(executionPayloadPublisher).publishSignedExecutionPayload(signedExecutionPayload);
+  }
+
+  @Test
+  public void publishSignedExecutionPayload_shouldHandleExceptions() {
+    final SignedExecutionPayloadEnvelope signedExecutionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(5);
+    final PublishSignedExecutionPayloadResult failedResult =
+        PublishSignedExecutionPayloadResult.rejected(
+            signedExecutionPayload.getBeaconBlockRoot(), "oopsy");
+    when(executionPayloadPublisher.publishSignedExecutionPayload(eq(signedExecutionPayload)))
+        .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")));
+
+    assertThat(validatorApiHandler.publishSignedExecutionPayload(signedExecutionPayload))
+        .isCompletedWithValue(failedResult);
 
     verify(executionPayloadPublisher).publishSignedExecutionPayload(signedExecutionPayload);
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisherGloasTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/ExecutionPayloadPublisherGloasTest.java
@@ -13,14 +13,14 @@
 
 package tech.pegasys.teku.validator.coordinator.publisher;
 
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.networking.eth2.gossip.DataColumnSidecarGossipChannel;
@@ -29,10 +29,11 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.coordinator.ExecutionPayloadFactory;
 
 class ExecutionPayloadPublisherGloasTest {
@@ -64,30 +65,37 @@ class ExecutionPayloadPublisherGloasTest {
 
   @BeforeEach
   public void setUp() {
+    when(executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
     when(executionPayloadFactory.createDataColumnSidecars(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(dataColumnSidecars));
     when(executionPayloadGossipChannel.publishExecutionPayload(signedExecutionPayload))
         .thenReturn(SafeFuture.COMPLETE);
-    when(executionPayloadManager.importExecutionPayload(signedExecutionPayload))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                ExecutionPayloadImportResult.successful(signedExecutionPayload)));
   }
 
   @Test
-  public void publishSignedExecutionPayload_shouldPublishImmediatelyAndImport() {
+  public void publishSignedExecutionPayload_shouldValidateAndPublish() {
     SafeFutureAssert.assertThatSafeFuture(
             executionPayloadPublisher.publishSignedExecutionPayload(signedExecutionPayload))
-        .isCompleted();
+        .isCompletedWithValue(
+            PublishSignedExecutionPayloadResult.success(
+                signedExecutionPayload.getBeaconBlockRoot()));
 
-    final InOrder inOrder =
-        inOrder(
-            executionPayloadGossipChannel, dataColumnSidecarGossipChannel, executionPayloadManager);
-
-    inOrder.verify(executionPayloadGossipChannel).publishExecutionPayload(signedExecutionPayload);
-    inOrder
-        .verify(dataColumnSidecarGossipChannel)
+    verify(executionPayloadGossipChannel).publishExecutionPayload(signedExecutionPayload);
+    verify(dataColumnSidecarGossipChannel)
         .publishDataColumnSidecars(dataColumnSidecars, RemoteOrigin.LOCAL_PROPOSAL);
-    inOrder.verify(executionPayloadManager).importExecutionPayload(signedExecutionPayload);
+  }
+
+  @Test
+  public void publishSignedExecutionPayload_shouldReturnRejectedResultIfGossipValidationFails() {
+    when(executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.reject("oopsy")));
+    SafeFutureAssert.assertThatSafeFuture(
+            executionPayloadPublisher.publishSignedExecutionPayload(signedExecutionPayload))
+        .isCompletedWithValue(
+            PublishSignedExecutionPayloadResult.rejected(
+                signedExecutionPayload.getBeaconBlockRoot(), "Failed gossip validation: oopsy"));
+
+    verifyNoInteractions(executionPayloadGossipChannel, dataColumnSidecarGossipChannel);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.epbs.versions.gloas;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
@@ -51,6 +52,10 @@ public class SignedExecutionPayloadEnvelope
 
   public UInt64 getSlot() {
     return getMessage().getSlot();
+  }
+
+  public Bytes32 getBeaconBlockRoot() {
+    return getMessage().getBeaconBlockRoot();
   }
 
   public SlotAndBlockRoot getSlotAndBlockRoot() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -66,6 +67,15 @@ public interface MutableStore extends ReadOnlyStore {
         Optional.of(blobSidecars),
         Optional.empty());
   }
+
+  /**
+   * Stores the corresponding data for this execution payload
+   *
+   * @param executionPayload Execution payload
+   * @param state Corresponding state
+   */
+  void putExecutionPayloadAndState(
+      SignedExecutionPayloadEnvelope executionPayload, BeaconState state);
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/execution/AbstractExecutionPayloadProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/execution/AbstractExecutionPayloadProcessor.java
@@ -47,7 +47,7 @@ public abstract class AbstractExecutionPayloadProcessor implements ExecutionPayl
               "State transition error while importing execution payload (builder index: %s, slot: %s, block root: %s)",
               signedEnvelope.getMessage().getBuilderIndex(),
               signedEnvelope.getMessage().getSlot(),
-              signedEnvelope.getMessage().getBeaconBlockRoot()),
+              signedEnvelope.getBeaconBlockRoot()),
           ex);
       throw new StateTransitionException(ex);
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -548,4 +548,9 @@ public class ForkChoiceUtil {
   public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
     return AvailabilityChecker.NOOP;
   }
+
+  public AvailabilityChecker<?> createAvailabilityChecker(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    return AvailabilityChecker.NOOP;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -40,15 +40,21 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
       final MutableStore store,
       final SignedExecutionPayloadEnvelope signedEnvelope,
       final BeaconState postState) {
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878
+    // Add new execution payload to store
+    store.putExecutionPayloadAndState(signedEnvelope, postState);
   }
 
+  // Checking of blob data availability is delayed until the processing of the execution payload
   @Override
   public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
-    // TODO-GLOAS: in ePBS, data availability is delayed until the processing of the execution
-    // payload.
-    // We may have a dedicated availability checker for the execution stage.
-    // If it will be the case, this will remain a NOOP
-    return AvailabilityChecker.NOOP;
+    return AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
+  }
+
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 add a real data availability check
+  // (not required for devnet-0)
+  @Override
+  public AvailabilityChecker<?> createAvailabilityChecker(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    return AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -278,7 +279,8 @@ class ForkChoiceUtilTest {
 
   @ParameterizedTest
   @EnumSource(SpecMilestone.class)
-  void createAvailabilityChecker_shouldCreateExpectedChecker(final SpecMilestone milestone) {
+  void createAvailabilityChecker_shouldCreateExpectedCheckerForBlock(
+      final SpecMilestone milestone) {
     final Spec spec = TestSpecFactory.createMinimal(milestone);
     final ForkChoiceUtil util = spec.getGenesisSpec().getForkChoiceUtil();
     @SuppressWarnings("unchecked")
@@ -304,7 +306,35 @@ class ForkChoiceUtilTest {
           verify(blobSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
       case FULU ->
           verify(dataColumnSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
-      case GLOAS -> assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP); // TODO
+      case GLOAS ->
+          assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR);
+      default -> throw new IllegalStateException("Unexpected milestone " + milestone);
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(SpecMilestone.class)
+  void createAvailabilityChecker_shouldCreateExpectedCheckerForExecutionPayload(
+      final SpecMilestone milestone) {
+    final Spec spec = TestSpecFactory.createMinimal(milestone);
+    final ForkChoiceUtil util = spec.getGenesisSpec().getForkChoiceUtil();
+
+    final SignedExecutionPayloadEnvelope executionPayload =
+        mock(SignedExecutionPayloadEnvelope.class);
+
+    spec.reinitializeForTesting(
+        AvailabilityCheckerFactory.NOOP_BLOB_SIDECAR,
+        AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
+        KZG.DISABLED);
+
+    final AvailabilityChecker<?> availabilityChecker =
+        util.createAvailabilityChecker(executionPayload);
+
+    switch (milestone) {
+      case PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA, FULU ->
+          assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP);
+      case GLOAS ->
+          assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR);
       default -> throw new IllegalStateException("Unexpected milestone " + milestone);
     }
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -77,7 +78,9 @@ public class TestStoreFactory {
         new HashMap<>(),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        new HashMap<>(),
+        new HashMap<>());
   }
 
   private AnchorPoint createAnchorForGenesis() {
@@ -99,6 +102,8 @@ public class TestStoreFactory {
     Map<Checkpoint, BeaconState> checkpointStates = new HashMap<>();
     Map<UInt64, VoteTracker> votes = new HashMap<>();
     Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars = new HashMap<>();
+    Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads = new HashMap<>();
+    Map<Bytes32, BeaconState> executionPayloadStates = new HashMap<>();
 
     blocks.put(anchorRoot, anchor.getSignedBeaconBlock().orElseThrow());
     blockStates.put(anchorRoot, anchorState);
@@ -124,7 +129,9 @@ public class TestStoreFactory {
         blobSidecars,
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        executionPayloads,
+        executionPayloadStates);
   }
 
   private BeaconState createRandomGenesisState() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -56,7 +57,10 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Optional<UInt64> earliestBlobSidecarSlot;
   protected Optional<Bytes32> latestCanonicalBlockRoot;
   protected Optional<UInt64> custodyGroupCount;
+  protected Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads;
+  protected Map<Bytes32, BeaconState> executionPayloadStates;
   protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
+
   protected final TestReadOnlyForkChoiceStrategy forkChoiceStrategy =
       new TestReadOnlyForkChoiceStrategy();
 
@@ -76,7 +80,9 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot,
       final Optional<Bytes32> maybeLatestCanonicalBlockRoot,
-      final Optional<UInt64> maybeCustodyGroupCount) {
+      final Optional<UInt64> maybeCustodyGroupCount,
+      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads,
+      final Map<Bytes32, BeaconState> executionPayloadStates) {
     this.spec = spec;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
@@ -93,6 +99,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     this.earliestBlobSidecarSlot = maybeEarliestBlobSidecarSlot;
     this.latestCanonicalBlockRoot = maybeLatestCanonicalBlockRoot;
     this.custodyGroupCount = maybeCustodyGroupCount;
+    this.executionPayloads = executionPayloads;
+    this.executionPayloadStates = executionPayloadStates;
   }
 
   // Readonly methods
@@ -302,6 +310,14 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     if (earliestBlobSidecarSlot.isEmpty()) {
       earliestBlobSidecarSlot = maybeEarliestBlobSidecarSlot;
     }
+  }
+
+  @Override
+  public void putExecutionPayloadAndState(
+      final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    executionPayloads.put(beaconBlockRoot, executionPayload);
+    executionPayloadStates.put(beaconBlockRoot, state);
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -163,10 +163,7 @@ public class ChainBuilder {
     executionPayloads.putAll(existingExecutionPayloads);
     existingExecutionPayloads
         .values()
-        .forEach(
-            e ->
-                executionPayloadsByHash.put(
-                    e.executionPayload().getMessage().getBeaconBlockRoot(), e));
+        .forEach(e -> executionPayloadsByHash.put(e.executionPayload().getBeaconBlockRoot(), e));
   }
 
   public static ChainBuilder create(final Spec spec) {
@@ -678,7 +675,7 @@ public class ChainBuilder {
     executionPayloads.put(
         executionPayload.executionPayload().getMessage().getSlot(), executionPayload);
     executionPayloadsByHash.put(
-        executionPayload.executionPayload().getMessage().getBeaconBlockRoot(), executionPayload);
+        executionPayload.executionPayload().getBeaconBlockRoot(), executionPayload);
   }
 
   private SignedBlockAndState appendNewBlockToChain(final UInt64 slot, final BlockOptions options) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -90,15 +90,16 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
         .runAsync(() -> forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
         .thenPeek(
             result -> {
-              if (!result.isSuccessful()) {
+              if (result.isSuccessful()) {
+                LOG.debug(
+                    "Successfully imported execution payload {}",
+                    signedExecutionPayload::toLogString);
+              } else {
                 LOG.debug(
                     "Failed to import execution payload for reason {}: {}",
                     result::getFailureReason,
                     signedExecutionPayload::toLogString);
               }
-              LOG.debug(
-                  "Successfully imported execution payload {}",
-                  signedExecutionPayload::toLogString);
             })
         .exceptionally(
             ex -> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -82,22 +82,10 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
     return validationResult;
   }
 
-  @Override
-  public SafeFuture<ExecutionPayloadImportResult> importExecutionPayload(
-      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
-    return doImportExecutionPayload(signedExecutionPayload)
-        .thenPeek(
-            result -> {
-              if (result.isSuccessful()) {
-                LOG.trace("Imported execution payload: {}", signedExecutionPayload);
-              }
-            });
-  }
-
   private SafeFuture<ExecutionPayloadImportResult> doImportExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     // cache the seen `beacon_block_root`
-    recentSeenExecutionPayloads.add(signedExecutionPayload.getMessage().getBeaconBlockRoot());
+    recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
     return asyncRunner
         .runAsync(() -> forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
         .thenPeek(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -18,7 +18,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public interface ExecutionPayloadManager {
@@ -26,7 +25,7 @@ public interface ExecutionPayloadManager {
   ExecutionPayloadManager NOOP =
       new ExecutionPayloadManager() {
         @Override
-        public boolean isExecutionPayloadRecentlySeen(Bytes32 beaconBlockRoot) {
+        public boolean isExecutionPayloadRecentlySeen(final Bytes32 beaconBlockRoot) {
           return false;
         }
 
@@ -36,24 +35,25 @@ public interface ExecutionPayloadManager {
             final Optional<UInt64> arrivalTimestamp) {
           return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
         }
-
-        @Override
-        public SafeFuture<ExecutionPayloadImportResult> importExecutionPayload(
-            final SignedExecutionPayloadEnvelope signedExecutionPayload) {
-          return SafeFuture.completedFuture(
-              ExecutionPayloadImportResult.successful(signedExecutionPayload));
-        }
       };
 
   /**
    * {@link SignedExecutionPayloadEnvelope} has been recently seen referencing the block. This
    * method is used for the `payload_present` vote.
    */
-  boolean isExecutionPayloadRecentlySeen(final Bytes32 beaconBlockRoot);
+  boolean isExecutionPayloadRecentlySeen(Bytes32 beaconBlockRoot);
 
+  /**
+   * Performs gossip validation on the {@code signedExecutionPayload} and imports it async if
+   * accepted
+   *
+   * @return the gossip validation result
+   */
   SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
       SignedExecutionPayloadEnvelope signedExecutionPayload, Optional<UInt64> arrivalTimestamp);
 
-  SafeFuture<ExecutionPayloadImportResult> importExecutionPayload(
-      SignedExecutionPayloadEnvelope signedExecutionPayload);
+  default SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+    return validateAndImportExecutionPayload(signedExecutionPayload, Optional.empty());
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -535,9 +535,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
     final ForkChoiceUtil forkChoiceUtil = spec.atSlot(signedEnvelope.getSlot()).getForkChoiceUtil();
 
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 add a real data availability check
-    // (not required for devnet-0)
-    final AvailabilityChecker<?> availabilityChecker = AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
+    final AvailabilityChecker<?> availabilityChecker =
+        forkChoiceUtil.createAvailabilityChecker(signedEnvelope);
 
     availabilityChecker.initiateDataAvailabilityCheck();
 
@@ -566,7 +565,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                         "Data availability check for slot: {}, builder: {}, block_root: {} result: {}",
                         signedEnvelope.getSlot(),
                         signedEnvelope.getMessage().getBuilderIndex(),
-                        signedEnvelope.getMessage().getBeaconBlockRoot(),
+                        signedEnvelope.getBeaconBlockRoot(),
                         result.toLogString()));
 
     return payloadExecutor
@@ -700,8 +699,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     return result;
   }
 
-  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 it requires more validations and more
-  // interactions with the store (e.g. onExecutionPayloadResult)
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 it requires potentially more
+  // validations and more interactions with the store (e.g. onExecutionPayloadResult)
   private ExecutionPayloadImportResult importExecutionPayloadAndState(
       final SignedExecutionPayloadEnvelope signedEnvelope,
       final ForkChoiceUtil forkChoiceUtil,
@@ -921,7 +920,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     P2P_LOG.onInvalidExecutionPayload(
         signedEnvelope.getSlot(),
         signedEnvelope.getMessage().getBuilderIndex(),
-        signedEnvelope.getMessage().getBeaconBlockRoot(),
+        signedEnvelope.getBeaconBlockRoot(),
         signedEnvelope.sszSerialize(),
         result.getFailureReason().name(),
         result.getFailureCause());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumper.java
@@ -182,7 +182,7 @@ public class DebugDataFileDumper implements DebugDataDumper {
       return;
     }
     final UInt64 slot = signedEnvelope.getSlot();
-    final Bytes32 blockRoot = signedEnvelope.getMessage().getBeaconBlockRoot();
+    final Bytes32 blockRoot = signedEnvelope.getBeaconBlockRoot();
     final UInt64 builderIndex = signedEnvelope.getMessage().getBuilderIndex();
     final String fileName =
         String.format("%s_%s_%s.ssz", slot, blockRoot.toUnprefixedHexString(), builderIndex);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -15,12 +15,11 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.spec.Spec;
@@ -28,7 +27,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
-import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult.FailureReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.validation.ExecutionPayloadGossipValidator;
@@ -57,65 +55,74 @@ class DefaultExecutionPayloadManagerTest {
       ExecutionPayloadImportResult.successful(signedExecutionPayload);
 
   @Test
-  public void shouldImport() {
-    when(forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
-        .thenReturn(SafeFuture.completedFuture(successfulImportResult));
-
-    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
-
-    asyncRunner.executeDueActions();
-
-    assertThat(resultFuture).isCompletedWithValue(successfulImportResult);
-
-    // verify the `beacon_block_root` is cached
-    assertThat(
-            executionPayloadManager.isExecutionPayloadRecentlySeen(
-                signedExecutionPayload.getMessage().getBeaconBlockRoot()))
-        .isTrue();
-  }
-
-  @Test
-  public void shouldHandleInternalErrors() {
-    final IllegalStateException exception = new IllegalStateException("oopsy");
-
-    when(forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
-        .thenThrow(exception);
-
-    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
-
-    asyncRunner.executeDueActions();
-
-    final ExecutionPayloadImportResult result = safeJoin(resultFuture);
-
-    assertThat(result.isSuccessful()).isFalse();
-    assertThat(result.getFailureReason()).isEqualTo(FailureReason.INTERNAL_ERROR);
-    assertThat(result.getFailureCause())
-        .hasValueSatisfying(cause -> assertThat(cause).hasCause(exception));
-  }
-
-  @Test
-  public void onAcceptedGossipExecutionPayload_shouldImport() {
+  public void shouldValidateAndImport() {
     when(executionPayloadGossipValidator.validate(signedExecutionPayload))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
     when(forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
         .thenReturn(SafeFuture.completedFuture(successfulImportResult));
 
     final SafeFuture<InternalValidationResult> resultFuture =
-        executionPayloadManager.validateAndImportExecutionPayload(
-            signedExecutionPayload, Optional.empty());
+        executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload);
 
-    asyncRunner.executeDueActions();
+    try (final LogCaptor logCaptor = LogCaptor.forClass(DefaultExecutionPayloadManager.class)) {
+      asyncRunner.executeDueActions();
+      logCaptor.assertDebugLog("Successfully imported execution payload");
+    }
 
     assertThat(resultFuture).isCompletedWithValue(InternalValidationResult.ACCEPT);
-
-    verify(forkChoice).onExecutionPayload(signedExecutionPayload, executionLayer);
 
     // verify the `beacon_block_root` is cached
     assertThat(
             executionPayloadManager.isExecutionPayloadRecentlySeen(
-                signedExecutionPayload.getMessage().getBeaconBlockRoot()))
+                signedExecutionPayload.getBeaconBlockRoot()))
+        .isTrue();
+  }
+
+  @Test
+  public void shouldNotImportIfValidationFails() {
+    final InternalValidationResult rejectedResult = InternalValidationResult.reject("oopsy");
+    when(executionPayloadGossipValidator.validate(signedExecutionPayload))
+        .thenReturn(SafeFuture.completedFuture(rejectedResult));
+
+    final SafeFuture<InternalValidationResult> resultFuture =
+        executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload);
+
+    asyncRunner.executeDueActions();
+
+    verifyNoInteractions(forkChoice);
+    assertThat(resultFuture).isCompletedWithValue(rejectedResult);
+
+    // `beacon_block_root` should not be cached when gossip validation fails
+    assertThat(
+            executionPayloadManager.isExecutionPayloadRecentlySeen(
+                signedExecutionPayload.getBeaconBlockRoot()))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldHandleInternalErrorsWhileImporting() {
+    when(executionPayloadGossipValidator.validate(signedExecutionPayload))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+
+    final IllegalStateException exception = new IllegalStateException("oopsy");
+
+    when(forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
+        .thenThrow(exception);
+
+    final SafeFuture<InternalValidationResult> resultFuture =
+        executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload);
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(DefaultExecutionPayloadManager.class)) {
+      asyncRunner.executeDueActions();
+      logCaptor.assertErrorLog("Internal error while importing execution payload");
+    }
+
+    assertThat(resultFuture).isCompletedWithValue(InternalValidationResult.ACCEPT);
+
+    // verify the `beacon_block_root` is cached
+    assertThat(
+            executionPayloadManager.isExecutionPayloadRecentlySeen(
+                signedExecutionPayload.getBeaconBlockRoot()))
         .isTrue();
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/DebugDataFileDumperTest.java
@@ -187,7 +187,7 @@ class DebugDataFileDumperTest {
         String.format(
             "%s_%s_%s.ssz",
             executionPayload.getSlot(),
-            executionPayload.getMessage().getBeaconBlockRoot().toUnprefixedHexString(),
+            executionPayload.getBeaconBlockRoot().toUnprefixedHexString(),
             executionPayload.getMessage().getBuilderIndex());
     final Path expectedFile = tempDir.resolve("invalid_execution_payloads").resolve(fileName);
     checkBytesSavedToFile(expectedFile, executionPayload.sszSerialize());

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -104,6 +105,12 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
       this.maybeEarliestBlobSidecarTransactionSlot = maybeEarliestBlobSidecarSlot;
     }
     putStateRoot(state.hashTreeRoot(), block.getSlotAndBlockRoot());
+  }
+
+  @Override
+  public void putExecutionPayloadAndState(
+      final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878
   }
 
   private boolean needToUpdateEarliestBlobSidecarSlot(

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/BuilderApiChannel.java
@@ -37,6 +37,6 @@ public interface BuilderApiChannel {
   SafeFuture<Optional<ExecutionPayloadEnvelope>> createUnsignedExecutionPayload(
       UInt64 slot, UInt64 builderIndex);
 
-  SafeFuture<Void> publishSignedExecutionPayload(
+  SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
       SignedExecutionPayloadEnvelope signedExecutionPayload);
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/PublishSignedExecutionPayloadResult.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/PublishSignedExecutionPayloadResult.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class PublishSignedExecutionPayloadResult {
+
+  private final Bytes32 beaconBlockRoot;
+  private final Optional<String> rejectionReason;
+  private final boolean published;
+
+  private PublishSignedExecutionPayloadResult(
+      final Bytes32 beaconBlockRoot,
+      final Optional<String> rejectionReason,
+      final boolean published) {
+    this.beaconBlockRoot = beaconBlockRoot;
+    this.rejectionReason = rejectionReason;
+    this.published = published;
+  }
+
+  public static PublishSignedExecutionPayloadResult success(final Bytes32 beaconBlockRoot) {
+    return new PublishSignedExecutionPayloadResult(beaconBlockRoot, Optional.empty(), true);
+  }
+
+  public static PublishSignedExecutionPayloadResult rejected(
+      final Bytes32 beaconBlockRoot, final String reason) {
+    return new PublishSignedExecutionPayloadResult(beaconBlockRoot, Optional.of(reason), false);
+  }
+
+  public Bytes32 getBeaconBlockRoot() {
+    return beaconBlockRoot;
+  }
+
+  public Optional<String> getRejectionReason() {
+    return rejectionReason;
+  }
+
+  public boolean isPublished() {
+    return published;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PublishSignedExecutionPayloadResult that = (PublishSignedExecutionPayloadResult) o;
+    return Objects.equals(beaconBlockRoot, that.beaconBlockRoot)
+        && Objects.equals(rejectionReason, that.rejectionReason)
+        && published == that.published;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(beaconBlockRoot, rejectionReason, published);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("beaconBlockRoot", beaconBlockRoot)
+        .add("rejectionReason", rejectionReason)
+        .add("published", published)
+        .toString();
+  }
+}

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -243,9 +243,11 @@ public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface
         }
 
         @Override
-        public SafeFuture<Void> publishSignedExecutionPayload(
+        public SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
             final SignedExecutionPayloadEnvelope signedExecutionPayload) {
-          return SafeFuture.COMPLETE;
+          return SafeFuture.completedFuture(
+              PublishSignedExecutionPayloadResult.success(
+                  signedExecutionPayload.getBeaconBlockRoot()));
         }
       };
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/TimeBasedEventAdapter.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
+// TODO-GLOAS: https://github.com/Consensys/teku/issues/10053
 public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
   private static final Logger LOG = LogManager.getLogger();
 
@@ -84,7 +85,6 @@ public class TimeBasedEventAdapter implements BeaconChainEventAdapter {
           millisPerSlot,
           this::onContributionCreationDue);
     }
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10018
     if (milestone.isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
       taskScheduler.scheduleRepeatingEventInMillis(
           nextSlotStartTimeMillis.plus(spec.getPayloadAttestationDueMillis(nextSlot)),

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -65,6 +65,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -335,7 +336,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> publishSignedExecutionPayload(
+  public SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return countDataRequest(
         delegate.publishSignedExecutionPayload(signedExecutionPayload),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
@@ -122,12 +122,12 @@ public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
                     executionPayload.getBeaconBlockRoot(),
                     getExecutionSummary(executionPayload));
               } else {
-                validatorLogger.executionPayloadDutyFailed(
-                    executionPayload.getSlot(),
-                    executionPayload.getBuilderIndex(),
+                final Throwable error =
                     new IllegalArgumentException(
                         "Execution payload was rejected by the beacon node: "
-                            + result.getRejectionReason().orElse("<reason unknown>")));
+                            + result.getRejectionReason().orElse("<reason unknown>"));
+                validatorLogger.executionPayloadDutyFailed(
+                    executionPayload.getSlot(), executionPayload.getBuilderIndex(), error);
               }
             });
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDuty.java
@@ -112,14 +112,23 @@ public class ExecutionPayloadDuty implements ExecutionPayloadBidEventsChannel {
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return validatorApiChannel
         .publishSignedExecutionPayload(signedExecutionPayload)
-        .thenRun(
-            () -> {
+        .thenAccept(
+            result -> {
               final ExecutionPayloadEnvelope executionPayload = signedExecutionPayload.getMessage();
-              validatorLogger.logExecutionPayloadDuty(
-                  executionPayload.getSlot(),
-                  executionPayload.getBuilderIndex(),
-                  executionPayload.getBeaconBlockRoot(),
-                  getExecutionSummary(executionPayload));
+              if (result.isPublished()) {
+                validatorLogger.logExecutionPayloadDuty(
+                    executionPayload.getSlot(),
+                    executionPayload.getBuilderIndex(),
+                    executionPayload.getBeaconBlockRoot(),
+                    getExecutionSummary(executionPayload));
+              } else {
+                validatorLogger.executionPayloadDutyFailed(
+                    executionPayload.getSlot(),
+                    executionPayload.getBuilderIndex(),
+                    new IllegalArgumentException(
+                        "Execution payload was rejected by the beacon node: "
+                            + result.getRejectionReason().orElse("<reason unknown>")));
+              }
             });
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.client.Validator;
 
@@ -78,7 +79,11 @@ class ExecutionPayloadDutyTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(signedExecutionPayload.getMessage())));
     when(signer.signExecutionPayloadEnvelope(signedExecutionPayload.getMessage(), fork))
         .thenReturn(SafeFuture.completedFuture(signedExecutionPayload.getSignature()));
-    when(validatorApiChannel.publishSignedExecutionPayload(any())).thenReturn(SafeFuture.COMPLETE);
+    when(validatorApiChannel.publishSignedExecutionPayload(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                PublishSignedExecutionPayloadResult.success(
+                    signedExecutionPayload.getBeaconBlockRoot())));
 
     duty.onSelfBuiltBidIncludedInBlock(validator, fork, bid);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/execution/ExecutionPayloadDutyTest.java
@@ -97,7 +97,7 @@ class ExecutionPayloadDutyTest {
         .logExecutionPayloadDuty(
             eq(signedExecutionPayload.getMessage().getSlot()),
             eq(signedExecutionPayload.getMessage().getBuilderIndex()),
-            eq(signedExecutionPayload.getMessage().getBeaconBlockRoot()),
+            eq(signedExecutionPayload.getBeaconBlockRoot()),
             any());
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -69,6 +69,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -414,7 +415,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> publishSignedExecutionPayload(
+  public SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return relayRequest(
         apiChannel -> apiChannel.publishSignedExecutionPayload(signedExecutionPayload),

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -73,6 +73,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
@@ -379,7 +380,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> publishSignedExecutionPayload(
+  public SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -55,6 +55,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -294,7 +295,7 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Void> publishSignedExecutionPayload(
+  public SafeFuture<PublishSignedExecutionPayloadResult> publishSignedExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {
     return blockHandlerChannel
         .orElse(dutiesProviderChannel)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Return `PublishSignedExecutionPayloadResult` instead of `Void`. Also only imports execution payload if gossip validation passes (which should have been the logic from the start and it is per current PR specs https://github.com/ethereum/beacon-APIs/pull/552)

Also small changes to clean ForkChoice slightly

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return a structured result when publishing execution payloads and only publish after successful gossip validation/import, with supporting store and fork-choice updates.
> 
> - **API/Interfaces**:
>   - Change `publishSignedExecutionPayload` (in `ValidatorApiChannel`, `BuilderApiChannel`, sentry/failover/metrics adapters) to return `PublishSignedExecutionPayloadResult` instead of `Void`.
>   - Add `validator/api/PublishSignedExecutionPayloadResult`.
>   - Update `ExecutionPayloadPublisher` to return the same result; adjust NOOP.
> - **Publishing behavior (Gloas)**:
>   - In `ExecutionPayloadPublisherGloas`, call `ExecutionPayloadManager.validateAndImportExecutionPayload` and publish payload/sidecars only on `ACCEPT`; otherwise return rejected with reason.
>   - `ValidatorApiHandler` maps exceptions to rejected results.
> - **Spec/State/Fork-choice**:
>   - Expose `SignedExecutionPayloadEnvelope.getBeaconBlockRoot()` and use it in logs.
>   - Add `MutableStore.putExecutionPayloadAndState`; implement in test store; stub in `StoreTransaction`.
>   - `ForkChoiceUtil/ForkChoiceUtilGloas`: add availability checker overload for execution payloads and store execution payloads; use `NOOP_DATACOLUMN_SIDECAR` for Gloas.
>   - `DefaultExecutionPayloadManager`: remove separate import method; validate then import async; cache seen roots; improved logging.
> - **Misc**:
>   - `ChainBuilder` and other callers switch to `getBeaconBlockRoot()`.
> - **Tests**:
>   - Update/extend unit tests across validator, publisher, fork-choice, execution manager, debug dumper to assert new return type and behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a6a912deee4dc3f6726ec830f0d4ae7528163a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->