### PR TITLE
fix custody limit always after fulu

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -247,11 +246,6 @@ public class DataColumnSidecarCustodyImpl
 
   @VisibleForTesting
   SafeFuture<SlotCustody> retrieveSlotCustody(final UInt64 slot) {
-    if (!spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
-      return SafeFuture.completedFuture(
-          new SlotCustody(
-              slot, Optional.empty(), Collections.emptyList(), Collections.emptyList()));
-    }
     if (slot.isLessThan(
         minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(currentSlot.get()))) {
       LOG.trace(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
@@ -16,27 +16,24 @@ package tech.pegasys.teku.statetransition.datacolumns;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.config.SpecConfigFulu;
 
 public interface MinCustodyPeriodSlotCalculator {
 
   static MinCustodyPeriodSlotCalculator createFromSpec(final Spec spec) {
     final UInt64 fuluActivationEpoch =
         spec.getForkSchedule().getFork(SpecMilestone.FULU).getEpoch();
+
     return currentSlot -> {
       final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
       final int custodyPeriodEpochs =
           spec.getSpecConfig(currentEpoch)
               .toVersionFulu()
-              .map(SpecConfigFulu::getMinEpochsForDataColumnSidecarsRequests)
-              .orElse(0);
-      if (custodyPeriodEpochs == 0) {
-        return currentSlot;
-      } else {
-        final UInt64 minCustodyEpoch =
-            currentEpoch.minusMinZero(custodyPeriodEpochs).max(fuluActivationEpoch);
-        return spec.computeStartSlotAtEpoch(minCustodyEpoch);
-      }
+              .orElseThrow()
+              .getMinEpochsForDataColumnSidecarsRequests();
+
+      final UInt64 minCustodyEpoch =
+          currentEpoch.minusMinZero(custodyPeriodEpochs).max(fuluActivationEpoch);
+      return spec.computeStartSlotAtEpoch(minCustodyEpoch);
     };
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
@@ -15,11 +15,13 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 
 public interface MinCustodyPeriodSlotCalculator {
 
   static MinCustodyPeriodSlotCalculator createFromSpec(final Spec spec) {
+    final UInt64 fuluActivationEpoch = spec.getForkSchedule().getFork(SpecMilestone.FULU).getEpoch();
     return currentSlot -> {
       final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
       final int custodyPeriodEpochs =
@@ -30,7 +32,7 @@ public interface MinCustodyPeriodSlotCalculator {
       if (custodyPeriodEpochs == 0) {
         return currentSlot;
       } else {
-        final UInt64 minCustodyEpoch = currentEpoch.minusMinZero(custodyPeriodEpochs);
+        final UInt64 minCustodyEpoch = currentEpoch.minusMinZero(custodyPeriodEpochs).max(fuluActivationEpoch);
         return spec.computeStartSlotAtEpoch(minCustodyEpoch);
       }
     };

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
@@ -21,7 +21,8 @@ import tech.pegasys.teku.spec.config.SpecConfigFulu;
 public interface MinCustodyPeriodSlotCalculator {
 
   static MinCustodyPeriodSlotCalculator createFromSpec(final Spec spec) {
-    final UInt64 fuluActivationEpoch = spec.getForkSchedule().getFork(SpecMilestone.FULU).getEpoch();
+    final UInt64 fuluActivationEpoch =
+        spec.getForkSchedule().getFork(SpecMilestone.FULU).getEpoch();
     return currentSlot -> {
       final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
       final int custodyPeriodEpochs =
@@ -32,7 +33,8 @@ public interface MinCustodyPeriodSlotCalculator {
       if (custodyPeriodEpochs == 0) {
         return currentSlot;
       } else {
-        final UInt64 minCustodyEpoch = currentEpoch.minusMinZero(custodyPeriodEpochs).max(fuluActivationEpoch);
+        final UInt64 minCustodyEpoch =
+            currentEpoch.minusMinZero(custodyPeriodEpochs).max(fuluActivationEpoch);
         return spec.computeStartSlotAtEpoch(minCustodyEpoch);
       }
     };

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculatorTest.java
@@ -1,7 +1,19 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -39,16 +51,18 @@ class MinCustodyPeriodSlotCalculatorTest {
 
     when(specConfig.toVersionFulu()).thenReturn(Optional.of(specConfigFulu));
     when(specConfigFulu.getMinEpochsForDataColumnSidecarsRequests())
-            .thenReturn(CUSTODY_PERIOD_EPOCHS);
+        .thenReturn(CUSTODY_PERIOD_EPOCHS);
 
     when(spec.computeEpochAtSlot(any(UInt64.class)))
-            .thenAnswer(invocation -> {
+        .thenAnswer(
+            invocation -> {
               UInt64 slot = invocation.getArgument(0);
               return slot.dividedBy(SLOTS_PER_EPOCH);
             });
 
     when(spec.computeStartSlotAtEpoch(any(UInt64.class)))
-            .thenAnswer(invocation -> {
+        .thenAnswer(
+            invocation -> {
               UInt64 epoch = invocation.getArgument(0);
               return epoch.times(SLOTS_PER_EPOCH);
             });
@@ -56,11 +70,11 @@ class MinCustodyPeriodSlotCalculatorTest {
 
   @Test
   void shouldClampResultToFuluActivationWhenCalculatedPeriodIsEarlier() {
-    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS-1);
+    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS - 1);
     final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
 
     final MinCustodyPeriodSlotCalculator calculator =
-            MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+        MinCustodyPeriodSlotCalculator.createFromSpec(spec);
 
     final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
 
@@ -70,11 +84,11 @@ class MinCustodyPeriodSlotCalculatorTest {
 
   @Test
   void shouldReturnCalculatedPeriodWhenWellAfterFuluActivation() {
-    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS+10);
+    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS + 10);
     final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
 
     final MinCustodyPeriodSlotCalculator calculator =
-            MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+        MinCustodyPeriodSlotCalculator.createFromSpec(spec);
 
     final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
 
@@ -88,10 +102,10 @@ class MinCustodyPeriodSlotCalculatorTest {
     final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
 
     final MinCustodyPeriodSlotCalculator calculator =
-            MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+        MinCustodyPeriodSlotCalculator.createFromSpec(spec);
 
     final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
-    
+
     assertThat(resultSlot).isEqualTo(FULU_ACTIVATION_EPOCH.times(SLOTS_PER_EPOCH));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculatorTest.java
@@ -1,0 +1,97 @@
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.ForkSchedule;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigFulu;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+
+class MinCustodyPeriodSlotCalculatorTest {
+
+  private final Spec spec = mock(Spec.class);
+  private final ForkSchedule forkSchedule = mock(ForkSchedule.class);
+  private final Fork fuluFork = mock(Fork.class);
+  private final SpecConfig specConfig = mock(SpecConfig.class);
+  private final SpecConfigFulu specConfigFulu = mock(SpecConfigFulu.class);
+
+  private static final UInt64 SLOTS_PER_EPOCH = UInt64.valueOf(32);
+  private static final UInt64 FULU_ACTIVATION_EPOCH = UInt64.valueOf(100);
+  private static final int CUSTODY_PERIOD_EPOCHS = 10;
+
+  @BeforeEach
+  void setUp() {
+    when(spec.getForkSchedule()).thenReturn(forkSchedule);
+    when(forkSchedule.getFork(SpecMilestone.FULU)).thenReturn(fuluFork);
+    when(fuluFork.getEpoch()).thenReturn(FULU_ACTIVATION_EPOCH);
+
+    when(spec.getSpecConfig(any(UInt64.class))).thenReturn(specConfig);
+
+    when(specConfig.toVersionFulu()).thenReturn(Optional.of(specConfigFulu));
+    when(specConfigFulu.getMinEpochsForDataColumnSidecarsRequests())
+            .thenReturn(CUSTODY_PERIOD_EPOCHS);
+
+    when(spec.computeEpochAtSlot(any(UInt64.class)))
+            .thenAnswer(invocation -> {
+              UInt64 slot = invocation.getArgument(0);
+              return slot.dividedBy(SLOTS_PER_EPOCH);
+            });
+
+    when(spec.computeStartSlotAtEpoch(any(UInt64.class)))
+            .thenAnswer(invocation -> {
+              UInt64 epoch = invocation.getArgument(0);
+              return epoch.times(SLOTS_PER_EPOCH);
+            });
+  }
+
+  @Test
+  void shouldClampResultToFuluActivationWhenCalculatedPeriodIsEarlier() {
+    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS-1);
+    final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
+
+    final MinCustodyPeriodSlotCalculator calculator =
+            MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+
+    final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
+
+    final UInt64 expectedEpoch = FULU_ACTIVATION_EPOCH; // 100
+    assertThat(resultSlot).isEqualTo(expectedEpoch.times(SLOTS_PER_EPOCH));
+  }
+
+  @Test
+  void shouldReturnCalculatedPeriodWhenWellAfterFuluActivation() {
+    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS+10);
+    final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
+
+    final MinCustodyPeriodSlotCalculator calculator =
+            MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+
+    final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
+
+    final UInt64 expectedEpoch = UInt64.valueOf(110);
+    assertThat(resultSlot).isEqualTo(expectedEpoch.times(SLOTS_PER_EPOCH));
+  }
+
+  @Test
+  void shouldHandleExactBoundaryAtFuluActivation() {
+    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH;
+    final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
+
+    final MinCustodyPeriodSlotCalculator calculator =
+            MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+
+    final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
+    
+    assertThat(resultSlot).isEqualTo(FULU_ACTIVATION_EPOCH.times(SLOTS_PER_EPOCH));
+  }
+}


### PR DESCRIPTION
Always consider custody no earlier than fulu activation

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clamp min custody period to FULU activation and remove redundant milestone gating; add unit tests for boundary cases.
> 
> - **Custody logic**:
>   - Update `MinCustodyPeriodSlotCalculator` to cap `minCustodyEpoch` at FULU activation (`max(fuluActivationEpoch)`), ensuring custody starts no earlier than FULU.
>   - Simplify FULU config access by requiring FULU (`orElseThrow`) and using `getMinEpochsForDataColumnSidecarsRequests`.
>   - In `DataColumnSidecarCustodyImpl`, remove explicit pre-FULU short-circuit; rely on calculator-based cutoff.
> - **Tests**:
>   - Add `MinCustodyPeriodSlotCalculatorTest` covering pre-/post-/at-activation boundaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3873bf0e98438ae6f05a94f03a9a224717180813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->