### PR TITLE
Cleaned up lookahead epochs constant in duties

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -29,9 +29,8 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   private static final Logger LOG = LogManager.getLogger();
   private final MetricsSystem metricsSystem;
   private final String dutyType;
-  private final Spec spec;
+  protected final Spec spec;
   private final DutyLoader<?> epochDutiesScheduler;
-  private final int lookAheadEpochs;
 
   private UInt64 lastProductionSlot;
 
@@ -42,12 +41,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
       final MetricsSystem metricsSystem,
       final String dutyType,
       final DutyLoader<?> epochDutiesScheduler,
-      final int lookAheadEpochs,
       final Spec spec) {
     this.metricsSystem = metricsSystem;
     this.dutyType = dutyType;
     this.epochDutiesScheduler = epochDutiesScheduler;
-    this.lookAheadEpochs = lookAheadEpochs;
     this.spec = spec;
   }
 
@@ -87,6 +84,8 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
                         dutyEpoch)));
   }
 
+  abstract int getLookAheadEpochs(UInt64 epoch);
+
   protected abstract Bytes32 getExpectedDependentRoot(
       Bytes32 headBlockRoot,
       Bytes32 previousDutyDependentRoot,
@@ -107,6 +106,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
 
   private void calculateDuties(final UInt64 epochNumber) {
     dutiesByEpoch.computeIfAbsent(epochNumber, this::createEpochDuties);
+    final int lookAheadEpochs = getLookAheadEpochs(epochNumber);
     for (int i = 1; i <= lookAheadEpochs; i++) {
       dutiesByEpoch.computeIfAbsent(epochNumber.plus(i), this::createEpochDuties);
     }
@@ -136,6 +136,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     }
     final UInt64 signingEpoch = spec.computeEpochAtSlot(slot);
     final UInt64 epoch = currentEpoch.get();
+    final int lookAheadEpochs = getLookAheadEpochs(epoch);
     return !signingEpoch.isGreaterThan(epoch.plus(lookAheadEpochs + 1));
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyScheduler.java
@@ -34,13 +34,13 @@ import tech.pegasys.teku.validator.client.duties.SlotBasedScheduledDuties;
 
 public class AttestationDutyScheduler extends AbstractDutyScheduler {
   private static final Logger LOG = LogManager.getLogger();
-  static final int LOOKAHEAD_EPOCHS = 1;
+  private static final int LOOKAHEAD_EPOCHS = 1;
 
   private final AtomicInteger nextAttestationSlot = new AtomicInteger();
 
   public AttestationDutyScheduler(
       final MetricsSystem metricsSystem, final DutyLoader<?> dutyLoader, final Spec spec) {
-    super(metricsSystem, "attestation", dutyLoader, LOOKAHEAD_EPOCHS, spec);
+    super(metricsSystem, "attestation", dutyLoader, spec);
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,
         "scheduled_attestation_duties_current",
@@ -111,6 +111,11 @@ public class AttestationDutyScheduler extends AbstractDutyScheduler {
           "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () -> headEpoch);
       return headBlockRoot;
     }
+  }
+
+  @Override
+  int getLookAheadEpochs(final UInt64 epoch) {
+    return LOOKAHEAD_EPOCHS;
   }
 
   @VisibleForTesting

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -27,11 +27,11 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 public class BlockDutyScheduler extends AbstractDutyScheduler {
-  static final int LOOKAHEAD_EPOCHS = 0;
+  private static final int LOOKAHEAD_EPOCHS = 0;
 
   public BlockDutyScheduler(
       final MetricsSystem metricsSystem, final DutyLoader<?> dutyLoader, final Spec spec) {
-    super(metricsSystem, "block", dutyLoader, LOOKAHEAD_EPOCHS, spec);
+    super(metricsSystem, "block", dutyLoader, spec);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,
@@ -78,5 +78,10 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
         dutyEpoch,
         headEpoch);
     return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
+  }
+
+  @Override
+  public int getLookAheadEpochs(final UInt64 epoch) {
+    return LOOKAHEAD_EPOCHS;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyScheduler.java
@@ -31,11 +31,11 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 public class PtcDutyScheduler extends AbstractDutyScheduler {
 
   private static final Logger LOG = LogManager.getLogger();
-  static final int LOOKAHEAD_EPOCHS = 1;
+  private static final int LOOKAHEAD_EPOCHS = 1;
 
   public PtcDutyScheduler(
       final MetricsSystem metricsSystem, final DutyLoader<?> dutyLoader, final Spec spec) {
-    super(metricsSystem, "payload_attestation", dutyLoader, LOOKAHEAD_EPOCHS, spec);
+    super(metricsSystem, "payload_attestation", dutyLoader, spec);
 
     metricsSystem.createIntegerGauge(
         TekuMetricCategory.VALIDATOR,
@@ -89,5 +89,10 @@ public class PtcDutyScheduler extends AbstractDutyScheduler {
           "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () -> headEpoch);
       return headBlockRoot;
     }
+  }
+
+  @Override
+  int getLookAheadEpochs(final UInt64 epoch) {
+    return LOOKAHEAD_EPOCHS;
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.validator.client.AttestationDutyScheduler.LOOKAHEAD_EPOCHS;
 
 import java.util.List;
 import java.util.Map;
@@ -316,8 +315,9 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldNotProcessAggregationIfCurrentEpochIsTooFarBeforeSlotEpoch() {
     createDutySchedulerWithMockDuties();
+    final int lookAheadEpoch = dutyScheduler.getLookAheadEpochs(UInt64.valueOf(2));
     // first slot of epoch 2
-    final UInt64 slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
+    final UInt64 slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(lookAheadEpoch + 1));
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationAggregationDue(slot);
     verify(scheduledDuties, never()).performAggregationDuty(slot);
@@ -326,8 +326,9 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldNotProcessAttestationIfCurrentEpochIsTooFarBeforeSlotEpoch() {
     createDutySchedulerWithMockDuties();
+    final int lookAheadEpoch = dutyScheduler.getLookAheadEpochs(UInt64.valueOf(2));
     // first slot of epoch 2
-    final UInt64 slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
+    final UInt64 slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(lookAheadEpoch + 1));
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationCreationDue(slot);
     verify(scheduledDuties, never()).performProductionDuty(slot);
@@ -336,9 +337,10 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldProcessAggregationIfCurrentEpochIsAtBoundaryOfLookaheadEpoch() {
     createDutySchedulerWithMockDuties();
+    final int lookAheadEpoch = dutyScheduler.getLookAheadEpochs(UInt64.valueOf(1));
     // last slot of epoch 1
     final UInt64 slot =
-        spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
+        spec.computeStartSlotAtEpoch(UInt64.valueOf(lookAheadEpoch + 1)).decrement();
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationAggregationDue(slot);
     verify(scheduledDuties).performAggregationDuty(slot);
@@ -347,9 +349,10 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldProcessAttestationIfCurrentEpochIsAtBoundaryOfLookaheadEpoch() {
     createDutySchedulerWithMockDuties();
+    final int lookAheadEpoch = dutyScheduler.getLookAheadEpochs(UInt64.valueOf(1));
     // last slot of epoch 1
     final UInt64 slot =
-        spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
+        spec.computeStartSlotAtEpoch(UInt64.valueOf(lookAheadEpoch + 1)).decrement();
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onAttestationCreationDue(slot);
     verify(scheduledDuties).performProductionDuty(slot);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.validator.client.BlockDutyScheduler.LOOKAHEAD_EPOCHS;
 
 import java.util.List;
 import java.util.Map;
@@ -54,7 +53,7 @@ import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
   private BlockDutyScheduler dutyScheduler;
 
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private Spec spec = TestSpecFactory.createMinimalPhase0();
   private final TimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(1000);
 
   private final BlockDutyFactory blockDutyFactory = mock(BlockDutyFactory.class);
@@ -112,6 +111,13 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     dutyScheduler.onBlockProductionDue(blockProposerSlot);
     // But shouldn't produce another block and get ourselves slashed.
     verifyNoMoreInteractions(blockCreationDuty);
+  }
+
+  @Test
+  public void lookaheadIsCurrentEpochBeforeFulu() {
+    spec = TestSpecFactory.createMinimalElectra();
+    createDutySchedulerWithRealDuties();
+    assertThat(dutyScheduler.getLookAheadEpochs(UInt64.ONE)).isEqualTo(0);
   }
 
   @Test
@@ -253,7 +259,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldNotProduceBlockIfCurrentEpochIsTooFarBeforeSlotEpoch() {
     createDutySchedulerWithMockDuties();
     // first slot of epoch 1
-    final UInt64 slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1));
+    final int lookAheadEpochs = dutyScheduler.getLookAheadEpochs(ONE);
+    final UInt64 slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(lookAheadEpochs + 1));
     dutyScheduler.onSlot(ONE); // epoch 0
     dutyScheduler.onBlockProductionDue(slot);
     verify(scheduledDuties, never()).performProductionDuty(slot);
@@ -263,8 +270,9 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
   public void shouldProduceBlockIfCurrentEpochIsAtBoundaryOfLookaheadEpoch() {
     createDutySchedulerWithMockDuties();
     // last slot of epoch 0
+    final int lookAheadEpochs = dutyScheduler.getLookAheadEpochs(ZERO);
     final UInt64 slot =
-        spec.computeStartSlotAtEpoch(UInt64.valueOf(LOOKAHEAD_EPOCHS + 1)).decrement();
+        spec.computeStartSlotAtEpoch(UInt64.valueOf(lookAheadEpochs + 1)).decrement();
     when(scheduledDuties.performProductionDuty(slot))
         .thenReturn(SafeFuture.completedFuture(DutyResult.success(Bytes32.ZERO)));
 


### PR DESCRIPTION
As part of proposer duties computation, this will no longer be constant.

This change introduces an epoch based lookup to each duty class, and currently it returns a constant but block proposer duties will get updated.

partially addresses #10124

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make duty lookahead epoch count dynamic by introducing a per-epoch `getLookAheadEpochs` and updating schedulers/tests accordingly.
> 
> - **Validator client – duty scheduling**:
>   - **AbstractDutyScheduler**:
>     - Replace fixed `lookAheadEpochs` with abstract `getLookAheadEpochs(UInt64 epoch)`; use it in `calculateDuties` and `isAbleToVerifyEpoch`.
>     - Change `spec` visibility to `protected` and remove `lookAheadEpochs` from constructor/signature.
>   - **Schedulers**:
>     - Implement `getLookAheadEpochs` in `AttestationDutyScheduler`, `BlockDutyScheduler`, and `PtcDutyScheduler` (returning existing constants).
>     - Adjust constructors to new `AbstractDutyScheduler` signature.
>   - **Tests**:
>     - Update tests to query `dutyScheduler.getLookAheadEpochs(...)` instead of constants; add coverage asserting block lookahead remains 0 on Electra spec; minor spec mutability tweak in `BlockDutySchedulerTest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3560675071774f2a16238a6373c26666d091441e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->