### PR TITLE
Fix `BlobSidecarSelectorFactory` for Gloas

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
@@ -46,8 +46,7 @@ import tech.pegasys.teku.storage.client.BlobSidecarReconstructionProvider;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-// TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-@TestSpecContext(allMilestones = true, ignoredMilestones = SpecMilestone.GLOAS)
+@TestSpecContext(allMilestones = true)
 public class BlobSidecarSelectorFactoryTest {
 
   private final CombinedChainDataClient client = mock(CombinedChainDataClient.class);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -22,8 +22,8 @@ public class Constants {
 
   // Teku Networking Specific
   public static final int VALID_BLOCK_SET_SIZE = 1000;
-  // Need to keep 2 slots worth of payload attestations
-  public static final int RECENT_SEEN_PAYLOAD_ATTESTATIONS_CACHE_SIZE = 512 * 2;
+  // Target holding 2 slots worth of payload attestations
+  public static final int VALID_PAYLOAD_ATTESTATION_SET_SIZE = 512 * 2;
   // Target holding two slots worth of aggregators (16 aggregators, 64 committees and 2 slots)
   public static final int VALID_AGGREGATE_SET_SIZE = 16 * 64 * 2;
   // Target 2 different attestation data (aggregators normally agree) for two slots

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -411,11 +411,6 @@ public final class DataStructureUtil {
   }
 
   public SszUInt64Vector randomSszUInt64Vector(
-      final SszUInt64VectorSchema<?> schema, final long numItems) {
-    return randomSszUInt64Vector(schema, numItems, this::randomUInt64);
-  }
-
-  public SszUInt64Vector randomSszUInt64Vector(
       final SszUInt64VectorSchema<?> schema,
       final long numItems,
       final Supplier<UInt64> valueGenerator) {
@@ -1527,7 +1522,16 @@ public final class DataStructureUtil {
   }
 
   public BeaconBlockBody randomBeaconBlockBodyWithEmptyCommitments() {
-    return randomBeaconBlockBody(builder -> builder.blobKzgCommitments(emptyBlobKzgCommitments()));
+    return randomBeaconBlockBody(
+        builder -> {
+          if (builder.supportsKzgCommitments()) {
+            builder.blobKzgCommitments(emptyBlobKzgCommitments());
+          }
+          if (builder.supportsSignedExecutionPayloadBid()) {
+            builder.signedExecutionPayloadBid(
+                randomSignedExecutionPayloadBidWithCommitments(emptyBlobKzgCommitments()));
+          }
+        });
   }
 
   public BeaconBlockBody randomBeaconBlockBodyWithCommitments(final int count) {
@@ -1540,6 +1544,10 @@ public final class DataStructureUtil {
         builder -> {
           if (builder.supportsKzgCommitments()) {
             builder.blobKzgCommitments(commitments);
+          }
+          if (builder.supportsSignedExecutionPayloadBid()) {
+            builder.signedExecutionPayloadBid(
+                randomSignedExecutionPayloadBidWithCommitments(commitments));
           }
         });
   }
@@ -3158,6 +3166,29 @@ public final class DataStructureUtil {
     return getGloasSchemaDefinitions()
         .getSignedExecutionPayloadBidSchema()
         .create(randomExecutionPayloadBid(), randomSignature());
+  }
+
+  public SignedExecutionPayloadBid randomSignedExecutionPayloadBidWithCommitments(
+      final SszList<SszKZGCommitment> blobKzgCommitments) {
+    final SchemaDefinitionsGloas schemaDefinitions = getGloasSchemaDefinitions();
+    return schemaDefinitions
+        .getSignedExecutionPayloadBidSchema()
+        .create(
+            schemaDefinitions
+                .getExecutionPayloadBidSchema()
+                .create(
+                    randomBytes32(),
+                    randomBytes32(),
+                    randomBytes32(),
+                    randomBytes32(),
+                    randomEth1Address(),
+                    randomUInt64(),
+                    randomBuilderIndex(),
+                    randomSlot(),
+                    randomUInt64(),
+                    randomUInt64(),
+                    blobKzgCommitments.hashTreeRoot()),
+            randomSignature());
   }
 
   public ExecutionPayloadEnvelope randomExecutionPayloadEnvelope() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.statetransition.payloadattestation;
 
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
-import static tech.pegasys.teku.spec.config.Constants.RECENT_SEEN_PAYLOAD_ATTESTATIONS_CACHE_SIZE;
+import static tech.pegasys.teku.spec.config.Constants.VALID_PAYLOAD_ATTESTATION_SET_SIZE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
@@ -42,11 +42,13 @@ import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 public class PayloadAttestationMessageGossipValidator {
 
   private static final Logger LOG = LogManager.getLogger();
-  final GossipValidationHelper gossipValidationHelper;
-  final SigningRootUtil signingRootUtil;
+
+  private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
+  private final SigningRootUtil signingRootUtil;
+
   private final Set<ValidatorIndexAndSlot> seenPayloadAttestations =
-      LimitedSet.createSynchronized(RECENT_SEEN_PAYLOAD_ATTESTATIONS_CACHE_SIZE);
+      LimitedSet.createSynchronized(VALID_PAYLOAD_ATTESTATION_SET_SIZE);
 
   public PayloadAttestationMessageGossipValidator(
       final Spec spec,
@@ -65,7 +67,7 @@ public class PayloadAttestationMessageGossipValidator {
      * [IGNORE] The message's slot is for the current slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance),
      * i.e. data.slot == current_slot
      */
-    if (!gossipValidationHelper.isCurrentSlotWithGossipDisparityAllowance(data.getSlot())) {
+    if (!gossipValidationHelper.isSlotCurrent(data.getSlot())) {
       LOG.trace(
           "Ignoring payload attestation with slot {} from validator with index {} because it's not from the current slot",
           data.getSlot(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -113,7 +113,7 @@ public class SignedContributionAndProofValidator {
 
     // [IGNORE] The contribution's slot is for the current slot (with a
     // `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e. `contribution.slot == current_slot`.
-    if (!gossipValidationHelper.isCurrentSlotWithGossipDisparityAllowance(contribution.getSlot())) {
+    if (!gossipValidationHelper.isSlotCurrent(contribution.getSlot())) {
       LOG.trace(
           "Ignoring proof from aggregator {}, "
               + "because it is not from the current slot "

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
@@ -85,7 +85,7 @@ public class SyncCommitteeMessageValidator {
     // [IGNORE] The message's slot is for the current slot(with a MAXIMUM_GOSSIP_CLOCK_DISPARITY
     // allowance),
     // i.e. sync_committee_message.slot == current_slot.
-    if (!gossipValidationHelper.isCurrentSlotWithGossipDisparityAllowance(message.getSlot())) {
+    if (!gossipValidationHelper.isSlotCurrent(message.getSlot())) {
       LOG.trace(
           "Ignoring sync committee message from validator {}, "
               + "because it is not from the current slot "

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
@@ -76,7 +76,7 @@ public class PayloadAttestationMessageGossipValidatorTest {
     blockRoot = payloadAttestationMessage.getData().getBeaconBlockRoot();
     postState = dataStructureUtil.randomBeaconState();
 
-    when(gossipValidationHelper.isCurrentSlotWithGossipDisparityAllowance(slot)).thenReturn(true);
+    when(gossipValidationHelper.isSlotCurrent(slot)).thenReturn(true);
     when(gossipValidationHelper.isBlockAvailable(blockRoot)).thenReturn(true);
     when(gossipValidationHelper.isValidatorInPayloadTimelinessCommittee(
             payloadAttestationMessage.getValidatorIndex(), postState, slot))
@@ -105,7 +105,7 @@ public class PayloadAttestationMessageGossipValidatorTest {
 
   @TestTemplate
   void shouldIgnore_whenSlotIsNotCurrent() {
-    when(gossipValidationHelper.isCurrentSlotWithGossipDisparityAllowance(slot)).thenReturn(false);
+    when(gossipValidationHelper.isSlotCurrent(slot)).thenReturn(false);
     assertThatSafeFuture(
             payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
         .isCompletedWithValue(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidatorTest.java
@@ -114,8 +114,7 @@ class SignedContributionAndProofValidatorTest {
     final SignedContributionAndProof message =
         chainBuilder.createValidSignedContributionAndProofBuilder().build();
     final GossipValidationHelper gossipValidationHelperMock = mock(GossipValidationHelper.class);
-    when(gossipValidationHelperMock.isCurrentSlotWithGossipDisparityAllowance(
-            message.getMessage().getContribution().getSlot()))
+    when(gossipValidationHelperMock.isSlotCurrent(message.getMessage().getContribution().getSlot()))
         .thenReturn(false);
     final SignedContributionAndProofValidator signedContributionAndProofValidator =
         new SignedContributionAndProofValidator(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
@@ -539,6 +540,22 @@ public class CombinedChainDataClient {
                 return SafeFuture.completedFuture(maybeBlock);
               }
               return historicalChainData.getBlockByBlockRoot(blockRoot);
+            });
+  }
+
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getExecutionPayloadByBlockRoot(
+      final Bytes32 blockRoot) {
+    return recentChainData
+        .retrieveSignedExecutionPayloadEnvelopeByBlockRoot(blockRoot)
+        .thenCompose(
+            maybeExecutionPayload -> {
+              if (maybeExecutionPayload.isPresent()) {
+                return SafeFuture.completedFuture(maybeExecutionPayload);
+              }
+              // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 query for an execution
+              // payload from the historical chain data
+              return SafeFuture.failedFuture(
+                  new UnsupportedOperationException("Not yet implemented"));
             });
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
In Gloas, there are no blob kzg commitments, for simplicity, we can still reuse the same logic as now and query the chain data for blob sidecars. The only thing we lose after Gloas, is checking for emptiness. But the chain data retrieval would take care of that anyways. The alternative is querying the execution payload or checking against the root of empty blob kzg commitments list based on the slot. Both seem more inefficient.

Also added some more nits + correct data structure util for gloas when stating empty commitments.

## Fixed Issue(s)
related to #9833 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates blob sidecar selection to work without in-block commitments (Gloas/ePBS) and replaces gossip slot check with a new isSlotCurrent; also renames payload attestation cache size constant and adds execution payload lookup by block root.
> 
> - **Blob Sidecars (provider)**:
>   - Update `BlobSidecarSelectorFactory` to handle Deneb/Gloas blocks without in-body blob commitments:
>     - Return empty list when commitments are explicitly empty, otherwise fetch sidecars; if commitments are only referenced by root (ePBS), query chain data directly.
> - **Gossip validation (statetransition)**:
>   - Replace `isCurrentSlotWithGossipDisparityAllowance` with `isSlotCurrent` in `GossipValidationHelper` and use it in payload attestation and sync-committee validators.
>   - Adjust visibility/fields in `PayloadAttestationMessageGossipValidator` and use new cache size constant.
> - **Constants**:
>   - Rename `RECENT_SEEN_PAYLOAD_ATTESTATIONS_CACHE_SIZE` to `VALID_PAYLOAD_ATTESTATION_SET_SIZE`.
> - **Data generation utilities (tests)**:
>   - Extend `DataStructureUtil` to support (ePBS) commitments via `signedExecutionPayloadBid` helpers and guard KZG fields; remove an unused vector overload.
> - **Storage**:
>   - Add `CombinedChainDataClient#getExecutionPayloadByBlockRoot` (recent-only, historical TODO).
> - **Tests**:
>   - Update/enable tests across modules to reflect new slot check, constant rename, and Gloas handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0226c2728606c3d9c9619de2fe95d46caba96a64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->