### PR TITLE
Fix 50% DAS Recover Acceptance Test flakiness

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
@@ -77,7 +77,8 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
                     .getConfig()
                     .getFuluForkEpoch())
             .intValue();
-    secondaryNode.waitForBlockAtOrAfterSlot(firstFuluSlot);
+    secondaryNode.waitForBlockSatisfying(
+        block -> assertThat(block.getSlot().intValue()).isGreaterThanOrEqualTo(firstFuluSlot));
 
     final SignedBeaconBlock blockAtHead = secondaryNode.getHeadBlock();
 
@@ -104,7 +105,7 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
           throws Exception {
     final TekuBeaconNode primaryNode =
         createTekuBeaconNode(
-            createSwiftConfigBuilder()
+            createFuluMinimalConfigBuilder()
                 .withRealNetwork()
                 .withDiscoveryNetwork()
                 // interop validators are not count for validator custody
@@ -120,7 +121,7 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
 
     final TekuBeaconNode secondaryNode =
         createTekuBeaconNode(
-            createSwiftConfigBuilder()
+            createFuluMinimalConfigBuilder()
                 .withRealNetwork()
                 .withDiscoveryNetwork()
                 .withGenesisTime(genesisTime.intValue())
@@ -133,7 +134,8 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
                 .build());
 
     // Wait for few epochs, so sync will kick-in when second node is started
-    primaryNode.waitForEpochAtOrAbove(4);
+    primaryNode.waitForEpochAtOrAbove(2);
+    primaryNode.waitForEpochAtOrAbove(3);
 
     secondaryNode.start();
     // DataColumnSidecars are reconstructed on secondaryNode
@@ -153,7 +155,8 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
                     .getConfig()
                     .getFuluForkEpoch())
             .intValue();
-    secondaryNode.waitForBlockAtOrAfterSlot(firstFuluSlot);
+    secondaryNode.waitForBlockSatisfying(
+        block -> assertThat(block.getSlot().intValue()).isGreaterThanOrEqualTo(firstFuluSlot));
     final SignedBeaconBlock blockAtHead = secondaryNode.getHeadBlock();
 
     final int endSlot = blockAtHead.getSlot().intValue();
@@ -205,20 +208,6 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
   private TekuNodeConfigBuilder createFuluMinimalConfigBuilder() throws Exception {
     return TekuNodeConfigBuilder.createBeaconNode()
         .withNetwork(Resources.getResource("fulu-minimal.yaml"))
-        .withStubExecutionEngine()
-        .withLogLevel("DEBUG");
-  }
-
-  private TekuNodeConfigBuilder createSwiftConfigBuilder() throws Exception {
-    return TekuNodeConfigBuilder.createBeaconNode()
-        .withNetwork("swift")
-        .withAltairEpoch(UInt64.ZERO)
-        .withBellatrixEpoch(UInt64.ZERO)
-        .withCapellaEpoch(UInt64.ZERO)
-        .withDenebEpoch(UInt64.ZERO)
-        .withElectraEpoch(UInt64.ZERO)
-        .withFuluEpoch(UInt64.ONE)
-        .withTotalTerminalDifficulty(0)
         .withStubExecutionEngine()
         .withLogLevel("DEBUG");
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
There is a big chance when not the first slot is recovered, and checks are started, but it's not first slot, so it's saved for the future and not imported. Adding wait for a head (just 1 minute, maybe not enough, checking on CI)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes 50% DAS recovery acceptance tests by switching to `fulu-minimal` config, adding deterministic waits around Fulu fork slots, tuning withhold/sync settings, disabling EL recovery, and removing flaky waits/helpers.
> 
> - **Acceptance Tests (`Das50PercentRecoveryAcceptanceTest`)**:
>   - Switch to `createFuluMinimalConfigBuilder()` (replace `Swift` config); remove `createSwiftConfigBuilder()`.
>   - Add deterministic wait for first Fulu slot via `waitForBlockSatisfying(...)`; remove `waitForNonOptimisticBlock()`.
>   - Tune runtime settings:
>     - Add `withDasPublishWithholdColumnsEverySlots(9999)`.
>     - Add `withDasDisableElRecovery()` on nodes.
>     - Adjust sync wait from epoch 5 to 3; ensure discovery network in syncing test.
>   - Unskip tests (remove `@Disabled`) and minor log-based readiness checks for column rebuilds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3de22e8cfffc683780b3d0ccb222114f7621497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->