### PR TITLE
Fix TOCTOU race condition for duplicate attestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,3 @@
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.
 - Fixed `peer_count` metric when using `--metrics-publish-endpoint` feature. 
-- Fixed attestation validation checks to avoid broadcasting attestations already seen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.
 - Fixed `peer_count` metric when using `--metrics-publish-endpoint` feature. 
+- Fixed attestation validation checks to avoid broadcasting attestations already seen.

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidatorTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.payloadattestation;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
@@ -27,6 +28,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -122,6 +124,31 @@ public class PayloadAttestationMessageGossipValidatorTest {
     assertThatSafeFuture(
             payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage))
         .isCompletedWithValue(
+            ignore(
+                "Payload attestation for slot %s and validator index %s already seen",
+                slot, validatorIndex));
+  }
+
+  @TestTemplate
+  void shouldIgnore_whenAlreadySeen_AfterInitialCheck() {
+    final SafeFuture<Optional<BeaconState>> getStateFuture1 = new SafeFuture<>();
+    final SafeFuture<Optional<BeaconState>> getStateFuture2 = new SafeFuture<>();
+    when(gossipValidationHelper.getStateAtSlotAndBlockRoot(any()))
+        .thenReturn(getStateFuture1)
+        .thenReturn(getStateFuture2);
+
+    final SafeFuture<InternalValidationResult> validationFuture1 =
+        payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage);
+    final SafeFuture<InternalValidationResult> validationFuture2 =
+        payloadAttestationMessageGossipValidator.validate(payloadAttestationMessage);
+
+    getStateFuture1.complete(Optional.of(postState));
+    assertThat(validationFuture1).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(ACCEPT);
+
+    getStateFuture2.complete(Optional.of(postState));
+    assertThat(validationFuture2)
+        .succeedsWithin(Duration.ofSeconds(10))
+        .isEqualTo(
             ignore(
                 "Payload attestation for slot %s and validator index %s already seen",
                 slot, validatorIndex));


### PR DESCRIPTION
## PR Description

When validating attestations, the node should not propagate an attestation that was previously seen. In our current implementation, the check if the attestation was seen and the resulting validation was not done atomically, which could lead to a race condition where we check two similar attestations but don't consider them seen.

This fix relies on our synchronised `seenPayloadAttestations` set `add()` function to perform a second check if the attestation has been seen.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes duplicate payload attestation detection atomic in the gossip validator and adds tests to cover the race scenario.
> 
> - **Validation (PayloadAttestationMessageGossipValidator)**:
>   - Atomically handle duplicates by checking `seenPayloadAttestations.add(key)` post-validation; return `ignore(...)` if already present.
>   - Replace pre-check return with `ignoreAttestationAlreadySeenValidationResult(...)` helper and reuse it after `add(...)`.
>   - Add private helper `ignoreAttestationAlreadySeenValidationResult(...)` to centralize logging and ignore result.
> - **Tests**:
>   - Add `shouldIgnore_whenAlreadySeen_AfterInitialCheck` to simulate concurrent validations and verify ignore-on-second.
>   - Tighten existing tests to verify no further validations on duplicates and behavior when validation fails then succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c7b9460b3e90df26a6d436331addb6b0e750ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->