### PR TITLE
Das custody backfiller activation

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -81,11 +81,6 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
     final int expectedCustodyCount = specConfigFulu.getCustodyRequirement();
     secondaryNode.waitForCustodyBackfill(firstFuluSlot, expectedCustodyCount);
 
-    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
-    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
-    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
-    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
-
     final SignedBeaconBlock blockAtHead = secondaryNode.getHeadBlock();
     final int checkpointSlot = checkpointFinalizedBlock.getSlot().intValue();
     final int endSlot = blockAtHead.getSlot().intValue();

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -19,7 +19,6 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -29,7 +28,6 @@ import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
 import tech.pegasys.teku.test.acceptance.dsl.TekuBeaconNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
 
-@Disabled("until new DasCustodyBackfiller is enabled by default")
 public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
   @Test
   public void shouldBeAbleToCheckpointSyncAndBackfillCustody() throws Exception {
@@ -138,6 +136,7 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
     return TekuNodeConfigBuilder.createBeaconNode()
         .withNetwork(Resources.getResource("fulu-minimal.yaml"))
         .withStubExecutionEngine(3)
+        .withReworkedCustodySync()
         .withLogLevel("DEBUG");
   }
 }

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -81,6 +81,11 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
     final int expectedCustodyCount = specConfigFulu.getCustodyRequirement();
     secondaryNode.waitForCustodyBackfill(firstFuluSlot, expectedCustodyCount);
 
+    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
+    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
+    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
+    primaryNode.waitForBlockAtSlot(primaryNode.getHeadBlock().getSlot().plus(3));
+
     final SignedBeaconBlock blockAtHead = secondaryNode.getHeadBlock();
     final int checkpointSlot = checkpointFinalizedBlock.getSlot().intValue();
     final int endSlot = blockAtHead.getSlot().intValue();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -746,7 +746,9 @@ public class TekuBeaconNode extends TekuNode {
           assertThat(maybeBlock).isPresent();
           assertThat(getDataColumnSidecarCount(maybeBlock.get().getRoot().toHexString()))
               .isEqualTo(expectedCustodyCount);
-        });
+        },
+        3,
+        MINUTES);
   }
 
   public void waitForValidators(final int numberOfValidators) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -691,6 +691,12 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
+  public TekuNodeConfigBuilder withReworkedCustodySync() {
+    LOG.debug("Xp2p-reworked-sidecar-custody-sync-enabled: {}", true);
+    configMap.put("Xp2p-reworked-sidecar-custody-sync-enabled", true);
+    return this;
+  }
+
   public TekuNodeConfigBuilder withReworkedRecoveryTimeouts(
       final int recoveryTimeout, final int downloadTimeout) {
     LOG.debug("Xp2p-reworked-sidecar-cancel-timeout-ms: {}", recoveryTimeout);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -126,7 +126,7 @@ public class HistoricalBatchFetcherTest {
     final RecentChainData recentChainData = storageSystem.recentChainData();
     chainDataClient =
         new CombinedChainDataClient(
-            recentChainData, historicalChainData, spec, LateBlockReorgPreparationHandler.NOOP);
+            recentChainData, historicalChainData, spec, LateBlockReorgPreparationHandler.NOOP, false);
 
     peer = RespondingEth2Peer.create(spec, chainBuilder);
     fetcher =

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -126,7 +126,11 @@ public class HistoricalBatchFetcherTest {
     final RecentChainData recentChainData = storageSystem.recentChainData();
     chainDataClient =
         new CombinedChainDataClient(
-            recentChainData, historicalChainData, spec, LateBlockReorgPreparationHandler.NOOP, false);
+            recentChainData,
+            historicalChainData,
+            spec,
+            LateBlockReorgPreparationHandler.NOOP,
+            false);
 
     peer = RespondingEth2Peer.create(spec, chainBuilder);
     fetcher =

--- a/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
@@ -142,7 +142,11 @@ public class StateSelectorFactoryTest {
     final RecentChainData recentChainData = mock(RecentChainData.class);
     final CombinedChainDataClient client1 =
         new CombinedChainDataClient(
-            recentChainData, historicalChainData, spec, LateBlockReorgPreparationHandler.NOOP, false);
+            recentChainData,
+            historicalChainData,
+            spec,
+            LateBlockReorgPreparationHandler.NOOP,
+            false);
     final StateSelectorFactory factory = new StateSelectorFactory(spec, client1);
     when(recentChainData.isPreGenesis()).thenReturn(false);
     when(recentChainData.isPreForkChoice()).thenReturn(true);

--- a/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
@@ -142,7 +142,7 @@ public class StateSelectorFactoryTest {
     final RecentChainData recentChainData = mock(RecentChainData.class);
     final CombinedChainDataClient client1 =
         new CombinedChainDataClient(
-            recentChainData, historicalChainData, spec, LateBlockReorgPreparationHandler.NOOP);
+            recentChainData, historicalChainData, spec, LateBlockReorgPreparationHandler.NOOP, false);
     final StateSelectorFactory factory = new StateSelectorFactory(spec, client1);
     when(recentChainData.isPreGenesis()).thenReturn(false);
     when(recentChainData.isPreForkChoice()).thenReturn(true);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
@@ -459,11 +459,11 @@ public class DasCustodyBackfiller extends Service
     pendingRequests.put(colId, req);
 
     return req.thenPeek(
-            __ -> LOG.debug("DasCustodyBackfiller: Data column sidecar {} retrieved.", colId))
+            __ -> LOG.trace("DasCustodyBackfiller: Data column sidecar {} retrieved.", colId))
         .thenCompose(
             sidecar ->
                 dataColumnSidecarCustody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC))
-        .thenPeek(__ -> LOG.debug("DasCustodyBackfiller: Data column sidecar {} stored.", colId))
+        .thenPeek(__ -> LOG.trace("DasCustodyBackfiller: Data column sidecar {} stored.", colId))
         .ignoreCancelException()
         .catchAndRethrow(
             err ->

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -183,14 +183,15 @@ public class DataColumnSidecarCustodyImpl
   @Override
   public void onNewFinalizedCheckpoint(
       final Checkpoint checkpoint, final boolean fromOptimisticBlock) {
-    advanceFirstIncompleteSlot(checkpoint.getEpoch())
-        .finish(
-            error ->
-                LOG.error(
-                    "Unexpected error while advancing first custody incomplete slot for checkpoint {}{}",
-                    checkpoint,
-                    fromOptimisticBlock ? " (from optimistic block)" : "",
-                    error));
+    //    advanceFirstIncompleteSlot(checkpoint.getEpoch())
+    //        .finish(
+    //            error ->
+    //                LOG.error(
+    //                    "Unexpected error while advancing first custody incomplete slot for
+    // checkpoint {}{}",
+    //                    checkpoint,
+    //                    fromOptimisticBlock ? " (from optimistic block)" : "",
+    //                    error));
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -183,15 +183,14 @@ public class DataColumnSidecarCustodyImpl
   @Override
   public void onNewFinalizedCheckpoint(
       final Checkpoint checkpoint, final boolean fromOptimisticBlock) {
-    //    advanceFirstIncompleteSlot(checkpoint.getEpoch())
-    //        .finish(
-    //            error ->
-    //                LOG.error(
-    //                    "Unexpected error while advancing first custody incomplete slot for
-    // checkpoint {}{}",
-    //                    checkpoint,
-    //                    fromOptimisticBlock ? " (from optimistic block)" : "",
-    //                    error));
+    advanceFirstIncompleteSlot(checkpoint.getEpoch())
+        .finish(
+            error ->
+                LOG.error(
+                    "Unexpected error while advancing first custody incomplete slot for checkpoint {}{}",
+                    checkpoint,
+                    fromOptimisticBlock ? " (from optimistic block)" : "",
+                    error));
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/ColumnIdCachingDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/ColumnIdCachingDasDb.java
@@ -128,4 +128,14 @@ class ColumnIdCachingDasDb implements DataColumnSidecarDB {
   public SafeFuture<Void> setFirstCustodyIncompleteSlot(final UInt64 slot) {
     return delegateDb.setFirstCustodyIncompleteSlot(slot);
   }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
+    return delegateDb.getEarliestAvailableDataSlot();
+  }
+
+  @Override
+  public SafeFuture<Void> setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+    return delegateDb.setEarliestAvailableDataColumnSlot(slot);
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/ColumnIdCachingDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/ColumnIdCachingDasDb.java
@@ -130,8 +130,8 @@ class ColumnIdCachingDasDb implements DataColumnSidecarDB {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
-    return delegateDb.getEarliestAvailableDataSlot();
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    return delegateDb.getEarliestAvailableDataColumnSlot();
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
@@ -34,7 +34,7 @@ public interface DataColumnSidecarDB extends DataColumnSidecarCoreDB {
 
   SafeFuture<Optional<UInt64>> getFirstCustodyIncompleteSlot();
 
-  SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot();
+  SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot();
 
   @Override
   SafeFuture<Optional<DataColumnSidecar>> getSidecar(DataColumnSlotAndIdentifier identifier);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
@@ -34,6 +34,8 @@ public interface DataColumnSidecarDB extends DataColumnSidecarCoreDB {
 
   SafeFuture<Optional<UInt64>> getFirstCustodyIncompleteSlot();
 
+  SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot();
+
   @Override
   SafeFuture<Optional<DataColumnSidecar>> getSidecar(DataColumnSlotAndIdentifier identifier);
 
@@ -43,6 +45,8 @@ public interface DataColumnSidecarDB extends DataColumnSidecarCoreDB {
   // update
 
   SafeFuture<Void> setFirstCustodyIncompleteSlot(UInt64 slot);
+
+  SafeFuture<Void> setEarliestAvailableDataColumnSlot(UInt64 slot);
 
   @Override
   SafeFuture<Void> addSidecar(DataColumnSidecar sidecar);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -72,6 +72,16 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
         .thenRun(() -> detailLogger.logOnNewSidecar(sidecar));
   }
 
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
+    return combinedChainDataClient.getEarliestAvailableDataSlot();
+  }
+
+  @Override
+  public SafeFuture<Void> setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+    return sidecarUpdateChannel.onEarliestAvailableDataColumnSlot(slot);
+  }
+
   private class DetailLogger {
     private final AtomicInteger addCounter = new AtomicInteger();
     private long maxAddedSlot = 0;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -73,8 +73,8 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
-    return combinedChainDataClient.getEarliestAvailableDataSlot();
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    return combinedChainDataClient.getEarliestAvailableDataColumnSlot();
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -200,8 +200,12 @@ public class SimpleSidecarRetriever
                 if (pendingRequest.activeRpcRequest != null) {
                   pendingRequest.activeRpcRequest.promise().cancel(true);
                 }
-                if(pendingRequest.result.isCancelled() || pendingRequest.result.isCompletedExceptionally()) {
-                  LOG.info("REMOVED (disposeCompletedRequests) {}: {}", pendingRequest.columnId, pendingRequest.result);
+                if (pendingRequest.result.isCancelled()
+                    || pendingRequest.result.isCompletedExceptionally()) {
+                  LOG.info(
+                      "REMOVED (disposeCompletedRequests) {}: {}",
+                      pendingRequest.columnId,
+                      pendingRequest.result);
                 }
                 return true;
               }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -152,7 +152,7 @@ public class SimpleSidecarRetriever
               reqRespCompleted(match.request, sidecar);
 
               if (err != null) {
-                LOG.debug(
+                LOG.info(
                     "SimpleSidecarRetriever.Request failed for {} due to: {}",
                     () -> match.request.columnId,
                     () -> ExceptionUtil.getMessageOrSimpleName(err));
@@ -199,6 +199,9 @@ public class SimpleSidecarRetriever
               if (pendingRequest.result.isDone()) {
                 if (pendingRequest.activeRpcRequest != null) {
                   pendingRequest.activeRpcRequest.promise().cancel(true);
+                }
+                if(pendingRequest.result.isCancelled() || pendingRequest.result.isCompletedExceptionally()) {
+                  LOG.info("REMOVED (disposeCompletedRequests) {}: {}", pendingRequest.columnId, pendingRequest.result);
                 }
                 return true;
               }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -152,7 +152,7 @@ public class SimpleSidecarRetriever
               reqRespCompleted(match.request, sidecar);
 
               if (err != null) {
-                LOG.info(
+                LOG.debug(
                     "SimpleSidecarRetriever.Request failed for {} due to: {}",
                     () -> match.request.columnId,
                     () -> ExceptionUtil.getMessageOrSimpleName(err));
@@ -199,13 +199,6 @@ public class SimpleSidecarRetriever
               if (pendingRequest.result.isDone()) {
                 if (pendingRequest.activeRpcRequest != null) {
                   pendingRequest.activeRpcRequest.promise().cancel(true);
-                }
-                if (pendingRequest.result.isCancelled()
-                    || pendingRequest.result.isCompletedExceptionally()) {
-                  LOG.info(
-                      "REMOVED (disposeCompletedRequests) {}: {}",
-                      pendingRequest.columnId,
-                      pendingRequest.result);
                 }
                 return true;
               }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
 
   private Optional<UInt64> firstCustodyIncompleteSlot = Optional.empty();
+  private Optional<UInt64> earliestAvailableDataSlot = Optional.empty();
   private final NavigableMap<DataColumnSlotAndIdentifier, DataColumnSidecar> db = new TreeMap<>();
   private final AtomicLong dbReadCounter = new AtomicLong();
   private final AtomicLong dbWriteCounter = new AtomicLong();
@@ -72,6 +73,19 @@ public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
             .stream()
             .sorted()
             .toList());
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
+    dbReadCounter.incrementAndGet();
+    return SafeFuture.completedFuture(earliestAvailableDataSlot);
+  }
+
+  @Override
+  public SafeFuture<Void> setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+    dbWriteCounter.incrementAndGet();
+    this.earliestAvailableDataSlot = Optional.of(slot);
+    return SafeFuture.COMPLETE;
   }
 
   public AtomicLong getDbReadCounter() {

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
@@ -76,7 +76,7 @@ public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
     dbReadCounter.incrementAndGet();
     return SafeFuture.completedFuture(earliestAvailableDataSlot);
   }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/db/DelayedDasDb.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/db/DelayedDasDb.java
@@ -68,4 +68,14 @@ public class DelayedDasDb implements DataColumnSidecarDB {
   public SafeFuture<Void> addSidecar(final DataColumnSidecar sidecar) {
     return delay(() -> delegate.addSidecar(sidecar));
   }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
+    return delay(delegate::getEarliestAvailableDataSlot);
+  }
+
+  @Override
+  public SafeFuture<Void> setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+    return delay(() -> delegate.setEarliestAvailableDataColumnSlot(slot));
+  }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/db/DelayedDasDb.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/db/DelayedDasDb.java
@@ -70,8 +70,8 @@ public class DelayedDasDb implements DataColumnSidecarDB {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
-    return delay(delegate::getEarliestAvailableDataSlot);
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    return delay(delegate::getEarliestAvailableDataColumnSlot);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -55,6 +55,10 @@ public class P2PConfig {
   public static final int DEFAULT_DAS_PUBLISH_WITHHOLD_COLUMNS_EVERY_SLOTS = -1;
   public static final int DEFAULT_RECOVERY_TIMEOUT_MS = 300_000;
   public static final int DEFAULT_DOWNLOAD_TIMEOUT_MS = 240_000;
+
+  public static final int DEFAULT_COLUMN_CUSTODY_BACKFILLER_POLL_PERIOD_SECONDS = 30;
+  public static final int DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE = 10;
+
   // RocksDB is configured with 6 background jobs and threads (DEFAULT_MAX_BACKGROUND_JOBS and
   // DEFAULT_BACKGROUND_THREAD_COUNT)
   // The storage query channel allows up to 10 parallel queries (STORAGE_QUERY_CHANNEL_PARALLELISM)
@@ -90,6 +94,9 @@ public class P2PConfig {
   private final int reworkedSidecarRecoveryTimeout;
   private final int reworkedSidecarDownloadTimeout;
   private final boolean reworkedSidecarRecoveryEnabled;
+  private final int reworkedSidecarSyncBatchSize;
+  private final int reworkedSidecarSyncPollPeriod;
+  private final boolean reworkedSidecarSyncEnabled;
   private final boolean executionProofTopicEnabled;
 
   private P2PConfig(
@@ -117,6 +124,9 @@ public class P2PConfig {
       final boolean reworkedSidecarRecoveryEnabled,
       final int reworkedSidecarRecoveryTimeout,
       final int reworkedSidecarDownloadTimeout,
+      final boolean reworkedSidecarSyncEnabled,
+      final Integer reworkedSidecarSyncBatchSize,
+      final Integer reworkedSidecarSyncPollPeriod,
       final boolean executionProofTopicEnabled) {
     this.spec = spec;
     this.networkConfig = networkConfig;
@@ -143,6 +153,9 @@ public class P2PConfig {
     this.reworkedSidecarRecoveryEnabled = reworkedSidecarRecoveryEnabled;
     this.reworkedSidecarDownloadTimeout = reworkedSidecarDownloadTimeout;
     this.reworkedSidecarRecoveryTimeout = reworkedSidecarRecoveryTimeout;
+    this.reworkedSidecarSyncEnabled = reworkedSidecarSyncEnabled;
+    this.reworkedSidecarSyncBatchSize = reworkedSidecarSyncBatchSize;
+    this.reworkedSidecarSyncPollPeriod = reworkedSidecarSyncPollPeriod;
     this.executionProofTopicEnabled = executionProofTopicEnabled;
   }
 
@@ -258,6 +271,18 @@ public class P2PConfig {
     return reworkedSidecarDownloadTimeout;
   }
 
+  public boolean isReworkedSidecarSyncEnabled() {
+    return reworkedSidecarSyncEnabled;
+  }
+
+  public int getReworkedSidecarSyncBatchSize() {
+    return reworkedSidecarSyncBatchSize;
+  }
+
+  public int getReworkedSidecarSyncPollPeriod() {
+    return reworkedSidecarSyncPollPeriod;
+  }
+
   public static class Builder {
     private final NetworkConfig.Builder networkConfig = NetworkConfig.builder();
     private final DiscoveryConfig.Builder discoveryConfig = DiscoveryConfig.builder();
@@ -290,6 +315,11 @@ public class P2PConfig {
     private boolean reworkedSidecarRecoveryEnabled = true;
     private Integer reworkedSidecarRecoveryTimeout = DEFAULT_RECOVERY_TIMEOUT_MS;
     private Integer reworkedSidecarDownloadTimeout = DEFAULT_DOWNLOAD_TIMEOUT_MS;
+
+    private boolean reworkedSidecarSyncEnabled = false;
+    private Integer reworkedSidecarSyncBatchSize = DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE;
+    private Integer reworkedSidecarSyncPollPeriod =
+        DEFAULT_COLUMN_CUSTODY_BACKFILLER_POLL_PERIOD_SECONDS;
 
     private Builder() {}
 
@@ -358,6 +388,9 @@ public class P2PConfig {
           reworkedSidecarRecoveryEnabled,
           reworkedSidecarRecoveryTimeout,
           reworkedSidecarDownloadTimeout,
+          reworkedSidecarSyncEnabled,
+          reworkedSidecarSyncBatchSize,
+          reworkedSidecarSyncPollPeriod,
           executionProofTopicEnabled);
     }
 
@@ -540,6 +573,21 @@ public class P2PConfig {
 
     public Builder reworkedSidecarRecoveryEnabled(final boolean reworkedSidecarRecoveryEnabled) {
       this.reworkedSidecarRecoveryEnabled = reworkedSidecarRecoveryEnabled;
+      return this;
+    }
+
+    public Builder reworkedSidecarSyncBatchSize(final Integer reworkedSidecarSyncBatchSize) {
+      this.reworkedSidecarRecoveryTimeout = reworkedSidecarSyncBatchSize;
+      return this;
+    }
+
+    public Builder reworkedSidecarSyncPollPeriod(final Integer reworkedSidecarSyncPollPeriod) {
+      this.reworkedSidecarSyncPollPeriod = reworkedSidecarSyncPollPeriod;
+      return this;
+    }
+
+    public Builder reworkedSidecarSyncEnabled(final boolean reworkedSidecarSyncEnabled) {
+      this.reworkedSidecarSyncEnabled = reworkedSidecarSyncEnabled;
       return this;
     }
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -577,7 +577,7 @@ public class P2PConfig {
     }
 
     public Builder reworkedSidecarSyncBatchSize(final Integer reworkedSidecarSyncBatchSize) {
-      this.reworkedSidecarRecoveryTimeout = reworkedSidecarSyncBatchSize;
+      this.reworkedSidecarSyncBatchSize = reworkedSidecarSyncBatchSize;
       return this;
     }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -127,7 +127,7 @@ public class StatusMessageFactory implements SlotEventsChannel {
     final SafeFuture<Optional<UInt64>> earliestAvailableBlockSlotFuture =
         combinedChainDataClient.getEarliestAvailableBlockSlot();
     final SafeFuture<Optional<UInt64>> earliestDataColumnSidecarSlotFuture =
-        combinedChainDataClient.getEarliestDataColumnSidecarSlot();
+        combinedChainDataClient.getEarliestAvailableDataColumnSlot();
 
     final BiFunction<Optional<UInt64>, Optional<UInt64>, Optional<UInt64>>
         combineEarliestSlotFunction =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -127,7 +127,7 @@ public class StatusMessageFactory implements SlotEventsChannel {
     final SafeFuture<Optional<UInt64>> earliestAvailableBlockSlotFuture =
         combinedChainDataClient.getEarliestAvailableBlockSlot();
     final SafeFuture<Optional<UInt64>> earliestDataColumnSidecarSlotFuture =
-        combinedChainDataClient.getEarliestAvailableDataColumnSlot();
+        combinedChainDataClient.getEarliestAvailableDataColumnSlotWithFallback();
 
     final BiFunction<Optional<UInt64>, Optional<UInt64>, Optional<UInt64>>
         combineEarliestSlotFunction =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
@@ -99,7 +99,7 @@ class StatusMessageFactoryTest {
   public void shouldOnlyUpdateEarliestSlotAvailableAtBeginningOfEpoch() {
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(UInt64.ZERO)));
-    when(combinedChainDataClient.getEarliestDataColumnSidecarSlot())
+    when(combinedChainDataClient.getEarliestAvailableDataColumnSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(UInt64.ZERO)));
 
     final UInt64 currentEpoch = UInt64.ONE;
@@ -155,7 +155,7 @@ class StatusMessageFactoryTest {
 
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(SafeFuture.completedFuture(blockEarliestAvailableSlot));
-    when(combinedChainDataClient.getEarliestDataColumnSidecarSlot())
+    when(combinedChainDataClient.getEarliestAvailableDataColumnSlot())
         .thenReturn(SafeFuture.completedFuture(dataColumnLatestAvailableSlot));
     statusMessageFactory.onSlot(UInt64.ZERO);
 
@@ -196,13 +196,13 @@ class StatusMessageFactoryTest {
     statusMessageFactory.onSlot(UInt64.ZERO);
 
     verify(combinedChainDataClient, never()).getEarliestAvailableBlockSlot();
-    verify(combinedChainDataClient, never()).getEarliestDataColumnSidecarSlot();
+    verify(combinedChainDataClient, never()).getEarliestAvailableDataColumnSlot();
   }
 
   private void tickOnSlotAndUpdatedEarliestSlotAvailable(final UInt64 earliestAvailableSlot) {
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(earliestAvailableSlot)));
-    when(combinedChainDataClient.getEarliestDataColumnSidecarSlot())
+    when(combinedChainDataClient.getEarliestAvailableDataColumnSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(earliestAvailableSlot)));
     statusMessageFactory.onSlot(UInt64.ZERO);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactoryTest.java
@@ -99,7 +99,7 @@ class StatusMessageFactoryTest {
   public void shouldOnlyUpdateEarliestSlotAvailableAtBeginningOfEpoch() {
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(UInt64.ZERO)));
-    when(combinedChainDataClient.getEarliestAvailableDataColumnSlot())
+    when(combinedChainDataClient.getEarliestAvailableDataColumnSlotWithFallback())
         .thenReturn(SafeFuture.completedFuture(Optional.of(UInt64.ZERO)));
 
     final UInt64 currentEpoch = UInt64.ONE;
@@ -155,7 +155,7 @@ class StatusMessageFactoryTest {
 
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(SafeFuture.completedFuture(blockEarliestAvailableSlot));
-    when(combinedChainDataClient.getEarliestAvailableDataColumnSlot())
+    when(combinedChainDataClient.getEarliestAvailableDataColumnSlotWithFallback())
         .thenReturn(SafeFuture.completedFuture(dataColumnLatestAvailableSlot));
     statusMessageFactory.onSlot(UInt64.ZERO);
 
@@ -196,13 +196,13 @@ class StatusMessageFactoryTest {
     statusMessageFactory.onSlot(UInt64.ZERO);
 
     verify(combinedChainDataClient, never()).getEarliestAvailableBlockSlot();
-    verify(combinedChainDataClient, never()).getEarliestAvailableDataColumnSlot();
+    verify(combinedChainDataClient, never()).getEarliestAvailableDataColumnSlotWithFallback();
   }
 
   private void tickOnSlotAndUpdatedEarliestSlotAvailable(final UInt64 earliestAvailableSlot) {
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(earliestAvailableSlot)));
-    when(combinedChainDataClient.getEarliestAvailableDataColumnSlot())
+    when(combinedChainDataClient.getEarliestAvailableDataColumnSlotWithFallback())
         .thenReturn(SafeFuture.completedFuture(Optional.of(earliestAvailableSlot)));
     statusMessageFactory.onSlot(UInt64.ZERO);
   }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -232,7 +232,11 @@ public class Eth2P2PNetworkFactory {
             new SubnetSubscriptionService();
         final CombinedChainDataClient combinedChainDataClient =
             new CombinedChainDataClient(
-                recentChainData, historicalChainData, spec, LateBlockReorgPreparationHandler.NOOP);
+                recentChainData,
+                historicalChainData,
+                spec,
+                LateBlockReorgPreparationHandler.NOOP,
+                config.isReworkedSidecarSyncEnabled());
         final DataColumnSidecarSubnetTopicProvider dataColumnSidecarSubnetTopicProvider =
             new DataColumnSidecarSubnetTopicProvider(
                 combinedChainDataClient.getRecentChainData(), gossipEncoding);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1042,7 +1042,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     final DasCustodyBackfiller s =
         new DasCustodyBackfiller(
             combinedChainDataClient,
-            Duration.ofSeconds(30),
+            Duration.ofSeconds(5),
             dataColumnSidecarRecoveringCustody,
             custodyGroupCountManager,
             recoveringSidecarRetriever,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1052,6 +1052,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             sidecarDB::setFirstCustodyIncompleteSlot,
             BATCH_SIZE_IN_SLOTS);
     eventChannels.subscribe(CustodyGroupCountChannel.class, s);
+    eventChannels.subscribe(FinalizedCheckpointChannel.class, s);
     dasCustodyBackfiller = Optional.of(s);
 
     final CurrentSlotProvider currentSlotProvider =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -2158,6 +2158,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
     syncService.subscribeToSyncStateChangesAndUpdate(
         event -> dataColumnSidecarELManager.onSyncingStatusChanged(event.isInSync()));
+
+    dasCustodyBackfiller.ifPresent(backfiller -> syncService.subscribeToSyncStateChangesAndUpdate(syncState -> backfiller.onNodeSyncStateChanged(syncState.isInSync())));
   }
 
   protected void initOperationsReOrgManager() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1480,7 +1480,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             spec,
             (slot, blockRoot) ->
                 beaconAsyncRunner.runAsync(
-                    () -> operationsReOrgManager.onLateBlockReorgPreparation(slot, blockRoot)));
+                    () -> operationsReOrgManager.onLateBlockReorgPreparation(slot, blockRoot)),
+            beaconConfig.p2pConfig().isReworkedSidecarSyncEnabled());
   }
 
   protected SafeFuture<Void> initWeakSubjectivity(
@@ -1887,7 +1888,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
                   recentChainData,
                   throttlingStorageQueryChannel,
                   spec,
-                  LateBlockReorgPreparationHandler.NOOP));
+                  LateBlockReorgPreparationHandler.NOOP,
+                  beaconConfig.p2pConfig().isReworkedSidecarSyncEnabled()));
     }
 
     this.p2pNetwork =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1046,7 +1046,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               recoveringSidecarRetriever,
               minCustodyPeriodSlotCalculator,
               dasAsyncRunner,
-              sidecarDB::getEarliestAvailableDataSlot,
+              sidecarDB::getEarliestAvailableDataColumnSlot,
               sidecarDB::setEarliestAvailableDataColumnSlot,
               beaconConfig.p2pConfig().getReworkedSidecarSyncBatchSize());
       eventChannels.subscribe(CustodyGroupCountChannel.class, custodyBackfiller);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -2159,7 +2159,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
     syncService.subscribeToSyncStateChangesAndUpdate(
         event -> dataColumnSidecarELManager.onSyncingStatusChanged(event.isInSync()));
 
-    dasCustodyBackfiller.ifPresent(backfiller -> syncService.subscribeToSyncStateChangesAndUpdate(syncState -> backfiller.onNodeSyncStateChanged(syncState.isInSync())));
+    dasCustodyBackfiller.ifPresent(
+        backfiller ->
+            syncService.subscribeToSyncStateChangesAndUpdate(
+                syncState -> backfiller.onNodeSyncStateChanged(syncState.isInSync())));
   }
 
   protected void initOperationsReOrgManager() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -509,6 +509,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
             p2pNetwork.start(),
             blockManager.start(),
             syncService.start(),
+            dasCustodyBackfiller.isPresent()
+                ? dasCustodyBackfiller.get().start()
+                : SafeFuture.COMPLETE,
             SafeFuture.fromRunnable(
                 () -> {
                   terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::start);
@@ -546,6 +549,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
             p2pNetwork.stop(),
             timerService.stop(),
             ephemerySlotValidationService.doStop(),
+            dasCustodyBackfiller.isPresent()
+                ? dasCustodyBackfiller.get().stop()
+                : SafeFuture.COMPLETE,
             SafeFuture.fromRunnable(
                 () -> {
                   terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop);
@@ -934,7 +940,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
             minCustodyPeriodSlotCalculator,
             custodyGroupCountManager);
     eventChannels.subscribe(SlotEventsChannel.class, dataColumnSidecarCustodyImpl);
-    eventChannels.subscribe(FinalizedCheckpointChannel.class, dataColumnSidecarCustodyImpl);
+
+    if (!beaconConfig.p2pConfig().isReworkedSidecarSyncEnabled()) {
+      // during finalization DataColumnSidecarCustody maintains FirstIncompleteSlot variable, which
+      // is not needed on reworked custody backfiller
+      eventChannels.subscribe(FinalizedCheckpointChannel.class, dataColumnSidecarCustodyImpl);
+    }
 
     final DataColumnSidecarByRootCustody dataColumnSidecarByRootCustody =
         new DataColumnSidecarByRootCustodyImpl(
@@ -1024,13 +1035,32 @@ public class BeaconChainController extends Service implements BeaconChainControl
               timeProvider,
               specConfigFulu.getNumberOfColumns());
     }
-    final DasCustodySync svc =
-        new DasCustodySync(
-            dataColumnSidecarRecoveringCustody,
-            recoveringSidecarRetriever,
-            minCustodyPeriodSlotCalculator);
-    dasCustodySync = Optional.of(svc);
-    eventChannels.subscribe(SlotEventsChannel.class, svc);
+
+    if (beaconConfig.p2pConfig().isReworkedSidecarSyncEnabled()) {
+      final DasCustodyBackfiller custodyBackfiller =
+          new DasCustodyBackfiller(
+              combinedChainDataClient,
+              Duration.ofSeconds(beaconConfig.p2pConfig().getReworkedSidecarSyncPollPeriod()),
+              dataColumnSidecarRecoveringCustody,
+              custodyGroupCountManager,
+              recoveringSidecarRetriever,
+              minCustodyPeriodSlotCalculator,
+              dasAsyncRunner,
+              sidecarDB::getEarliestAvailableDataSlot,
+              sidecarDB::setEarliestAvailableDataColumnSlot,
+              beaconConfig.p2pConfig().getReworkedSidecarSyncBatchSize());
+      eventChannels.subscribe(CustodyGroupCountChannel.class, custodyBackfiller);
+      eventChannels.subscribe(FinalizedCheckpointChannel.class, custodyBackfiller);
+      dasCustodyBackfiller = Optional.of(custodyBackfiller);
+    } else {
+      final DasCustodySync custodySync =
+          new DasCustodySync(
+              dataColumnSidecarRecoveringCustody,
+              recoveringSidecarRetriever,
+              minCustodyPeriodSlotCalculator);
+      dasCustodySync = Optional.of(custodySync);
+      eventChannels.subscribe(SlotEventsChannel.class, custodySync);
+    }
 
     final CurrentSlotProvider currentSlotProvider =
         CurrentSlotProvider.create(spec, recentChainData.getStore());
@@ -2135,6 +2165,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
     syncService.subscribeToSyncStateChangesAndUpdate(
         event -> dataColumnSidecarELManager.onSyncingStatusChanged(event.isInSync()));
+
+    dasCustodyBackfiller.ifPresent(
+        backfiller ->
+            syncService.subscribeToSyncStateChangesAndUpdate(
+                syncState -> backfiller.onNodeSyncStateChanged(syncState.isInSync())));
   }
 
   protected void initOperationsReOrgManager() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_KZG_PR
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_KZG_PRECOMPUTE_SUPERNODE;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.DEFAULT_MAXIMUM_ATTESTATION_COUNT;
+import static tech.pegasys.teku.statetransition.datacolumns.DasCustodyBackfiller.BATCH_SIZE_IN_SLOTS;
 import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MAX_WAIT_RELATIVE_TO_ATT_DUE_MILLIS;
 import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_MIN_WAIT_MILLIS;
 import static tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider.DEFAULT_TARGET_WAIT_MILLIS;
@@ -164,6 +165,7 @@ import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolver;
 import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManagerImpl;
+import tech.pegasys.teku.statetransition.datacolumns.DasCustodyBackfiller;
 import tech.pegasys.teku.statetransition.datacolumns.DasCustodySync;
 import tech.pegasys.teku.statetransition.datacolumns.DasPreSampler;
 import tech.pegasys.teku.statetransition.datacolumns.DasSamplerBasic;
@@ -381,6 +383,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile ExecutionPayloadBidManager executionPayloadBidManager;
   protected volatile ExecutionPayloadManager executionPayloadManager;
   protected volatile ExecutionProofManager executionProofManager;
+  protected volatile Optional<DasCustodyBackfiller> dasCustodyBackfiller = Optional.empty();
   protected volatile DasSamplerBasic dasSamplerBasic;
   protected volatile Optional<DasCustodySync> dasCustodySync = Optional.empty();
   protected volatile Optional<DataColumnSidecarRetriever> recoveringSidecarRetriever =
@@ -507,6 +510,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
             p2pNetwork.start(),
             blockManager.start(),
             syncService.start(),
+            dasCustodyBackfiller.isPresent()
+                ? dasCustodyBackfiller.get().start()
+                : SafeFuture.COMPLETE,
             SafeFuture.fromRunnable(
                 () -> {
                   terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::start);
@@ -544,6 +550,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
             p2pNetwork.stop(),
             timerService.stop(),
             ephemerySlotValidationService.doStop(),
+            dasCustodyBackfiller.isPresent()
+                ? dasCustodyBackfiller.get().stop()
+                : SafeFuture.COMPLETE,
             SafeFuture.fromRunnable(
                 () -> {
                   terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop);
@@ -1022,13 +1031,28 @@ public class BeaconChainController extends Service implements BeaconChainControl
               timeProvider,
               specConfigFulu.getNumberOfColumns());
     }
-    final DasCustodySync svc =
-        new DasCustodySync(
+    //    final DasCustodySync svc =
+    //        new DasCustodySync(
+    //            dataColumnSidecarRecoveringCustody,
+    //            recoveringSidecarRetriever,
+    //            minCustodyPeriodSlotCalculator);
+    //    dasCustodySync = Optional.of(svc);
+    //    eventChannels.subscribe(SlotEventsChannel.class, svc);
+
+    final DasCustodyBackfiller s =
+        new DasCustodyBackfiller(
+            combinedChainDataClient,
+            Duration.ofSeconds(30),
             dataColumnSidecarRecoveringCustody,
+            custodyGroupCountManager,
             recoveringSidecarRetriever,
-            minCustodyPeriodSlotCalculator);
-    dasCustodySync = Optional.of(svc);
-    eventChannels.subscribe(SlotEventsChannel.class, svc);
+            minCustodyPeriodSlotCalculator,
+            dasAsyncRunner,
+            sidecarDB::getFirstCustodyIncompleteSlot,
+            sidecarDB::setFirstCustodyIncompleteSlot,
+            BATCH_SIZE_IN_SLOTS);
+    eventChannels.subscribe(CustodyGroupCountChannel.class, s);
+    dasCustodyBackfiller = Optional.of(s);
 
     final CurrentSlotProvider currentSlotProvider =
         CurrentSlotProvider.create(spec, recentChainData.getStore());

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
@@ -22,6 +22,8 @@ public interface SidecarUpdateChannel extends ChannelInterface {
 
   SafeFuture<Void> onFirstCustodyIncompleteSlot(UInt64 slot);
 
+  SafeFuture<Void> onEarliestAvailableDataColumnSlot(UInt64 slot);
+
   SafeFuture<Void> onNewSidecar(DataColumnSidecar sidecar);
 
   SafeFuture<Void> onNewNonCanonicalSidecar(DataColumnSidecar sidecar);

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -100,6 +100,8 @@ public interface StorageQueryChannel extends ChannelInterface {
    */
   SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot();
 
+  SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot();
+
   SafeFuture<Optional<BlobSidecar>> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
 
   SafeFuture<Optional<BlobSidecar>> getNonCanonicalBlobSidecar(SlotAndBlockRootAndBlobIndex key);

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/ThrottlingStorageQueryChannel.java
@@ -228,6 +228,11 @@ public class ThrottlingStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    return taskQueue.queueTask(delegate::getEarliestAvailableDataColumnSlot);
+  }
+
+  @Override
   public SafeFuture<Optional<DataColumnSidecar>> getSidecar(
       final DataColumnSlotAndIdentifier identifier) {
     return taskQueue.queueTask(() -> delegate.getSidecar(identifier));

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -2362,6 +2362,18 @@ public class DatabaseTest {
   }
 
   @TestTemplate
+  public void setEarliestAvailableDataColumnSlot_isOperative(final DatabaseContext context)
+      throws IOException {
+    setupWithSpec(TestSpecFactory.createMinimalFulu());
+    initialize(context);
+    assertThat(database.getEarliestAvailableDataColumnSlot().isEmpty()).isTrue();
+
+    final UInt64 earliestSlot = UInt64.valueOf(123);
+    database.setEarliestAvailableDataColumnSlot(UInt64.valueOf(123));
+    assertThat(database.getEarliestAvailableDataColumnSlot()).contains(earliestSlot);
+  }
+
+  @TestTemplate
   public void streamDataColumnIdentifiers_isOperative(final DatabaseContext context)
       throws IOException {
     setupWithSpec(TestSpecFactory.createMinimalFulu());

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -563,6 +563,10 @@ public class CombinedChainDataClient {
     return historicalChainData.getEarliestAvailableBlobSidecarSlot();
   }
 
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
+    return historicalChainData.getEarliestAvailableDataColumnSlot();
+  }
+
   /**
    * This is supposed to be consumed by RPC only, because it returns gossip-validated but not yet
    * imported sidecars from the blobSidecar pool.

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -71,16 +71,19 @@ public class CombinedChainDataClient {
   private final Spec spec;
 
   private final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler;
+  private final boolean isEarliestAvailableDataColumnSlotSupported;
 
   public CombinedChainDataClient(
       final RecentChainData recentChainData,
       final StorageQueryChannel historicalChainData,
       final Spec spec,
-      final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler) {
+      final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler,
+      final boolean isEarliestAvailableDataColumnSlotSupported) {
     this.recentChainData = recentChainData;
     this.historicalChainData = historicalChainData;
     this.spec = spec;
     this.lateBlockReorgPreparationHandler = lateBlockReorgPreparationHandler;
+    this.isEarliestAvailableDataColumnSlotSupported = isEarliestAvailableDataColumnSlotSupported;
   }
 
   /**
@@ -837,7 +840,11 @@ public class CombinedChainDataClient {
     return historicalChainData.getDataColumnIdentifiers(startSlot, endSlot, limit);
   }
 
-  public SafeFuture<Optional<UInt64>> getEarliestDataColumnSidecarSlot() {
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    if (isEarliestAvailableDataColumnSlotSupported) {
+      return historicalChainData.getEarliestAvailableDataColumnSlot();
+    }
+
     return historicalChainData.getEarliestDataColumnSidecarSlot();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -566,7 +566,7 @@ public class CombinedChainDataClient {
     return historicalChainData.getEarliestAvailableBlobSidecarSlot();
   }
 
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataSlot() {
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
     return historicalChainData.getEarliestAvailableDataColumnSlot();
   }
 
@@ -840,7 +840,7 @@ public class CombinedChainDataClient {
     return historicalChainData.getDataColumnIdentifiers(startSlot, endSlot, limit);
   }
 
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlotWithFallback() {
     if (isEarliestAvailableDataColumnSlotSupported) {
       return historicalChainData.getEarliestAvailableDataColumnSlot();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -462,6 +462,16 @@ public class ChainStorage
   }
 
   @Override
+  public SafeFuture<Void> onEarliestAvailableDataColumnSlot(final UInt64 slot) {
+    return SafeFuture.fromRunnable(() -> database.setEarliestAvailableDataColumnSlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    return SafeFuture.of(database::getEarliestAvailableDataColumnSlot);
+  }
+
+  @Override
   public SafeFuture<Void> onNewSidecar(final DataColumnSidecar sidecar) {
     return SafeFuture.fromRunnable(() -> database.addSidecar(sidecar));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -226,6 +226,11 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    return asyncRunner.runAsync(queryDelegate::getEarliestAvailableDataColumnSlot);
+  }
+
+  @Override
   public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecar(key));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -283,9 +283,13 @@ public interface Database extends AutoCloseable {
 
   Optional<UInt64> getEarliestDataColumnSidecarSlot();
 
+  Optional<UInt64> getEarliestAvailableDataColumnSlot();
+
   Optional<UInt64> getLastDataColumnSidecarsProofsSlot();
 
-  Optional<List<List<KZGProof>>> getDataColumnSidecarsProofs(final UInt64 slot);
+  Optional<List<List<KZGProof>>> getDataColumnSidecarsProofs(UInt64 slot);
+
+  void setEarliestAvailableDataColumnSlot(UInt64 slot);
 
   void setFirstCustodyIncompleteSlot(UInt64 slot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1165,7 +1165,7 @@ public class KvStoreDatabase implements Database {
 
   @Override
   public void setEarliestAvailableDataColumnSlot(final UInt64 slot) {
-    try (final CombinedUpdater updater = combinedUpdater()) {
+    try (final FinalizedUpdater updater = finalizedUpdater()) {
       updater.setEarliestAvailableDataColumnSlot(slot);
       updater.commit();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1159,6 +1159,19 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
+    return dao.getEarliestAvailableDataColumnSlot();
+  }
+
+  @Override
+  public void setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+    try (final CombinedUpdater updater = combinedUpdater()) {
+      updater.setEarliestAvailableDataColumnSlot(slot);
+      updater.commit();
+    }
+  }
+
+  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return dao.getLastDataColumnSidecarsProofsSlot();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -433,6 +433,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
+    return db.get(schema.getVariableEarliestAvailableDataColumnSlot());
+  }
+
+  @Override
   public Map<String, Long> getColumnCounts(final Optional<String> maybeColumnFilter) {
     final Map<String, Long> columnCounts = new LinkedHashMap<>();
     schema
@@ -811,6 +816,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     @Override
     public void setEarliestBlobSidecarSlot(final UInt64 slot) {
       transaction.put(schema.getVariableEarliestBlobSidecarSlot(), slot);
+    }
+
+    @Override
+    public void setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+      transaction.put(schema.getVariableEarliestAvailableDataColumnSlot(), slot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -191,6 +191,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<UInt64> getEarliestDataSidecarColumnSlot();
 
+  Optional<UInt64> getEarliestAvailableDataColumnSlot();
+
   Optional<UInt64> getLastDataColumnSidecarsProofsSlot();
 
   Optional<List<List<KZGProof>>> getDataColumnSidecarsProofs(UInt64 slot);
@@ -297,6 +299,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
     void setEarliestBlobSidecarSlot(UInt64 slot);
 
     void setEarliestBlockSlot(UInt64 slot);
+
+    void setEarliestAvailableDataColumnSlot(UInt64 slot);
 
     void deleteEarliestBlockSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -320,6 +320,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
+    return finalizedDao.getEarliestAvailableDataColumnSlot();
+  }
+
+  @Override
   @MustBeClosed
   public Stream<Map.Entry<Bytes32, UInt64>> getFinalizedStateRoots() {
     return finalizedDao.getFinalizedStateRoots();
@@ -668,6 +673,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     @Override
     public void setEarliestBlobSidecarSlot(final UInt64 slot) {
       finalizedUpdater.setEarliestBlobSidecarSlot(slot);
+    }
+
+    @Override
+    public void setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+      finalizedUpdater.setEarliestAvailableDataColumnSlot(slot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -373,7 +373,7 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
 
   @Override
   public Optional<UInt64> getEarliestDataSidecarColumnSlot() {
-    return finalizedDao.getEarliestAvailableDataColumnSlot();
+    return finalizedDao.getEarliestDataSidecarColumnSlot();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -246,9 +246,12 @@ public class V4FinalizedKvStoreDao {
   }
 
   public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
-    return db.getFirstEntry(schema.getColumnSidecarByColumnSlotAndIdentifier())
-        .map(ColumnEntry::getKey)
-        .map(DataColumnSlotAndIdentifier::slot);
+    return db.get(schema.getVariableEarliestAvailableDataColumnSlot())
+        .or(
+            () ->
+                db.getFirstEntry(schema.getColumnSidecarByColumnSlotAndIdentifier())
+                    .map(ColumnEntry::getKey)
+                    .map(DataColumnSlotAndIdentifier::slot));
   }
 
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
@@ -486,7 +489,7 @@ public class V4FinalizedKvStoreDao {
 
     @Override
     public void setEarliestAvailableDataColumnSlot(final UInt64 slot) {
-      transaction.put(schema.getVariableEarliestBlobSidecarSlot(), slot);
+      transaction.put(schema.getVariableEarliestAvailableDataColumnSlot(), slot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -485,6 +485,11 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
+    public void setEarliestAvailableDataColumnSlot(final UInt64 slot) {
+      transaction.put(schema.getVariableEarliestBlobSidecarSlot(), slot);
+    }
+
+    @Override
     public void setEarliestBlockSlot(final UInt64 slot) {
       transaction.put(schema.getVariableEarliestBlockSlot(), slot);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -245,13 +245,14 @@ public class V4FinalizedKvStoreDao {
     }
   }
 
+  public Optional<UInt64> getEarliestDataSidecarColumnSlot() {
+    return db.getFirstEntry(schema.getColumnSidecarByColumnSlotAndIdentifier())
+        .map(ColumnEntry::getKey)
+        .map(DataColumnSlotAndIdentifier::slot);
+  }
+
   public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
-    return db.get(schema.getVariableEarliestAvailableDataColumnSlot())
-        .or(
-            () ->
-                db.getFirstEntry(schema.getColumnSidecarByColumnSlotAndIdentifier())
-                    .map(ColumnEntry::getKey)
-                    .map(DataColumnSlotAndIdentifier::slot));
+    return db.get(schema.getVariableEarliestAvailableDataColumnSlot());
   }
 
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -93,6 +93,8 @@ public interface SchemaCombined extends Schema {
 
   KvStoreVariable<UInt64> getVariableEarliestBlobSidecarSlot();
 
+  KvStoreVariable<UInt64> getVariableEarliestAvailableDataColumnSlot();
+
   KvStoreVariable<Bytes32> getVariableLatestCanonicalBlockRoot();
 
   KvStoreVariable<UInt64> getVariableCustodyGroupCount();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
@@ -136,6 +136,10 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
     return delegate.getVariableEarliestBlobSidecarSlot();
   }
 
+  public KvStoreVariable<UInt64> getVariableEarliestAvailableDataColumnSlot() {
+    return delegate.getVariableEarliestAvailableDataColumnSlot();
+  }
+
   public KvStoreVariable<UInt64> getVariableEarliestBlockSlot() {
     return delegate.getVariableEarliestBlockSlot();
   }
@@ -153,6 +157,8 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
         "EARLIEST_BLOCK_SLOT_AVAILABLE",
         getVariableEarliestBlockSlot(),
         "FIRST_CUSTODY_INCOMPLETE_SLOT",
-        getVariableFirstCustodyIncompleteSlot());
+        getVariableFirstCustodyIncompleteSlot(),
+        "EARLIEST_AVAILABLE_DATA_COLUMN_SLOT",
+        getVariableEarliestAvailableDataColumnSlot());
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
@@ -276,6 +276,7 @@ public abstract class V6SchemaCombined implements SchemaCombined {
         .put("LATEST_CANONICAL_BLOCK_ROOT", getVariableLatestCanonicalBlockRoot())
         .put("CUSTODY_GROUP_COUNT", getVariableCustodyGroupCount())
         .put("FIRST_CUSTODY_INCOMPLETE_SLOT", getVariableFirstCustodyIncompleteSlot())
+        .put("EARLIEST_AVAILABLE_DATA_COLUMN_SLOT", getVariableEarliestAvailableDataColumnSlot())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
@@ -94,6 +94,7 @@ public abstract class V6SchemaCombined implements SchemaCombined {
   private final KvStoreVariable<UInt64> earliestBlobSidecarSlot;
   private final KvStoreVariable<UInt64> earliestBlockSlot;
   private final KvStoreVariable<UInt64> firstCustodyIncompleteSlot;
+  private final KvStoreVariable<UInt64> earliestAvailableDataColumnSlot;
 
   private final List<Bytes> deletedVariableIds;
 
@@ -114,6 +115,9 @@ public abstract class V6SchemaCombined implements SchemaCombined {
     earliestBlobSidecarSlot = KvStoreVariable.create(finalizedOffset + 2, UINT64_SERIALIZER);
     earliestBlockSlot = KvStoreVariable.create(finalizedOffset + 3, UINT64_SERIALIZER);
     firstCustodyIncompleteSlot = KvStoreVariable.create(finalizedOffset + 4, UINT64_SERIALIZER);
+    // finalizedOffset + 5 has been deleted
+    earliestAvailableDataColumnSlot =
+        KvStoreVariable.create(finalizedOffset + 6, UINT64_SERIALIZER);
 
     deletedVariableIds = List.of(asVariableId(finalizedOffset + 5));
   }
@@ -206,6 +210,11 @@ public abstract class V6SchemaCombined implements SchemaCombined {
   @Override
   public KvStoreVariable<UInt64> getVariableEarliestBlobSidecarSlot() {
     return earliestBlobSidecarSlot;
+  }
+
+  @Override
+  public KvStoreVariable<UInt64> getVariableEarliestAvailableDataColumnSlot() {
+    return earliestAvailableDataColumnSlot;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -202,6 +202,7 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
         .put("LATEST_CANONICAL_BLOCK_ROOT", getVariableLatestCanonicalBlockRoot())
         .put("CUSTODY_GROUP_COUNT", getVariableCustodyGroupCount())
         .put("FIRST_CUSTODY_INCOMPLETE_SLOT", getVariableFirstCustodyIncompleteSlot())
+        .put("EARLIEST_AVAILABLE_DATA_COLUMN_SLOT", getVariableEarliestAvailableDataColumnSlot())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -397,6 +397,14 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Optional<UInt64> getEarliestAvailableDataColumnSlot() {
+    return Optional.empty();
+  }
+
+  @Override
+  public void setEarliestAvailableDataColumnSlot(final UInt64 slot) {}
+
+  @Override
   public Optional<UInt64> getLastDataColumnSidecarsProofsSlot() {
     return Optional.empty();
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -60,7 +61,7 @@ class CombinedChainDataClientTest {
   private final UpdatableStore store = mock(UpdatableStore.class);
   private final CombinedChainDataClient client =
       new CombinedChainDataClient(
-          recentChainData, historicalChainData, spec, lateBlockReorgPreparationHandler);
+          recentChainData, historicalChainData, spec, lateBlockReorgPreparationHandler, false);
   private final ChainHead chainHead = mock(ChainHead.class);
 
   final List<SignedBeaconBlock> nonCanonicalBlocks = new ArrayList<>();
@@ -348,6 +349,23 @@ class CombinedChainDataClientTest {
     when(recentChainData.getStore()).thenReturn(null);
     final SafeFuture<Optional<BeaconState>> maybeFinalizedState = client.getBestFinalizedState();
     assertThat(maybeFinalizedState.get()).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void getEarliestAvailableDataColumnSlot_shouldRespectConfig() {
+    client.getEarliestAvailableDataColumnSlot();
+
+    verify(historicalChainData).getEarliestDataColumnSidecarSlot();
+
+    final CombinedChainDataClient clientWithEarliestAvailableDataColumnSlotSupport =
+        new CombinedChainDataClient(
+            recentChainData, historicalChainData, spec, lateBlockReorgPreparationHandler, true);
+
+    clientWithEarliestAvailableDataColumnSlotSupport.getEarliestAvailableDataColumnSlot();
+    verify(historicalChainData).getEarliestAvailableDataColumnSlot();
+
+    verifyNoMoreInteractions(historicalChainData);
   }
 
   private void setupGetBlobSidecar(

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -353,8 +353,8 @@ class CombinedChainDataClientTest {
 
   @Test
   @SuppressWarnings("FutureReturnValueIgnored")
-  void getEarliestAvailableDataColumnSlot_shouldRespectConfig() {
-    client.getEarliestAvailableDataColumnSlot();
+  void getEarliestAvailableDataColumnSlot_WithFallback_shouldRespectConfig() {
+    client.getEarliestAvailableDataColumnSlotWithFallback();
 
     verify(historicalChainData).getEarliestDataColumnSidecarSlot();
 
@@ -362,7 +362,8 @@ class CombinedChainDataClientTest {
         new CombinedChainDataClient(
             recentChainData, historicalChainData, spec, lateBlockReorgPreparationHandler, true);
 
-    clientWithEarliestAvailableDataColumnSlotSupport.getEarliestAvailableDataColumnSlot();
+    clientWithEarliestAvailableDataColumnSlotSupport
+        .getEarliestAvailableDataColumnSlotWithFallback();
     verify(historicalChainData).getEarliestAvailableDataColumnSlot();
 
     verifyNoMoreInteractions(historicalChainData);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -244,4 +244,9 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   public SafeFuture<Optional<List<List<KZGProof>>>> getDataColumnSidecarsProofs(final UInt64 slot) {
     return SafeFuture.completedFuture(Optional.empty());
   }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableDataColumnSlot() {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -120,7 +120,11 @@ public class StorageSystem implements AutoCloseable {
     // Create combined client
     final CombinedChainDataClient combinedChainDataClient =
         new CombinedChainDataClient(
-            recentChainData, chainStorageServer, spec, LateBlockReorgPreparationHandler.NOOP);
+            recentChainData,
+            chainStorageServer,
+            spec,
+            LateBlockReorgPreparationHandler.NOOP,
+            false);
 
     final BlobSidecarManager blobSidecarManager = BlobSidecarManager.NOOP;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory.DEFAULT_MAX_QUEUE_SIZE_ALL_SUBNETS;
+import static tech.pegasys.teku.networking.eth2.P2PConfig.DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE;
+import static tech.pegasys.teku.networking.eth2.P2PConfig.DEFAULT_COLUMN_CUSTODY_BACKFILLER_POLL_PERIOD_SECONDS;
 import static tech.pegasys.teku.networking.eth2.P2PConfig.DEFAULT_DOWNLOAD_TIMEOUT_MS;
 import static tech.pegasys.teku.networking.eth2.P2PConfig.DEFAULT_RECOVERY_TIMEOUT_MS;
 import static tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig.DEFAULT_P2P_PEERS_LOWER_BOUND;
@@ -327,6 +329,36 @@ public class P2POptions {
       arity = "1")
   private Integer forwardSyncBlobSidecarsRateLimit =
       SyncConfig.DEFAULT_FORWARD_SYNC_MAX_BLOB_SIDECARS_PER_MINUTE;
+
+  @Option(
+      names = {"--Xp2p-reworked-sidecar-custody-sync-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "",
+      arity = "0..1",
+      hidden = true,
+      fallbackValue = "true")
+  private boolean reworkedSidecarCustodySyncEnabled = false;
+
+  @Option(
+      names = {"--Xp2p-reworked-sidecar-custody-sync-batch-size"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "backfill sync custody batch size in slots",
+      arity = "0..1",
+      hidden = true)
+  private Integer reworkedSidecarCustodySyncBatchSize =
+      DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE;
+
+  @Option(
+      names = {"--Xp2p-reworked-sidecar-custody-sync-poll-period-seconds"},
+      paramLabel = "<NUMBER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "backfill sync custody poll period",
+      arity = "0..1",
+      hidden = true)
+  private Integer reworkedSidecarCustodySyncPollPeriodSeconds =
+      DEFAULT_COLUMN_CUSTODY_BACKFILLER_POLL_PERIOD_SECONDS;
 
   @Option(
       names = {"--Xp2p-reworked-sidecar-recovery-enabled"},
@@ -672,7 +704,10 @@ public class P2POptions {
                   .executionProofTopicEnabled(executionProofTopicEnabled)
                   .reworkedSidecarRecoveryTimeout(sidecarCancelTimeoutMs)
                   .reworkedSidecarDownloadTimeout(sidecarDownloadTimeoutMs)
-                  .reworkedSidecarRecoveryEnabled(reworkedSidecarRecoveryEnabled);
+                  .reworkedSidecarRecoveryEnabled(reworkedSidecarRecoveryEnabled)
+                  .reworkedSidecarSyncPollPeriod(reworkedSidecarCustodySyncPollPeriodSeconds)
+                  .reworkedSidecarSyncBatchSize(reworkedSidecarCustodySyncBatchSize)
+                  .reworkedSidecarSyncEnabled(reworkedSidecarCustodySyncEnabled);
               batchVerifyQueueCapacity.ifPresent(b::batchVerifyQueueCapacity);
             })
         .discovery(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -342,10 +342,10 @@ public class P2POptions {
 
   @Option(
       names = {"--Xp2p-reworked-sidecar-custody-sync-batch-size"},
-      paramLabel = "<BOOLEAN>",
+      paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
       description = "backfill sync custody batch size in slots",
-      arity = "0..1",
+      arity = "1",
       hidden = true)
   private Integer reworkedSidecarCustodySyncBatchSize =
       DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE;
@@ -355,7 +355,7 @@ public class P2POptions {
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
       description = "backfill sync custody poll period",
-      arity = "0..1",
+      arity = "1",
       hidden = true)
   private Integer reworkedSidecarCustodySyncPollPeriodSeconds =
       DEFAULT_COLUMN_CUSTODY_BACKFILLER_POLL_PERIOD_SECONDS;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -344,7 +344,7 @@ public class P2POptions {
       names = {"--Xp2p-reworked-sidecar-custody-sync-batch-size"},
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "backfill sync custody batch size in slots",
+      description = "Backfill sync custody batch size in slots",
       arity = "1",
       hidden = true)
   private Integer reworkedSidecarCustodySyncBatchSize =
@@ -354,7 +354,7 @@ public class P2POptions {
       names = {"--Xp2p-reworked-sidecar-custody-sync-poll-period-seconds"},
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "backfill sync custody poll period",
+      description = "Backfill sync custody poll period",
       arity = "1",
       hidden = true)
   private Integer reworkedSidecarCustodySyncPollPeriodSeconds =


### PR DESCRIPTION
on the DB side we will have 
- `EarliestAvailableDataColumnSlot` the new variable that will be maintained by the new backfiller
- `EarliestDataColumnSidecarSlot` the "old" iterator-backed which will be only used by the pruner

I decided to keep them separated separated because the pruner can still prune stuff from DB while we (restart) columns backfill, which will bring `EarliestAvailableDataColumnSlot` back to current slot and moving it backward, while `EarliestDataColumnSidecarSlot` will keep giving the actual oldest slot of data we have on DB.

fixes #10230

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a reworked custody backfiller with new P2P/CLI switches and introduces DB/API plumbing for `earliestAvailableDataColumnSlot`, wiring it through client/network and tests.
> 
> - **DAS Custody Backfill (Reworked)**:
>   - Introduces `DasCustodyBackfiller` with polling and batch controls; integrates start/stop and sync-state handling in `BeaconChainController`.
>   - Switches between new backfiller and legacy `DasCustodySync` via P2P config.
>   - Acceptance test enabled and configured; increased backfill wait timeout.
> - **P2P/CLI**:
>   - Extends `P2PConfig` and CLI (`P2POptions`) with `reworkedSidecarSyncEnabled`, `reworkedSidecarSyncBatchSize`, `reworkedSidecarSyncPollPeriod` defaults and wiring.
>   - Propagates flag into `CombinedChainDataClient` construction across components.
> - **Storage/API**:
>   - Adds `earliestAvailableDataColumnSlot` variable to DB (schemas, DAO, KV), with read/write methods.
>   - Extends `SidecarUpdateChannel` and `StorageQueryChannel`; implements in `ChainStorage`, throttled splitter, and no-op DB.
> - **Client/Networking**:
>   - Updates `CombinedChainDataClient` (new ctor param) and adds `getEarliestAvailableDataColumnSlotWithFallback()`; adjusts call sites and tests.
>   - `StatusMessageFactory` now uses the new fallback when computing `earliest_available_slot`; tests updated.
> - **Misc**:
>   - Lowers some custody backfiller logs from debug to trace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53e0dccfbc3fe4756a5969c799eac9b470e8db81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->