### PR TITLE
Updated BeaconStateAccessorsFulu for proposer lookahead

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
@@ -17,6 +17,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
@@ -29,6 +31,7 @@ import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessor
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
 
 public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
+  private static final Logger LOG = LogManager.getLogger();
 
   public BeaconStateAccessorsFulu(
       final SpecConfig config,
@@ -40,12 +43,34 @@ public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
   @Override
   public int getBeaconProposerIndex(final BeaconState state, final UInt64 requestedSlot) {
     validateStateCanCalculateProposerIndexAtSlot(state, requestedSlot);
-    final int lookaheadIndex = requestedSlot.mod(config.getSlotsPerEpoch()).intValue();
-    return BeaconStateFulu.required(state)
-        .getProposerLookahead()
-        .get(lookaheadIndex)
-        .get()
-        .intValue();
+    final UInt64 stateEpoch = miscHelpers.computeEpochAtSlot(state.getSlot());
+    final UInt64 requestedEpoch = miscHelpers.computeEpochAtSlot(requestedSlot);
+    final int epochOffset = stateEpoch.equals(requestedEpoch) ? 0 : config.getSlotsPerEpoch();
+    final int lookaheadIndex =
+        requestedSlot.mod(config.getSlotsPerEpoch()).intValue() + epochOffset;
+    final int proposerIndex =
+        BeaconStateFulu.required(state).getProposerLookahead().get(lookaheadIndex).get().intValue();
+    LOG.debug(
+        "get proposer index for slot {} from state at slot {}, will be lookahead index {} - proposer will be {}",
+        requestedSlot,
+        state.getSlot(),
+        lookaheadIndex,
+        proposerIndex);
+    return proposerIndex;
+  }
+
+  @Override
+  protected void validateStateCanCalculateProposerIndexAtSlot(
+      final BeaconState state, final UInt64 requestedSlot) {
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(requestedSlot);
+    final UInt64 stateEpoch = getCurrentEpoch(state);
+    checkArgument(
+        stateEpoch.equals(epoch) || stateEpoch.increment().equals(epoch),
+        "get_beacon_proposer_index is only used for requesting a slot in the current or next epoch. Requested slot %s (in epoch %s), state slot %s (in epoch %s)",
+        requestedSlot,
+        epoch,
+        state.getSlot(),
+        stateEpoch);
   }
 
   public List<Integer> getBeaconProposerIndices(final BeaconState state, final UInt64 epoch) {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystemBuilder.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystemBuilder.java
@@ -68,6 +68,10 @@ public class InMemoryStorageSystemBuilder {
     return create().storageMode(storageMode).specProvider(spec).build();
   }
 
+  public static StorageSystem buildDefault(final int numberOfValidators, final Spec spec) {
+    return create().numberOfValidators(numberOfValidators).specProvider(spec).build();
+  }
+
   public static StorageSystem buildDefault(final Spec spec) {
     return create().specProvider(spec).build();
   }


### PR DESCRIPTION
Allows epoch duties to be fetched from the next epoch, which is contained in the proposer_lookahead for the state, we just need to return it.

also extended the number of validators in the test suite so that it's a better example.

partially addresses #10124

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow fetching beacon proposer indices for the current or next epoch via proposer_lookahead with tests updated and a builder overload added.
> 
> - **Fulu spec logic**:
>   - `getBeaconProposerIndex`: compute `lookaheadIndex` with epoch offset to support current/next epoch; add validation to restrict to current or next epoch; add debug logging.
> - **Tests**:
>   - Update expectations for current-epoch proposer index and add next-epoch coverage by iterating `proposer_lookahead`.
>   - Adjust failure case to only allow current/next epoch; minor imports updated.
>   - Use `InMemoryStorageSystemBuilder.buildDefault(16, spec)` to increase validator count.
> - **Test fixtures**:
>   - Add `InMemoryStorageSystemBuilder.buildDefault(int numberOfValidators, Spec)` overload to configure validator count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0bb82f53cc5265729e905127e133d2919f4acbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->