### PR TITLE
Simplify padding check

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -34,10 +34,9 @@ class BitvectorImpl {
         size);
     BitSet bitset = new BitSet(size);
 
-    final int paddingSize = (size % 8);
+    final int paddingSize = size % 8;
     if (paddingSize != 0) {
-      final byte paddingMask = (byte) (0xFF << paddingSize);
-      if ((bytes.get((size - 1) / 8) & paddingMask) != 0) {
+      if ((bytes.get((size - 1) / 8) >>> paddingSize) != 0) {
         throw new IllegalArgumentException("Invalid padding bits for Bitvector");
       }
     }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitvectorImpl.java
@@ -34,9 +34,9 @@ class BitvectorImpl {
         size);
     BitSet bitset = new BitSet(size);
 
-    final int paddingSize = size % 8;
-    if (paddingSize != 0) {
-      if ((bytes.get((size - 1) / 8) >>> paddingSize) != 0) {
+    final int bitsInLastByte = size % 8;
+    if (bitsInLastByte != 0) {
+      if ((bytes.get((size - 1) / 8) >>> bitsInLastByte) != 0) {
         throw new IllegalArgumentException("Invalid padding bits for Bitvector");
       }
     }


### PR DESCRIPTION


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies padding validation in Bitvector deserialization by using a right-shift check on the last byte.
> 
> - **SSZ Bitvector deserialization** (`infrastructure/ssz/.../BitvectorImpl.java`):
>   - Simplifies padding check in `fromBytes` by computing `bitsInLastByte` and validating via right-shift of the last byte.
>   - Core deserialization and bit-setting logic remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f7ecfe3ab63b8992f9fe0b175ea2bc8daa6936d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->