### PR TITLE
cleanup for proposer duties computation

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -49,15 +49,11 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
@@ -385,37 +381,6 @@ class ValidatorApiHandlerTest {
         validatorApiHandler.getProposerDuties(EPOCH);
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(IllegalArgumentException.class);
-  }
-
-  public static Stream<Arguments> getStateSlotForProposerDutiesTestCases() {
-    // | EPOCH | START SLOT | END SLOT |
-    // |   0   |       0    |     7    |
-    // |   1   |       8    |    15    |
-    // |   2   |      16    |    23    |
-    // |   3   |      24    |    31    |
-    return Stream.of(
-        Arguments.of(SpecMilestone.PHASE0, 0, 0),
-        Arguments.of(SpecMilestone.PHASE0, 1, 8),
-        Arguments.of(SpecMilestone.PHASE0, 2, 16),
-        Arguments.of(SpecMilestone.PHASE0, 3, 24),
-        Arguments.of(SpecMilestone.FULU, 0, 0),
-        Arguments.of(SpecMilestone.FULU, 1, 0),
-        Arguments.of(SpecMilestone.FULU, 2, 8),
-        Arguments.of(SpecMilestone.FULU, 3, 16));
-  }
-
-  @ParameterizedTest
-  @MethodSource("getStateSlotForProposerDutiesTestCases")
-  public void getStateSlotForProposerDuties(
-      final SpecMilestone specMilestone, final int requestedEpoch, final int expectedSlot) {
-    final Spec localSpec = TestSpecFactory.createMinimal(specMilestone);
-    final UInt64 querySlot =
-        localSpec
-            .getGenesisSpec()
-            .getBlockProposalUtil()
-            .getStateSlotForProposerDuties(localSpec, UInt64.valueOf(requestedEpoch));
-
-    assertThat(querySlot.intValue()).isEqualTo(expectedSlot);
   }
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -410,8 +410,10 @@ class ValidatorApiHandlerTest {
       final SpecMilestone specMilestone, final int requestedEpoch, final int expectedSlot) {
     final Spec localSpec = TestSpecFactory.createMinimal(specMilestone);
     final UInt64 querySlot =
-        ValidatorApiHandler.getStateSlotForProposerDuties(
-            localSpec, UInt64.valueOf(requestedEpoch));
+        localSpec
+            .getGenesisSpec()
+            .getBlockProposalUtil()
+            .getStateSlotForProposerDuties(localSpec, UInt64.valueOf(requestedEpoch));
 
     assertThat(querySlot.intValue()).isEqualTo(expectedSlot);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.Attest
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProposalUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
 public class SpecLogicAltair extends AbstractSpecLogic {
@@ -168,7 +169,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         new ForkChoiceUtil(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilPhase0(schemaDefinitions, blockProcessor);
 
     // State upgrade
     final AltairStateUpgrade stateUpgrade =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.Attest
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProposalUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class SpecLogicBellatrix extends AbstractSpecLogic {
@@ -173,7 +174,7 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
         new ForkChoiceUtil(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilPhase0(schemaDefinitions, blockProcessor);
 
     final BlindBlockUtilBellatrix blindBlockUtil = new BlindBlockUtilBellatrix(schemaDefinitions);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.spec.logic.versions.capella.withdrawals.WithdrawalsHelp
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProposalUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
 public class SpecLogicCapella extends AbstractSpecLogic {
@@ -181,7 +182,7 @@ public class SpecLogicCapella extends AbstractSpecLogic {
         new ForkChoiceUtil(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilPhase0(schemaDefinitions, blockProcessor);
 
     final BlindBlockUtilBellatrix blindBlockUtil = new BlindBlockUtilBellatrix(schemaDefinitions);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.operations.validation.Attesta
 import tech.pegasys.teku.spec.logic.versions.deneb.util.AttestationUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProposalUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
 public class SpecLogicDeneb extends AbstractSpecLogic {
@@ -181,7 +182,7 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
         new ForkChoiceUtilDeneb(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilPhase0(schemaDefinitions, blockProcessor);
 
     final BlindBlockUtilBellatrix blindBlockUtil = new BlindBlockUtilBellatrix(schemaDefinitions);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.Volun
 import tech.pegasys.teku.spec.logic.versions.electra.statetransition.epoch.EpochProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.withdrawals.WithdrawalsHelpersElectra;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProposalUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
 public class SpecLogicElectra extends AbstractSpecLogic {
@@ -201,7 +202,7 @@ public class SpecLogicElectra extends AbstractSpecLogic {
         new ForkChoiceUtilDeneb(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilPhase0(schemaDefinitions, blockProcessor);
 
     final BlindBlockUtilBellatrix blindBlockUtil = new BlindBlockUtilBellatrix(schemaDefinitions);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BeaconStateAccessorsFu
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.statetransition.epoch.EpochProcessorFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.BlindBlockUtilFulu;
+import tech.pegasys.teku.spec.logic.versions.fulu.util.BlockProposalUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.ForkChoiceUtilFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 
@@ -202,7 +203,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
         new ForkChoiceUtilFulu(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilFulu(schemaDefinitions, blockProcessor, config.getFuluForkEpoch());
 
     final BlindBlockUtilFulu blindBlockUtil = new BlindBlockUtilFulu(schemaDefinitions);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFulu.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.fulu.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProposalUtilPhase0;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+
+public class BlockProposalUtilFulu extends BlockProposalUtilPhase0 {
+  private static final Logger LOG = LogManager.getLogger();
+  private final Optional<UInt64> forkEpoch;
+
+  public BlockProposalUtilFulu(
+      final SchemaDefinitions schemaDefinitions,
+      final BlockProcessor blockProcessor,
+      final UInt64 forkEpoch) {
+    super(schemaDefinitions, blockProcessor);
+    this.forkEpoch = forkEpoch.equals(UInt64.MAX_VALUE) ? Optional.empty() : Optional.of(forkEpoch);
+  }
+
+  @Override
+  public int getProposerLookAheadEpochs() {
+    return 1;
+  }
+
+  @Override
+  public UInt64 getStateSlotForProposerDuties(final Spec spec, final UInt64 dutiesEpoch) {
+    if (forkEpoch.isPresent()
+        && dutiesEpoch.minusMinZero(1).isGreaterThanOrEqualTo(forkEpoch.get())) {
+      // on fulu boundary we have no context,
+      // but after fulu boundary our dependent root is previous epoch
+      return spec.computeStartSlotAtEpoch(dutiesEpoch.minusMinZero(1));
+    }
+    return super.getStateSlotForProposerDuties(spec, dutiesEpoch);
+  }
+
+  @Override
+  public Bytes32 getBlockProposalDependentRoot(
+      final Bytes32 headBlockRoot,
+      final Bytes32 previousTargetRoot,
+      final Bytes32 currentTargetRoot,
+      final UInt64 headEpoch,
+      final UInt64 dutyEpoch) {
+    if (forkEpoch.isEmpty() || forkEpoch.get().isLessThanOrEqualTo(dutyEpoch.minusMinZero(1))) {
+      return super.getBlockProposalDependentRoot(
+          headBlockRoot, previousTargetRoot, currentTargetRoot, headEpoch, dutyEpoch);
+    }
+    checkArgument(
+        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
+        "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
+        dutyEpoch,
+        headEpoch);
+    if (headEpoch.equals(dutyEpoch)) {
+      LOG.debug("headEpoch {} - returning previousDutyDependentRoot", () -> headEpoch);
+      return previousTargetRoot;
+    } else if (headEpoch.increment().equals(dutyEpoch)) {
+      LOG.debug("dutyEpoch (next epoch) {} - returning currentDutyDependentRoot", () -> dutyEpoch);
+      return currentTargetRoot;
+    } else {
+      LOG.debug(
+          "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () -> headEpoch);
+      return headBlockRoot;
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequests
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.BlindBlockUtilFulu;
+import tech.pegasys.teku.spec.logic.versions.fulu.util.BlockProposalUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.block.BlockProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.execution.ExecutionPayloadProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.forktransition.GloasStateUpgrade;
@@ -212,7 +213,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
         new ForkChoiceUtilGloas(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilFulu(schemaDefinitions, blockProcessor, config.getFuluForkEpoch());
 
     final BlindBlockUtilFulu blindBlockUtil = new BlindBlockUtilFulu(schemaDefinitions);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.Volunt
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.BlockProposalUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class SpecLogicPhase0 extends AbstractSpecLogic {
@@ -147,7 +148,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         new ForkChoiceUtil(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
-        new BlockProposalUtil(schemaDefinitions, blockProcessor);
+        new BlockProposalUtilPhase0(schemaDefinitions, blockProcessor);
 
     return new SpecLogicPhase0(
         predicates,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.phase0.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
+import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+
+public class BlockProposalUtilPhase0 implements BlockProposalUtil {
+
+  private final BlockProcessor blockProcessor;
+  private final SchemaDefinitions schemaDefinitions;
+
+  public BlockProposalUtilPhase0(
+      final SchemaDefinitions schemaDefinitions, final BlockProcessor blockProcessor) {
+    this.schemaDefinitions = schemaDefinitions;
+    this.blockProcessor = blockProcessor;
+  }
+
+  @Override
+  public int getProposerLookAheadEpochs() {
+    return 0;
+  }
+
+  @Override
+  public Bytes32 getBlockProposalDependentRoot(
+      final Bytes32 headBlockRoot,
+      final Bytes32 previousTargetRoot,
+      final Bytes32 currentTargetRoot,
+      final UInt64 headEpoch,
+      final UInt64 dutyEpoch) {
+    checkArgument(
+        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
+        "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
+        dutyEpoch,
+        headEpoch);
+    return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
+  }
+
+  @Override
+  public UInt64 getStateSlotForProposerDuties(final Spec spec, final UInt64 dutiesEpoch) {
+    return spec.computeStartSlotAtEpoch(dutiesEpoch);
+  }
+
+  @Override
+  public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
+      final UInt64 proposalSlot,
+      final int proposerIndex,
+      final BeaconState blockSlotState,
+      final Bytes32 parentBlockSigningRoot,
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder,
+      final BlockProductionPerformance blockProductionPerformance) {
+    checkArgument(
+        blockSlotState.getSlot().equals(proposalSlot),
+        "Block slot state from incorrect slot. Expected %s but got %s",
+        proposalSlot,
+        blockSlotState.getSlot());
+
+    // Create block body
+    final SafeFuture<? extends BeaconBlockBody> beaconBlockBody = createBlockBody(bodyBuilder);
+
+    // Create initial block with some stubs
+    final Bytes32 tmpStateRoot = Bytes32.ZERO;
+    final SafeFuture<BeaconBlock> newBlock =
+        beaconBlockBody.thenApply(
+            body -> {
+              final BeaconBlockSchema beaconBlockSchema =
+                  body.isBlinded()
+                      ? schemaDefinitions.getBlindedBeaconBlockSchema()
+                      : schemaDefinitions.getBeaconBlockSchema();
+              return beaconBlockSchema.create(
+                  proposalSlot,
+                  UInt64.valueOf(proposerIndex),
+                  parentBlockSigningRoot,
+                  tmpStateRoot,
+                  body);
+            });
+
+    return newBlock
+        .thenApplyChecked(
+            block -> {
+              blockProductionPerformance.beaconBlockCreated();
+              // Run state transition and set state root
+              // Skip verifying signatures as all operations are coming from our own pools.
+
+              final BeaconState newState =
+                  blockProcessor.processUnsignedBlock(
+                      blockSlotState,
+                      block,
+                      IndexedAttestationCache.NOOP,
+                      BLSSignatureVerifier.NO_OP,
+                      Optional.empty());
+
+              blockProductionPerformance.stateTransition();
+
+              final Bytes32 stateRoot = newState.hashTreeRoot();
+
+              blockProductionPerformance.stateHashing();
+              final BeaconBlock newCompleteBlock = block.withStateRoot(stateRoot);
+
+              return new BeaconBlockAndState(newCompleteBlock, newState);
+            })
+        .exceptionallyCompose(
+            error -> {
+              if (ExceptionUtil.hasCause(error, BlockProcessingException.class)) {
+                return SafeFuture.failedFuture(new StateTransitionException(error));
+              }
+              return SafeFuture.failedFuture(error);
+            });
+  }
+
+  private SafeFuture<? extends BeaconBlockBody> createBlockBody(
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
+    final BeaconBlockBodyBuilder builder = schemaDefinitions.createBeaconBlockBodyBuilder();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFuluTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.fulu.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+
+class BlockProposalUtilFuluTest {
+  public static Stream<Arguments> getStateSlotForProposerDutiesTestCases() {
+    // | EPOCH | START SLOT | END SLOT |
+    // |   0   |       0    |     7    |
+    // |   1   |       8    |    15    |
+    // |   2   |      16    |    23    |
+    // |   3   |      24    |    31    |
+    return Stream.of(
+        Arguments.of(0, 0), Arguments.of(1, 0), Arguments.of(2, 8), Arguments.of(3, 16));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getStateSlotForProposerDutiesTestCases")
+  public void getStateSlotForProposerDuties(final int requestedEpoch, final int expectedSlot) {
+    final Spec localSpec = TestSpecFactory.createMinimal(SpecMilestone.FULU);
+    final UInt64 querySlot =
+        localSpec
+            .getGenesisSpec()
+            .getBlockProposalUtil()
+            .getStateSlotForProposerDuties(localSpec, UInt64.valueOf(requestedEpoch));
+
+    assertThat(querySlot.intValue()).isEqualTo(expectedSlot);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.phase0.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+
+class BlockProposalUtilPhase0Test {
+  public static Stream<Arguments> getStateSlotForProposerDutiesTestCases() {
+    // | EPOCH | START SLOT | END SLOT |
+    // |   0   |       0    |     7    |
+    // |   1   |       8    |    15    |
+    // |   2   |      16    |    23    |
+    // |   3   |      24    |    31    |
+    return Stream.of(
+        Arguments.of(0, 0), Arguments.of(1, 8), Arguments.of(2, 16), Arguments.of(3, 24));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getStateSlotForProposerDutiesTestCases")
+  public void getStateSlotForProposerDuties(final int requestedEpoch, final int expectedSlot) {
+    final Spec localSpec = TestSpecFactory.createMinimal(SpecMilestone.PHASE0);
+    final UInt64 querySlot =
+        localSpec
+            .getGenesisSpec()
+            .getBlockProposalUtil()
+            .getStateSlotForProposerDuties(localSpec, UInt64.valueOf(requestedEpoch));
+
+    assertThat(querySlot.intValue()).isEqualTo(expectedSlot);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.validator.client;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -25,7 +23,6 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
@@ -75,39 +72,48 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
       final Bytes32 currentTargetRoot,
       final UInt64 headEpoch,
       final UInt64 dutyEpoch) {
-    if (spec.atEpoch(dutyEpoch).getMilestone().isLessThan(SpecMilestone.FULU)
-        || spec.atEpoch(dutyEpoch.minusMinZero(1)).getMilestone().isLessThan(SpecMilestone.FULU)) {
-      // prior to fulu, and also fulu change epoch, will just use phase0 dependent root
-      checkArgument(
-          dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
-          "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
-          dutyEpoch,
-          headEpoch);
-      return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
-    }
-
-    checkArgument(
-        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
-        "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
-        dutyEpoch,
-        headEpoch);
-    if (headEpoch.equals(dutyEpoch)) {
-      LOG.debug("headEpoch {} - returning previousDutyDependentRoot", () -> headEpoch);
-      return previousTargetRoot;
-    } else if (headEpoch.increment().equals(dutyEpoch)) {
-      LOG.debug("dutyEpoch (next epoch) {} - returning currentDutyDependentRoot", () -> dutyEpoch);
-      return currentTargetRoot;
-    } else {
-      LOG.debug(
-          "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () -> headEpoch);
-      return headBlockRoot;
-    }
+    return spec.atEpoch(dutyEpoch)
+        .getBlockProposalUtil()
+        .getBlockProposalDependentRoot(
+            headBlockRoot, previousTargetRoot, currentTargetRoot, headEpoch, dutyEpoch);
+    //    if (spec.atEpoch(dutyEpoch).getMilestone().isLessThan(SpecMilestone.FULU)
+    //        ||
+    // spec.atEpoch(dutyEpoch.minusMinZero(1)).getMilestone().isLessThan(SpecMilestone.FULU)) {
+    //      // prior to fulu, and also fulu change epoch, will just use phase0 dependent root
+    //      checkArgument(
+    //          dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
+    //          "Attempting to calculate dependent root for duty epoch %s that is before the updated
+    // head epoch %s",
+    //          dutyEpoch,
+    //          headEpoch);
+    //      return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
+    //    }
+    //
+    //    checkArgument(
+    //        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
+    //        "Attempting to calculate dependent root for duty epoch %s that is before the updated
+    // head epoch %s",
+    //        dutyEpoch,
+    //        headEpoch);
+    //    if (headEpoch.equals(dutyEpoch)) {
+    //      LOG.debug("headEpoch {} - returning previousDutyDependentRoot", () -> headEpoch);
+    //      return previousTargetRoot;
+    //    } else if (headEpoch.increment().equals(dutyEpoch)) {
+    //      LOG.debug("dutyEpoch (next epoch) {} - returning currentDutyDependentRoot", () ->
+    // dutyEpoch);
+    //      return currentTargetRoot;
+    //    } else {
+    //      LOG.debug(
+    //          "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () ->
+    // headEpoch);
+    //      return headBlockRoot;
+    //    }
   }
 
   @Override
   public int getLookAheadEpochs(final UInt64 epoch) {
     final int lookAheadEpochs =
-        spec.atEpoch(epoch).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.FULU) ? 1 : 0;
+        spec.atEpoch(epoch).getBlockProposalUtil().getProposerLookAheadEpochs();
     LOG.trace(
         "LookAhead period for block duty at milestone {} is {}",
         () -> spec.atEpoch(epoch).getMilestone(),

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockDutyScheduler.java
@@ -76,38 +76,6 @@ public class BlockDutyScheduler extends AbstractDutyScheduler {
         .getBlockProposalUtil()
         .getBlockProposalDependentRoot(
             headBlockRoot, previousTargetRoot, currentTargetRoot, headEpoch, dutyEpoch);
-    //    if (spec.atEpoch(dutyEpoch).getMilestone().isLessThan(SpecMilestone.FULU)
-    //        ||
-    // spec.atEpoch(dutyEpoch.minusMinZero(1)).getMilestone().isLessThan(SpecMilestone.FULU)) {
-    //      // prior to fulu, and also fulu change epoch, will just use phase0 dependent root
-    //      checkArgument(
-    //          dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
-    //          "Attempting to calculate dependent root for duty epoch %s that is before the updated
-    // head epoch %s",
-    //          dutyEpoch,
-    //          headEpoch);
-    //      return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
-    //    }
-    //
-    //    checkArgument(
-    //        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
-    //        "Attempting to calculate dependent root for duty epoch %s that is before the updated
-    // head epoch %s",
-    //        dutyEpoch,
-    //        headEpoch);
-    //    if (headEpoch.equals(dutyEpoch)) {
-    //      LOG.debug("headEpoch {} - returning previousDutyDependentRoot", () -> headEpoch);
-    //      return previousTargetRoot;
-    //    } else if (headEpoch.increment().equals(dutyEpoch)) {
-    //      LOG.debug("dutyEpoch (next epoch) {} - returning currentDutyDependentRoot", () ->
-    // dutyEpoch);
-    //      return currentTargetRoot;
-    //    } else {
-    //      LOG.debug(
-    //          "headBlockRoot returned - dutyEpoch {}, headEpoch {}", () -> dutyEpoch, () ->
-    // headEpoch);
-    //      return headBlockRoot;
-    //    }
   }
 
   @Override


### PR DESCRIPTION
fixes #10183

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes proposer-duty dependent root/slot and lookahead logic in milestone-specific BlockProposalUtil implementations and updates validator APIs/scheduler to use them.
> 
> - **Spec logic**:
>   - Introduce `BlockProposalUtil` interface; add `BlockProposalUtilPhase0` and `BlockProposalUtilFulu`.
>   - Wire `BlockProposalUtilPhase0` into Phase0–Deneb/Electra; wire `BlockProposalUtilFulu` into Fulu and Gloas with fork-epoch–aware logic (`getStateSlotForProposerDuties`, `getBlockProposalDependentRoot`, `getProposerLookAheadEpochs`).
> - **Validator**:
>   - `ValidatorApiHandler`: obtain proposer-duty state slot via `spec.atEpoch(epoch).getBlockProposalUtil().getStateSlotForProposerDuties(...)`.
> - **Validator client**:
>   - `BlockDutyScheduler`: delegate dependent-root and lookahead calculations to `BlockProposalUtil`.
> - **Tests**:
>   - Remove old state-slot tests from `ValidatorApiHandlerTest` and add focused tests for `BlockProposalUtilPhase0` and `BlockProposalUtilFulu`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6638a4d4f906d56d758a1c0fef57730ca2aaae50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->