### PR TITLE
updated log levels in execution stub.

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -171,7 +171,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     }
     if (blockHash.equals(terminalBlockHash)) {
       // TBH flow
-      LOG.info("TBH: sending terminal block hash " + terminalBlockHash);
+      LOG.debug("TBH: sending terminal block hash " + terminalBlockHash);
       terminalBlockSent = true;
       return SafeFuture.completedFuture(Optional.of(terminalBlock));
     }
@@ -198,7 +198,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     }
     if (timeProvider.getTimeInSeconds().isGreaterThanOrEqualTo(transitionTime)) {
       // TTD flow
-      LOG.info("TTD: sending terminal block hash " + terminalBlockHash);
+      LOG.debug("TTD: sending terminal block hash " + terminalBlockHash);
       terminalBlockSent = true;
       return SafeFuture.completedFuture(terminalBlock);
     }
@@ -212,7 +212,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     offlineCheck();
 
     if (!bellatrixActivationDetected) {
-      LOG.info(
+      LOG.debug(
           "forkChoiceUpdated received before terminalBlock has been sent. Assuming transition already happened");
 
       // do the activation check to be able to respond to terminal block verification
@@ -233,7 +233,15 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                   return payloadId;
                 }));
 
-    LOG.info(
+    if (!LOG.isDebugEnabled()) {
+      LOG.info(
+          "head: {}:{}, payload: {}:{}",
+          forkChoiceState.getHeadBlockSlot(),
+          forkChoiceState.getHeadBlockRoot(),
+          forkChoiceState.getHeadExecutionBlockNumber(),
+          forkChoiceState.getHeadExecutionBlockHash());
+    }
+    LOG.debug(
         "forkChoiceUpdated: forkChoiceState: {} payloadBuildingAttributes: {} -> forkChoiceUpdatedResult: {}",
         forkChoiceState,
         payloadBuildingAttributes,
@@ -248,7 +256,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     offlineCheck();
 
     if (!bellatrixActivationDetected) {
-      LOG.info(
+      LOG.debug(
           "getPayload received before terminalBlock has been sent. Assuming transition already happened");
 
       // do the activation check to be able to respond to terminal block verification
@@ -306,9 +314,9 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     headAndAttrs.currentExecutionPayload = Optional.of(executionPayload);
 
     LOG.info(
-        "getPayload: payloadId: {} slot: {} -> executionPayload blockHash: {}",
-        executionPayloadContext.getPayloadId(),
+        "slot: {}, payloadId: {}, Payload hash: {}",
         state.getSlot(),
+        executionPayloadContext.getPayloadId(),
         executionPayload.getBlockHash());
 
     final Optional<ExecutionRequests> maybeExecutionRequests = getExecutionRequests(slot);
@@ -318,7 +326,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
             .currentBlobsBundle
             .map(
                 blobsBundle -> {
-                  LOG.info("getPayload: blobsBundle: {}", blobsBundle.toBriefString());
+                  LOG.debug("getPayload: blobsBundle: {}", blobsBundle.toBriefString());
                   return maybeExecutionRequests
                       .map(
                           executionRequests ->
@@ -362,7 +370,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     final PayloadStatus returnedStatus =
         Optional.ofNullable(knownPosBlocks.get(executionPayload.getBlockHash()))
             .orElse(payloadStatus);
-    LOG.info(
+    LOG.debug(
         "newPayload: executionPayload blockHash: {}  versionedHashes: {} parentBeaconBlockRoot: {} -> {}",
         executionPayload.getBlockHash(),
         newPayloadRequest.getVersionedHashes(),
@@ -407,7 +415,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     offlineCheck();
 
     final UInt64 slot = state.getSlot();
-    LOG.info(
+    LOG.debug(
         "getPayloadHeader: payloadId: {} slot: {} ... delegating to getPayload ...",
         executionPayloadContext,
         slot);
@@ -420,7 +428,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
         .thenApply(
             getPayloadResponse -> {
               final ExecutionPayload executionPayload = getPayloadResponse.getExecutionPayload();
-              LOG.info(
+              LOG.debug(
                   "getPayloadHeader: payloadId: {} slot: {} -> executionPayload blockHash: {}",
                   executionPayloadContext,
                   slot,
@@ -509,7 +517,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
         "provided signed blinded block contains an execution payload header not matching the previously retrieved "
             + "execution payload via getPayloadHeader");
 
-    LOG.info(
+    LOG.debug(
         "proposeBlindedBlock: slot: {} block: {} -> unblinded executionPayload blockHash: {}",
         slot,
         signedBeaconBlock.getRoot(),
@@ -579,7 +587,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   private void checkBellatrixActivation() {
     if (!bellatrixActivationDetected) {
-      LOG.info("Bellatrix activation detected");
+      LOG.debug("Bellatrix activation detected");
       bellatrixActivationDetected = true;
       prepareTransitionBlocks(timeProvider.getTimeInSeconds());
     }
@@ -591,10 +599,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     final SpecConfigBellatrix specConfigBellatrix =
         specVersion.getConfig().toVersionBellatrix().orElseThrow();
 
-    LOG.info("Preparing transition blocks using spec");
+    LOG.debug("Preparing transition blocks using spec");
     final Bytes32 configTerminalBlockHash = specConfigBellatrix.getTerminalBlockHash();
 
-    LOG.info("Preparing transition via TBH: {}", configTerminalBlockHash);
+    LOG.debug("Preparing transition via TBH: {}", configTerminalBlockHash);
     this.transitionTime = bellatrixActivationTime;
     this.terminalBlockHash = configTerminalBlockHash;
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -235,7 +235,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
     if (!LOG.isDebugEnabled()) {
       LOG.info(
-          "head: {}:{}, payload: {}:{}",
+          "EL Stub FCU head: {}:{}, payload: {}:{}",
           forkChoiceState.getHeadBlockSlot(),
           forkChoiceState.getHeadBlockRoot(),
           forkChoiceState.getHeadExecutionBlockNumber(),


### PR DESCRIPTION
The goal was to have a less verbose output by default while still having a good level of information to see what's going on.

With everything at info it was so noisy on screen that it was hard to track what was going on.

Arguably this could be further tweaked to have some of the less common things at trace level, and then we can maybe still see when we want 'more' but not 'everything'.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades many INFO logs to DEBUG, adds a conditional INFO summary for FCU, and tweaks a few log messages in ExecutionLayerChannelStub.
> 
> - **Logging**
>   - Downgrade `LOG.info` to `LOG.debug` across transition/TBH/TTD paths, `forkChoiceUpdated`, `getPayload`, `newPayload`, `getPayloadHeader`, `proposeBlindedBlock`, Bellatrix activation, and transition prep in `ExecutionLayerChannelStub`.
>   - Add conditional `LOG.info` (when debug is disabled) summarizing FCU head/payload in `engineForkChoiceUpdated`.
>   - Tweak `engineGetPayload` info log to: `slot`, `payloadId`, `Payload hash`.
>   - Log `blobsBundle` details at DEBUG instead of INFO.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a619e82cff0287eca98822c50835e3b8892a500d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->