### PR TITLE
increase download timeouts for sidecar retriever

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
@@ -131,7 +131,8 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
                 .withSubscribeAllCustodySubnetsEnabled()
                 .withInteropValidators(0, 0)
                 .withDasDisableElRecovery()
-                .withExperimentalReworkedRecovery()
+                .withReworkedRecovery()
+                .withReworkedRecoveryTimeouts(100_000, 40_000)
                 .build());
 
     // Wait for few epochs, so sync will kick-in when second node is started

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -674,9 +674,18 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
-  public TekuNodeConfigBuilder withExperimentalReworkedRecovery() {
+  public TekuNodeConfigBuilder withReworkedRecovery() {
     LOG.debug("Xp2p-reworked-sidecar-recovery-enabled: {}", true);
     configMap.put("Xp2p-reworked-sidecar-recovery-enabled", true);
+    return this;
+  }
+
+  public TekuNodeConfigBuilder withReworkedRecoveryTimeouts(
+      final int recoveryTimeout, final int downloadTimeout) {
+    LOG.debug("Xp2p-reworked-sidecar-cancel-timeout-ms: {}", recoveryTimeout);
+    configMap.put("Xp2p-reworked-sidecar-cancel-timeout-ms", recoveryTimeout);
+    LOG.debug("Xp2p-reworked-sidecar-download-timeout-ms: {}", downloadTimeout);
+    configMap.put("Xp2p-reworked-sidecar-download-timeout-ms", downloadTimeout);
     return this;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever.recovering;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
@@ -190,38 +192,45 @@ public class SidecarRetriever implements DataColumnSidecarRetriever {
     // make sure requests are within their timeout
     requests.values().forEach(request -> request.checkTimeout(currentTime));
 
+    final List<DataColumnSlotAndIdentifier> cancelledRequests = new ArrayList<>();
     // update state of any requests that are active
-    requests.values().stream()
-        .filter(PendingRecoveryRequest::isFailedDownloading)
-        .forEach(
-            request -> {
-              if (custodyGroupCountManager.getCustodyGroupCount() == 128) {
-                final RebuildColumnsTask rebuildColumnsTask =
-                    rebuildTasks.computeIfAbsent(
-                        request.getBlockRoot(),
-                        __ -> {
-                          LOG.debug(
-                              "Rebuilding columns for slot {} root {}",
-                              request.getSlot(),
-                              request.getBlockRoot());
-                          return new RebuildColumnsTask(
-                              request.getSlotAndBlockRoot(),
-                              currentTime,
-                              recoveryTimeout.minus(downloadTimeout),
-                              numberOfColumnsRequiredToReconstruct,
-                              sidecarDB,
-                              miscHelpersFulu);
-                        });
-                rebuildColumnsTask.addTask(request);
-              } else {
-                LOG.debug(
-                    "Custody group count {} is not viable to reconstruct for slot {} root {}",
-                    custodyGroupCountManager.getCustodyGroupCount(),
-                    request.getSlot(),
-                    request.getBlockRoot());
-                request.cancel();
-              }
-            });
+    requests.forEach(
+        (columnId, request) -> {
+          if (!request.isFailedDownloading()) {
+            return;
+          }
+          if (custodyGroupCountManager.getCustodyGroupCount()
+              >= numberOfColumnsRequiredToReconstruct) {
+            final RebuildColumnsTask rebuildColumnsTask =
+                rebuildTasks.computeIfAbsent(
+                    request.getBlockRoot(),
+                    __ -> {
+                      LOG.debug(
+                          "Rebuilding columns for slot {} root {}",
+                          request.getSlot(),
+                          request.getBlockRoot());
+                      return new RebuildColumnsTask(
+                          request.getSlotAndBlockRoot(),
+                          currentTime,
+                          recoveryTimeout.minus(downloadTimeout),
+                          numberOfColumnsRequiredToReconstruct,
+                          sidecarDB,
+                          miscHelpersFulu);
+                    });
+            rebuildColumnsTask.addTask(request);
+          } else {
+            LOG.debug("Cancelled request for {}", columnId);
+            request.cancel();
+            // this will be cleaned to allow it to be added by another task, since its currently not
+            // recoverable.
+            cancelledRequests.add(columnId);
+          }
+        });
+    if (!cancelledRequests.isEmpty()) {
+      LOG.debug("Removing {} pending requests", cancelledRequests.size());
+      cancelledRequests.forEach(requests::remove);
+    }
+
     rebuildTasks.entrySet().removeIf(entry -> entry.getValue().isDone(currentTime));
 
     rebuildTasks.forEach((key, value) -> value.checkQueryResult());

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -53,8 +53,8 @@ public class P2PConfig {
   // it's not allowed to set less than requirement which is > 0, so it's safe value
   public static final int DEFAULT_CUSTODY_GROUP_COUNT_OVERRIDE = 0;
   public static final int DEFAULT_DAS_PUBLISH_WITHHOLD_COLUMNS_EVERY_SLOTS = -1;
-  public static final int DEFAULT_RECOVERY_TIMEOUT_MS = 180_000;
-  public static final int DEFAULT_DOWNLOAD_TIMEOUT_MS = 40_000;
+  public static final int DEFAULT_RECOVERY_TIMEOUT_MS = 300_000;
+  public static final int DEFAULT_DOWNLOAD_TIMEOUT_MS = 240_000;
   // RocksDB is configured with 6 background jobs and threads (DEFAULT_MAX_BACKGROUND_JOBS and
   // DEFAULT_BACKGROUND_THREAD_COUNT)
   // The storage query channel allows up to 10 parallel queries (STORAGE_QUERY_CHANNEL_PARALLELISM)


### PR DESCRIPTION
This will help with recovery process.

Also changed logging a little for DasSampler to not just ignore timeouts, but currently just logging it explicitly as a warning.

Also removing cancelled downloads from the pending requests map.

The original recovery process had a 5-minute timeout for the downloads portion, we're up to 240s on download timeout after this change by default (from 40s). Having that increase seems to be related to longer range queries and having tons of column downloads in flight.

partially addresses #10185

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase default sidecar download/recovery timeouts, refine recovery logic and cancellation handling, and update tests/config builder accordingly.
> 
> - **P2P defaults**:
>   - Increase `DEFAULT_RECOVERY_TIMEOUT_MS` to `300_000` and `DEFAULT_DOWNLOAD_TIMEOUT_MS` to `240_000` in `P2PConfig`.
> - **Sidecar recovery**:
>   - In `SidecarRetriever#checkPendingRequests`, trigger rebuild when custody groups `>= numberOfColumnsRequiredToReconstruct` (was strict value), cancel and remove non-recoverable pending requests, and track cancellations.
> - **DAS sampling**:
>   - In `DasSamplerBasic`, replace `ignoreCancelException().finishError(LOG)` with explicit `finish` handler: log `CancellationException` as warning; log other errors.
> - **Acceptance tests & DSL**:
>   - Rename config builder method to `withReworkedRecovery()` and add `withReworkedRecoveryTimeouts(...)` in `TekuNodeConfigBuilder`.
>   - Update `Das50PercentRecoveryAcceptanceTest` to use new methods and assert rebuild log messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89ee0bbd887069e867b30e76231b3c052ee04c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->