### PR TITLE
Add User Agent to Builder's headers

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
@@ -120,7 +120,8 @@ class OkHttpRestClientTest {
   void getsResponseAsyncIgnoringResponseBody() throws InterruptedException {
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
-    final SafeFuture<Response<Void>> responseFuture = underTest.getAsync(TEST_PATH, TEST_TIMEOUT);
+    final SafeFuture<Response<Void>> responseFuture =
+        underTest.getAsync(TEST_PATH, TEST_HEADERS, TEST_TIMEOUT);
 
     assertThat(responseFuture)
         .succeedsWithin(Duration.ofSeconds(1))
@@ -142,7 +143,7 @@ class OkHttpRestClientTest {
         new MockResponse().setResponseCode(200).setHeadersDelay(1, TimeUnit.SECONDS));
 
     final SafeFuture<Response<Void>> responseFuture =
-        underTest.getAsync(TEST_PATH, Duration.ofMillis(100));
+        underTest.getAsync(TEST_PATH, TEST_HEADERS, Duration.ofMillis(100));
 
     assertThat(responseFuture)
         .failsWithin(Duration.ofSeconds(1))

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
@@ -364,7 +364,8 @@ class RestBuilderClientTest {
     // Mock asyncPost with ssz to fail
     doReturn(SafeFuture.failedFuture(new ConnectException()))
         .when(okHttpRestClient)
-        .postAsync(eq(BuilderApiMethod.REGISTER_VALIDATOR.getPath()), any(), eq(true), any());
+        .postAsync(
+            eq(BuilderApiMethod.REGISTER_VALIDATOR.getPath()), any(), any(), eq(true), any());
     restBuilderClient =
         new RestBuilderClient(restBuilderClientOptions, okHttpRestClient, timeProvider, spec, true);
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -51,8 +51,9 @@ public class OkHttpRestClient implements RestClient {
   }
 
   @Override
-  public SafeFuture<Response<Void>> getAsync(final String apiPath, final Duration timeout) {
-    final Request request = createGetRequest(apiPath, NO_HEADERS);
+  public SafeFuture<Response<Void>> getAsync(
+      final String apiPath, final Map<String, String> headers, final Duration timeout) {
+    final Request request = createGetRequest(apiPath, headers);
     return makeAsyncVoidRequest(request, timeout);
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.ethereum.executionclient.rest;
 
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -60,11 +62,6 @@ public class RestBuilderClient implements BuilderClient {
   private static final Map.Entry<String, String> ACCEPT_HEADER =
       Map.entry("Accept", "application/octet-stream;q=1.0,application/json;q=0.9");
 
-  private static final Map<String, String> GET_HEADER_HTTP_HEADERS_WITH_USER_AGENT =
-      Map.ofEntries(USER_AGENT_HEADER, ACCEPT_HEADER);
-  private static final Map<String, String> GET_HEADER_HTTP_HEADERS_WITHOUT_USER_AGENT =
-      Map.ofEntries(ACCEPT_HEADER);
-
   private static final AtomicBoolean LAST_RECEIVED_HEADER_WAS_IN_SSZ = new AtomicBoolean(false);
 
   private final Map<
@@ -101,7 +98,7 @@ public class RestBuilderClient implements BuilderClient {
   @Override
   public SafeFuture<Response<Void>> status() {
     return restClient.getAsync(
-        BuilderApiMethod.GET_STATUS.getPath(), options.builderStatusTimeout());
+        BuilderApiMethod.GET_STATUS.getPath(), buildHeadersWith(), options.builderStatusTimeout());
   }
 
   @Override
@@ -139,6 +136,7 @@ public class RestBuilderClient implements BuilderClient {
       final SszList<SignedValidatorRegistration> signedValidatorRegistrations) {
     return restClient.postAsync(
         BuilderApiMethod.REGISTER_VALIDATOR.getPath(),
+        buildHeadersWith(),
         signedValidatorRegistrations,
         false,
         options.builderRegisterValidatorTimeout());
@@ -148,6 +146,7 @@ public class RestBuilderClient implements BuilderClient {
       final SszList<SignedValidatorRegistration> signedValidatorRegistrations) {
     return restClient.postAsync(
         BuilderApiMethod.REGISTER_VALIDATOR.getPath(),
+        buildHeadersWith(),
         signedValidatorRegistrations,
         true,
         options.builderRegisterValidatorTimeout());
@@ -183,9 +182,7 @@ public class RestBuilderClient implements BuilderClient {
     return restClient
         .getAsync(
             BuilderApiMethod.GET_HEADER.resolvePath(urlParams),
-            setUserAgentHeader
-                ? GET_HEADER_HTTP_HEADERS_WITH_USER_AGENT
-                : GET_HEADER_HTTP_HEADERS_WITHOUT_USER_AGENT,
+            buildHeadersWith(ACCEPT_HEADER),
             responseTypeDefinition,
             options.builderProposalDelayTolerance())
         .thenApply(
@@ -215,9 +212,9 @@ public class RestBuilderClient implements BuilderClient {
     return restClient
         .postAsync(
             BuilderApiMethod.GET_PAYLOAD.getPath(),
-            Map.ofEntries(
-                Map.entry(HEADER_CONSENSUS_VERSION, milestone.name().toLowerCase(Locale.ROOT)),
-                ACCEPT_HEADER),
+            buildHeadersWith(
+                ACCEPT_HEADER,
+                Map.entry(HEADER_CONSENSUS_VERSION, milestone.name().toLowerCase(Locale.ROOT))),
             signedBlindedBeaconBlock,
             LAST_RECEIVED_HEADER_WAS_IN_SSZ.get(),
             responseTypeDefinition,
@@ -236,11 +233,22 @@ public class RestBuilderClient implements BuilderClient {
 
     return restClient.postAsync(
         BuilderApiMethod.GET_PAYLOAD_V2.getPath(),
-        Map.ofEntries(
+        buildHeadersWith(
             Map.entry(HEADER_CONSENSUS_VERSION, milestone.name().toLowerCase(Locale.ROOT))),
         signedBlindedBeaconBlock,
         LAST_RECEIVED_HEADER_WAS_IN_SSZ.get(),
         options.builderGetPayloadTimeout());
+  }
+
+  @SafeVarargs
+  public final Map<String, String> buildHeadersWith(final Map.Entry<String, String>... headers) {
+    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    if (setUserAgentHeader) {
+      builder.put(USER_AGENT_HEADER);
+    }
+    Arrays.stream(headers).forEach(builder::put);
+
+    return builder.build();
   }
 
   private <T extends BuilderPayload>

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
@@ -26,7 +26,8 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 public interface RestClient {
   Map<String, String> NO_HEADERS = Collections.emptyMap();
 
-  SafeFuture<Response<Void>> getAsync(String apiPath, Duration timeout);
+  SafeFuture<Response<Void>> getAsync(
+      String apiPath, Map<String, String> headers, Duration timeout);
 
   <TResp extends SszData> SafeFuture<Response<BuilderApiResponse<TResp>>> getAsync(
       String apiPath,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Plumbs headers through RestClient and updates builder REST calls to include conditional User-Agent, Accept, and consensus-version headers, with tests adjusted accordingly.
> 
> Adds centralized header construction for builder REST calls and updates the Rest client API to carry headers.
> 
> - Introduces `buildHeadersWith(...)` to conditionally include `User-Agent` and set `Accept`, plus additional entries like `Eth-Consensus-Version`
> - Changes `RestClient.getAsync` to require headers; implements in `OkHttpRestClient` and updates call sites
> - Updates builder methods (`status`, `registerValidators`, `getHeader`, `getPayload`, `getPayloadV2`) to send appropriate headers (User-Agent when enabled, `Accept`, and consensus version)
> - Adjusts tests to assert header presence and updated method signatures
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a08ab55bb930496cab3ab1740cac1e120d3e2b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->