### PR TITLE
+1 minute wait time for fulu block reconstruction

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -156,7 +157,9 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
                     .getFuluForkEpoch())
             .intValue();
     secondaryNode.waitForBlockSatisfying(
-        block -> assertThat(block.getSlot().intValue()).isGreaterThanOrEqualTo(firstFuluSlot));
+        block -> assertThat(block.getSlot().intValue()).isGreaterThanOrEqualTo(firstFuluSlot),
+        2,
+        TimeUnit.MINUTES);
     final SignedBeaconBlock blockAtHead = secondaryNode.getHeadBlock();
 
     final int endSlot = blockAtHead.getSlot().intValue();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -494,7 +495,10 @@ public class TekuBeaconNode extends TekuNode {
     LOG.debug("Non default execution payload found at slot " + slot);
   }
 
-  public void waitForBlockSatisfying(final ThrowingConsumer<? super SignedBeaconBlock> assertions) {
+  public void waitForBlockSatisfying(
+      final ThrowingConsumer<? super SignedBeaconBlock> assertions,
+      final int timeout,
+      final TimeUnit timeUnit) {
     LOG.debug("Wait for a block satisfying certain assertions");
 
     waitFor(
@@ -503,8 +507,12 @@ public class TekuBeaconNode extends TekuNode {
           assertThat(block).isPresent();
           assertThat(block.get()).satisfies(assertions);
         },
-        1,
-        MINUTES);
+        timeout,
+        timeUnit);
+  }
+
+  public void waitForBlockSatisfying(final ThrowingConsumer<? super SignedBeaconBlock> assertions) {
+    waitForBlockSatisfying(assertions, 1, MINUTES);
   }
 
   public void waitForGenesisWithNonDefaultExecutionPayload() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

The issue is that recovery has no priority and it's common when, say slot 10, 15, 18 etc (all slots are with half custody provided) are reconstructing slowing down slot 8 order, and CI is slow, so it's not enough time to reach first fulu slot. Adding 1 more minute for wait time

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase DAS recovery test wait to 2 minutes by adding a timeout-configurable waitForBlockSatisfying in TekuBeaconNode.
> 
> - **Acceptance Tests**:
>   - Update `Das50PercentRecoveryAcceptanceTest` to call `waitForBlockSatisfying(..., 2, TimeUnit.MINUTES)` when awaiting the first Fulu slot.
> - **Test DSL**:
>   - Add overloaded `waitForBlockSatisfying(assertions, timeout, timeUnit)` in `TekuBeaconNode` and keep existing method delegating to a 1-minute default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5c3fbc9864ba219df1b0416113b056c821fb27a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->