### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare
@@ -83,7 +83,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare
@@ -115,7 +115,7 @@ jobs:
       publish-version: ${{ steps.projectDetails.outputs.publish-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: get workflow_details
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare
@@ -206,7 +206,7 @@ jobs:
   #   runs-on: ubuntu-24.04
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v5
+  #       uses: actions/checkout@v6
   #       with:
   #         submodules: 'recursive'
   #     - name: Prepare
@@ -250,7 +250,7 @@ jobs:
     needs: unitTests
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/collate-junit-reports
         if: always()        
         with:
@@ -261,7 +261,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare
@@ -298,7 +298,7 @@ jobs:
     needs: propertyTests
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/collate-junit-reports
         if: always()        
         with:
@@ -322,7 +322,7 @@ jobs:
   #   runs-on: ubuntu-24.04
   #   needs: acceptanceTests
   #   steps:
-  #     - uses: actions/checkout@v5
+  #     - uses: actions/checkout@v6
   #     - uses: ./.github/actions/collate-junit-reports
   #       if: always()        
   #       with:
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare
@@ -389,7 +389,7 @@ jobs:
         total: [8]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare
@@ -467,7 +467,7 @@ jobs:
     needs: referenceTests
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/collate-junit-reports
         if: always()
         with:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
           fetch-depth: 0  # Full history

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,7 +30,7 @@ jobs:
     environment: publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
     environment: publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
       - name: Prepare


### PR DESCRIPTION
Bumps to v6 for Node.js 24 support. Requires runner v2.329.0+.

https://github.com/actions/checkout/releases/tag/v6.0.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `actions/checkout` from v5 to v6 across all CI, matrix, publish-docker, and publish-release workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56936739131c5c01844dc0bb3173fd2483034964. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->