### PR TITLE
cleanup minimumBroadcastTimeMillis function

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
@@ -122,11 +122,11 @@ public class AttestationUtilPhase0 extends AttestationUtil {
 
   private UInt64 minimumBroadcastTimeMillis(
       final UInt64 attestationSlot, final UInt64 genesisTime) {
-    final UInt64 lastAllowedTime =
-        genesisTime.plus(attestationSlot.times(specConfig.getSecondsPerSlot()));
-    final UInt64 lastAllowedTimeMillis = secondsToMillis(lastAllowedTime);
-    return lastAllowedTimeMillis.isGreaterThanOrEqualTo(specConfig.getMaximumGossipClockDisparity())
-        ? lastAllowedTimeMillis.minus(specConfig.getMaximumGossipClockDisparity())
+    final UInt64 genesisTimeMillis = secondsToMillis(genesisTime);
+    final UInt64 attestationSlotTimeMillis =
+        miscHelpers.computeTimeMillisAtSlot(genesisTimeMillis, attestationSlot);
+    return attestationSlotTimeMillis.isGreaterThan(specConfig.getMaximumGossipClockDisparity())
+        ? attestationSlotTimeMillis.minus(specConfig.getMaximumGossipClockDisparity())
         : ZERO;
   }
 }


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors minimum attestation broadcast time to use millis-based slot computation via MiscHelpers with a strict > comparison.
> 
> - **Phase0 Attestation utils (`AttestationUtilPhase0`)**:
>   - Rework `minimumBroadcastTimeMillis` to compute slot time in millis using `miscHelpers.computeTimeMillisAtSlot` instead of manual seconds arithmetic.
>   - Adjust comparison to strict `>` before subtracting `specConfig.getMaximumGossipClockDisparity()` and defaulting to `ZERO`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a9d6e07d4f5a6993ce0d282e010b4b3172090d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->