### PR TITLE
looking at matrixEntrySchema

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -401,8 +401,8 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
                         .create(
                             kzgCellAndProofs.get(cellIndex).cell(),
                             kzgCellAndProofs.get(cellIndex).proof(),
-                            blobIndex,
-                            cellIndex));
+                            cellIndex,
+                            blobIndex));
               }
               return row;
             })
@@ -426,8 +426,8 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
                         .create(
                             kzgCells.get(cellIndex),
                             blobAndCellProofs.cellProofs().get(cellIndex),
-                            blobIndex,
-                            cellIndex));
+                            cellIndex,
+                            blobIndex));
               }
               return row;
             })


### PR DESCRIPTION
investigating a potential inconsistency

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Swap `MatrixEntrySchema.create` index arguments to pass `(cellIndex, blobIndex)` when building extended matrices.
> 
> - **Helpers (Fulu)**
>   - **Extended matrix construction**:
>     - In `computeExtendedMatrixAndProofs` and `computeExtendedMatrix` within `tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java`, update `getMatrixEntrySchema().create(...)` calls to pass indices as `(cellIndex, blobIndex)` instead of `(blobIndex, cellIndex)` for each `MatrixEntry`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 888ed7225eac30bfb6fa87ed6e8d4f61a3beba5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->