### PR TITLE
Disable DasCustodySync when not in sync

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -59,6 +59,7 @@ public class DasCustodySync implements SlotEventsChannel {
   private volatile boolean fillingUp = false;
   private final AtomicLong syncedColumnCount = new AtomicLong();
   private final AtomicReference<UInt64> currentSlot = new AtomicReference<>(ZERO);
+  private volatile boolean inSync = false;
 
   DasCustodySync(
       final DataColumnSidecarCustody custody,
@@ -83,6 +84,10 @@ public class DasCustodySync implements SlotEventsChannel {
         minCustodyPeriodSlotCalculator,
         MIN_PENDING_COLUMN_REQUESTS,
         MAX_PENDING_COLUMN_REQUESTS);
+  }
+
+  public synchronized void onNodeSyncStateChanged(final boolean inSync) {
+    this.inSync = inSync;
   }
 
   private void onRequestComplete(final PendingRequest request, final DataColumnSidecar response) {
@@ -118,7 +123,9 @@ public class DasCustodySync implements SlotEventsChannel {
     if (started
         && pendingRequests.size() <= minPendingColumnRequests
         && !coolDownTillNextSlot
-        && !fillingUp) {
+        && !fillingUp
+        // TODO: add test
+        && inSync) {
       fillUp();
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -203,7 +203,7 @@ public class DasCustodySync implements SlotEventsChannel {
 
   public void start() {
     started = true;
-    fillUp();
+    fillUpIfNeeded();
   }
 
   public synchronized void stop() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -124,7 +124,6 @@ public class DasCustodySync implements SlotEventsChannel {
         && pendingRequests.size() <= minPendingColumnRequests
         && !coolDownTillNextSlot
         && !fillingUp
-        // TODO: add test
         && inSync) {
       fillUp();
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
@@ -94,6 +94,7 @@ public class DasCustodySyncTest {
   public void setup() {
     when(minCustodyPeriodSlotCalculator.getMinCustodyPeriodSlot(any()))
         .thenReturn(Optional.of(UInt64.ZERO));
+    dasCustodySync.onNodeSyncStateChanged(true);
   }
 
   @Test
@@ -121,6 +122,27 @@ public class DasCustodySyncTest {
 
     printAndResetStats();
     assertThat(retrieverStub.requests).isNotEmpty();
+
+    advanceTimeGraduallyUntilAllDone();
+
+    custodyStand.setCurrentSlot(7);
+
+    printAndResetStats();
+  }
+
+  @Test
+  void doesNothingWhenNotInSync() {
+    dasCustodySync.onNodeSyncStateChanged(false);
+    assertThat(retrieverStub.requests).isEmpty();
+
+    final SignedBeaconBlock block = custodyStand.createBlockWithBlobs(1);
+    custodyStand.blockResolver.addBlock(block.getMessage());
+    custodyStand.setCurrentSlot(6);
+
+    advanceTimeGraduallyUntilAllDone();
+
+    printAndResetStats();
+    assertThat(retrieverStub.requests).isEmpty();
 
     advanceTimeGraduallyUntilAllDone();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
@@ -132,6 +132,10 @@ public class DasCustodySyncTest {
 
   @Test
   void doesNothingWhenNotInSync() {
+    custodyStand.setCurrentSlot(0);
+    custodyStand.subscribeToSlotEvents(dasCustodySync);
+    dasCustodySync.start();
+
     dasCustodySync.onNodeSyncStateChanged(false);
     assertThat(retrieverStub.requests).isEmpty();
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -2159,6 +2159,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
         backfiller ->
             syncService.subscribeToSyncStateChangesAndUpdate(
                 syncState -> backfiller.onNodeSyncStateChanged(syncState.isInSync())));
+
+    dasCustodySync.ifPresent(
+        custodySync ->
+            syncService.subscribeToSyncStateChangesAndUpdate(
+                syncState -> custodySync.onNodeSyncStateChanged(syncState.isInSync())));
   }
 
   protected void initOperationsReOrgManager() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Simple and straightforward.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate `DasCustodySync` fill/requests on node sync state, wire sync-state subscription, adjust start behavior, and add tests for not-in-sync behavior.
> 
> - **DAS Custody Sync (`ethereum/statetransition/.../DasCustodySync.java`)**
>   - Add `volatile boolean inSync` and `onNodeSyncStateChanged(boolean)` setter.
>   - Require `inSync` in `fillUpIfNeeded()`; change `start()` to call `fillUpIfNeeded()` instead of `fillUp()`.
>   - Minor: trigger `fillUpIfNeeded()` after request completion and on slot.
> - **Wiring (`services/beaconchain/.../BeaconChainController.java`)**
>   - Subscribe sync service to forward `syncState.isInSync()` to `dasCustodySync.onNodeSyncStateChanged(...)`.
> - **Tests (`ethereum/statetransition/.../DasCustodySyncTest.java`)**
>   - Initialize sync state in `@BeforeEach` via `onNodeSyncStateChanged(true)`.
>   - Add `doesNothingWhenNotInSync` test to ensure no retriever requests when out of sync.
>   - Update existing tests to align with conditional `fillUpIfNeeded()` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fb56b2439d7d8f8e98cd933f8bbda1ee9155fe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->