### PR TITLE
Enable late block reorg and block preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added new metrics `beacon_earliest_available_slot` and
   `data_column_sidecar_processing_validated_total`.
 - Block proposal duties can now be scheduled in advance for fulu.
+- Late block reorg enabled by default.
+- Block building preparation enabled by default. The beacon node will now pre-compute head and pre-state selection in preparation for block building. (Disabled in Gnosis).
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -480,6 +480,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     final BlockProductionPerformance blockProductionPerformance =
         blockProductionContext.blockProductionPerformance;
 
+    blockProductionPerformance.validatorBlockRequested();
+
     return blockProductionContext
         .stateFuture
         .thenCompose(

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.networks.Eth2Presets;
 
 public class Eth2NetworkConfiguration {
 
@@ -609,7 +610,7 @@ public class Eth2NetworkConfiguration {
           asyncBeaconChainMaxThreads,
           asyncBeaconChainMaxQueue.orElse(DEFAULT_ASYNC_BEACON_CHAIN_MAX_QUEUE),
           forkChoiceLateBlockReorgEnabled,
-          filterPrepareBlockProductionEnabledByNetPreset(prepareBlockProductionEnabled),
+          resolvePrepareBlockProductionAbility(prepareBlockProductionEnabled),
           forkChoiceUpdatedAlwaysSendPayloadAttributes,
           pendingAttestationsMaxQueue.orElse(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS),
           rustKzgEnabled,
@@ -621,7 +622,7 @@ public class Eth2NetworkConfiguration {
           attestationWaitLimitMillis);
     }
 
-    private boolean filterPrepareBlockProductionEnabledByNetPreset(
+    private boolean resolvePrepareBlockProductionAbility(
         final boolean prepareBlockProductionEnabled) {
       if (!prepareBlockProductionEnabled) {
         return false;
@@ -630,7 +631,7 @@ public class Eth2NetworkConfiguration {
       final Object networkPreset =
           spec.getGenesisSpecConfig().getRawConfig().getOrDefault(PRESET_KEY, "");
 
-      if (networkPreset.equals(MAINNET.configName())) {
+      if (networkPreset.equals(Eth2Presets.MAINNET.presetName())) {
         return true;
       }
 

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory.DEFAULT_MAX_QUEUE_SIZE;
 import static tech.pegasys.teku.spec.config.SpecConfigLoader.EPHEMERY_CONFIG_URL;
+import static tech.pegasys.teku.spec.config.SpecConfigReader.PRESET_KEY;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.DEFAULT_SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY;
 import static tech.pegasys.teku.spec.networks.Eth2Network.CHIADO;
 import static tech.pegasys.teku.spec.networks.Eth2Network.GNOSIS;
@@ -58,12 +59,11 @@ public class Eth2NetworkConfiguration {
   private static final int DEFAULT_STARTUP_TARGET_PEER_COUNT = 5;
   private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 30;
 
-  public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = false;
+  public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = true;
 
-  public static final boolean DEFAULT_PREPARE_BLOCK_PRODUCTION_ENABLED = false;
+  public static final boolean DEFAULT_PREPARE_BLOCK_PRODUCTION_ENABLED = true;
 
   public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_PROFILING_ENABLED = false;
-  public static final boolean DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_ENABLED = true;
   public static final int
       DEFAULT_AGGREGATING_ATTESTATION_POOL_V2_BLOCK_AGGREGATION_TIME_LIMIT_MILLIS = 150;
   public static final int
@@ -609,7 +609,7 @@ public class Eth2NetworkConfiguration {
           asyncBeaconChainMaxThreads,
           asyncBeaconChainMaxQueue.orElse(DEFAULT_ASYNC_BEACON_CHAIN_MAX_QUEUE),
           forkChoiceLateBlockReorgEnabled,
-          prepareBlockProductionEnabled,
+          filterPrepareBlockProductionEnabledByNetPreset(prepareBlockProductionEnabled),
           forkChoiceUpdatedAlwaysSendPayloadAttributes,
           pendingAttestationsMaxQueue.orElse(DEFAULT_MAX_QUEUE_PENDING_ATTESTATIONS),
           rustKzgEnabled,
@@ -619,6 +619,24 @@ public class Eth2NetworkConfiguration {
           aggregatingAttestationPoolV2BlockAggregationTimeLimit,
           aggregatingAttestationPoolV2TotalBlockAggregationTimeLimit,
           attestationWaitLimitMillis);
+    }
+
+    private boolean filterPrepareBlockProductionEnabledByNetPreset(
+        final boolean prepareBlockProductionEnabled) {
+      if (!prepareBlockProductionEnabled) {
+        return false;
+      }
+
+      final Object networkPreset =
+          spec.getGenesisSpecConfig().getRawConfig().getOrDefault(PRESET_KEY, "");
+
+      if (networkPreset.equals(MAINNET.configName())) {
+        return true;
+      }
+
+      // We don't want to affect fast slot networks like GNOSIS
+      LOG.info("Disabling early block preparation on {} preset network", networkPreset);
+      return false;
     }
 
     private void validateCommandLineParameters() {

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformance.java
@@ -31,7 +31,8 @@ package tech.pegasys.teku.ethereum.performance.trackers;
  *       retrieve_state
  *    (which set slotTime too)
  *         |
- *         v
+ *         |        <-     validatorBlockRequested (VC triggers block production continuation,
+ *         |                           after prepareBlockProductionInternal has been processed)
  *         |
  *         v
  *    beaconBlockPrepared (attestations_for_block is part of the process of beaconBlockPrepared)
@@ -81,6 +82,9 @@ public interface BlockProductionPerformance {
         public void lateBlockReorgPreparationCompleted() {}
 
         @Override
+        public void validatorBlockRequested() {}
+
+        @Override
         public void getState() {}
 
         @Override
@@ -119,6 +123,8 @@ public interface BlockProductionPerformance {
   void beaconBlockBodyPrepared();
 
   void lateBlockReorgPreparationCompleted();
+
+  void validatorBlockRequested();
 
   void getState();
 

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
@@ -29,6 +29,7 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   public static final String RETRIEVE_STATE = "retrieve_state";
   public static final String LATE_BLOCK_REORG_PREPARATION_COMPLETED =
       "late_block_reorg_preparation_completed";
+  public static final String VALIDATOR_BLOCK_REQUESTED = "validator_block_requested";
   public static final String LOCAL_GET_PAYLOAD = "local_get_payload";
   public static final String BUILDER_GET_HEADER = "builder_get_header";
   public static final String BUILDER_BID_VALIDATED = "builder_bid_validated";
@@ -98,6 +99,11 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   @Override
   public void lateBlockReorgPreparationCompleted() {
     performanceTracker.addEvent(LATE_BLOCK_REORG_PREPARATION_COMPLETED);
+  }
+
+  @Override
+  public void validatorBlockRequested() {
+    performanceTracker.addEvent(VALIDATOR_BLOCK_REQUESTED);
   }
 
   @Override

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -70,6 +70,33 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void shouldPrepareBlockProductionIsEnabledByDefaultOnMainnet() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldPrepareBlockProductionIsEnabledByDefaultOnHoodi() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments("--network", "hoodi");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldDisablePrepareBlockProduction() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xprepare-block-production-enabled", "false");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldDisablePrepareBlockProductionForGnosis() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments(
+            "--network", "gnosis", "--Xprepare-block-production-enabled", "true");
+    assertThat(config.eth2NetworkConfiguration().isPrepareBlockProductionEnabled()).isFalse();
+  }
+
+  @Test
   void shouldUseBellatrixForkEpochIfSpecified() {
     final TekuConfiguration config =
         getTekuConfigurationFromArguments(


### PR DESCRIPTION
fixes https://github.com/Consensys/teku/issues/6595

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables late block reorg and block production preparation by default (disabled on fast-slot presets like Gnosis) and adds a new validator block requested performance event.
> 
> - **Config/Network**:
>   - Default `DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED` and `DEFAULT_PREPARE_BLOCK_PRODUCTION_ENABLED` set to `true` in `Eth2NetworkConfiguration`.
>   - Introduce `resolvePrepareBlockProductionAbility(...)` to gate `prepareBlockProduction` by network preset (`mainnet` enabled; fast-slot presets like `gnosis` disabled).
> - **Validator/Performance Tracking**:
>   - `ValidatorApiHandler#createUnsignedBlockInternal` records `validatorBlockRequested()` on `BlockProductionPerformance`.
>   - Add `validatorBlockRequested()` to `BlockProductionPerformance` and implement event `validator_block_requested` in `BlockProductionPerformanceImpl`.
> - **Tests**:
>   - Add tests in `Eth2NetworkOptionsTest` asserting `prepareBlockProduction` defaults to enabled on `mainnet`/`hoodi`, can be disabled via flag, and is disabled on `gnosis` even when requested.
> - **Changelog**:
>   - Document defaults: late block reorg enabled; block building preparation enabled (disabled on Gnosis).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f9b04ff46290abedb1e53d580f375115cb08ae9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->