### PR TITLE
Simplify `get_beacon_proposer_index` when slot is current

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
@@ -40,6 +40,17 @@ public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
     super(SpecConfigFulu.required(config), predicatesElectra, miscHelpers);
   }
 
+  /**
+   * get_beacon_proposer_index
+   *
+   * <p>Return the beacon proposer index at the current slot.
+   */
+  @Override
+  public int getBeaconProposerIndex(final BeaconState state) {
+    return getProposerLookaheadValue(
+        state, state.getSlot().mod(config.getSlotsPerEpoch()).intValue());
+  }
+
   @Override
   public int getBeaconProposerIndex(final BeaconState state, final UInt64 requestedSlot) {
     validateStateCanCalculateProposerIndexAtSlot(state, requestedSlot);
@@ -48,8 +59,7 @@ public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
     final int epochOffset = stateEpoch.equals(requestedEpoch) ? 0 : config.getSlotsPerEpoch();
     final int lookaheadIndex =
         requestedSlot.mod(config.getSlotsPerEpoch()).intValue() + epochOffset;
-    final int proposerIndex =
-        BeaconStateFulu.required(state).getProposerLookahead().get(lookaheadIndex).get().intValue();
+    final int proposerIndex = getProposerLookaheadValue(state, lookaheadIndex);
     LOG.debug(
         "get proposer index for slot {} from state at slot {}, will be lookahead index {} - proposer will be {}",
         requestedSlot,
@@ -77,6 +87,14 @@ public class BeaconStateAccessorsFulu extends BeaconStateAccessorsElectra {
     final IntList indices = getActiveValidatorIndices(state, epoch);
     final Bytes32 seed = getSeed(state, epoch, Domain.BEACON_PROPOSER);
     return miscHelpers.computeProposerIndices(state, epoch, seed, indices);
+  }
+
+  private int getProposerLookaheadValue(final BeaconState state, final int lookaheadIndex) {
+    return BeaconStateFulu.required(state)
+        .getProposerLookahead()
+        .get(lookaheadIndex)
+        .get()
+        .intValue();
   }
 
   public static BeaconStateAccessorsFulu required(final BeaconStateAccessors beaconStateAccessors) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,9 +52,13 @@ public class BeaconStateAccessorsFuluTest {
       new BeaconStateAccessorsFulu(spec.getGenesisSpecConfig(), predicatesElectra, miscHelpers);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(16, spec);
 
+  @BeforeEach
+  public void setUp() {
+    storageSystem.chainUpdater().initializeGenesis();
+  }
+
   @Test
   void getProposerIndices_notGenesisEpoch() {
-    storageSystem.chainUpdater().initializeGenesis();
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
     final List<Integer> proposerLookahead =
         getProposerLookaheadFromState(blockAndState.getState().toVersionFulu().orElseThrow());
@@ -69,8 +75,6 @@ public class BeaconStateAccessorsFuluTest {
   @Test
   @Disabled
   void getProposerIndices_genesisEpoch() {
-    storageSystem.chainUpdater().initializeGenesis();
-
     final StateAndBlockSummary blockAndState = storageSystem.getChainHead();
     final List<Integer> proposerLookahead =
         getProposerLookaheadFromState(blockAndState.getState().toVersionFulu().orElseThrow());
@@ -85,17 +89,21 @@ public class BeaconStateAccessorsFuluTest {
   }
 
   @Test
+  void getBeaconProposerIndex_currentSlot() {
+    final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
+    assertThat(stateAccessorsFulu.getBeaconProposerIndex(blockAndState.getState())).isEqualTo(14);
+  }
+
+  @Test
   void getBeaconProposerIndex_currentEpoch() {
-    storageSystem.chainUpdater().initializeGenesis();
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
     assertThat(
-            stateAccessorsFulu.getBeaconProposerIndex(blockAndState.getState(), UInt64.valueOf(16)))
-        .isEqualTo(14);
+            stateAccessorsFulu.getBeaconProposerIndex(blockAndState.getState(), UInt64.valueOf(17)))
+        .isEqualTo(13);
   }
 
   @Test
   void getBeaconProposerIndex_nextEpoch() {
-    storageSystem.chainUpdater().initializeGenesis();
     final int stateSlot = 16;
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(stateSlot);
     final List<Integer> proposers =
@@ -117,7 +125,6 @@ public class BeaconStateAccessorsFuluTest {
   @ParameterizedTest
   @ValueSource(ints = {8, 33})
   void getBeaconProposerIndex_shouldThrowIfNotCurrentOrNextEpoch(final int slot) {
-    storageSystem.chainUpdater().initializeGenesis();
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
     assertThatThrownBy(
             () ->

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,13 +50,10 @@ public class BeaconStateAccessorsFuluTest {
       new BeaconStateAccessorsFulu(spec.getGenesisSpecConfig(), predicatesElectra, miscHelpers);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(16, spec);
 
-  @BeforeEach
-  public void setUp() {
-    storageSystem.chainUpdater().initializeGenesis();
-  }
-
   @Test
   void getProposerIndices_notGenesisEpoch() {
+    storageSystem.chainUpdater().initializeGenesis();
+
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
     final List<Integer> proposerLookahead =
         getProposerLookaheadFromState(blockAndState.getState().toVersionFulu().orElseThrow());
@@ -75,6 +70,8 @@ public class BeaconStateAccessorsFuluTest {
   @Test
   @Disabled
   void getProposerIndices_genesisEpoch() {
+    storageSystem.chainUpdater().initializeGenesis();
+
     final StateAndBlockSummary blockAndState = storageSystem.getChainHead();
     final List<Integer> proposerLookahead =
         getProposerLookaheadFromState(blockAndState.getState().toVersionFulu().orElseThrow());
@@ -90,12 +87,16 @@ public class BeaconStateAccessorsFuluTest {
 
   @Test
   void getBeaconProposerIndex_currentSlot() {
+    storageSystem.chainUpdater().initializeGenesis();
+
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
     assertThat(stateAccessorsFulu.getBeaconProposerIndex(blockAndState.getState())).isEqualTo(14);
   }
 
   @Test
   void getBeaconProposerIndex_currentEpoch() {
+    storageSystem.chainUpdater().initializeGenesis();
+
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
     assertThat(
             stateAccessorsFulu.getBeaconProposerIndex(blockAndState.getState(), UInt64.valueOf(17)))
@@ -104,6 +105,8 @@ public class BeaconStateAccessorsFuluTest {
 
   @Test
   void getBeaconProposerIndex_nextEpoch() {
+    storageSystem.chainUpdater().initializeGenesis();
+
     final int stateSlot = 16;
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(stateSlot);
     final List<Integer> proposers =
@@ -125,6 +128,8 @@ public class BeaconStateAccessorsFuluTest {
   @ParameterizedTest
   @ValueSource(ints = {8, 33})
   void getBeaconProposerIndex_shouldThrowIfNotCurrentOrNextEpoch(final int slot) {
+    storageSystem.chainUpdater().initializeGenesis();
+
     final SignedBlockAndState blockAndState = storageSystem.chainUpdater().advanceChain(16);
     assertThatThrownBy(
             () ->

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -2652,7 +2652,7 @@
 - name: get_beacon_proposer_index#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFulu.java
-      search: public int getBeaconProposerIndex(
+      search: public int getBeaconProposerIndex(final BeaconState state)
   spec: |
     <spec fn="get_beacon_proposer_index" fork="fulu" hash="8e1ef77d">
     def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We can avoid the call below to simplify the cases for the current slot, which can just use the spec logic and don't do additional unnecessary logic which is required when we pass an arbitrary slot as a second parameter:

```
  public int getBeaconProposerIndex(final BeaconState state) {
    return getBeaconProposerIndex(state, state.getSlot());
  }
```

## Fixed Issue(s)
related to https://github.com/Consensys/teku/pull/10162

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a current-slot `getBeaconProposerIndex(state)` using proposer_lookahead, refactor shared lookup, update tests, and align spec references.
> 
> - **Fulu state accessors (`BeaconStateAccessorsFulu`)**:
>   - Add override `getBeaconProposerIndex(BeaconState)` to return current-slot proposer from `state.proposer_lookahead[state.slot % SLOTS_PER_EPOCH]`.
>   - Refactor `getBeaconProposerIndex(state, slot)` to reuse new `getProposerLookaheadValue(...)` helper.
>   - Introduce private `getProposerLookaheadValue(...)` for proposer lookahead access.
> - **Tests**:
>   - Add test for current-slot `getBeaconProposerIndex(state)` and adjust expectations for current/next-epoch cases.
> - **Spec refs**:
>   - Update `specrefs/functions.yml` to reference the new no-arg method signature and include the Fulu spec snippet for `get_beacon_proposer_index`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac38761b88bb457c45e1630bea0feab7e3d1a18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->