### PR TITLE
Allow sampler to reissue RPC requests

### DIFF
--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -120,9 +120,11 @@ public class DasSamplerBasicTest {
 
     sampler.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC);
 
+    assertSamplerTrackerHasRPCFetchScheduled(sidecar.getBeaconBlockRoot(), true);
+
     assertRPCFetchInMillis(
         sidecar.getSlot(), sidecar.getBeaconBlockRoot(), remainingColumns, 1_000);
-    assertSamplerTrackerHasRPCFetchScheduled(sidecar.getBeaconBlockRoot(), true);
+    assertSamplerTrackerHasRPCFetchScheduled(sidecar.getBeaconBlockRoot(), false);
   }
 
   @Test


### PR DESCRIPTION
If RPC requests issued by the sampler fail (due to timeout or other problems) the sampler stalls and never retries downloads.

This can stall the sync itself, because even in the case `SyncStallDetector` restarts the sync, the sampler will always have the same trackers with RPCFetched marked as `true`. Thus no more attempts on restart.


With this change, multiple calls to `checkDataAvailability` can cause redownloads attempt on incomplete trackers.

related to: #10185


NOTE: A limitation of the current sync design is that the sync has no feedback from the PreSampler, so the only way it has to attempt a recovery is via `SyncStallDetector`, which requires a relatively long timeout.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows `DasSamplerBasic` to retry RPC data fetches by resetting the scheduled flag and short-circuiting completed trackers; updates tests to cover retry and scheduling behavior.
> 
> - **Statetransition (DAS Sampler)**
>   - In `checkDataAvailability(...)`:
>     - Return early if `completionFuture` is already done.
>     - Atomically schedule RPC fetch with `rpcFetchScheduled().compareAndSet(false, true)`.
>   - In `fetchMissingColumnsViaRPC(...)`:
>     - After completion (success or failure), reset `rpcFetchScheduled` via `.alwaysRun(() -> ...set(false))` to allow retries.
> - **Tests**
>   - Add coverage for retry on failure and scheduling reset/behavior.
>   - Introduce helper to assert `rpcFetchScheduled` state; adjust expectations for zero/non-zero delays.
>   - Minor refactor to map construction for sidecars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9950140251d2a64a1e0a5747ccfe8d0200c4ddb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->