### PR TITLE
Fix early tracker removal

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -234,11 +234,12 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
         .values()
         .removeIf(
             tracker -> {
-              if (tracker.completionFuture().isDone()) {
-                return true;
-              }
               if (tracker.slot().isLessThan(firstNonFinalizedSlot)
                   || recentChainData.containsBlock(tracker.blockRoot())) {
+
+                if (tracker.completionFuture().isDone()) {
+                  return true;
+                }
 
                 // make sure the future releases any pending waiters
                 tracker

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -366,6 +366,8 @@ public class DasSamplerBasicTest {
 
     final DataColumnSamplingTracker completedTracker = mock(DataColumnSamplingTracker.class);
     when(completedTracker.completionFuture()).thenReturn(SafeFuture.completedFuture(null));
+    when(completedTracker.blockRoot()).thenReturn(dataStructureUtil.randomBytes32());
+    when(completedTracker.slot()).thenReturn(lastFinalizedSlot.decrement());
 
     final SafeFuture<List<UInt64>> trackerForFinalizedSlotFuture = new SafeFuture<>();
     final DataColumnSamplingTracker trackerForFinalizedSlot = mock(DataColumnSamplingTracker.class);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Also fixes duplicated sidecars downloading and storing.
It's a quick fix, some refactoring will go next.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts on-slot pruning to only remove trackers when expired or block is imported, completing pending futures exceptionally; updates tests accordingly.
> 
> - **DAS sampling (`DasSamplerBasic`)**:
>   - Refines `onSlot` pruning: only remove trackers when `slot < firstNonFinalizedSlot` or `recentChainData.containsBlock(root)`.
>     - If tracker is already completed, remove immediately.
>     - If not completed, complete its `completionFuture` exceptionally before removal.
> - **Tests (`DasSamplerBasicTest`)**:
>   - Update `onSlot_shouldPruneTrackers` to stub `blockRoot`/`slot` and assert correct pruning and exceptional completion for expired/imported trackers, while retaining valid tracker.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a23bbb6fd58675b52fcbf9b79c30a31282331a9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->