### PR TITLE
[Gloas] Store full expected withdrawals in BeaconState + spec alignment

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -273,7 +273,7 @@ public class BlockOperationSelectorFactory {
             beaconStateElectra ->
                 beaconStateElectra.getPendingPartialWithdrawals().stream()
                     .map(PendingPartialWithdrawal::getValidatorIndex)
-                    .noneMatch(index -> index == validatorIndex.intValue()))
+                    .noneMatch(index -> index.equals(validatorIndex)))
         .orElse(true);
   }
 

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconStateGloas.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconStateGloas.json
@@ -1,7 +1,7 @@
 {
   "title" : "BeaconStateGloas",
   "type" : "object",
-  "required" : [ "genesis_time", "genesis_validators_root", "slot", "fork", "latest_block_header", "block_roots", "state_roots", "historical_roots", "eth1_data", "eth1_data_votes", "eth1_deposit_index", "validators", "balances", "randao_mixes", "slashings", "previous_epoch_participation", "current_epoch_participation", "justification_bits", "previous_justified_checkpoint", "current_justified_checkpoint", "finalized_checkpoint", "inactivity_scores", "current_sync_committee", "next_sync_committee", "latest_execution_payload_bid", "next_withdrawal_index", "next_withdrawal_validator_index", "historical_summaries", "deposit_requests_start_index", "deposit_balance_to_consume", "exit_balance_to_consume", "earliest_exit_epoch", "consolidation_balance_to_consume", "earliest_consolidation_epoch", "pending_deposits", "pending_partial_withdrawals", "pending_consolidations", "proposer_lookahead", "execution_payload_availability", "builder_pending_payments", "builder_pending_withdrawals", "latest_block_hash", "latest_withdrawals_root" ],
+  "required" : [ "genesis_time", "genesis_validators_root", "slot", "fork", "latest_block_header", "block_roots", "state_roots", "historical_roots", "eth1_data", "eth1_data_votes", "eth1_deposit_index", "validators", "balances", "randao_mixes", "slashings", "previous_epoch_participation", "current_epoch_participation", "justification_bits", "previous_justified_checkpoint", "current_justified_checkpoint", "finalized_checkpoint", "inactivity_scores", "current_sync_committee", "next_sync_committee", "latest_execution_payload_bid", "next_withdrawal_index", "next_withdrawal_validator_index", "historical_summaries", "deposit_requests_start_index", "deposit_balance_to_consume", "exit_balance_to_consume", "earliest_exit_epoch", "consolidation_balance_to_consume", "earliest_consolidation_epoch", "pending_deposits", "pending_partial_withdrawals", "pending_consolidations", "proposer_lookahead", "execution_payload_availability", "builder_pending_payments", "builder_pending_withdrawals", "latest_block_hash", "payload_expected_withdrawals" ],
   "properties" : {
     "genesis_time" : {
       "type" : "string",
@@ -258,11 +258,11 @@
       "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
       "format" : "byte"
     },
-    "latest_withdrawals_root" : {
-      "type" : "string",
-      "description" : "Bytes32 hexadecimal",
-      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-      "format" : "byte"
+    "payload_expected_withdrawals" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Withdrawal"
+      }
     }
   }
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -69,10 +69,10 @@ public class ReferenceTestFinder {
                 return Stream.of(
                         new BlsTestFinder(),
                         new KzgTestFinder(),
-                        new SszTestFinder("ssz_generic"),
-                        new SszTestFinder("ssz_static"),
+                        // new SszTestFinder("ssz_generic"),
+                        // new SszTestFinder("ssz_static"),
                         new ShufflingTestFinder(),
-                        new PyspecTestFinder(List.of(), List.of("fork_choice/")),
+                        // new PyspecTestFinder(List.of(), List.of("fork_choice/")),
                         new MerkleProofTestFinder())
                     .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
               }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -69,6 +69,8 @@ public class ReferenceTestFinder {
                 return Stream.of(
                         new BlsTestFinder(),
                         new KzgTestFinder(),
+                        // TODO-GLOAS: not running these reference tests until the upcoming specs
+                        // have been implemented
                         // new SszTestFinder("ssz_generic"),
                         // new SszTestFinder("ssz_static"),
                         new ShufflingTestFinder(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -35,6 +35,6 @@ public class Domain {
   public static final Bytes4 BLS_TO_EXECUTION_CHANGE = Bytes4.fromHexString("0x0A000000");
 
   // Gloas
-  public static final Bytes4 BEACON_BUILDER = Bytes4.fromHexString("0x1B000000");
+  public static final Bytes4 BEACON_BUILDER = Bytes4.fromHexString("0x0B000000");
   public static final Bytes4 PTC_ATTESTER = Bytes4.fromHexString("0x0C000000");
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
@@ -87,7 +87,7 @@ public enum BeaconStateFields implements SszFieldName {
   BUILDER_PENDING_PAYMENTS,
   BUILDER_PENDING_WITHDRAWALS,
   LATEST_BLOCK_HASH,
-  LATEST_WITHDRAWALS_ROOT;
+  PAYLOAD_EXPECTED_WITHDRAWALS;
 
   private final String sszFieldName;
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloas.java
@@ -18,7 +18,7 @@ import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.Bea
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.EXECUTION_PAYLOAD_AVAILABILITY;
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.LATEST_BLOCK_HASH;
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.LATEST_EXECUTION_PAYLOAD_BID;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.LATEST_WITHDRAWALS_ROOT;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.PAYLOAD_EXPECTED_WITHDRAWALS;
 
 import com.google.common.base.MoreObjects;
 import java.util.Optional;
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingP
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingWithdrawal;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
 
@@ -71,7 +72,7 @@ public interface BeaconStateGloas extends BeaconStateFulu {
     addItems(stringBuilder, "builder_pending_payments", state.getBuilderPendingPayments());
     addItems(stringBuilder, "builder_pending_withdrawals", state.getBuilderPendingWithdrawals());
     stringBuilder.add("latest_block_hash", state.getLatestBlockHash());
-    stringBuilder.add("latest_withdrawals_root", state.getLatestWithdrawalsRoot());
+    stringBuilder.add("payload_expected_withdrawals", state.getPayloadExpectedWithdrawals());
   }
 
   @Override
@@ -115,8 +116,8 @@ public interface BeaconStateGloas extends BeaconStateFulu {
     return ((SszBytes32) getAny(index)).get();
   }
 
-  default Bytes32 getLatestWithdrawalsRoot() {
-    final int index = getSchema().getFieldIndex(LATEST_WITHDRAWALS_ROOT);
-    return ((SszBytes32) getAny(index)).get();
+  default SszList<Withdrawal> getPayloadExpectedWithdrawals() {
+    final int index = getSchema().getFieldIndex(PAYLOAD_EXPECTED_WITHDRAWALS);
+    return getAny(index);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateSchemaGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateSchemaGloas.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BUILDER_PENDIN
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BUILDER_PENDING_WITHDRAWALS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_AVAILABILITY_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_BID_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYLOAD_SCHEMA;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
@@ -36,6 +37,7 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingPayment;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingWithdrawal;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
@@ -52,7 +54,7 @@ public class BeaconStateSchemaGloas
   public static final int BUILDER_PENDING_PAYMENTS_FIELD_INDEX = 39;
   public static final int BUILDER_PENDING_WITHDRAWALS_FIELD_INDEX = 40;
   public static final int LATEST_BLOCK_HASH_FIELD_INDEX = 41;
-  public static final int LATEST_WITHDRAWALS_ROOT_FIELD_INDEX = 42;
+  public static final int PAYLOAD_EXPECTED_WITHDRAWALS_FIELD_INDEX = 42;
 
   @VisibleForTesting
   BeaconStateSchemaGloas(final SpecConfig specConfig, final SchemaRegistry schemaRegistry) {
@@ -80,9 +82,9 @@ public class BeaconStateSchemaGloas
                 BeaconStateFields.LATEST_BLOCK_HASH,
                 () -> SszPrimitiveSchemas.BYTES32_SCHEMA),
             new SszField(
-                LATEST_WITHDRAWALS_ROOT_FIELD_INDEX,
-                BeaconStateFields.LATEST_WITHDRAWALS_ROOT,
-                () -> SszPrimitiveSchemas.BYTES32_SCHEMA));
+                PAYLOAD_EXPECTED_WITHDRAWALS_FIELD_INDEX,
+                BeaconStateFields.PAYLOAD_EXPECTED_WITHDRAWALS,
+                () -> schemaRegistry.get(EXECUTION_PAYLOAD_SCHEMA).getWithdrawalsSchemaRequired()));
 
     return Stream.concat(
             BeaconStateSchemaFulu.getUniqueFields(specConfig, schemaRegistry).stream()
@@ -158,6 +160,12 @@ public class BeaconStateSchemaGloas
   public SszListSchema<BuilderPendingWithdrawal, ?> getBuilderPendingWithdrawalsSchema() {
     return (SszListSchema<BuilderPendingWithdrawal, ?>)
         getChildSchema(getFieldIndex(BeaconStateFields.BUILDER_PENDING_WITHDRAWALS));
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszListSchema<Withdrawal, ?> getPayloadExpectedWithdrawalsSchema() {
+    return (SszListSchema<Withdrawal, ?>)
+        getChildSchema(getFieldIndex(BeaconStateFields.PAYLOAD_EXPECTED_WITHDRAWALS));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloas.java
@@ -18,7 +18,7 @@ import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.Bea
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.EXECUTION_PAYLOAD_AVAILABILITY;
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.LATEST_BLOCK_HASH;
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.LATEST_EXECUTION_PAYLOAD_BID;
-import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.LATEST_WITHDRAWALS_ROOT;
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.PAYLOAD_EXPECTED_WITHDRAWALS;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingP
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingWithdrawal;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.MutableBeaconStateFulu;
 
@@ -98,8 +99,8 @@ public interface MutableBeaconStateGloas extends MutableBeaconStateFulu, BeaconS
     set(fieldIndex, SszBytes32.of(latestBlockHash));
   }
 
-  default void setLatestWithdrawalsRoot(final Bytes32 latestWithdrawalsRoot) {
-    final int fieldIndex = getSchema().getFieldIndex(LATEST_WITHDRAWALS_ROOT);
-    set(fieldIndex, SszBytes32.of(latestWithdrawalsRoot));
+  default void setPayloadExpectedWithdrawals(final SszList<Withdrawal> payloadExpectedWithdrawals) {
+    final int fieldIndex = getSchema().getFieldIndex(PAYLOAD_EXPECTED_WITHDRAWALS);
+    set(fieldIndex, payloadExpectedWithdrawals);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingPartialWithdrawal.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingPartialWithdrawal.java
@@ -50,18 +50,6 @@ public class PendingPartialWithdrawal
       return new PendingPartialWithdrawal(this, validatorIndex, amount, withdrawableEpoch);
     }
 
-    public SszUInt64 getValidatorIndexSchema() {
-      return (SszUInt64) getFieldSchema0();
-    }
-
-    public SszUInt64 getAmountSchema() {
-      return (SszUInt64) getFieldSchema1();
-    }
-
-    public SszUInt64 getWithdrawableEpochSchema() {
-      return (SszUInt64) getFieldSchema2();
-    }
-
     @Override
     public PendingPartialWithdrawal createFromBackingNode(final TreeNode node) {
       return new PendingPartialWithdrawal(this, node);
@@ -74,8 +62,8 @@ public class PendingPartialWithdrawal
     super(type, backingNode);
   }
 
-  public int getValidatorIndex() {
-    return ((SszUInt64) get(0)).get().intValue();
+  public UInt64 getValidatorIndex() {
+    return ((SszUInt64) get(0)).get();
   }
 
   public UInt64 getAmount() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -177,8 +178,8 @@ public class ValidatorsUtil {
   }
 
   public UInt64 getPendingBalanceToWithdraw(final BeaconState state, final int validatorIndex) {
-    return state.toVersionElectra().orElseThrow().getPendingPartialWithdrawals().stream()
-        .filter(withdrawal -> withdrawal.getValidatorIndex() == validatorIndex)
+    return BeaconStateElectra.required(state).getPendingPartialWithdrawals().stream()
+        .filter(withdrawal -> withdrawal.getValidatorIndex().intValue() == validatorIndex)
         .map(PendingPartialWithdrawal::getAmount)
         .reduce(UInt64::plus)
         .orElse(UInt64.ZERO);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
@@ -41,8 +41,7 @@ public interface WithdrawalsHelpers {
       int processedPartialWithdrawalsCount,
       int processedValidatorsSweepCount) {}
 
-  static UInt64 getWithdrawnAmount(
-      final List<Withdrawal> withdrawals, final UInt64 validatorIndex) {
+  static UInt64 getTotalWithdrawn(final List<Withdrawal> withdrawals, final UInt64 validatorIndex) {
     return withdrawals.stream()
         .filter(withdrawal -> withdrawal.getValidatorIndex().equals(validatorIndex))
         .map(Withdrawal::getAmount)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
@@ -41,7 +41,7 @@ public interface WithdrawalsHelpers {
       int processedPartialWithdrawalsCount,
       int processedValidatorsSweepCount) {}
 
-  static UInt64 getPartiallyWithdrawnBalance(
+  static UInt64 getWithdrawnAmount(
       final List<Withdrawal> withdrawals, final UInt64 validatorIndex) {
     return withdrawals.stream()
         .filter(withdrawal -> withdrawal.getValidatorIndex().equals(validatorIndex))

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
@@ -38,7 +38,8 @@ public interface WithdrawalsHelpers {
   record ExpectedWithdrawals(
       List<Withdrawal> withdrawals,
       int processedBuilderWithdrawalsCount,
-      int processedPartialWithdrawalsCount) {}
+      int processedPartialWithdrawalsCount,
+      int processedValidatorsSweepCount) {}
 
   static UInt64 getPartiallyWithdrawnBalance(
       final List<Withdrawal> withdrawals, final UInt64 validatorIndex) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -106,7 +106,7 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
 
     for (int i = 0; i < bound; i++) {
       if (withdrawals.size() == maxWithdrawalsPerPayload) {
-        break;
+        return processedValidatorsSweepCount;
       }
       final Validator validator = validators.get(validatorIndex);
       final UInt64 withdrawn =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -94,7 +94,7 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
     final SszList<Validator> validators = state.getValidators();
     final SszUInt64List balances = state.getBalances();
     final int validatorCount = validators.size();
-    final int maxWithdrawalsPerPayload = specConfig.getMaxWithdrawalsPerPayload();
+    final int withdrawalsLimit = specConfig.getMaxWithdrawalsPerPayload();
 
     UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);
     int validatorIndex =
@@ -102,10 +102,10 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
 
     int processedValidatorsSweepCount = 0;
 
-    final int bound = Math.min(validatorCount, specConfig.getMaxValidatorsPerWithdrawalSweep());
+    final int validatorsLimit = Math.min(validatorCount, specConfig.getMaxValidatorsPerWithdrawalSweep());
 
-    for (int i = 0; i < bound; i++) {
-      if (withdrawals.size() == maxWithdrawalsPerPayload) {
+    for (int i = 0; i < validatorsLimit; i++) {
+      if (withdrawals.size() == withdrawalsLimit) {
         return processedValidatorsSweepCount;
       }
       final Validator validator = validators.get(validatorIndex);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -18,7 +18,6 @@ import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
@@ -92,7 +91,6 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
     final WithdrawalSchema withdrawalSchema = schemaDefinitions.getWithdrawalSchema();
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(state.getSlot());
     final SszList<Validator> validators = state.getValidators();
-    final SszUInt64List balances = state.getBalances();
     final int validatorCount = validators.size();
     final int withdrawalsLimit = specConfig.getMaxWithdrawalsPerPayload();
 
@@ -106,7 +104,7 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
 
     for (int i = 0; i < validatorsLimit; i++) {
       if (withdrawals.size() == withdrawalsLimit) {
-        return processedValidatorsSweepCount;
+        break;
       }
       final Validator validator = validators.get(validatorIndex.intValue());
       if (predicates.hasExecutionWithdrawalCredential(validator)) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -109,31 +109,27 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
         break;
       }
       final Validator validator = validators.get(validatorIndex);
-      if (predicates.hasExecutionWithdrawalCredential(validator)) {
-        final UInt64 partiallyWithdrawnBalance =
-            WithdrawalsHelpers.getPartiallyWithdrawnBalance(
-                withdrawals, UInt64.valueOf(validatorIndex));
-        final UInt64 balance =
-            balances.get(validatorIndex).get().minusMinZero(partiallyWithdrawnBalance);
+      final UInt64 withdrawn =
+          WithdrawalsHelpers.getWithdrawnAmount(withdrawals, UInt64.valueOf(validatorIndex));
+      final UInt64 balance = balances.get(validatorIndex).get().minusMinZero(withdrawn);
 
-        if (predicates.isFullyWithdrawableValidatorCredentialsChecked(validator, balance, epoch)) {
-          withdrawals.add(
-              withdrawalSchema.create(
-                  withdrawalIndex,
-                  UInt64.valueOf(validatorIndex),
-                  WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
-                  balance));
-          withdrawalIndex = withdrawalIndex.increment();
-        } else if (predicates.isPartiallyWithdrawableValidatorEth1CredentialsChecked(
-            validator, balance)) {
-          withdrawals.add(
-              withdrawalSchema.create(
-                  withdrawalIndex,
-                  UInt64.valueOf(validatorIndex),
-                  WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
-                  balance.minusMinZero(miscHelpers.getMaxEffectiveBalance(validator))));
-          withdrawalIndex = withdrawalIndex.increment();
-        }
+      if (predicates.isFullyWithdrawableValidatorCredentialsChecked(validator, balance, epoch)) {
+        withdrawals.add(
+            withdrawalSchema.create(
+                withdrawalIndex,
+                UInt64.valueOf(validatorIndex),
+                WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
+                balance));
+        withdrawalIndex = withdrawalIndex.increment();
+      } else if (predicates.isPartiallyWithdrawableValidatorEth1CredentialsChecked(
+          validator, balance)) {
+        withdrawals.add(
+            withdrawalSchema.create(
+                withdrawalIndex,
+                UInt64.valueOf(validatorIndex),
+                WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
+                balance.minusMinZero(miscHelpers.getMaxEffectiveBalance(validator))));
+        withdrawalIndex = withdrawalIndex.increment();
       }
 
       validatorIndex = (validatorIndex + 1) % validatorCount;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -61,14 +61,11 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
   public ExpectedWithdrawals getExpectedWithdrawals(final BeaconState state) {
     final List<Withdrawal> withdrawals = new ArrayList<>();
 
-    // Process builder withdrawals
     final int processedBuilderWithdrawalsCount = processBuilderWithdrawals(state, withdrawals);
 
-    // Process partial withdrawals
     final int processedPartialWithdrawalsCount =
         processPendingPartialWithdrawals(state, withdrawals);
 
-    // Process validators sweep withdrawals
     final int processedValidatorsSweepCount = processValidatorsSweepWithdrawals(state, withdrawals);
 
     return new ExpectedWithdrawals(
@@ -214,13 +211,17 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
     applyWithdrawals(state, withdrawals);
 
     updateNextWithdrawalIndex(state, withdrawals);
+
     updatePayloadExpectedWithdrawals(state, withdrawals);
+
     if (processedBuilderWithdrawalsCount > 0) {
       updateBuilderPendingWithdrawals(state, processedBuilderWithdrawalsCount);
     }
+
     if (processedPartialWithdrawalsCount > 0) {
       updatePendingPartialWithdrawals(state, processedPartialWithdrawalsCount);
     }
+
     updateNextWithdrawalValidatorIndex(state, processedValidatorsSweepCount);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -201,6 +201,7 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
         expectedWithdrawals.processedValidatorsSweepCount());
   }
 
+  @SuppressWarnings("unused")
   private void processWithdrawalsUnchecked(
       final MutableBeaconState state,
       final List<Withdrawal> withdrawals,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -109,27 +109,29 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
         return processedValidatorsSweepCount;
       }
       final Validator validator = validators.get(validatorIndex);
-      final UInt64 withdrawn =
-          WithdrawalsHelpers.getWithdrawnAmount(withdrawals, UInt64.valueOf(validatorIndex));
-      final UInt64 balance = balances.get(validatorIndex).get().minusMinZero(withdrawn);
+      if (predicates.hasExecutionWithdrawalCredential(validator)) {
+        final UInt64 withdrawn =
+            WithdrawalsHelpers.getTotalWithdrawn(withdrawals, UInt64.valueOf(validatorIndex));
+        final UInt64 balance = balances.get(validatorIndex).get().minusMinZero(withdrawn);
 
-      if (predicates.isFullyWithdrawableValidatorCredentialsChecked(validator, balance, epoch)) {
-        withdrawals.add(
-            withdrawalSchema.create(
-                withdrawalIndex,
-                UInt64.valueOf(validatorIndex),
-                WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
-                balance));
-        withdrawalIndex = withdrawalIndex.increment();
-      } else if (predicates.isPartiallyWithdrawableValidatorEth1CredentialsChecked(
-          validator, balance)) {
-        withdrawals.add(
-            withdrawalSchema.create(
-                withdrawalIndex,
-                UInt64.valueOf(validatorIndex),
-                WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
-                balance.minusMinZero(miscHelpers.getMaxEffectiveBalance(validator))));
-        withdrawalIndex = withdrawalIndex.increment();
+        if (predicates.isFullyWithdrawableValidatorCredentialsChecked(validator, balance, epoch)) {
+          withdrawals.add(
+              withdrawalSchema.create(
+                  withdrawalIndex,
+                  UInt64.valueOf(validatorIndex),
+                  WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
+                  balance));
+          withdrawalIndex = withdrawalIndex.increment();
+        } else if (predicates.isPartiallyWithdrawableValidatorEth1CredentialsChecked(
+            validator, balance)) {
+          withdrawals.add(
+              withdrawalSchema.create(
+                  withdrawalIndex,
+                  UInt64.valueOf(validatorIndex),
+                  WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
+                  balance.minusMinZero(miscHelpers.getMaxEffectiveBalance(validator))));
+          withdrawalIndex = withdrawalIndex.increment();
+        }
       }
 
       validatorIndex = (validatorIndex + 1) % validatorCount;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -108,6 +108,9 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
     final int bound = Math.min(validatorCount, specConfig.getMaxValidatorsPerWithdrawalSweep());
 
     for (int i = 0; i < bound; i++) {
+      if (withdrawals.size() == maxWithdrawalsPerPayload) {
+        break;
+      }
       final Validator validator = validators.get(validatorIndex);
       if (predicates.hasExecutionWithdrawalCredential(validator)) {
         final UInt64 partiallyWithdrawnBalance =
@@ -133,10 +136,6 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
                   WithdrawalsHelpers.getEthAddressFromWithdrawalCredentials(validator),
                   balance.minusMinZero(miscHelpers.getMaxEffectiveBalance(validator))));
           withdrawalIndex = withdrawalIndex.increment();
-        }
-
-        if (withdrawals.size() == maxWithdrawalsPerPayload) {
-          return processedValidatorsSweepCount;
         }
       }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
@@ -71,7 +71,7 @@ public class BeaconStateAccessorsElectra extends BeaconStateAccessorsDeneb {
   public UInt64 getPendingBalanceToWithdraw(
       final BeaconStateElectra state, final int validatorIndex) {
     return state.getPendingPartialWithdrawals().stream()
-        .filter(withdrawal -> withdrawal.getValidatorIndex() == validatorIndex)
+        .filter(withdrawal -> withdrawal.getValidatorIndex().intValue() == validatorIndex)
         .map(PendingPartialWithdrawal::getAmount)
         .reduce(UInt64.ZERO, UInt64::plus);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
@@ -68,7 +68,7 @@ public class WithdrawalsHelpersElectra extends WithdrawalsHelpersCapella {
       final int validatorIndex = withdrawal.getValidatorIndex();
       final Validator validator = state.getValidators().get(validatorIndex);
       final UInt64 withdrawn =
-          WithdrawalsHelpers.getWithdrawnAmount(withdrawals, UInt64.valueOf(validatorIndex));
+          WithdrawalsHelpers.getTotalWithdrawn(withdrawals, UInt64.valueOf(validatorIndex));
       final UInt64 remainingBalance =
           state.getBalances().get(withdrawal.getValidatorIndex()).get().minusMinZero(withdrawn);
       final boolean hasSufficientEffectiveBalance =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
@@ -52,7 +52,7 @@ public class WithdrawalsHelpersElectra extends WithdrawalsHelpersCapella {
   }
 
   @Override
-  protected int sweepForPendingPartialWithdrawals(
+  protected int processPendingPartialWithdrawals(
       final BeaconState state, final List<Withdrawal> withdrawals) {
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(state.getSlot());
     UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
@@ -67,15 +67,10 @@ public class WithdrawalsHelpersElectra extends WithdrawalsHelpersCapella {
       }
       final int validatorIndex = withdrawal.getValidatorIndex();
       final Validator validator = state.getValidators().get(validatorIndex);
-      final UInt64 partiallyWithdrawnBalance =
-          WithdrawalsHelpers.getPartiallyWithdrawnBalance(
-              withdrawals, UInt64.valueOf(validatorIndex));
+      final UInt64 withdrawn =
+          WithdrawalsHelpers.getWithdrawnAmount(withdrawals, UInt64.valueOf(validatorIndex));
       final UInt64 remainingBalance =
-          state
-              .getBalances()
-              .get(withdrawal.getValidatorIndex())
-              .get()
-              .minusMinZero(partiallyWithdrawnBalance);
+          state.getBalances().get(withdrawal.getValidatorIndex()).get().minusMinZero(withdrawn);
       final boolean hasSufficientEffectiveBalance =
           validator
               .getEffectiveBalance()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
@@ -53,15 +53,15 @@ public class WithdrawalsHelpersElectra extends WithdrawalsHelpersCapella {
 
   @Override
   protected int sweepForPendingPartialWithdrawals(
-      final List<Withdrawal> withdrawals, final BeaconState state) {
-    final BeaconStateElectra stateElectra = BeaconStateElectra.required(state);
+      final BeaconState state, final List<Withdrawal> withdrawals) {
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(state.getSlot());
     UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);
     int processedPartialWithdrawalsCount = 0;
 
     final int bound = getBoundForPendingPartialWithdrawals(withdrawals);
 
-    for (PendingPartialWithdrawal withdrawal : stateElectra.getPendingPartialWithdrawals()) {
+    for (final PendingPartialWithdrawal withdrawal :
+        BeaconStateElectra.required(state).getPendingPartialWithdrawals()) {
       if (withdrawal.getWithdrawableEpoch().isGreaterThan(epoch) || withdrawals.size() == bound) {
         break;
       }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -376,8 +376,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       }
       // Verify signature
       final IndexedPayloadAttestation indexedPayloadAttestation =
-          beaconStateAccessorsGloas.getIndexedPayloadAttestation(
-              state, data.getSlot(), payloadAttestation);
+          beaconStateAccessorsGloas.getIndexedPayloadAttestation(state, payloadAttestation);
 
       if (!attestationUtilGloas.isValidIndexedPayloadAttestation(
           state, indexedPayloadAttestation)) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
@@ -154,13 +154,13 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
       throw new ExecutionPayloadProcessingException(
           "Prev randao of the envelope is not consistent with the prev randao of the committed bid");
     }
-    // Verify the withdrawals root
+    // Verify consistency with expected withdrawals
     if (!ExecutionPayloadCapella.required(payload)
         .getWithdrawals()
         .hashTreeRoot()
-        .equals(stateGloas.getLatestWithdrawalsRoot())) {
+        .equals(stateGloas.getPayloadExpectedWithdrawals().hashTreeRoot())) {
       throw new ExecutionPayloadProcessingException(
-          "Withdrawals root of the envelope is not consistent with the latest withdrawals root in the state");
+          "Withdrawals of the envelope are not consistent with the expected withdrawals in the state");
     }
     // Verify the gas_limit
     if (!committedBid.getGasLimit().equals(payload.getGasLimit())) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -119,7 +119,11 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
               state.setBuilderPendingWithdrawals(
                   schemaDefinitions.getBuilderPendingWithdrawalsSchema().getDefault());
               state.setLatestBlockHash(latestBlockHash);
-              state.setLatestWithdrawalsRoot(Bytes32.ZERO);
+              state.setPayloadExpectedWithdrawals(
+                  schemaDefinitions
+                      .getExecutionPayloadSchema()
+                      .getWithdrawalsSchemaRequired()
+                      .of());
             });
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -70,7 +70,8 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
    * <p>Return the indexed payload attestation corresponding to ``payload_attestation``.
    */
   public IndexedPayloadAttestation getIndexedPayloadAttestation(
-      final BeaconState state, final UInt64 slot, final PayloadAttestation payloadAttestation) {
+      final BeaconState state, final PayloadAttestation payloadAttestation) {
+    final UInt64 slot = payloadAttestation.getData().getSlot();
     final IntList ptc = getPtc(state, slot);
     final SszBitvector aggregationBits = payloadAttestation.getAggregationBits();
     final IntList attestingIndices = new IntArrayList();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
@@ -76,7 +76,7 @@ public class EpochProcessorGloas extends EpochProcessorFulu {
         .forEach(
             i -> {
               final BuilderPendingPayment payment = builderPendingPayments.get(i);
-              if (payment.getWeight().isGreaterThan(quorum)) {
+              if (payment.getWeight().isGreaterThanOrEqualTo(quorum)) {
                 final UInt64 amount = payment.getWithdrawal().getAmount();
                 final UInt64 exitQueueEpoch =
                     BeaconStateMutatorsElectra.required(beaconStateMutators)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -58,7 +58,7 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
   }
 
   @Override
-  protected int sweepForBuilderPayments(
+  protected int processBuilderWithdrawals(
       final BeaconState state, final List<Withdrawal> withdrawals) {
     UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);
 
@@ -131,7 +131,7 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
   }
 
   @Override
-  protected void updatePendingBuilderWithdrawals(
+  protected void updateBuilderPendingWithdrawals(
       final MutableBeaconState state, final int processedBuilderWithdrawalsCount) {
     final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
     final SszListSchema<BuilderPendingWithdrawal, ?> schema =
@@ -163,7 +163,7 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
       final BeaconState state, final BuilderPendingWithdrawal withdrawal) {
     final Validator builder = state.getValidators().get(withdrawal.getBuilderIndex().intValue());
     final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(state.getSlot());
-    return builder.getWithdrawableEpoch().isGreaterThanOrEqualTo(currentEpoch)
+    return currentEpoch.isGreaterThanOrEqualTo(builder.getWithdrawableEpoch())
         || !builder.isSlashed();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -75,14 +75,9 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
       if (isBuilderPaymentWithdrawable(state, withdrawal)) {
         final UInt64 builderIndex = withdrawal.getBuilderIndex();
         final Validator builder = state.getValidators().get(builderIndex.intValue());
-        final UInt64 partiallyWithdrawnBalance =
-            WithdrawalsHelpers.getPartiallyWithdrawnBalance(withdrawals, builderIndex);
+        final UInt64 withdrawn = WithdrawalsHelpers.getWithdrawnAmount(withdrawals, builderIndex);
         final UInt64 remainingBalance =
-            state
-                .getBalances()
-                .get(builderIndex.intValue())
-                .get()
-                .minusMinZero(partiallyWithdrawnBalance);
+            state.getBalances().get(builderIndex.intValue()).get().minusMinZero(withdrawn);
         final UInt64 withdrawableBalance;
         if (builder.isSlashed()) {
           withdrawableBalance = remainingBalance.min(withdrawal.getAmount());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -58,20 +58,8 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
   }
 
   @Override
-  protected void setLatestWithdrawalsRoot(
-      final List<Withdrawal> expectedWithdrawals, final MutableBeaconState state) {
-    MutableBeaconStateGloas.required(state)
-        .setLatestWithdrawalsRoot(
-            schemaDefinitionsGloas
-                .getExecutionPayloadSchema()
-                .getWithdrawalsSchemaRequired()
-                .createFromElements(expectedWithdrawals)
-                .hashTreeRoot());
-  }
-
-  @Override
   protected int sweepForBuilderPayments(
-      final List<Withdrawal> withdrawals, final BeaconState state) {
+      final BeaconState state, final List<Withdrawal> withdrawals) {
     UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);
 
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(state.getSlot());
@@ -129,6 +117,17 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
     return Math.min(
         withdrawals.size() + specConfigElectra.getMaxPendingPartialsPerWithdrawalsSweep(),
         specConfig.getMaxWithdrawalsPerPayload() - 1);
+  }
+
+  @Override
+  protected void updatePayloadExpectedWithdrawals(
+      final MutableBeaconState state, final List<Withdrawal> withdrawals) {
+    MutableBeaconStateGloas.required(state)
+        .setPayloadExpectedWithdrawals(
+            schemaDefinitionsGloas
+                .getExecutionPayloadSchema()
+                .getWithdrawalsSchemaRequired()
+                .createFromElements(withdrawals));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -75,7 +75,7 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
       if (isBuilderPaymentWithdrawable(state, withdrawal)) {
         final UInt64 builderIndex = withdrawal.getBuilderIndex();
         final Validator builder = state.getValidators().get(builderIndex.intValue());
-        final UInt64 withdrawn = WithdrawalsHelpers.getWithdrawnAmount(withdrawals, builderIndex);
+        final UInt64 withdrawn = WithdrawalsHelpers.getTotalWithdrawn(withdrawals, builderIndex);
         final UInt64 remainingBalance =
             state.getBalances().get(builderIndex.intValue()).get().minusMinZero(withdrawn);
         final UInt64 withdrawableBalance;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/withdrawal/WithdrawalHelpersTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/withdrawal/WithdrawalHelpersTest.java
@@ -37,30 +37,28 @@ public class WithdrawalHelpersTest {
   private static final UInt64 ONE_ETH = UInt64.valueOf(1_000_000_000L);
 
   @Test
-  void getPartiallyWithdrawnBalance_returnsZeroIfNotSet() {
+  void getWithdrawnAmount_returnsZeroIfNotSet() {
     final List<Withdrawal> withdrawalList = List.of();
-    assertThat(WithdrawalsHelpers.getPartiallyWithdrawnBalance(withdrawalList, ZERO))
-        .isEqualTo(ZERO);
+    assertThat(WithdrawalsHelpers.getWithdrawnAmount(withdrawalList, ZERO)).isEqualTo(ZERO);
   }
 
   @Test
-  void getPartiallyWithdrawnBalance_returnsCurrentValue() {
+  void getWithdrawnAmount_returnsCurrentValue() {
     final List<Withdrawal> withdrawalList =
         List.of(
             dataStructureUtil.randomWithdrawal(ZERO, ONE_ETH),
             dataStructureUtil.randomWithdrawal(ZERO, ONE_ETH));
-    assertThat(WithdrawalsHelpers.getPartiallyWithdrawnBalance(withdrawalList, ZERO))
+    assertThat(WithdrawalsHelpers.getWithdrawnAmount(withdrawalList, ZERO))
         .isEqualTo(ONE_ETH.times(2));
   }
 
   @Test
-  void getPartiallyWithdrawnBalance_returnsCurrentValueSpecificToValidator() {
+  void getWithdrawnAmount_returnsCurrentValueSpecificToValidator() {
     final List<Withdrawal> withdrawalList =
         List.of(
             dataStructureUtil.randomWithdrawal(ZERO, ONE_ETH),
             dataStructureUtil.randomWithdrawal(ONE, ONE_ETH));
-    assertThat(WithdrawalsHelpers.getPartiallyWithdrawnBalance(withdrawalList, ZERO))
-        .isEqualTo(ONE_ETH);
+    assertThat(WithdrawalsHelpers.getWithdrawnAmount(withdrawalList, ZERO)).isEqualTo(ONE_ETH);
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/withdrawal/WithdrawalHelpersTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/withdrawal/WithdrawalHelpersTest.java
@@ -37,28 +37,28 @@ public class WithdrawalHelpersTest {
   private static final UInt64 ONE_ETH = UInt64.valueOf(1_000_000_000L);
 
   @Test
-  void getWithdrawnAmount_returnsZeroIfNotSet() {
+  void getTotalWithdrawn_returnsZeroIfNoWithdrawals() {
     final List<Withdrawal> withdrawalList = List.of();
-    assertThat(WithdrawalsHelpers.getWithdrawnAmount(withdrawalList, ZERO)).isEqualTo(ZERO);
+    assertThat(WithdrawalsHelpers.getTotalWithdrawn(withdrawalList, ZERO)).isEqualTo(ZERO);
   }
 
   @Test
-  void getWithdrawnAmount_returnsCurrentValue() {
+  void getTotalWithdrawn_returnsSummedValue() {
     final List<Withdrawal> withdrawalList =
         List.of(
             dataStructureUtil.randomWithdrawal(ZERO, ONE_ETH),
             dataStructureUtil.randomWithdrawal(ZERO, ONE_ETH));
-    assertThat(WithdrawalsHelpers.getWithdrawnAmount(withdrawalList, ZERO))
+    assertThat(WithdrawalsHelpers.getTotalWithdrawn(withdrawalList, ZERO))
         .isEqualTo(ONE_ETH.times(2));
   }
 
   @Test
-  void getWithdrawnAmount_returnsCurrentValueSpecificToValidator() {
+  void getTotalWithdrawn_returnsValueSpecificToValidator() {
     final List<Withdrawal> withdrawalList =
         List.of(
             dataStructureUtil.randomWithdrawal(ZERO, ONE_ETH),
             dataStructureUtil.randomWithdrawal(ONE, ONE_ETH));
-    assertThat(WithdrawalsHelpers.getWithdrawnAmount(withdrawalList, ZERO)).isEqualTo(ONE_ETH);
+    assertThat(WithdrawalsHelpers.getTotalWithdrawn(withdrawalList, ZERO)).isEqualTo(ONE_ETH);
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectraTest.java
@@ -412,7 +412,8 @@ class ExecutionRequestsProcessorElectraTest extends ProcessorTestHelper {
             .getPendingPartialWithdrawals()
             .get(postState.getPendingPartialWithdrawals().size() - 1);
 
-    assertThat(mostRecentPendingPartialWithdrawal.getValidatorIndex()).isEqualTo(validatorIndex);
+    assertThat(mostRecentPendingPartialWithdrawal.getValidatorIndex().intValue())
+        .isEqualTo(validatorIndex);
     assertThat(mostRecentPendingPartialWithdrawal.getAmount())
         .isEqualTo(UInt64.valueOf(123_456_789));
     assertThat(mostRecentPendingPartialWithdrawal.getWithdrawableEpoch())

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -225,7 +225,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "jKXnVjb5vBjxXDb3SDaoU0nXkfZEvbHjtUlR5X4YQxpjECxhGCbuWDU736kvV5C2BUD7aGjk6iHMPv3qyr/YNcbnoyZczx5c9hKy5nLZAxbkQLIhsVUElFDn0TfolUy2"));
+                "sl534h/uxZZgPxcpx51IqZwOdJ0p5Jqwr1EqpJMQXfal4Wyw9RV9AC617smQOYrkCniCiwHpaM+kehHXOXUI3VUOhony4zRJ7y7y9a4okW6qjhjjBeESQXDIfIvboxLk"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadBid(bid, fork);
     asyncRunner.executeQueuedActions();
@@ -245,7 +245,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "lj8tDRzsm+L87EpnFKCF6h+KNxkw2z7C+ltZ3lLy+AqqjFLCTTvUvrhn2w1WkEgnDRSytxINuWt+cvn1f9dJ83ZurN+Q/0uHtSeXujENLFK4Msbxbh+PzM+nxI4Ixc71"));
+                "rYQ+MMyhTXyzCx4e2GMAI56Fz9vy204+O6UzWa7xyXg149jpP/gNeOD4j5/tmodSEsKlYCQgvinEFQR6XDI7jnNC6we5meqlPcGUlXCrb1UHPz+EifQ0E+saZZsU5Ssf"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadEnvelope(envelope, fork);
     asyncRunner.executeQueuedActions();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingPayment;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BuilderPendingWithdrawal;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateSchemaGloas;
@@ -70,7 +71,7 @@ public class BeaconStateBuilderGloas
   private SszVector<BuilderPendingPayment> builderPendingPayments;
   private SszList<BuilderPendingWithdrawal> builderPendingWithdrawals;
   private Bytes32 latestBlockHash;
-  private Bytes32 latestWithdrawalsRoot;
+  private SszList<Withdrawal> payloadExpectedWithdrawals;
 
   protected BeaconStateBuilderGloas(
       final SpecVersion spec,
@@ -112,7 +113,7 @@ public class BeaconStateBuilderGloas
     state.setBuilderPendingPayments(builderPendingPayments);
     state.setBuilderPendingWithdrawals(builderPendingWithdrawals);
     state.setLatestBlockHash(latestBlockHash);
-    state.setLatestWithdrawalsRoot(latestWithdrawalsRoot);
+    state.setPayloadExpectedWithdrawals(payloadExpectedWithdrawals);
   }
 
   public static BeaconStateBuilderGloas create(
@@ -219,9 +220,10 @@ public class BeaconStateBuilderGloas
     return this;
   }
 
-  public BeaconStateBuilderGloas latestWithdrawalsRoot(final Bytes32 latestWithdrawalsRoot) {
-    checkNotNull(latestWithdrawalsRoot);
-    this.latestWithdrawalsRoot = latestWithdrawalsRoot;
+  public BeaconStateBuilderGloas payloadExpectedWithdrawals(
+      final SszList<Withdrawal> payloadExpectedWithdrawals) {
+    checkNotNull(payloadExpectedWithdrawals);
+    this.payloadExpectedWithdrawals = payloadExpectedWithdrawals;
     return this;
   }
 
@@ -287,6 +289,7 @@ public class BeaconStateBuilderGloas
     this.builderPendingWithdrawals =
         schema.getBuilderPendingWithdrawalsSchema().createFromElements(List.of());
     this.latestBlockHash = Bytes32.ZERO;
-    this.latestWithdrawalsRoot = Bytes32.ZERO;
+    this.payloadExpectedWithdrawals =
+        schema.getPayloadExpectedWithdrawalsSchema().createFromElements(List.of());
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Disabling reference tests for Gloas, since there would be too many changes upcoming in the next release.

**Main change:**
https://github.com/ethereum/consensus-specs/pull/4745
**Refactor of withdrawals:**
https://github.com/ethereum/consensus-specs/pull/4765
https://github.com/ethereum/consensus-specs/pull/4766
**Other small changes:**
https://github.com/ethereum/consensus-specs/pull/4775
https://github.com/ethereum/consensus-specs/pull/4797
https://github.com/ethereum/consensus-specs/pull/4774
https://github.com/ethereum/consensus-specs/pull/4753

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Gloas with updated consensus specs by persisting full expected withdrawals and validating payloads against them.
> 
> - Replace `latest_withdrawals_root` with `payload_expected_withdrawals` across state, schemas, REST schema, builders, and upgrade path
> - Refactor withdrawals flow: compute/track expected withdrawals (builder, partials, validator sweep), apply to state, update next indices, and compare payload withdrawals to expected list; add helpers like `getTotalWithdrawn`
> - Update execution processing to verify envelope withdrawals match `payload_expected_withdrawals`; cache and update related builder payment/withdrawal queues
> - Type/logic cleanups: use `UInt64` validator indices in Electra pending withdrawals paths; fix equality checks, quorum `>=`, attestation indexing API, and various helpers
> - Spec constants: change Gloas `BEACON_BUILDER` domain to `0x0B000000`
> - Testing: adjust expected signatures/APIs; temporarily skip some Gloas reference tests (SSZ, pyspec fork_choice)
> - Minor validator/util predicates and exit rules tweaks (e.g., pending withdrawal checks in exits)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93655da251e0637d58aeee36a258e076f290d51b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->