### PR TITLE
fix: return numeric index in submitPoolBLSToExecutionChange response

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/PostAttestationsV2IntegrationTest.java
@@ -103,12 +103,12 @@ public class PostAttestationsV2IntegrationTest extends AbstractDataBackedRestAPI
     assertThat(resultAsJsonNode.get("message").asText())
         .isEqualTo("Some items failed to publish, refer to errors for details");
     assertThat(resultAsJsonNode.get("failures").size()).isEqualTo(2);
-    assertThat(resultAsJsonNode.get("failures").get(0).get("index").asText())
-        .isEqualTo(firstSubmitDataError.index().toString());
+    assertThat(resultAsJsonNode.get("failures").get(0).get("index").asLong())
+        .isEqualTo(firstSubmitDataError.index().longValue());
     assertThat(resultAsJsonNode.get("failures").get(0).get("message").asText())
         .isEqualTo(firstSubmitDataError.message());
-    assertThat(resultAsJsonNode.get("failures").get(1).get("index").asText())
-        .isEqualTo(secondSubmitDataError.index().toString());
+    assertThat(resultAsJsonNode.get("failures").get(1).get("index").asLong())
+        .isEqualTo(secondSubmitDataError.index().longValue());
     assertThat(resultAsJsonNode.get("failures").get(1).get("message").asText())
         .isEqualTo(secondSubmitDataError.message());
   }

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/errorListBadRequest.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/errorListBadRequest.json
@@ -1,1 +1,1 @@
-{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":"0","message":"Darn"},{"index":"1","message":"Incorrect"}]}
+{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":0,"message":"Darn"},{"index":1,"message":"Incorrect"}]}

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/postSyncCommittees.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/postSyncCommittees.json
@@ -1,1 +1,1 @@
-{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":"0","message":"Darn"},{"index":"1","message":"Incorrect"}]}
+{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":0,"message":"Darn"},{"index":1,"message":"Incorrect"}]}

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/errorListBadRequest.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/errorListBadRequest.json
@@ -1,1 +1,1 @@
-{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":"0","message":"Darn"},{"index":"1","message":"Incorrect"}]}
+{"code":400,"message":"Some items failed to publish, refer to errors for details","failures":[{"index":0,"message":"Darn"},{"index":1,"message":"Incorrect"}]}

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
@@ -61,6 +61,9 @@ public class CoreTypes {
           .format("uint64")
           .build();
 
+  public static final StringValueTypeDefinition<UInt64> UINT64_NUMERIC_TYPE =
+      new UInt64NumericTypeDefinition();
+
   public static final DeserializableTypeDefinition<UInt256> UINT256_TYPE =
       DeserializableTypeDefinition.string(UInt256.class)
           .formatter(value -> value.toBigInteger().toString(10))

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt64NumericTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt64NumericTypeDefinition.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.IOException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class UInt64NumericTypeDefinition extends PrimitiveTypeDefinition<UInt64> {
+
+  @Override
+  public void serializeOpenApiTypeFields(final JsonGenerator gen) throws IOException {
+    gen.writeStringField("type", "number");
+  }
+
+  @Override
+  public void serialize(final UInt64 value, final JsonGenerator gen) throws IOException {
+    gen.writeNumber(value.longValue());
+  }
+
+  @Override
+  public UInt64 deserialize(final JsonParser parser) throws IOException {
+    return UInt64.valueOf(parser.getLongValue());
+  }
+
+  @Override
+  public String serializeToString(final UInt64 value) {
+    return value.toString();
+  }
+
+  @Override
+  public UInt64 deserializeFromString(final String value) {
+    return UInt64.valueOf(value);
+  }
+}
+

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataError.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SubmitDataError.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.validator.api;
 
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
-import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_NUMERIC_TYPE;
 
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -26,7 +26,7 @@ public record SubmitDataError(UInt64 index, String message) {
         .name("SubmitDataError")
         .initializer(SubmitDataErrorBuilder::new)
         .finisher(SubmitDataErrorBuilder::build)
-        .withField("index", UINT64_TYPE, SubmitDataError::index, SubmitDataErrorBuilder::index)
+        .withField("index", UINT64_NUMERIC_TYPE, SubmitDataError::index, SubmitDataErrorBuilder::index)
         .withField(
             "message", STRING_TYPE, SubmitDataError::message, SubmitDataErrorBuilder::message)
         .build();


### PR DESCRIPTION
Fixes #9569

Changes `index` field in `SubmitDataError` failures from string to number to match beacon-API spec.

- Added `UInt64NumericTypeDefinition` for numeric UInt64 serialization
- Updated `SubmitDataError` to use numeric type
- Updated tests and test resources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns error response schema with beacon-API by emitting numeric indices.
> 
> - Adds `UInt64NumericTypeDefinition` and exposes `CoreTypes.UINT64_NUMERIC_TYPE` for numeric `UInt64` JSON serialization
> - Updates `SubmitDataError.getJsonTypeDefinition()` to use numeric `index`
> - Adjusts integration tests and fixtures to assert/expect numeric `index` values (e.g., `asLong()` and unquoted numbers)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d91537fd56f208686f2c41b9d156b7739b178edd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->