### PR TITLE
Fix pre-fulu minCustodyPeriodSlotCalculator

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -151,8 +151,9 @@ public class DasCustodySync implements SlotEventsChannel {
                 if (missingColumn
                     .slot()
                     .isGreaterThan(
-                        minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(
-                            currentSlot.get()))) {
+                        minCustodyPeriodSlotCalculator
+                            .getMinCustodyPeriodSlot(currentSlot.get())
+                            .orElseThrow())) {
                   addPendingRequest(missingColumn);
                 } else {
                   LOG.debug(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.config.SpecConfigFulu;
 
 public interface MinCustodyPeriodSlotCalculator {
 
@@ -25,17 +27,15 @@ public interface MinCustodyPeriodSlotCalculator {
 
     return currentSlot -> {
       final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
-      final int custodyPeriodEpochs =
-          spec.getSpecConfig(currentEpoch)
-              .toVersionFulu()
-              .orElseThrow()
-              .getMinEpochsForDataColumnSidecarsRequests();
-
-      final UInt64 minCustodyEpoch =
-          currentEpoch.minusMinZero(custodyPeriodEpochs).max(fuluActivationEpoch);
-      return spec.computeStartSlotAtEpoch(minCustodyEpoch);
+      return spec.getSpecConfig(currentEpoch)
+          .toVersionFulu()
+          .map(SpecConfigFulu::getMinEpochsForDataColumnSidecarsRequests)
+          .map(
+              custodyPeriodEpochs ->
+                  currentEpoch.minusMinZero(custodyPeriodEpochs).max(fuluActivationEpoch))
+          .map(spec::computeStartSlotAtEpoch);
     };
   }
 
-  UInt64 getMinCustodyPeriodSlot(UInt64 currentSlot);
+  Optional<UInt64> getMinCustodyPeriodSlot(UInt64 currentSlot);
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
@@ -92,7 +92,8 @@ public class DasCustodySyncTest {
 
   @BeforeEach
   public void setup() {
-    when(minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(any())).thenReturn(UInt64.ZERO);
+    when(minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(any()))
+        .thenReturn(Optional.of(UInt64.ZERO));
   }
 
   @Test
@@ -280,7 +281,7 @@ public class DasCustodySyncTest {
     final DataColumnSidecarRetriever retriever = mock(DataColumnSidecarRetriever.class);
     final DataColumnSidecarCustody custody = mock(DataColumnSidecarCustody.class);
     when(minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(any()))
-        .thenReturn(UInt64.valueOf(1024));
+        .thenReturn(Optional.of(UInt64.valueOf(1024)));
     when(custody.retrieveMissingColumns()).thenReturn(testData(columns));
     final DasCustodySync custodySync =
         new DasCustodySync(
@@ -371,7 +372,8 @@ public class DasCustodySyncTest {
 
   private void assertAllCustodyColumnsPresent() {
     assertCustodyColumnsPresent(
-        custodyStand.getMinCustodySlot().intValue(), custodyStand.getCurrentSlot().intValue());
+        custodyStand.getMinCustodySlot().orElseThrow().intValue(),
+        custodyStand.getCurrentSlot().intValue());
   }
 
   private void assertCustodyColumnsPresent(final int fromSlot, final int tillSlot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -75,11 +75,11 @@ public class DataColumnSidecarCustodyImplTest {
 
   public static Stream<Arguments> minCustodyScenarios() {
     return Stream.of(
-        Arguments.of(0, 0),
-        Arguments.of(32768, 0),
-        Arguments.of(32765, 0),
-        Arguments.of(32776, 8),
-        Arguments.of(32784, 16));
+        Arguments.of(0, Optional.of(ZERO)),
+        Arguments.of(32768, Optional.of(ZERO)),
+        Arguments.of(32765, Optional.of(ZERO)),
+        Arguments.of(32776, Optional.of(UInt64.valueOf(8))),
+        Arguments.of(32784, Optional.of(UInt64.valueOf(16))));
   }
 
   @BeforeEach
@@ -163,9 +163,10 @@ public class DataColumnSidecarCustodyImplTest {
 
   @ParameterizedTest
   @MethodSource("minCustodyScenarios")
-  public void computesCustodyPeriodCorrectly(final int currentSlot, final int expectedCustodySlot) {
+  public void computesCustodyPeriodCorrectly(
+      final int currentSlot, final Optional<UInt64> expectedCustodySlot) {
     assertThat(minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(UInt64.valueOf(currentSlot)))
-        .isEqualTo(UInt64.valueOf(expectedCustodySlot));
+        .isEqualTo(expectedCustodySlot);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculatorTest.java
@@ -14,98 +14,79 @@
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.ForkSchedule;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.config.SpecConfigFulu;
-import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.TestSpecFactory;
 
 class MinCustodyPeriodSlotCalculatorTest {
+  private final UInt64 fuluActivationEpoch = UInt64.valueOf(100);
 
-  private final Spec spec = mock(Spec.class);
-  private final ForkSchedule forkSchedule = mock(ForkSchedule.class);
-  private final Fork fuluFork = mock(Fork.class);
-  private final SpecConfig specConfig = mock(SpecConfig.class);
-  private final SpecConfigFulu specConfigFulu = mock(SpecConfigFulu.class);
-
-  private static final UInt64 SLOTS_PER_EPOCH = UInt64.valueOf(32);
-  private static final UInt64 FULU_ACTIVATION_EPOCH = UInt64.valueOf(100);
-  private static final int CUSTODY_PERIOD_EPOCHS = 10;
-
-  @BeforeEach
-  void setUp() {
-    when(spec.getForkSchedule()).thenReturn(forkSchedule);
-    when(forkSchedule.getFork(SpecMilestone.FULU)).thenReturn(fuluFork);
-    when(fuluFork.getEpoch()).thenReturn(FULU_ACTIVATION_EPOCH);
-
-    when(spec.getSpecConfig(any(UInt64.class))).thenReturn(specConfig);
-
-    when(specConfig.toVersionFulu()).thenReturn(Optional.of(specConfigFulu));
-    when(specConfigFulu.getMinEpochsForDataColumnSidecarsRequests())
-        .thenReturn(CUSTODY_PERIOD_EPOCHS);
-
-    when(spec.computeEpochAtSlot(any(UInt64.class)))
-        .thenAnswer(
-            invocation -> {
-              UInt64 slot = invocation.getArgument(0);
-              return slot.dividedBy(SLOTS_PER_EPOCH);
-            });
-
-    when(spec.computeStartSlotAtEpoch(any(UInt64.class)))
-        .thenAnswer(
-            invocation -> {
-              UInt64 epoch = invocation.getArgument(0);
-              return epoch.times(SLOTS_PER_EPOCH);
-            });
-  }
+  private final Spec spec = TestSpecFactory.createMinimalWithFuluForkEpoch(fuluActivationEpoch);
+  private final int slotsPerEpoch = spec.getGenesisSpec().getSlotsPerEpoch();
+  private final int minEpochsForDataColumnSidecarsRequests =
+      spec.forMilestone(SpecMilestone.FULU)
+          .getConfig()
+          .toVersionFulu()
+          .orElseThrow()
+          .getMinEpochsForDataColumnSidecarsRequests();
 
   @Test
   void shouldClampResultToFuluActivationWhenCalculatedPeriodIsEarlier() {
-    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS - 1);
-    final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
+    final UInt64 currentEpoch =
+        fuluActivationEpoch.plus(minEpochsForDataColumnSidecarsRequests - 1);
+    final UInt64 currentSlot = currentEpoch.times(slotsPerEpoch);
 
     final MinCustodyPeriodSlotCalculator calculator =
         MinCustodyPeriodSlotCalculator.createFromSpec(spec);
 
-    final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
+    final Optional<UInt64> resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
 
-    final UInt64 expectedEpoch = FULU_ACTIVATION_EPOCH; // 100
-    assertThat(resultSlot).isEqualTo(expectedEpoch.times(SLOTS_PER_EPOCH));
+    final UInt64 expectedEpoch = fuluActivationEpoch; // 100
+    assertThat(resultSlot).contains(expectedEpoch.times(slotsPerEpoch));
   }
 
   @Test
   void shouldReturnCalculatedPeriodWhenWellAfterFuluActivation() {
-    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH.plus(CUSTODY_PERIOD_EPOCHS + 10);
-    final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
+    final UInt64 currentEpoch =
+        fuluActivationEpoch.plus(minEpochsForDataColumnSidecarsRequests + 10);
+    final UInt64 currentSlot = currentEpoch.times(slotsPerEpoch);
 
     final MinCustodyPeriodSlotCalculator calculator =
         MinCustodyPeriodSlotCalculator.createFromSpec(spec);
 
-    final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
+    final Optional<UInt64> resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
 
     final UInt64 expectedEpoch = UInt64.valueOf(110);
-    assertThat(resultSlot).isEqualTo(expectedEpoch.times(SLOTS_PER_EPOCH));
+    assertThat(resultSlot).contains(expectedEpoch.times(slotsPerEpoch));
   }
 
   @Test
   void shouldHandleExactBoundaryAtFuluActivation() {
-    final UInt64 currentEpoch = FULU_ACTIVATION_EPOCH;
-    final UInt64 currentSlot = currentEpoch.times(SLOTS_PER_EPOCH);
+    final UInt64 currentEpoch = fuluActivationEpoch;
+    final UInt64 currentSlot = currentEpoch.times(slotsPerEpoch);
 
     final MinCustodyPeriodSlotCalculator calculator =
         MinCustodyPeriodSlotCalculator.createFromSpec(spec);
 
-    final UInt64 resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
+    final Optional<UInt64> resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
 
-    assertThat(resultSlot).isEqualTo(FULU_ACTIVATION_EPOCH.times(SLOTS_PER_EPOCH));
+    assertThat(resultSlot).contains(fuluActivationEpoch.times(slotsPerEpoch));
+  }
+
+  @Test
+  void shouldHandlePreFuluSlot() {
+    final UInt64 currentEpoch = fuluActivationEpoch.minus(10);
+    final UInt64 currentSlot = currentEpoch.times(slotsPerEpoch);
+
+    final MinCustodyPeriodSlotCalculator calculator =
+        MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+
+    final Optional<UInt64> resultSlot = calculator.getMinCustodyPeriodSlot(currentSlot);
+
+    assertThat(resultSlot).isEmpty();
   }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
@@ -156,7 +156,7 @@ public class DasCustodyStand {
     return custodyGroupCountManager.getCustodyColumnIndices();
   }
 
-  public UInt64 getMinCustodySlot() {
+  public Optional<UInt64> getMinCustodySlot() {
     return minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(currentSlot);
   }
 


### PR DESCRIPTION
fixes: #10172

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `getMinCustodyPeriodSlot` return `Optional` (empty pre-Fulu) and update custody and sync flows to respect absent custody period with adjusted behavior and tests.
> 
> - **Core API**:
>   - Change `MinCustodyPeriodSlotCalculator#getMinCustodyPeriodSlot` to return `Optional<UInt64>`; pre-Fulu now returns empty.
>   - Update implementation in `createFromSpec` to conditionally compute/start slot; add `SpecConfigFulu` usage.
> - **Custody Logic**:
>   - `DataColumnSidecarCustodyImpl`:
>     - On custody group increase, update `firstCustodyIncompleteSlot` only if min custody period present.
>     - `retrievePotentiallyIncompleteSlotCustodies` handles empty start slot (no stream).
>     - `retrieveSlotCustody` throws if called outside custody period; otherwise keeps skip behavior when below min slot.
>   - `DasCustodySync`:
>     - Filter missing columns using `minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(...).orElseThrow()`; skip requests outside retention.
> - **Test Fixtures**:
>   - `DasCustodyStand#getMinCustodySlot` now returns `Optional`.
> - **Tests**:
>   - Update mocks and assertions to use `Optional` for min custody slot (e.g., `DasCustodySyncTest`).
>   - Expand `DataColumnSidecarCustodyImplTest`: pre-Fulu behavior, epoch-boundary updates, exception on pre-Fulu retrieval, adjusted slots around Fulu activation.
>   - Rework `MinCustodyPeriodSlotCalculatorTest` to use real spec; add cases for clamping to Fulu activation, post-activation, exact boundary, and pre-Fulu (empty).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3a51d5d43cf1b3940f3429eb7557ec9e1a9ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->