### PR TITLE
Run `kzg.loadTrustedSetup` in thread with 8MB stack size

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -792,7 +792,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 stackSize);
         loaderThread.start();
         try {
-          loaderThread.join();
+          loaderThread.join(Duration.ofMinutes(5).toMillis());
+          if (loaderThread.isAlive()) {
+            loaderThread.interrupt();
+            throw new RuntimeException("KZG trusted setup loading timed out after five minutes");
+          }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throw new RuntimeException("KZG trusted setup loading was interrupted", e);


### PR DESCRIPTION
## PR Description

This PR runs `kzg.loadTrustedSetup()` in a separate, temporary, short-lived thread with an 8MB stack.

This was segfaulting with higher precompute values (greater than 10) because the default stack size for java threads is 1MB. It worked just fine in c-kzg-4844 testing because the tests ran on the main thread which is 8MB.

To test this out, you can run the following command before & after the change:

```
./build/install/teku/bin/teku --Xkzg-precompute=15 --ee-endpoint=http://blah --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io
```

You can also test this by setting all threads to be 8MB 😅 

```
JAVA_OPTS="-Xss8m" ./build/install/teku/bin/teku --Xkzg-precompute=15 ...
```

## Fixed Issue(s)

* https://github.com/ethereum/c-kzg-4844/issues/611

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loads `kzg.loadTrustedSetup` on a dedicated 8MB-stack thread when `kzgPrecompute` exceeds `DEFAULT_KZG_PRECOMPUTE_SUPERNODE`, with timeout and error handling; otherwise uses current thread.
> 
> - **KZG trusted setup loading**:
>   - Conditionally executes `kzg.loadTrustedSetup(trustedSetupFile, kzgPrecompute)` on a dedicated thread with 8MB stack when `kzgPrecompute` > `DEFAULT_KZG_PRECOMPUTE_SUPERNODE`.
>   - Adds 5-minute join timeout, interruption handling, and exception propagation from the loader thread.
>   - Retains current-thread execution (1MB stack) for lower/equal precompute values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc197e1960cf3d3082915d61fcb4e245b3926444. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->