### PR TITLE
fixed dynamic leveldb loading

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
@@ -32,6 +32,15 @@ public enum DatabaseVersion {
   public static final DatabaseVersion DEFAULT_VERSION = V6;
   private final String value;
 
+  static {
+    if (isLevelDbSupported()) {
+      LOG.info("Leveldb is supported");
+    }
+    if (DatabaseVersion.isRocksDbSupported()) {
+      LOG.info("RocksDb is supported");
+    }
+  }
+
   public static boolean isLevelDbSupported() {
     // Use JNI to load as the native library is loaded in a static block
     try {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DatabaseVersion.java
@@ -33,15 +33,10 @@ public enum DatabaseVersion {
   private final String value;
 
   static {
-    if (isLevelDbSupported()) {
-      LOG.info("Leveldb is supported");
-    }
-    if (DatabaseVersion.isRocksDbSupported()) {
-      LOG.info("RocksDb is supported");
-    }
+    tryLoadLeveldbNativeLibrary();
   }
 
-  public static boolean isLevelDbSupported() {
+  public static boolean tryLoadLeveldbNativeLibrary() {
     // Use JNI to load as the native library is loaded in a static block
     try {
       LevelDbJniLoader.loadNativeLibrary();
@@ -55,7 +50,7 @@ public enum DatabaseVersion {
     }
   }
 
-  public static boolean isRocksDbSupported() {
+  public static boolean tryLoadRocksdbLibrary() {
     try {
       RocksDB.loadLibrary();
       return true;

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbStatsTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbStatsTest.java
@@ -36,7 +36,7 @@ class RocksDbStatsTest {
 
   @BeforeAll
   static void setUp() {
-    assumeThat(DatabaseVersion.isRocksDbSupported())
+    assumeThat(DatabaseVersion.tryLoadRocksdbLibrary())
         .describedAs("RocksDB support required")
         .isTrue();
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/SupportedDatabaseVersionArgumentsProvider.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/SupportedDatabaseVersionArgumentsProvider.java
@@ -29,12 +29,12 @@ public class SupportedDatabaseVersionArgumentsProvider implements ArgumentsProvi
 
   public static Collection<DatabaseVersion> supportedDatabaseVersions() {
     final List<DatabaseVersion> supportedVersions = new ArrayList<>();
-    if (DatabaseVersion.isRocksDbSupported()) {
+    if (DatabaseVersion.tryLoadRocksdbLibrary()) {
       supportedVersions.add(DatabaseVersion.V4);
       supportedVersions.add(DatabaseVersion.V5);
       supportedVersions.add(DatabaseVersion.V6);
     }
-    if (DatabaseVersion.isLevelDbSupported()) {
+    if (DatabaseVersion.tryLoadLeveldbNativeLibrary()) {
       supportedVersions.add(DatabaseVersion.LEVELDB1);
       supportedVersions.add(DatabaseVersion.LEVELDB2);
       supportedVersions.add(DatabaseVersion.LEVELDB_TREE);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -259,7 +259,7 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
 
   public DatabaseVersion parseDatabaseVersion() {
     if (createDbVersion == null) {
-      if (dataStorageFrequency == 1 && !DatabaseVersion.isLevelDbSupported()) {
+      if (dataStorageFrequency == 1 && !DatabaseVersion.tryLoadLeveldbNativeLibrary()) {
         throw new InvalidConfigurationException(
             "Native LevelDB support is required for archive frequency 1");
       }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
@@ -95,7 +95,7 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
   public void dataStorageCreateDbVersion_shouldOverrideIfFrequencyIsLowAndSupported() {
     final Supplier<TekuConfiguration> tekuConfigurationSupplier =
         () -> getTekuConfigurationFromArguments("--data-storage-archive-frequency", "1");
-    if (DatabaseVersion.isLevelDbSupported()) {
+    if (DatabaseVersion.tryLoadLeveldbNativeLibrary()) {
       final StorageConfiguration config = tekuConfigurationSupplier.get().storageConfiguration();
       assertThat(config.getDataStorageCreateDbVersion()).isEqualTo(DatabaseVersion.LEVELDB_TREE);
     } else {

--- a/teku/src/test/java/tech/pegasys/teku/cli/util/DatabaseMigraterTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/util/DatabaseMigraterTest.java
@@ -50,11 +50,11 @@ public class DatabaseMigraterTest {
 
   @BeforeEach
   void setUp() {
-    assumeThat(DatabaseVersion.isLevelDbSupported())
+    assumeThat(DatabaseVersion.tryLoadLeveldbNativeLibrary())
         .describedAs("LevelDB support required")
         .isTrue();
 
-    assumeThat(DatabaseVersion.isRocksDbSupported())
+    assumeThat(DatabaseVersion.tryLoadRocksdbLibrary())
         .describedAs("RocksDB support required")
         .isTrue();
   }


### PR DESCRIPTION
After changing the default, some of the library finding code got removed and broke leveldb.

Now calling that again.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores dynamic LevelDB native library loading and replaces DB support checks with `tryLoad...` methods across core code and tests.
> 
> - **Storage**:
>   - `DatabaseVersion`
>     - Add static init to invoke `tryLoadLeveldbNativeLibrary()` on class load.
>     - Replace `isLevelDbSupported`/`isRocksDbSupported` with `tryLoadLeveldbNativeLibrary` and `tryLoadRocksdbLibrary`.
>     - Improve logging when libraries aren’t available.
> - **CLI**:
>   - `BeaconNodeDataOptions.parseDatabaseVersion()` now uses `tryLoadLeveldbNativeLibrary()` for archive frequency validation.
> - **Tests**:
>   - Update assumptions and support checks to use `tryLoadRocksdbLibrary()` and `tryLoadLeveldbNativeLibrary()` in:
>     - `RocksDbStatsTest`
>     - `SupportedDatabaseVersionArgumentsProvider`
>     - `DatabaseMigraterTest`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 851f1c48fbdf9aa3165603fe020114d2dc3d10e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->