### PR TITLE
default the reworked recovery sidecar option to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Block proposal duties can now be scheduled in advance for fulu.
 - Late block reorg enabled by default.
 - Block building preparation enabled by default. The beacon node will now pre-compute head and pre-state selection in preparation for block building. (Disabled in Gnosis).
+- Enabled a new version of sidecar recovery by default, which can be disabled with `--Xp2p-reworked-sidecar-recovery-enabled=false` if required.
 
 ### Bug Fixes
 - Fixed a storage issue which sometimes caused Teku to crash during shut down.

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -287,7 +287,7 @@ public class P2PConfig {
         DEFAULT_FLOOD_PUBLISH_MAX_MESSAGE_SIZE_THRESHOLD;
     private boolean gossipBlobsAfterBlockEnabled = DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED;
     private boolean executionProofTopicEnabled = DEFAULT_EXECUTION_PROOF_GOSSIP_ENABLED;
-    private boolean reworkedSidecarRecoveryEnabled = false;
+    private boolean reworkedSidecarRecoveryEnabled = true;
     private Integer reworkedSidecarRecoveryTimeout = DEFAULT_RECOVERY_TIMEOUT_MS;
     private Integer reworkedSidecarDownloadTimeout = DEFAULT_DOWNLOAD_TIMEOUT_MS;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -336,7 +336,7 @@ public class P2POptions {
       arity = "0..1",
       hidden = true,
       fallbackValue = "true")
-  private boolean reworkedSidecarRecoveryEnabled = false;
+  private boolean reworkedSidecarRecoveryEnabled = true;
 
   @Option(
       names = {"--Xp2p-reworked-sidecar-cancel-timeout-ms"},


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables reworked sidecar recovery by default in P2P config and CLI, and documents the change in the changelog.
> 
> - **Networking/P2P**:
>   - Default `reworkedSidecarRecoveryEnabled` set to `true` in `P2PConfig.Builder` and `P2POptions` (`--Xp2p-reworked-sidecar-recovery-enabled`).
> - **Changelog**:
>   - Notes sidecar recovery is enabled by default and can be disabled with `--Xp2p-reworked-sidecar-recovery-enabled=false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe4abd2761e3fcba05421c42c90070b0c540242e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->