### PR TITLE
Add padding check in ssz bitvector

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -34,6 +34,14 @@ class BitvectorImpl {
         size);
     BitSet bitset = new BitSet(size);
 
+    final int paddingSize = (size % 8);
+    if(paddingSize != 0) {
+      final byte paddingMask = (byte) (0xFF << paddingSize);
+        if ((bytes.get((size - 1) / 8) & paddingMask) != 0) {
+          throw new IllegalArgumentException("Invalid padding bits for Bitvector");
+        }
+    }
+
     for (int i = size - 1; i >= 0; i--) {
       if (((bytes.get(i / 8) >>> (i % 8)) & 0x01) == 1) {
         bitset.set(i);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -35,11 +35,11 @@ class BitvectorImpl {
     BitSet bitset = new BitSet(size);
 
     final int paddingSize = (size % 8);
-    if(paddingSize != 0) {
+    if (paddingSize != 0) {
       final byte paddingMask = (byte) (0xFF << paddingSize);
-        if ((bytes.get((size - 1) / 8) & paddingMask) != 0) {
-          throw new IllegalArgumentException("Invalid padding bits for Bitvector");
-        }
+      if ((bytes.get((size - 1) / 8) & paddingMask) != 0) {
+        throw new IllegalArgumentException("Invalid padding bits for Bitvector");
+      }
     }
 
     for (int i = size - 1; i >= 0; i--) {

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImplTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImplTest.java
@@ -88,6 +88,21 @@ class BitvectorImplTest {
   }
 
   @Test
+  public void deserializationNonZeroPadding() {
+    assertThatThrownBy(() -> BitvectorImpl.fromBytes(Bytes.of(5), 2))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid padding bits for Bitvector");
+  }
+
+  @Test
+  public void deserializationNoPadding() {
+    BitvectorImpl bitvector = BitvectorImpl.fromBytes(Bytes.of(5, 9), 16);
+    Bytes ssz = bitvector.serialize();
+    BitvectorImpl bitvector1 = BitvectorImpl.fromBytes(ssz, 16);
+    Assertions.assertEquals(bitvector, bitvector1);
+  }
+
+  @Test
   void bitlistHashTest() {
     Bytes32 hashOld =
         Bytes32.fromHexString("0x447ac4def72d4aa09ded8e1130cbe013511d4881c3393903ada630f034e985d7");

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImplTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImplTest.java
@@ -90,8 +90,8 @@ class BitvectorImplTest {
   @Test
   public void deserializationNonZeroPadding() {
     assertThatThrownBy(() -> BitvectorImpl.fromBytes(Bytes.of(5), 2))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Invalid padding bits for Bitvector");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid padding bits for Bitvector");
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate zero padding during Bitvector SSZ deserialization and add targeted tests.
> 
> - **SSZ Bitvector deserialization (`BitvectorImpl.fromBytes`)**:
>   - Validate and reject non‑zero padding bits when `size` is not a multiple of 8 (throws `IllegalArgumentException`).
>   - No changes to core bit parsing or size checks.
> - **Tests**:
>   - Add tests for non‑zero padding rejection and valid no‑padding round‑trip in `BitvectorImplTest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccc2af7b91cfa5b2368e036da444be87ba5f3160. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->