### PR TITLE
Updated block production duties for fulu 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Added new metrics `beacon_earliest_available_slot` and
   `data_column_sidecar_processing_validated_total`.
+- Block proposal duties can now be scheduled in advance for fulu.
 
 ### Bug Fixes
-- Teku may crash when shutting down
+- Fixed a storage issue which sometimes caused Teku to crash during shut down.

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -324,7 +324,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
           new IllegalArgumentException(
               String.format(
                   "Proposer duties were requested %s epochs ahead, only 1 epoch in future is supported.",
-                  epoch.minus(combinedChainDataClient.getCurrentEpoch()).toString())));
+                  epoch.minus(currentEpoch).toString())));
     }
 
     final UInt64 stateSlot = getStateSlotForProposerDuties(spec, epoch);
@@ -340,10 +340,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
 
   // PRE: the distance between dutiesEpoch and currentEpoch is validated
   static UInt64 getStateSlotForProposerDuties(final Spec spec, final UInt64 dutiesEpoch) {
-    if (spec.atEpoch(dutiesEpoch).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
-      if (spec.atEpoch(dutiesEpoch.minusMinZero(1))
-          .getMilestone()
-          .isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
+    if (spec.isMilestoneSupported(SpecMilestone.FULU)) {
+      final UInt64 fuluActivationEpoch =
+          spec.getForkSchedule().getFork(SpecMilestone.FULU).getEpoch();
+      if (dutiesEpoch.minusMinZero(1).isGreaterThanOrEqualTo(fuluActivationEpoch)) {
         // on fulu boundary we have no context,
         // but after fulu boundary our dependent root is previous epoch
         return spec.computeStartSlotAtEpoch(dutiesEpoch.minusMinZero(1));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
@@ -33,11 +33,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 
 public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
 
-  // epoch | 0                   | 1
-  // slot  | 1  2  3  4  5  6  7 | 8
-  // query |                     | ^
-  // dep   |                   D |
-  // EXPECT epoch 1 duties with dependent root slot 7
   private static final Logger LOG = LogManager.getLogger();
 
   @Test
@@ -52,13 +47,13 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
   }
 
-  // epoch | 0                   | 1
+  // epoch | 0                   |<1>
   // slot  | 1  2  3  4  5  6  7 |
   // query |                   ^ |
   // dep   |                   D |
-  // EXPECT - should be able to query for the next epoch, may not be stable if its too early.
+  // EXPECT - should be able to query for the next epoch, may not be stable if it's too early.
   @Test
-  void shouldReturnNextEpochDutiesBeforeEpochTransition() throws IOException {
+  void shouldReturnNextEpochDutiesFutureEpoch() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.ALTAIR);
     final List<SignedBlockAndState> chain = createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
@@ -70,7 +65,7 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getRoot());
   }
 
-  // epoch | 0                   | 1                      | 2
+  // epoch | 0                   | 1                      | <2>
   // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
   // query |                     |                        |  ^
   // dep   |                     |                      D |
@@ -90,11 +85,11 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
   }
 
-  // epoch | 0                   | 1                      | 2
-  // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
-  // query |                     |                        |  ^
-  // dep   |                     |                      D |
-  // EXPECT - expect epoch 2 duties with dependent root slot 15
+  // epoch | 0                   |<1>
+  // slot  | 1  2  3  4  5  6  7 | 8
+  // query |                     | ^
+  // dep   |                   D |
+  // EXPECT epoch 1 duties with dependent root slot 7
   @Test
   void shouldReturnCorrectDependentRootPostFulu() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
@@ -107,6 +102,11 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
   }
 
+  // epoch | 0                   |<1>                     |  2
+  // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
+  // query |                     |                        |  ^
+  // dep   |                   D |                        |
+  // EXPECT - expect epoch 1 duties with dependent root slot 7
   @Test
   void shouldReturnCorrectDependentRootPostFuluExtraSlots() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
@@ -121,13 +121,13 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     assertThat(dependentRoot(responseBody)).isEqualTo(chain.get(6).getRoot());
   }
 
-  // epoch | 0                   | 1                      | 2
+  // epoch | 0                   | 1                      | <2>
   // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 |
   // query |                     |                      ^ |
-  // dep   |                     |                      D |
+  // dep   |                   D |                        |
   // EXPECT - expect epoch 2 duties with dependent root slot 15
   @Test
-  void shouldReturnCorrectDependentRootPostFuluExtraSlots2() throws IOException {
+  void shouldReturnCorrectDependentRootPostFuluExtraSlotsFutureEpoch() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
     final List<SignedBlockAndState> chain =
         createBlocksAtSlots(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -138,10 +138,10 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     final Response response = getProposerDuties("2");
     final String responseBody = response.body().string();
     assertThat(response.code()).isEqualTo(200);
-    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getRoot());
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.get(6).getRoot());
   }
 
-  // epoch | 0                   | 1                      | 2
+  // epoch | 0                   | 1                      | <2>
   // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
   // query |                     |                        |  ^
   // dep   |                     |                      D |
@@ -177,9 +177,8 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     chain.forEach(
         signedBlockAndState ->
             LOG.info(
-                "SLOT: {}, root: {}, ROOT: {}",
+                "slot: {}, root: {}",
                 signedBlockAndState.getSlot(),
-                signedBlockAndState.getRoot(),
-                signedBlockAndState.getBlock().getRoot()));
+                signedBlockAndState.getRoot()));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -113,6 +113,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   }
 
   private PendingDuties createEpochDuties(final UInt64 epochNumber) {
+    LOG.trace("Creating epoch duties for epoch {}", epochNumber);
     return PendingDuties.calculateDuties(metricsSystem, epochDutiesScheduler, epochNumber);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -54,4 +54,9 @@ public class AttestationDutyLoader
         .selectStrategy(duties.getDuties().size())
         .scheduleAllDuties(epoch, duties);
   }
+
+  @Override
+  public String getDutyType() {
+    return "Attestation";
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -110,8 +110,8 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
         spec.atEpoch(epoch).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU) ? 1 : 0;
     LOG.trace(
         "LookAhead period for block duty at milestone {} is {}",
-            () -> spec.atEpoch(epoch).getMilestone(),
-            () -> lookAheadEpochs);
+        () -> spec.atEpoch(epoch).getMilestone(),
+        () -> lookAheadEpochs);
     return lookAheadEpochs;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.validator.client;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.api.response.ValidatorStatus;
@@ -23,11 +25,12 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 public class BlockDutyScheduler extends AbstractDutyScheduler {
-  private static final int LOOKAHEAD_EPOCHS = 0;
+  private static final Logger LOG = LogManager.getLogger();
 
   public BlockDutyScheduler(
       final MetricsSystem metricsSystem, final DutyLoader<?> dutyLoader, final Spec spec) {
@@ -82,6 +85,12 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
 
   @Override
   public int getLookAheadEpochs(final UInt64 epoch) {
-    return LOOKAHEAD_EPOCHS;
+    final int lookAheadEpochs =
+        spec.atEpoch(epoch).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU) ? 1 : 0;
+    LOG.debug(
+        "LookAhead period for block duty at milestone {} is {}",
+        spec.atEpoch(epoch).getMilestone(),
+        lookAheadEpochs);
+    return lookAheadEpochs;
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -70,4 +70,9 @@ public class BlockProductionDutyLoader
         .getValidator(duty.getPublicKey())
         .ifPresent(validator -> scheduledDuties.scheduleProduction(duty.getSlot(), validator));
   }
+
+  @Override
+  public String getDutyType() {
+    return "Block Production";
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DutyLoader.java
@@ -20,4 +20,6 @@ import tech.pegasys.teku.validator.client.duties.ScheduledDuties;
 
 public interface DutyLoader<T extends ScheduledDuties> {
   SafeFuture<Optional<T>> loadDutiesForEpoch(final UInt64 epoch);
+
+  String getDutyType();
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
@@ -105,7 +105,7 @@ class PendingDuties {
   }
 
   public synchronized void recalculate() {
-    LOG.trace("Recalculating duties, epoch {}", epoch);
+    LOG.trace("Recalculating {} duties, epoch {}", dutyLoader::getDutyType, () -> epoch);
     scheduledDuties.cancel(false);
     // We need to ensure the duties future is completed before .
     scheduledDuties = dutyLoader.loadDutiesForEpoch(epoch);
@@ -113,9 +113,9 @@ class PendingDuties {
         this::processPendingActions,
         error -> {
           if (!(Throwables.getRootCause(error) instanceof CancellationException)) {
-            LOG.error("Failed to load duties", error);
+            LOG.error("Failed to load {} duties", dutyLoader::getDutyType, () -> error);
           } else {
-            LOG.trace("Loading duties cancelled", error);
+            LOG.trace("Loading {} duties cancelled", dutyLoader::getDutyType, () -> error);
           }
         });
   }
@@ -159,6 +159,10 @@ class PendingDuties {
   }
 
   public synchronized void onHeadUpdate(final Bytes32 dependentRoot) {
+    LOG.trace(
+        "Received head update for {} duties,  dependentRoot {}",
+        dutyLoader::getDutyType,
+        () -> dependentRoot);
     getCurrentDuties()
         .ifPresentOrElse(
             duties -> {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PendingDuties.java
@@ -105,6 +105,7 @@ class PendingDuties {
   }
 
   public synchronized void recalculate() {
+    LOG.trace("Recalculating duties, epoch {}", epoch);
     scheduledDuties.cancel(false);
     // We need to ensure the duties future is completed before .
     scheduledDuties = dutyLoader.loadDutiesForEpoch(epoch);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/PtcDutyLoader.java
@@ -79,4 +79,9 @@ public class PtcDutyLoader extends AbstractDutyLoader<PtcDuties, SlotBasedSchedu
                       return null;
                     }));
   }
+
+  @Override
+  public String getDutyType() {
+    return "PTC";
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/RetryingDutyLoader.java
@@ -52,6 +52,11 @@ public class RetryingDutyLoader<S extends ScheduledDuties> implements DutyLoader
     return duties;
   }
 
+  @Override
+  public String getDutyType() {
+    return delegate.getDutyType();
+  }
+
   private SafeFuture<Optional<S>> requestDuties(
       final UInt64 epoch, final SafeFuture<Optional<S>> cancellable) {
     LOG.trace("Request duties for epoch {}", epoch);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoader.java
@@ -111,4 +111,9 @@ public class SyncCommitteeDutyLoader
                 dutyBuilder.committeeAssignments(
                     validator, duty.getValidatorIndex(), duty.getValidatorSyncCommitteeIndices()));
   }
+
+  @Override
+  public String getDutyType() {
+    return "Sync Committee";
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
@@ -120,6 +120,8 @@ public class SlotBasedScheduledDuties<P extends Duty, A extends Duty> implements
 
   @Override
   public boolean requiresRecalculation(final Bytes32 newDependentRoot) {
+    LOG.trace(
+        "current dependent root {}, new dependent root {}", getDependentRoot(), newDependentRoot);
     final boolean requiresRecalculation = !getDependentRoot().equals(newDependentRoot);
     if (requiresRecalculation) {
       LOG.debug(


### PR DESCRIPTION
Expanded tests to show how things work.

Did some manual testing on minimal network and on testnets, and looking right. Had to expand some logs to improve what we can see.

fixes #10124

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables advance block proposal scheduling and correct dependent-root handling around Fulu by adjusting proposer-duty tolerance and state-slot selection, adds duty-type-aware logging, and expands unit/integration tests; updates changelog.
> 
> - **Validator API (`ValidatorApiHandler`)**:
>   - Proposer duties: enforce future-epoch tolerance using `minSeedLookahead + DUTY_EPOCH_TOLERANCE`; compute state slot via `getStateSlotForProposerDuties` with Fulu-aware epoch offset; select dependent root pre/post-Fulu correctly.
>   - Add helper `getStateSlotForProposerDuties`; refine logs. Apply same tolerance pattern to `getPtcDuties`.
> - **Validator Client (scheduling)**:
>   - Block duties: Fulu-aware `getExpectedDependentRoot` and `getLookAheadEpochs` (now 1 epoch look-ahead at/after Fulu).
>   - Add `DutyLoader#getDutyType` and implement across loaders; use in `PendingDuties`/schedulers for clearer logs.
>   - Minor trace logging improvements in `AbstractDutyScheduler`, `PendingDuties`, and `SlotBasedScheduledDuties`.
> - **Tests**:
>   - Add/expand unit tests for Fulu state-slot selection and proposer duties; adjust expectations for next/current epoch cases.
>   - Add REST integration tests verifying dependent root pre/post-Fulu across epochs.
> - **Changelog**:
>   - Note advance scheduling of block proposal duties for Fulu and a shutdown storage crash fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a14fde2b9eb6e9aab83919743f0e8b0ed298a0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->