### PR TITLE
fix(json): parse LONG_TYPE via Long.valueOf instead of Long.getLong

### DIFF
--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
@@ -85,7 +85,7 @@ public class CoreTypes {
   public static final StringValueTypeDefinition<Long> LONG_TYPE =
       DeserializableTypeDefinition.string(Long.class)
           .formatter(Object::toString)
-          .parser(Long::getLong)
+          .parser(Long::valueOf)
           .example("1")
           .description("long string")
           .format("long")

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/CoreTypesTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/CoreTypesTest.java
@@ -98,6 +98,18 @@ class CoreTypesTest {
   }
 
   @Test
+  void long_shouldRoundTrip() throws Exception {
+    assertRoundTrip(123L, CoreTypes.LONG_TYPE);
+    assertRoundTrip(-1L, CoreTypes.LONG_TYPE);
+  }
+
+  @Test
+  void long_shouldRejectInvalidString() {
+    assertThatThrownBy(() -> CoreTypes.LONG_TYPE.deserializeFromString("abc"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void stringListShouldAcceptBooleanAsString() throws Exception {
     final String input = "[\"a\", \"b\", true, \"c\"]";
     final List<String> result = JsonUtil.parse(input, stringListType);


### PR DESCRIPTION
## PR Description

Long.getLong looks up a JVM system property by name and returns null when not set. LONG_TYPE is intended to parse decimal strings, so use Long.valueOf to match other numeric string types. Added tests covering long round-trip and invalid input to prevent regressions.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use Long.valueOf for LONG_TYPE parsing and add tests for round-trip and invalid input.
> 
> - **Core JSON types**:
>   - Change `CoreTypes.LONG_TYPE` parser from `Long::getLong` to `Long::valueOf`.
> - **Tests**:
>   - Add `long_shouldRoundTrip` and `long_shouldRejectInvalidString` in `CoreTypesTest` to validate parsing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b78194007d7cc66ceaf9e2f401009f2ac3d4fd06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->