### PR TITLE
Make builders non-validating staked actors

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
 
 import java.util.Collections;
@@ -602,7 +603,7 @@ public abstract class AbstractBlockFactoryTest {
                           executionPayload.getFeeRecipient(),
                           executionPayload.getGasLimit(),
                           // self-built for simplification
-                          UInt64.valueOf(spec.getBeaconProposerIndex(state, slot)),
+                          BUILDER_INDEX_SELF_BUILD,
                           slot,
                           ZERO,
                           ZERO,

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Builder.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Builder.json
@@ -11,7 +11,9 @@
     },
     "version" : {
       "type" : "string",
-      "format" : "byte"
+      "example" : "1",
+      "description" : "unsigned 8 bit integer, max value 255",
+      "format" : "uint8"
     },
     "execution_address" : {
       "type" : "string",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderPendingWithdrawal.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BuilderPendingWithdrawal.json
@@ -1,7 +1,7 @@
 {
   "title" : "BuilderPendingWithdrawal",
   "type" : "object",
-  "required" : [ "fee_recipient", "amount", "builder_index", "withdrawable_epoch" ],
+  "required" : [ "fee_recipient", "amount", "builder_index" ],
   "properties" : {
     "fee_recipient" : {
       "type" : "string",
@@ -16,12 +16,6 @@
       "format" : "uint64"
     },
     "builder_index" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
-    },
-    "withdrawable_epoch" : {
       "type" : "string",
       "description" : "unsigned 64 bit integer",
       "example" : "1",

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.state.ForkData;
 import tech.pegasys.teku.spec.datastructures.state.SigningData;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
+import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
@@ -246,6 +247,7 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
                   schemas -> SchemaDefinitionsFulu.required(schemas).getMatrixEntrySchema()))
 
           // Gloas types
+          .put("ssz_static/Builder", new SszTestExecutor<>(__ -> Builder.SSZ_SCHEMA))
           .put(
               "ssz_static/BuilderPendingPayment",
               new SszTestExecutor<>(
@@ -300,6 +302,9 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
                   schemas ->
                       SchemaDefinitionsGloas.required(schemas)
                           .getSignedExecutionPayloadEnvelopeSchema()))
+          // TODO-GLOAS: https://github.com/Consensys/teku/issues/10259
+          .put("ssz_static/ProposerPreferences", IGNORE_TESTS)
+          .put("ssz_static/SignedProposerPreferences", IGNORE_TESTS)
           .put("ssz_static/ForkChoiceNode", IGNORE_TESTS)
 
           // Legacy Schemas (Not yet migrated to SchemaDefinitions)

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -69,12 +69,10 @@ public class ReferenceTestFinder {
                 return Stream.of(
                         new BlsTestFinder(),
                         new KzgTestFinder(),
-                        // TODO-GLOAS: not running these reference tests until the upcoming specs
-                        // have been implemented
-                        // new SszTestFinder("ssz_generic"),
-                        // new SszTestFinder("ssz_static"),
+                        new SszTestFinder("ssz_generic"),
+                        new SszTestFinder("ssz_static"),
                         new ShufflingTestFinder(),
-                        // new PyspecTestFinder(List.of(), List.of("fork_choice/")),
+                        new PyspecTestFinder(List.of(), List.of("fork_choice/")),
                         new MerkleProofTestFinder())
                     .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
               }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1130,6 +1130,16 @@ public class Spec {
         .getPtc(state, slot);
   }
 
+  // Builder Utils
+  public Optional<BLSPublicKey> getBuilderPubKey(
+      final BeaconState state, final UInt64 builderIndex) {
+    return atState(state).beaconStateAccessors().getBuilderPubKey(state, builderIndex);
+  }
+
+  public Optional<Integer> getBuilderIndex(final BeaconState state, final BLSPublicKey publicKey) {
+    return atState(state).beaconStateAccessors().getBuilderIndex(state, publicKey);
+  }
+
   // Attestation helpers
   public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
     return atSlot(attestation.getData().getSlot())

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -56,7 +56,9 @@ public class TransitionCaches {
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
-          ProgressiveTotalBalancesUpdates.NOOP) {
+          ProgressiveTotalBalancesUpdates.NOOP,
+          NoOpCache.getNoOpCache(),
+          NoOpCache.getNoOpCache()) {
 
         @Override
         public TransitionCaches copy() {
@@ -85,6 +87,8 @@ public class TransitionCaches {
   private final Cache<Bytes32, IntList> committeeShuffle;
   private final Cache<UInt64, List<UInt64>> effectiveBalances;
   private final Cache<UInt64, UInt64> baseRewardPerIncrement;
+  private final Cache<UInt64, BLSPublicKey> buildersPubKeys;
+  private final Cache<BLSPublicKey, Integer> builderIndexCache;
 
   private final Cache<UInt64, Map<UInt64, SyncSubcommitteeAssignments>> syncCommitteeCache;
 
@@ -105,6 +109,8 @@ public class TransitionCaches {
     syncCommitteeCache = LRUCache.create(MAX_SYNC_COMMITTEE_CACHE);
     baseRewardPerIncrement = LRUCache.create(MAX_BASE_REWARD_PER_INCREMENT_CACHE);
     progressiveTotalBalances = ProgressiveTotalBalancesUpdates.NOOP;
+    buildersPubKeys = LRUCache.create(Integer.MAX_VALUE - 1);
+    builderIndexCache = LRUCache.create(Integer.MAX_VALUE - 1);
   }
 
   private TransitionCaches(
@@ -120,7 +126,9 @@ public class TransitionCaches {
       final Cache<UInt64, List<UInt64>> effectiveBalances,
       final Cache<UInt64, Map<UInt64, SyncSubcommitteeAssignments>> syncCommitteeCache,
       final Cache<UInt64, UInt64> baseRewardPerIncrement,
-      final ProgressiveTotalBalancesUpdates progressiveTotalBalances) {
+      final ProgressiveTotalBalancesUpdates progressiveTotalBalances,
+      final Cache<UInt64, BLSPublicKey> buildersPubKeys,
+      final Cache<BLSPublicKey, Integer> builderIndexCache) {
     this.activeValidators = activeValidators;
     this.beaconProposerIndex = beaconProposerIndex;
     this.beaconCommittee = beaconCommittee;
@@ -134,6 +142,8 @@ public class TransitionCaches {
     this.syncCommitteeCache = syncCommitteeCache;
     this.baseRewardPerIncrement = baseRewardPerIncrement;
     this.progressiveTotalBalances = progressiveTotalBalances;
+    this.buildersPubKeys = buildersPubKeys;
+    this.builderIndexCache = builderIndexCache;
   }
 
   public void setLatestTotalBalances(final TotalBalances totalBalances) {
@@ -224,6 +234,21 @@ public class TransitionCaches {
     return baseRewardPerIncrement;
   }
 
+  /** (builder index) -> (builder pub key) cache */
+  public Cache<UInt64, BLSPublicKey> getBuildersPubKeys() {
+    return buildersPubKeys;
+  }
+
+  /**
+   * (builder pub key) -> (builder index) cache
+   *
+   * <p>More complicated cache such as the {@link ValidatorIndexCache} is not required since the
+   * builders in the state are expected to be a tiny number initially
+   */
+  public Cache<BLSPublicKey, Integer> getBuilderIndexCache() {
+    return builderIndexCache;
+  }
+
   /**
    * Makes an independent copy which contains all the data in this instance Modifications to
    * returned caches shouldn't affect caches from this instance
@@ -242,6 +267,8 @@ public class TransitionCaches {
         effectiveBalances.copy(),
         syncCommitteeCache.copy(),
         baseRewardPerIncrement.copy(),
-        progressiveTotalBalances.copy());
+        progressiveTotalBalances.copy(),
+        buildersPubKeys.copy(),
+        builderIndexCache.copy());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.spec.datastructures.state.versions.gloas;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
@@ -76,7 +74,6 @@ public class Builder
         SszUInt64.of(balance),
         SszUInt64.of(depositEpoch),
         SszUInt64.of(withdrawableEpoch));
-    checkArgument(version >= 0 && version <= 255, "version must be in uint8 range (0–255)");
   }
 
   public BLSPublicKey getPublicKey() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.ByteUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKeySchema;
@@ -81,7 +82,7 @@ public class Builder
   }
 
   public int getVersion() {
-    return getField1().get();
+    return ByteUtil.toUnsignedInt(getField1().get());
   }
 
   public Eth1Address getExecutionAddress() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
@@ -100,6 +100,26 @@ public class Builder
     return getField5().get();
   }
 
+  public Builder copyWithNewWithdrawableEpoch(final UInt64 withdrawableEpoch) {
+    return new Builder(
+        getPublicKey(),
+        getVersion(),
+        getExecutionAddress(),
+        getBalance(),
+        getDepositEpoch(),
+        withdrawableEpoch);
+  }
+
+  public Builder copyWithNewBalance(final UInt64 balance) {
+    return new Builder(
+        getPublicKey(),
+        getVersion(),
+        getExecutionAddress(),
+        balance,
+        getDepositEpoch(),
+        getWithdrawableEpoch());
+  }
+
   @Override
   public BuilderSchema getSchema() {
     return (BuilderSchema) super.getSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.state.versions.gloas;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
@@ -40,7 +42,7 @@ public class Builder
       super(
           "Builder",
           namedSchema("pubkey", SszPublicKeySchema.INSTANCE),
-          namedSchema("version", SszPrimitiveSchemas.BYTE_SCHEMA),
+          namedSchema("version", SszPrimitiveSchemas.UINT8_SCHEMA),
           namedSchema("execution_address", SszByteVectorSchema.create(Bytes20.SIZE)),
           namedSchema("balance", SszPrimitiveSchemas.UINT64_SCHEMA),
           namedSchema("deposit_epoch", SszPrimitiveSchemas.UINT64_SCHEMA),
@@ -61,7 +63,7 @@ public class Builder
 
   public Builder(
       final BLSPublicKey pubkey,
-      final Byte version,
+      final int version,
       final Eth1Address executionAddress,
       final UInt64 balance,
       final UInt64 depositEpoch,
@@ -69,18 +71,19 @@ public class Builder
     super(
         SSZ_SCHEMA,
         new SszPublicKey(pubkey),
-        SszByte.of(version),
+        SszByte.asUInt8(version),
         SszByteVector.fromBytes(executionAddress.getWrappedBytes()),
         SszUInt64.of(balance),
         SszUInt64.of(depositEpoch),
         SszUInt64.of(withdrawableEpoch));
+    checkArgument(version >= 0 && version <= 255, "version must be in uint8 range (0–255)");
   }
 
   public BLSPublicKey getPublicKey() {
     return getField0().getBLSPublicKey();
   }
 
-  public Byte getVersion() {
+  public int getVersion() {
     return getField1().get();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingWithdrawal.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingWithdrawal.java
@@ -15,26 +15,24 @@ package tech.pegasys.teku.spec.datastructures.state.versions.gloas;
 
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class BuilderPendingWithdrawal
-    extends Container4<BuilderPendingWithdrawal, SszByteVector, SszUInt64, SszUInt64, SszUInt64> {
+    extends Container3<BuilderPendingWithdrawal, SszByteVector, SszUInt64, SszUInt64> {
 
   protected BuilderPendingWithdrawal(
       final BuilderPendingWithdrawalSchema schema,
       final Eth1Address feeRecipient,
       final UInt64 amount,
-      final UInt64 builderIndex,
-      final UInt64 withdrawableEpoch) {
+      final UInt64 builderIndex) {
     super(
         schema,
         SszByteVector.fromBytes(feeRecipient.getWrappedBytes()),
         SszUInt64.of(amount),
-        SszUInt64.of(builderIndex),
-        SszUInt64.of(withdrawableEpoch));
+        SszUInt64.of(builderIndex));
   }
 
   protected BuilderPendingWithdrawal(
@@ -52,15 +50,6 @@ public class BuilderPendingWithdrawal
 
   public UInt64 getBuilderIndex() {
     return getField2().get();
-  }
-
-  public UInt64 getWithdrawableEpoch() {
-    return getField3().get();
-  }
-
-  public BuilderPendingWithdrawal copyWithNewWithdrawableEpoch(final UInt64 withdrawableEpoch) {
-    return new BuilderPendingWithdrawal(
-        getSchema(), getFeeRecipient(), getAmount(), getBuilderIndex(), withdrawableEpoch);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingWithdrawalSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingWithdrawalSchema.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.datastructures.state.versions.gloas;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
@@ -24,25 +24,19 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class BuilderPendingWithdrawalSchema
-    extends ContainerSchema4<
-        BuilderPendingWithdrawal, SszByteVector, SszUInt64, SszUInt64, SszUInt64> {
+    extends ContainerSchema3<BuilderPendingWithdrawal, SszByteVector, SszUInt64, SszUInt64> {
 
   public BuilderPendingWithdrawalSchema() {
     super(
         "BuilderPendingWithdrawal",
         namedSchema("fee_recipient", SszByteVectorSchema.create(Bytes20.SIZE)),
         namedSchema("amount", SszPrimitiveSchemas.UINT64_SCHEMA),
-        namedSchema("builder_index", SszPrimitiveSchemas.UINT64_SCHEMA),
-        namedSchema("withdrawable_epoch", SszPrimitiveSchemas.UINT64_SCHEMA));
+        namedSchema("builder_index", SszPrimitiveSchemas.UINT64_SCHEMA));
   }
 
   public BuilderPendingWithdrawal create(
-      final Eth1Address feeRecipient,
-      final UInt64 amount,
-      final UInt64 builderIndex,
-      final UInt64 withdrawableEpoch) {
-    return new BuilderPendingWithdrawal(
-        this, feeRecipient, amount, builderIndex, withdrawableEpoch);
+      final Eth1Address feeRecipient, final UInt64 amount, final UInt64 builderIndex) {
+    return new BuilderPendingWithdrawal(this, feeRecipient, amount, builderIndex);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -819,14 +819,20 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
                 "process_voluntary_exits: %s",
                 invalidReason.map(OperationInvalidReason::describe).orElse(""));
 
-            // - Run initiate_validator_exit(state, exit.validator_index)
-
-            beaconStateMutators.initiateValidatorExit(
-                state,
-                signedExit.getMessage().getValidatorIndex().intValue(),
-                validatorExitContextSupplier);
+            initiateExit(state, signedExit, validatorExitContextSupplier);
           }
         });
+  }
+
+  protected void initiateExit(
+      final MutableBeaconState state,
+      final SignedVoluntaryExit signedExit,
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+    // - Run initiate_validator_exit(state, exit.validator_index)
+    beaconStateMutators.initiateValidatorExit(
+        state,
+        signedExit.getMessage().getValidatorIndex().intValue(),
+        validatorExitContextSupplier);
   }
 
   protected BlockValidationResult verifyVoluntaryExits(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -87,7 +87,8 @@ public abstract class BeaconStateAccessors {
             .get(
                 validatorIndex,
                 i -> {
-                  BLSPublicKey pubKey = state.getValidators().get(i.intValue()).getPublicKey();
+                  final BLSPublicKey pubKey =
+                      state.getValidators().get(i.intValue()).getPublicKey();
 
                   // eagerly pre-cache pubKey => validatorIndex mapping
                   BeaconStateCache.getTransitionCaches(state)
@@ -361,5 +362,16 @@ public abstract class BeaconStateAccessors {
   public Bytes32 getVoluntaryExitDomain(
       final UInt64 epoch, final Fork fork, final Bytes32 genesisValidatorsRoot) {
     return getDomain(Domain.VOLUNTARY_EXIT, epoch, fork, genesisValidatorsRoot);
+  }
+
+  public Optional<BLSPublicKey> getBuilderPubKey(
+      final BeaconState state, final UInt64 builderIndex) {
+    // NO-OP
+    return Optional.empty();
+  }
+
+  public Optional<Integer> getBuilderIndex(final BeaconState state, final BLSPublicKey publicKey) {
+    // NO-OP
+    return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -35,7 +35,7 @@ public class BeaconStateMutators {
 
   protected final SpecConfig specConfig;
   protected final MiscHelpers miscHelpers;
-  protected final BeaconStateAccessors beaconStateAccessors;
+  private final BeaconStateAccessors beaconStateAccessors;
 
   public BeaconStateMutators(
       final SpecConfig specConfig,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -35,7 +35,7 @@ public class BeaconStateMutators {
 
   protected final SpecConfig specConfig;
   protected final MiscHelpers miscHelpers;
-  private final BeaconStateAccessors beaconStateAccessors;
+  protected final BeaconStateAccessors beaconStateAccessors;
 
   public BeaconStateMutators(
       final SpecConfig specConfig,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
@@ -34,6 +34,8 @@ import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -152,8 +154,10 @@ public class OperationSignatureVerifier {
       final BeaconState state,
       final SignedExecutionPayloadBid signedBid,
       final BLSSignatureVerifier signatureVerifier) {
-    final Validator builder =
-        state.getValidators().get(signedBid.getMessage().getBuilderIndex().intValue());
+    final Builder builder =
+        BeaconStateGloas.required(state)
+            .getBuilders()
+            .get(signedBid.getMessage().getBuilderIndex().intValue());
     final Bytes signingRoot =
         calculateExecutionPayloadBidSigningRoot(state, signedBid.getMessage());
     return signatureVerifier.verify(builder.getPublicKey(), signingRoot, signedBid.getSignature());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChan
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
-import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
@@ -43,7 +43,7 @@ public class OperationSignatureVerifier {
   private static final Logger LOG = LogManager.getLogger();
 
   private final MiscHelpers miscHelpers;
-  private final BeaconStateAccessors beaconStateAccessors;
+  protected final BeaconStateAccessors beaconStateAccessors;
 
   public OperationSignatureVerifier(
       final MiscHelpers miscHelpers, final BeaconStateAccessors beaconStateAccessors) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
@@ -39,6 +39,7 @@ public interface WithdrawalsHelpers {
       List<Withdrawal> withdrawals,
       int processedBuilderWithdrawalsCount,
       int processedPartialWithdrawalsCount,
+      int processedBuildersSweepCount,
       int processedValidatorsSweepCount) {}
 
   static UInt64 getTotalWithdrawn(final List<Withdrawal> withdrawals, final UInt64 validatorIndex) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -65,12 +65,15 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
     final int processedPartialWithdrawalsCount =
         processPendingPartialWithdrawals(state, withdrawals);
 
+    final int processedBuildersSweepCount = processBuildersSweepWithdrawals(state, withdrawals);
+
     final int processedValidatorsSweepCount = processValidatorsSweepWithdrawals(state, withdrawals);
 
     return new ExpectedWithdrawals(
         withdrawals,
         processedBuilderWithdrawalsCount,
         processedPartialWithdrawalsCount,
+        processedBuildersSweepCount,
         processedValidatorsSweepCount);
   }
 
@@ -82,6 +85,12 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
 
   // NO-OP
   protected int processPendingPartialWithdrawals(
+      final BeaconState state, final List<Withdrawal> withdrawals) {
+    return 0;
+  }
+
+  // NO-OP
+  protected int processBuildersSweepWithdrawals(
       final BeaconState state, final List<Withdrawal> withdrawals) {
     return 0;
   }
@@ -161,7 +170,8 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
         state,
         expectedWithdrawals.withdrawals(),
         expectedWithdrawals.processedBuilderWithdrawalsCount(),
-        expectedWithdrawals.processedPartialWithdrawalsCount());
+        expectedWithdrawals.processedPartialWithdrawalsCount(),
+        expectedWithdrawals.processedBuildersSweepCount());
   }
 
   private void assertWithdrawalsInExecutionPayloadMatchExpected(
@@ -196,14 +206,16 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
         state,
         expectedWithdrawals.withdrawals(),
         expectedWithdrawals.processedBuilderWithdrawalsCount(),
-        expectedWithdrawals.processedPartialWithdrawalsCount());
+        expectedWithdrawals.processedPartialWithdrawalsCount(),
+        expectedWithdrawals.processedBuildersSweepCount());
   }
 
   private void processWithdrawalsUnchecked(
       final MutableBeaconState state,
       final List<Withdrawal> withdrawals,
       final int processedBuilderWithdrawalsCount,
-      final int processedPartialWithdrawalsCount) {
+      final int processedPartialWithdrawalsCount,
+      final int processedBuildersSweepCount) {
 
     applyWithdrawals(state, withdrawals);
 
@@ -217,6 +229,10 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
 
     if (processedPartialWithdrawalsCount > 0) {
       updatePendingPartialWithdrawals(state, processedPartialWithdrawalsCount);
+    }
+
+    if (processedBuildersSweepCount > 0) {
+      updateNextWithdrawalBuilderIndex(state, processedBuildersSweepCount);
     }
 
     updateNextWithdrawalValidatorIndex(state, withdrawals);
@@ -251,6 +267,10 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
   // NO-OP
   protected void updatePendingPartialWithdrawals(
       final MutableBeaconState state, final int processedPartialWithdrawalsCount) {}
+
+  // NO-OP
+  protected void updateNextWithdrawalBuilderIndex(
+      final MutableBeaconState state, final int processedBuildersSweepCount) {}
 
   protected void updateNextWithdrawalValidatorIndex(
       final MutableBeaconState state, final List<Withdrawal> withdrawals) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
@@ -234,9 +234,7 @@ public class WithdrawalsHelpersCapella implements WithdrawalsHelpers {
       updatePendingPartialWithdrawals(state, processedPartialWithdrawalsCount);
     }
 
-    if (processedBuildersSweepCount > 0) {
-      updateNextWithdrawalBuilderIndex(state, processedBuildersSweepCount);
-    }
+    updateNextWithdrawalBuilderIndex(state, processedBuildersSweepCount);
 
     updateNextWithdrawalValidatorIndex(state, processedValidatorsSweepCount);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -86,20 +86,20 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
   @Override
   public void processDepositRequests(
       final MutableBeaconState state, final List<DepositRequest> depositRequests) {
+    final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
     for (DepositRequest depositRequest : depositRequests) {
-      processDepositRequest(state, depositRequest);
+      processDepositRequest(stateElectra, depositRequest);
     }
   }
 
   // process_deposit_request
   protected void processDepositRequest(
-      final MutableBeaconState state, final DepositRequest depositRequest) {
-    final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
-    final SszMutableList<PendingDeposit> pendingDeposits = stateElectra.getPendingDeposits();
-    if (stateElectra
+      final MutableBeaconStateElectra state, final DepositRequest depositRequest) {
+    final SszMutableList<PendingDeposit> pendingDeposits = state.getPendingDeposits();
+    if (state
         .getDepositRequestsStartIndex()
         .equals(SpecConfigElectra.UNSET_DEPOSIT_REQUESTS_START_INDEX)) {
-      stateElectra.setDepositRequestsStartIndex(depositRequest.getIndex());
+      state.setDepositRequestsStartIndex(depositRequest.getIndex());
     }
 
     final PendingDeposit deposit =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -92,7 +92,6 @@ public class ExecutionRequestsProcessorElectra implements ExecutionRequestsProce
     }
   }
 
-  // process_deposit_request
   protected void processDepositRequest(
       final MutableBeaconStateElectra state, final DepositRequest depositRequest) {
     final SszMutableList<PendingDeposit> pendingDeposits = state.getPendingDeposits();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
@@ -18,7 +18,7 @@ import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
@@ -113,17 +113,14 @@ public class WithdrawalsHelpersElectra extends WithdrawalsHelpersCapella {
   protected void updatePendingPartialWithdrawals(
       final MutableBeaconState state, final int processedPartialWithdrawalsCount) {
     final MutableBeaconStateElectra stateElectra = MutableBeaconStateElectra.required(state);
-    final SszListSchema<PendingPartialWithdrawal, ?> schema =
-        stateElectra.getPendingPartialWithdrawals().getSchema();
-    if (stateElectra.getPendingPartialWithdrawals().size() == processedPartialWithdrawalsCount) {
-      stateElectra.setPendingPartialWithdrawals(schema.createFromElements(List.of()));
-    } else {
-      final List<PendingPartialWithdrawal> pendingPartialWithdrawals =
-          stateElectra.getPendingPartialWithdrawals().asList();
-      stateElectra.setPendingPartialWithdrawals(
-          schema.createFromElements(
-              pendingPartialWithdrawals.subList(
-                  processedPartialWithdrawalsCount, pendingPartialWithdrawals.size())));
-    }
+    final SszList<PendingPartialWithdrawal> pendingPartialWithdrawals =
+        stateElectra.getPendingPartialWithdrawals();
+    stateElectra.setPendingPartialWithdrawals(
+        pendingPartialWithdrawals
+            .getSchema()
+            .createFromElements(
+                pendingPartialWithdrawals
+                    .asList()
+                    .subList(processedPartialWithdrawalsCount, pendingPartialWithdrawals.size())));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
@@ -58,11 +58,15 @@ public class WithdrawalsHelpersElectra extends WithdrawalsHelpersCapella {
     UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);
     int processedPartialWithdrawalsCount = 0;
 
-    final int bound = getBoundForPendingPartialWithdrawals(withdrawals);
+    final int withdrawalsLimit =
+        Math.min(
+            withdrawals.size() + specConfigElectra.getMaxPendingPartialsPerWithdrawalsSweep(),
+            specConfig.getMaxWithdrawalsPerPayload() - 1);
 
     for (final PendingPartialWithdrawal withdrawal :
         BeaconStateElectra.required(state).getPendingPartialWithdrawals()) {
-      if (withdrawal.getWithdrawableEpoch().isGreaterThan(epoch) || withdrawals.size() == bound) {
+      if (withdrawal.getWithdrawableEpoch().isGreaterThan(epoch)
+          || withdrawals.size() == withdrawalsLimit) {
         break;
       }
       final UInt64 validatorIndex = withdrawal.getValidatorIndex();
@@ -103,10 +107,6 @@ public class WithdrawalsHelpersElectra extends WithdrawalsHelpersCapella {
       processedPartialWithdrawalsCount++;
     }
     return processedPartialWithdrawalsCount;
-  }
-
-  protected int getBoundForPendingPartialWithdrawals(final List<Withdrawal> withdrawals) {
-    return specConfigElectra.getMaxPendingPartialsPerWithdrawalsSweep();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -35,16 +35,19 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransiti
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
-import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.BlindBlockUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.BlockProposalUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.block.BlockProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.execution.ExecutionPayloadProcessorGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.execution.ExecutionRequestsProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.forktransition.GloasStateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateMutatorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.operations.OperationSignatureVerifierGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.operations.validation.AttestationDataValidatorGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.operations.validation.VoluntaryExitValidatorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch.EpochProcessorGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.AttestationUtilGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
@@ -118,13 +121,12 @@ public class SpecLogicGloas extends AbstractSpecLogic {
         new MiscHelpersGloas(config, predicates, schemaDefinitions);
     final BeaconStateAccessorsGloas beaconStateAccessors =
         new BeaconStateAccessorsGloas(config, schemaDefinitions, predicates, miscHelpers);
-    final BeaconStateMutatorsElectra beaconStateMutators =
-        new BeaconStateMutatorsElectra(
-            config, miscHelpers, beaconStateAccessors, schemaDefinitions);
+    final BeaconStateMutatorsGloas beaconStateMutators =
+        new BeaconStateMutatorsGloas(config, miscHelpers, beaconStateAccessors, schemaDefinitions);
 
     // Operation validation
-    final OperationSignatureVerifier operationSignatureVerifier =
-        new OperationSignatureVerifier(miscHelpers, beaconStateAccessors);
+    final OperationSignatureVerifierGloas operationSignatureVerifier =
+        new OperationSignatureVerifierGloas(miscHelpers, beaconStateAccessors, predicates);
 
     // Util
     final ValidatorsUtilGloas validatorsUtil =
@@ -136,15 +138,15 @@ public class SpecLogicGloas extends AbstractSpecLogic {
         new AttestationUtilGloas(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidatorGloas attestationDataValidator =
         new AttestationDataValidatorGloas(config, miscHelpers, beaconStateAccessors);
-    final VoluntaryExitValidatorElectra voluntaryExitValidatorElectra =
-        new VoluntaryExitValidatorElectra(config, predicates, beaconStateAccessors);
+    final VoluntaryExitValidatorGloas voluntaryExitValidator =
+        new VoluntaryExitValidatorGloas(config, predicates, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         new OperationValidatorCapella(
             predicates,
             beaconStateAccessors,
             attestationDataValidator,
             attestationUtil,
-            voluntaryExitValidatorElectra);
+            voluntaryExitValidator);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,
@@ -174,8 +176,8 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     final WithdrawalsHelpersGloas withdrawalsHelpers =
         new WithdrawalsHelpersGloas(
             schemaDefinitions, miscHelpers, config, predicates, beaconStateMutators);
-    final ExecutionRequestsProcessorElectra executionRequestsProcessor =
-        new ExecutionRequestsProcessorElectra(
+    final ExecutionRequestsProcessorGloas executionRequestsProcessor =
+        new ExecutionRequestsProcessorGloas(
             schemaDefinitions,
             miscHelpers,
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -200,7 +200,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
                   UInt64.ZERO,
                   schemaDefinitionsGloas
                       .getBuilderPendingWithdrawalSchema()
-                      .create(bid.getFeeRecipient(), amount, builderIndex, UInt64.ZERO));
+                      .create(bid.getFeeRecipient(), amount, builderIndex));
 
       stateGloas
           .getBuilderPendingPayments()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.block;
 
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
+
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Supplier;
@@ -20,8 +22,6 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
-import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.config.SpecConfigElectra;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -34,14 +34,13 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingPayment;
-import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingWithdrawal;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
@@ -50,9 +49,9 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
 import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
-import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.fulu.block.BlockProcessorFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateMutatorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.util.AttestationUtilGloas;
@@ -63,7 +62,9 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
 
   private final PredicatesGloas predicatesGloas;
   private final SchemaDefinitionsGloas schemaDefinitionsGloas;
+  private final MiscHelpersGloas miscHelpersGloas;
   private final BeaconStateAccessorsGloas beaconStateAccessorsGloas;
+  private final BeaconStateMutatorsGloas beaconStateMutatorsGloas;
   private final AttestationUtilGloas attestationUtilGloas;
 
   public BlockProcessorGloas(
@@ -72,7 +73,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final MiscHelpersGloas miscHelpers,
       final SyncCommitteeUtil syncCommitteeUtil,
       final BeaconStateAccessorsGloas beaconStateAccessors,
-      final BeaconStateMutatorsElectra beaconStateMutators,
+      final BeaconStateMutatorsGloas beaconStateMutators,
       final OperationSignatureVerifier operationSignatureVerifier,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtilGloas attestationUtil,
@@ -100,7 +101,9 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
         executionRequestsProcessor);
     this.predicatesGloas = predicates;
     this.schemaDefinitionsGloas = schemaDefinitions;
+    this.miscHelpersGloas = miscHelpers;
     this.beaconStateAccessorsGloas = beaconStateAccessors;
+    this.beaconStateMutatorsGloas = beaconStateMutators;
     this.attestationUtilGloas = attestationUtil;
   }
 
@@ -142,11 +145,10 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     final ExecutionPayloadBid bid = signedBid.getMessage();
 
     final UInt64 builderIndex = bid.getBuilderIndex();
-    final Validator builder = state.getValidators().get(builderIndex.intValue());
 
     final UInt64 amount = bid.getValue();
 
-    if (builderIndex.equals(beaconBlock.getProposerIndex())) {
+    if (builderIndex.equals(BUILDER_INDEX_SELF_BUILD)) {
       // For self-builds, amount must be zero regardless of withdrawal credential prefix
       if (!amount.isZero()) {
         throw new BlockProcessingException("Amount must be zero for self-build blocks");
@@ -156,9 +158,13 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
             "Signature must be G2_POINT_AT_INFINITY for self-builds");
       }
     } else {
-      // Non-self builds require builder withdrawal credential
-      if (!predicatesGloas.hasBuilderWithdrawalCredential(builder)) {
+      // Verify that the builder is active
+      if (!predicatesGloas.isActiveBuilder(state, builderIndex)) {
         throw new BlockProcessingException("Non-self builds require builder withdrawal credential");
+      }
+      // Verify that the builder has funds to cover the bid
+      if (!beaconStateAccessorsGloas.canBuilderCoverBid(state, builderIndex, amount)) {
+        throw new BlockProcessingException("Builder doesn't have funds to cover the bid");
       }
       if (!operationSignatureVerifier.verifyExecutionPayloadBidSignature(
           state, signedBid, BLSSignatureVerifier.SIMPLE)) {
@@ -166,45 +172,12 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       }
     }
 
-    // Check that the builder is active, non-slashed
-    if (!predicatesGloas.isActiveValidator(
-        builder, miscHelpers.computeEpochAtSlot(state.getSlot()))) {
-      throw new BlockProcessingException("Builder is not an active validator");
-    }
-    if (builder.isSlashed()) {
-      throw new BlockProcessingException("Builder is slashed");
-    }
-
-    final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
-
-    // Check that the builder has funds to cover the bid
-    final UInt64 pendingPayments =
-        stateGloas.getBuilderPendingPayments().stream()
-            .filter(payment -> payment.getWithdrawal().getBuilderIndex().equals(builderIndex))
-            .map(payment -> payment.getWithdrawal().getAmount())
-            .reduce(UInt64.ZERO, UInt64::plus);
-
-    final UInt64 pendingWithdrawals =
-        stateGloas.getBuilderPendingWithdrawals().stream()
-            .filter(withdrawal -> withdrawal.getBuilderIndex().equals(builderIndex))
-            .map(BuilderPendingWithdrawal::getAmount)
-            .reduce(UInt64.ZERO, UInt64::plus);
-
-    final UInt64 builderBalance = state.getBalances().get(builderIndex.intValue()).get();
-
-    if (!amount.isZero()
-        && !builderBalance.isGreaterThanOrEqualTo(
-            amount
-                .plus(pendingPayments)
-                .plus(pendingWithdrawals)
-                .plus(SpecConfigElectra.required(specConfig).getMinActivationBalance()))) {
-      throw new BlockProcessingException("Builder doesn't have funds to cover the bid");
-    }
-
     // Verify that the bid is for the current slot
     if (!bid.getSlot().equals(beaconBlock.getSlot())) {
       throw new BlockProcessingException("Bid is not for the current slot");
     }
+
+    final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
 
     // Verify that the bid is for the right parent block
     if (!bid.getParentBlockHash().equals(stateGloas.getLatestBlockHash())
@@ -227,11 +200,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
                   UInt64.ZERO,
                   schemaDefinitionsGloas
                       .getBuilderPendingWithdrawalSchema()
-                      .create(
-                          bid.getFeeRecipient(),
-                          amount,
-                          builderIndex,
-                          SpecConfig.FAR_FUTURE_EPOCH));
+                      .create(bid.getFeeRecipient(), amount, builderIndex, UInt64.ZERO));
 
       stateGloas
           .getBuilderPendingPayments()
@@ -334,7 +303,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final MutableBeaconState state,
       final BeaconBlockBody body,
       final IndexedAttestationCache indexedAttestationCache,
-      final Supplier<BeaconStateMutators.ValidatorExitContext> validatorExitContextSupplier)
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
       throws BlockProcessingException {
     super.processOperationsNoValidation(
         state, body, indexedAttestationCache, validatorExitContextSupplier);
@@ -351,10 +320,27 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
   }
 
   @Override
+  protected void initiateExit(
+      final MutableBeaconState state,
+      final SignedVoluntaryExit signedExit,
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+    final UInt64 validatorIndex = signedExit.getMessage().getValidatorIndex();
+    if (predicatesGloas.isBuilderIndex(validatorIndex)) {
+      // - Run initiate_builder_exit(state, builder_index)
+      beaconStateMutatorsGloas.initiateBuilderExit(
+          state, miscHelpersGloas.convertValidatorIndexToBuilderIndex(validatorIndex));
+    } else {
+      // - Run initiate_validator_exit(state, exit.validator_index)
+      beaconStateMutators.initiateValidatorExit(
+          state, validatorIndex.intValue(), validatorExitContextSupplier);
+    }
+  }
+
+  @Override
   public void processExecutionRequests(
       final MutableBeaconState state,
       final BeaconBlockBody body,
-      final Supplier<BeaconStateMutators.ValidatorExitContext> validatorExitContextSupplier) {
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
     // Execution requests are removed from the BeaconBlockBody in Gloas and are instead processed as
     // part of process_execution_payload
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -160,7 +160,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     } else {
       // Verify that the builder is active
       if (!predicatesGloas.isActiveBuilder(state, builderIndex)) {
-        throw new BlockProcessingException("Non-self builds require builder withdrawal credential");
+        throw new BlockProcessingException("Builder is not active");
       }
       // Verify that the builder has funds to cover the bid
       if (!beaconStateAccessorsGloas.canBuilderCoverBid(state, builderIndex, amount)) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingPayment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
@@ -100,13 +99,9 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
     final BLSPublicKey pubkey;
     if (builderIndex.equals(BUILDER_INDEX_SELF_BUILD)) {
       final UInt64 validatorIndex = preState.getLatestBlockHeader().getProposerIndex();
-      pubkey = preState.getValidators().get(validatorIndex.intValue()).getPublicKey();
+      pubkey = beaconStateAccessors.getValidatorPubKey(preState, validatorIndex).orElseThrow();
     } else {
-      pubkey =
-          BeaconStateGloas.required(preState)
-              .getBuilders()
-              .get(builderIndex.intValue())
-              .getPublicKey();
+      pubkey = beaconStateAccessors.getBuilderPubKey(preState, builderIndex).orElseThrow();
     }
     final Bytes32 domain =
         beaconStateAccessors.getDomain(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
@@ -13,12 +13,15 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.execution;
 
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
+
 import java.util.BitSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
@@ -32,12 +35,11 @@ import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
-import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingPayment;
-import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingWithdrawal;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.execution.AbstractExecutionPayloadProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
@@ -94,16 +96,25 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
       final BeaconState preState,
       final SignedExecutionPayloadEnvelope signedEnvelope,
       final BLSSignatureVerifier signatureVerifier) {
-    final Validator builder =
-        preState.getValidators().get(signedEnvelope.getMessage().getBuilderIndex().intValue());
+    final UInt64 builderIndex = signedEnvelope.getMessage().getBuilderIndex();
+    final BLSPublicKey pubkey;
+    if (builderIndex.equals(BUILDER_INDEX_SELF_BUILD)) {
+      final UInt64 validatorIndex = preState.getLatestBlockHeader().getProposerIndex();
+      pubkey = preState.getValidators().get(validatorIndex.intValue()).getPublicKey();
+    } else {
+      pubkey =
+          BeaconStateGloas.required(preState)
+              .getBuilders()
+              .get(builderIndex.intValue())
+              .getPublicKey();
+    }
     final Bytes32 domain =
         beaconStateAccessors.getDomain(
             preState.getForkInfo(),
             Domain.BEACON_BUILDER,
             miscHelpers.computeEpochAtSlot(preState.getSlot()));
     final Bytes signingRoot = miscHelpers.computeSigningRoot(signedEnvelope.getMessage(), domain);
-    return signatureVerifier.verify(
-        builder.getPublicKey(), signingRoot, signedEnvelope.getSignature());
+    return signatureVerifier.verify(pubkey, signingRoot, signedEnvelope.getSignature());
   }
 
   @Override
@@ -212,14 +223,7 @@ public class ExecutionPayloadProcessorGloas extends AbstractExecutionPayloadProc
     final BuilderPendingPayment payment = stateGloas.getBuilderPendingPayments().get(paymentIndex);
     final UInt64 amount = payment.getWithdrawal().getAmount();
     if (amount.isGreaterThan(0)) {
-      final UInt64 exitQueueEpoch =
-          beaconStateMutators.computeExitEpochAndUpdateChurn(stateGloas, amount);
-      final BuilderPendingWithdrawal withdrawalToQueue =
-          payment
-              .getWithdrawal()
-              .copyWithNewWithdrawableEpoch(
-                  exitQueueEpoch.plus(specConfig.getMinValidatorWithdrawabilityDelay()));
-      stateGloas.getBuilderPendingWithdrawals().append(withdrawalToQueue);
+      stateGloas.getBuilderPendingWithdrawals().append(payment.getWithdrawal());
     }
     stateGloas
         .getBuilderPendingPayments()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.execution;
+
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
+import tech.pegasys.teku.spec.logic.versions.electra.execution.ExecutionRequestsProcessorElectra;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateMutatorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorElectra {
+
+  private final PredicatesGloas predicatesGloas;
+  private final BeaconStateMutatorsGloas beaconStateMutatorsGloas;
+  private final BeaconStateAccessorsGloas beaconStateAccessorsGloas;
+
+  public ExecutionRequestsProcessorGloas(
+      final SchemaDefinitionsGloas schemaDefinitions,
+      final MiscHelpersGloas miscHelpers,
+      final SpecConfigGloas specConfig,
+      final PredicatesGloas predicates,
+      final ValidatorsUtil validatorsUtil,
+      final BeaconStateMutatorsGloas beaconStateMutators,
+      final BeaconStateAccessorsGloas beaconStateAccessors) {
+    super(
+        schemaDefinitions,
+        miscHelpers,
+        specConfig,
+        predicates,
+        validatorsUtil,
+        beaconStateMutators,
+        beaconStateAccessors);
+    this.predicatesGloas = predicates;
+    this.beaconStateMutatorsGloas = beaconStateMutators;
+    this.beaconStateAccessorsGloas = beaconStateAccessors;
+  }
+
+  @Override
+  protected void processDepositRequest(
+      final MutableBeaconState state, final DepositRequest depositRequest) {
+    // Regardless of the withdrawal credentials prefix, if a builder/validator already exists with
+    // this pubkey, apply the deposit to their balance
+    final boolean isBuilder =
+        beaconStateAccessorsGloas.getBuilderIndex(state, depositRequest.getPubkey()).isPresent();
+    final boolean isValidator =
+        validatorsUtil.getValidatorIndex(state, depositRequest.getPubkey()).isPresent();
+    final boolean isBuilderPrefix =
+        predicatesGloas.isBuilderWithdrawalCredential(depositRequest.getWithdrawalCredentials());
+    if (isBuilder || (isBuilderPrefix && !isValidator)) {
+      // Apply builder deposits immediately
+      beaconStateMutatorsGloas.applyDepositForBuilder(
+          state,
+          depositRequest.getPubkey(),
+          depositRequest.getWithdrawalCredentials(),
+          depositRequest.getAmount(),
+          depositRequest.getSignature());
+      return;
+    }
+    // Add validator deposits to the queue
+    final SszMutableList<PendingDeposit> pendingDeposits =
+        MutableBeaconStateGloas.required(state).getPendingDeposits();
+    final PendingDeposit deposit =
+        schemaDefinitions
+            .getPendingDepositSchema()
+            .create(
+                new SszPublicKey(depositRequest.getPubkey()),
+                SszBytes32.of(depositRequest.getWithdrawalCredentials()),
+                SszUInt64.of(depositRequest.getAmount()),
+                new SszSignature(depositRequest.getSignature()),
+                SszUInt64.of(state.getSlot()));
+    pendingDeposits.append(deposit);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -18,8 +18,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.MutableBeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
@@ -60,7 +59,7 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
 
   @Override
   protected void processDepositRequest(
-      final MutableBeaconState state, final DepositRequest depositRequest) {
+      final MutableBeaconStateElectra state, final DepositRequest depositRequest) {
     // Regardless of the withdrawal credentials prefix, if a builder/validator already exists with
     // this pubkey, apply the deposit to their balance
     final boolean isBuilder =
@@ -80,8 +79,7 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorE
       return;
     }
     // Add validator deposits to the queue
-    final SszMutableList<PendingDeposit> pendingDeposits =
-        MutableBeaconStateGloas.required(state).getPendingDeposits();
+    final SszMutableList<PendingDeposit> pendingDeposits = state.getPendingDeposits();
     final PendingDeposit deposit =
         schemaDefinitions
             .getPendingDepositSchema()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -123,7 +123,7 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                       .getBuilderPendingPaymentsSchema()
                       .createFromElements(builderPendingPayments));
               state.setBuilderPendingWithdrawals(
-                  schemaDefinitions.getBuilderPendingWithdrawalsSchema().getDefault());
+                  schemaDefinitions.getBuilderPendingWithdrawalsSchema().of());
               state.setLatestBlockHash(latestBlockHash);
               state.setPayloadExpectedWithdrawals(
                   schemaDefinitions

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -279,7 +279,6 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
         BeaconStateCache.getTransitionCaches(state).getBuilderIndexCache();
     return builderIndexCache
         .getCached(publicKey)
-        .filter(index -> index < builders.size())
         .or(
             () -> {
               for (int i = 0; i < builders.size(); i++) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -14,13 +14,19 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
+import static tech.pegasys.teku.spec.logic.common.helpers.Predicates.getExecutionAddressUnchecked;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.collections.cache.Cache;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
@@ -31,8 +37,9 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadA
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingPayment;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingWithdrawal;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -62,6 +69,36 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
     super(config, predicates, miscHelpers);
     this.schemaDefinitions = schemaDefinitions;
     this.miscHelpersGloas = miscHelpers;
+  }
+
+  public UInt64 getPendingBalanceToWithdrawForBuilder(
+      final BeaconState state, final UInt64 builderIndex) {
+    final BeaconStateGloas stateGloas = BeaconStateGloas.required(state);
+    final UInt64 pendingBuilderWithdrawalsBalance =
+        stateGloas.getBuilderPendingWithdrawals().stream()
+            .filter(withdrawal -> withdrawal.getBuilderIndex().equals(builderIndex))
+            .map(BuilderPendingWithdrawal::getAmount)
+            .reduce(UInt64.ZERO, UInt64::plus);
+    final UInt64 pendingBuilderPaymentsBalance =
+        stateGloas.getBuilderPendingPayments().stream()
+            .map(BuilderPendingPayment::getWithdrawal)
+            .filter(withdrawal -> withdrawal.getBuilderIndex().equals(builderIndex))
+            .map(BuilderPendingWithdrawal::getAmount)
+            .reduce(UInt64.ZERO, UInt64::plus);
+    return pendingBuilderWithdrawalsBalance.plus(pendingBuilderPaymentsBalance);
+  }
+
+  public boolean canBuilderCoverBid(
+      final BeaconState state, final UInt64 builderIndex, final UInt64 bidAmount) {
+    final UInt64 builderBalance =
+        BeaconStateGloas.required(state).getBuilders().get(builderIndex.intValue()).getBalance();
+    final UInt64 pendingWithdrawalsAmount =
+        getPendingBalanceToWithdrawForBuilder(state, builderIndex);
+    final UInt64 minBalance = config.getMinDepositAmount().plus(pendingWithdrawalsAmount);
+    if (builderBalance.isLessThan(minBalance)) {
+      return false;
+    }
+    return builderBalance.minusMinZero(minBalance).isGreaterThanOrEqualTo(bidAmount);
   }
 
   /**
@@ -167,29 +204,6 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
     }
   }
 
-  /** get_pending_balance_to_withdraw is modified to account for pending builder payments. */
-  @Override
-  public UInt64 getPendingBalanceToWithdraw(
-      final BeaconStateElectra state, final int validatorIndex) {
-    final BeaconStateGloas stateGloas = BeaconStateGloas.required(state);
-    final UInt64 pendingPartialWithdrawalsBalance =
-        super.getPendingBalanceToWithdraw(state, validatorIndex);
-    final UInt64 pendingBuilderWithdrawalsBalance =
-        stateGloas.getBuilderPendingWithdrawals().stream()
-            .filter(withdrawal -> withdrawal.getBuilderIndex().intValue() == validatorIndex)
-            .map(BuilderPendingWithdrawal::getAmount)
-            .reduce(UInt64.ZERO, UInt64::plus);
-    final UInt64 pendingBuilderPaymentsBalance =
-        stateGloas.getBuilderPendingPayments().stream()
-            .map(BuilderPendingPayment::getWithdrawal)
-            .filter(withdrawal -> withdrawal.getBuilderIndex().intValue() == validatorIndex)
-            .map(BuilderPendingWithdrawal::getAmount)
-            .reduce(UInt64.ZERO, UInt64::plus);
-    return pendingPartialWithdrawalsBalance
-        .plus(pendingBuilderWithdrawalsBalance)
-        .plus(pendingBuilderPaymentsBalance);
-  }
-
   /**
    * get_next_sync_committee_indices is refactored to use compute_balance_weighted_selection as a
    * helper for the balance-weighted sampling process.
@@ -203,5 +217,79 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
     final Bytes32 seed = getSeed(state, epoch, Domain.SYNC_COMMITTEE);
     return miscHelpersGloas.computeBalanceWeightedSelection(
         state, activeValidatorIndices, seed, configElectra.getSyncCommitteeSize(), true);
+  }
+
+  public UInt64 getIndexForNewBuilder(final BeaconState state) {
+    final SszList<Builder> builders = BeaconStateGloas.required(state).getBuilders();
+    for (int index = 0; index < builders.size(); index++) {
+      final Builder builder = builders.get(index);
+      if (builder.getWithdrawableEpoch().isLessThanOrEqualTo(getCurrentEpoch(state))
+          && builder.getBalance().isZero()) {
+        return UInt64.valueOf(index);
+      }
+    }
+    return UInt64.valueOf(builders.size());
+  }
+
+  public Builder getBuilderFromDeposit(
+      final BeaconState state,
+      final BLSPublicKey pubkey,
+      final Bytes32 withdrawalCredentials,
+      final UInt64 amount) {
+    return new Builder(
+        pubkey,
+        withdrawalCredentials.get(0),
+        getExecutionAddressUnchecked(withdrawalCredentials),
+        amount,
+        getCurrentEpoch(state),
+        FAR_FUTURE_EPOCH);
+  }
+
+  @Override
+  public Optional<BLSPublicKey> getBuilderPubKey(
+      final BeaconState state, final UInt64 builderIndex) {
+    final Optional<SszList<Builder>> maybeBuilders =
+        state.toVersionGloas().map(BeaconStateGloas::getBuilders);
+    if (maybeBuilders.isEmpty()) {
+      return Optional.empty();
+    }
+    final SszList<Builder> builders = maybeBuilders.get();
+    if (builderIndex.isGreaterThanOrEqualTo(builders.size()) || builderIndex.longValue() < 0) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        BeaconStateCache.getTransitionCaches(state)
+            .getBuildersPubKeys()
+            .get(
+                builderIndex,
+                i -> {
+                  final BLSPublicKey pubKey = builders.get(i.intValue()).getPublicKey();
+                  // eagerly pre-cache pubKey => builderIndex mapping
+                  BeaconStateCache.getTransitionCaches(state)
+                      .getBuilderIndexCache()
+                      .invalidateWithNewValue(pubKey, i.intValue());
+                  return pubKey;
+                }));
+  }
+
+  @Override
+  public Optional<Integer> getBuilderIndex(final BeaconState state, final BLSPublicKey publicKey) {
+    final SszList<Builder> builders = BeaconStateGloas.required(state).getBuilders();
+    final Cache<BLSPublicKey, Integer> builderIndexCache =
+        BeaconStateCache.getTransitionCaches(state).getBuilderIndexCache();
+    return builderIndexCache
+        .getCached(publicKey)
+        .filter(index -> index < builders.size())
+        .or(
+            () -> {
+              for (int i = 0; i < builders.size(); i++) {
+                final BLSPublicKey builderPubKey = builders.get(i).getPublicKey();
+                if (builderPubKey.equals(publicKey)) {
+                  builderIndexCache.invalidateWithNewValue(builderPubKey, i);
+                  return Optional.of(i);
+                }
+              }
+              return Optional.empty();
+            });
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
@@ -93,13 +93,15 @@ public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
       LOG.debug("Adding new builder with index {} to state", builders.size());
       builders.append(builder);
     } else {
-      // the index is reassigned to a new builder, so updating the caches
+      // The index is reassigned to a new builder, so updating the caches
       final TransitionCaches caches = BeaconStateCache.getTransitionCaches(state);
       caches.getBuildersPubKeys().invalidateWithNewValue(index, pubkey);
       caches.getBuilderIndexCache().invalidateWithNewValue(pubkey, index.intValue());
-      // remove the pubkey mapping for the old builder
+      // Remove the pubkey mapping for the old builder
       caches.getBuilderIndexCache().invalidate(builders.get(index.intValue()).getPublicKey());
-      LOG.debug("Adding new builder to an existing index {} in the state", index.intValue());
+      LOG.debug(
+          "Adding new builder to an existing index {} (builder has exited) in the state",
+          index.intValue());
       builders.set(index.intValue(), builder);
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
@@ -73,7 +73,7 @@ public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
     }
     // Set builder exit epoch
     final UInt64 exitEpoch =
-        beaconStateAccessors
+        beaconStateAccessorsGloas
             .getCurrentEpoch(state)
             .plus(specConfigGloas.getMinBuilderWithdrawabilityDelay());
     builders.set(builderIndex.intValue(), builder.copyWithNewWithdrawableEpoch(exitEpoch));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -32,6 +34,8 @@ import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutators
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   private final SpecConfigGloas specConfigGloas;
   private final BeaconStateAccessorsGloas beaconStateAccessorsGloas;
@@ -86,6 +90,7 @@ public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
             state, pubkey, withdrawalCredentials, amount);
     final SszMutableList<Builder> builders = MutableBeaconStateGloas.required(state).getBuilders();
     if (index.isGreaterThanOrEqualTo(builders.size())) {
+      LOG.debug("Adding new builder with index {} to state", builders.size());
       builders.append(builder);
     } else {
       // the index is reassigned to a new builder, so updating the caches
@@ -94,6 +99,7 @@ public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
       caches.getBuilderIndexCache().invalidateWithNewValue(pubkey, index.intValue());
       // remove the pubkey mapping for the old builder
       caches.getBuilderIndexCache().invalidate(builders.get(index.intValue()).getPublicKey());
+      LOG.debug("Adding new builder to an existing index {} in the state", index.intValue());
       builders.set(index.intValue(), builder);
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
+
+  private final SpecConfigGloas specConfigGloas;
+  private final BeaconStateAccessorsGloas beaconStateAccessorsGloas;
+
+  public static BeaconStateMutatorsGloas required(final BeaconStateMutators beaconStateMutators) {
+    checkArgument(
+        beaconStateMutators instanceof BeaconStateMutatorsGloas,
+        "Expected %s but it was %s",
+        BeaconStateMutatorsGloas.class,
+        beaconStateMutators.getClass());
+    return (BeaconStateMutatorsGloas) beaconStateMutators;
+  }
+
+  public BeaconStateMutatorsGloas(
+      final SpecConfigGloas specConfig,
+      final MiscHelpersGloas miscHelpers,
+      final BeaconStateAccessorsGloas beaconStateAccessors,
+      final SchemaDefinitionsGloas schemaDefinitions) {
+    super(specConfig, miscHelpers, beaconStateAccessors, schemaDefinitions);
+    this.specConfigGloas = specConfig;
+    this.beaconStateAccessorsGloas = beaconStateAccessors;
+  }
+
+  /**
+   * initiate_builder_exit
+   *
+   * <p>Initiate the exit of the builder with index ``index``.
+   */
+  public void initiateBuilderExit(final MutableBeaconState state, final UInt64 builderIndex) {
+    final SszMutableList<Builder> builders = MutableBeaconStateGloas.required(state).getBuilders();
+    final Builder builder = builders.get(builderIndex.intValue());
+    // Return if builder already initiated exit
+    if (!builder.getWithdrawableEpoch().equals(FAR_FUTURE_EPOCH)) {
+      return;
+    }
+    // Set builder exit epoch
+    final UInt64 exitEpoch =
+        beaconStateAccessors
+            .getCurrentEpoch(state)
+            .plus(specConfigGloas.getMinBuilderWithdrawabilityDelay());
+    builders.set(builderIndex.intValue(), builder.copyWithNewWithdrawableEpoch(exitEpoch));
+  }
+
+  public void addBuilderToRegistry(
+      final MutableBeaconState state,
+      final BLSPublicKey pubkey,
+      final Bytes32 withdrawalCredentials,
+      final UInt64 amount) {
+    final UInt64 index = beaconStateAccessorsGloas.getIndexForNewBuilder(state);
+    final Builder builder =
+        beaconStateAccessorsGloas.getBuilderFromDeposit(
+            state, pubkey, withdrawalCredentials, amount);
+    final SszMutableList<Builder> builders = MutableBeaconStateGloas.required(state).getBuilders();
+    if (index.isGreaterThanOrEqualTo(builders.size())) {
+      builders.append(builder);
+    } else {
+      // the index is reassigned to a new builder, so updating the caches
+      final TransitionCaches caches = BeaconStateCache.getTransitionCaches(state);
+      caches.getBuildersPubKeys().invalidateWithNewValue(index, pubkey);
+      caches.getBuilderIndexCache().invalidateWithNewValue(pubkey, index.intValue());
+      // remove the pubkey mapping for the old builder
+      caches.getBuilderIndexCache().invalidate(builders.get(index.intValue()).getPublicKey());
+      builders.set(index.intValue(), builder);
+    }
+  }
+
+  public void applyDepositForBuilder(
+      final MutableBeaconState state,
+      final BLSPublicKey pubkey,
+      final Bytes32 withdrawalCredentials,
+      final UInt64 amount,
+      final BLSSignature signature) {
+    beaconStateAccessorsGloas
+        .getBuilderIndex(state, pubkey)
+        .ifPresentOrElse(
+            builderIndex -> {
+              // Increase balance by deposit amount
+              final SszMutableList<Builder> builders =
+                  MutableBeaconStateGloas.required(state).getBuilders();
+              final Builder builder = builders.get(builderIndex);
+              builders.set(
+                  builderIndex, builder.copyWithNewBalance(builder.getBalance().plus(amount)));
+            },
+            () -> {
+              // Verify the deposit signature (proof of possession) which is not checked by the
+              // deposit contract
+              if (miscHelpers.isValidDepositSignature(
+                  pubkey, withdrawalCredentials, amount, signature)) {
+                addBuilderToRegistry(state, pubkey, withdrawalCredentials, amount);
+              }
+            });
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_FLAG;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 
@@ -56,6 +57,14 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
       final PredicatesGloas predicates,
       final SchemaDefinitionsGloas schemaDefinitions) {
     super(specConfig, predicates, schemaDefinitions);
+  }
+
+  public UInt64 convertBuilderIndexToValidatorIndex(final UInt64 builderIndex) {
+    return UInt64.valueOf(builderIndex.longValue() | BUILDER_INDEX_FLAG.longValue());
+  }
+
+  public UInt64 convertValidatorIndexToBuilderIndex(final UInt64 validatorIndex) {
+    return UInt64.valueOf(validatorIndex.longValue() & ~BUILDER_INDEX_FLAG.longValue());
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/OperationSignatureVerifierGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/OperationSignatureVerifierGloas.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.operations;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+
+public class OperationSignatureVerifierGloas extends OperationSignatureVerifier {
+
+  private final MiscHelpersGloas miscHelpersGloas;
+  private final PredicatesGloas predicatesGloas;
+
+  public OperationSignatureVerifierGloas(
+      final MiscHelpersGloas miscHelpers,
+      final BeaconStateAccessorsGloas beaconStateAccessors,
+      final PredicatesGloas predicates) {
+    super(miscHelpers, beaconStateAccessors);
+    this.miscHelpersGloas = miscHelpers;
+    this.predicatesGloas = predicates;
+  }
+
+  @Override
+  public boolean verifyVoluntaryExitSignature(
+      final BeaconState state,
+      final SignedVoluntaryExit signedExit,
+      final BLSSignatureVerifier signatureVerifier) {
+    final VoluntaryExit exit = signedExit.getMessage();
+    final UInt64 validatorIndex = exit.getValidatorIndex();
+    final Bytes32 domain =
+        beaconStateAccessors.getVoluntaryExitDomain(
+            exit.getEpoch(), state.getFork(), state.getGenesisValidatorsRoot());
+    final Bytes signingRoot = miscHelpersGloas.computeSigningRoot(exit, domain);
+    final Optional<BLSPublicKey> maybePubkey;
+    if (predicatesGloas.isBuilderIndex(validatorIndex)) {
+      final UInt64 builderIndex =
+          miscHelpersGloas.convertValidatorIndexToBuilderIndex(validatorIndex);
+      maybePubkey = beaconStateAccessors.getBuilderPubKey(state, builderIndex);
+    } else {
+      maybePubkey = beaconStateAccessors.getValidatorPubKey(state, validatorIndex);
+    }
+    return maybePubkey
+        .map(pubkey -> signatureVerifier.verify(pubkey, signingRoot, signedExit.getSignature()))
+        .orElse(false);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/validation/VoluntaryExitValidatorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/validation/VoluntaryExitValidatorGloas.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.operations.validation;
+
+import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
+import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.firstOf;
+
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+
+public class VoluntaryExitValidatorGloas extends VoluntaryExitValidatorElectra {
+
+  private final PredicatesGloas predicates;
+  private final BeaconStateAccessorsGloas beaconStateAccessors;
+  private final MiscHelpersGloas miscHelpers;
+
+  public VoluntaryExitValidatorGloas(
+      final SpecConfigGloas specConfig,
+      final PredicatesGloas predicates,
+      final BeaconStateAccessorsGloas beaconStateAccessors,
+      final MiscHelpersGloas miscHelpers) {
+    super(specConfig, predicates, beaconStateAccessors);
+    this.predicates = predicates;
+    this.beaconStateAccessors = beaconStateAccessors;
+    this.miscHelpers = miscHelpers;
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validate(
+      final Fork fork, final BeaconState state, final SignedVoluntaryExit signedExit) {
+    if (predicates.isBuilderIndex(signedExit.getMessage().getValidatorIndex())) {
+      final UInt64 builderIndex =
+          miscHelpers.convertValidatorIndexToBuilderIndex(
+              signedExit.getMessage().getValidatorIndex());
+      return validateBuilderExit(state, builderIndex);
+    }
+    return super.validate(fork, state, signedExit);
+  }
+
+  protected Optional<OperationInvalidReason> validateBuilderExit(
+      final BeaconState state, final UInt64 builderIndex) {
+    return firstOf(
+        () ->
+            check(
+                predicates.isActiveBuilder(state, builderIndex),
+                ExitInvalidReason.builderInactive()),
+        () ->
+            check(
+                beaconStateAccessors
+                    .getPendingBalanceToWithdrawForBuilder(state, builderIndex)
+                    .equals(UInt64.ZERO),
+                ExitInvalidReason.pendingWithdrawalsInQueueForBuilder()));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
@@ -77,16 +77,7 @@ public class EpochProcessorGloas extends EpochProcessorFulu {
             i -> {
               final BuilderPendingPayment payment = builderPendingPayments.get(i);
               if (payment.getWeight().isGreaterThanOrEqualTo(quorum)) {
-                final UInt64 amount = payment.getWithdrawal().getAmount();
-                final UInt64 exitQueueEpoch =
-                    BeaconStateMutatorsElectra.required(beaconStateMutators)
-                        .computeExitEpochAndUpdateChurn(stateGloas, amount);
-                final UInt64 withdrawableEpoch =
-                    exitQueueEpoch.plus(specConfig.getMinValidatorWithdrawabilityDelay());
-                stateGloas
-                    .getBuilderPendingWithdrawals()
-                    .append(
-                        payment.getWithdrawal().copyWithNewWithdrawableEpoch(withdrawableEpoch));
+                stateGloas.getBuilderPendingWithdrawals().append(payment.getWithdrawal());
               }
             });
     final List<BuilderPendingPayment> oldPayments =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -146,7 +146,9 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
             MutableBeaconStateGloas.required(state).getBuilders();
         final Builder builder = builders.get(builderIndex.intValue());
         final UInt64 builderBalance = builder.getBalance();
-        state.set(builderIndex.intValue(), builder.copyWithNewBalance(builderBalance));
+        builders.set(
+            builderIndex.intValue(),
+            builder.copyWithNewBalance(builderBalance.minusMinZero(withdrawal.getAmount())));
       } else {
         beaconStateMutators.decreaseBalance(
             state, validatorIndex.intValue(), withdrawal.getAmount());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
@@ -13,19 +13,20 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.withdrawals;
 
-import java.util.ArrayList;
 import java.util.List;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
-import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingWithdrawal;
-import tech.pegasys.teku.spec.logic.common.withdrawals.WithdrawalsHelpers;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.withdrawals.WithdrawalsHelpersElectra;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
@@ -34,8 +35,10 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
 
+  private final MiscHelpersGloas miscHelpersGloas;
   private final PredicatesGloas predicatesGloas;
   private final SchemaDefinitionsGloas schemaDefinitionsGloas;
+  private final SpecConfigGloas specConfigGloas;
 
   public WithdrawalsHelpersGloas(
       final SchemaDefinitionsGloas schemaDefinitions,
@@ -44,8 +47,10 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
       final PredicatesGloas predicates,
       final BeaconStateMutatorsElectra beaconStateMutators) {
     super(schemaDefinitions, miscHelpers, specConfig, predicates, beaconStateMutators);
+    this.miscHelpersGloas = miscHelpers;
     this.predicatesGloas = predicates;
     this.schemaDefinitionsGloas = schemaDefinitions;
+    this.specConfigGloas = specConfig;
   }
 
   @Override
@@ -61,46 +66,26 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
   protected int processBuilderWithdrawals(
       final BeaconState state, final List<Withdrawal> withdrawals) {
     UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);
-
-    final UInt64 epoch = miscHelpers.computeEpochAtSlot(state.getSlot());
-
     int processedBuilderWithdrawalsCount = 0;
+
+    final int withdrawalsLimit = specConfig.getMaxWithdrawalsPerPayload();
 
     for (BuilderPendingWithdrawal withdrawal :
         BeaconStateGloas.required(state).getBuilderPendingWithdrawals()) {
-      if (withdrawal.getWithdrawableEpoch().isGreaterThan(epoch)
-          || withdrawals.size() + 1 == specConfig.getMaxWithdrawalsPerPayload()) {
+      if (withdrawals.size() == withdrawalsLimit) {
         break;
       }
-      if (isBuilderPaymentWithdrawable(state, withdrawal)) {
-        final UInt64 builderIndex = withdrawal.getBuilderIndex();
-        final Validator builder = state.getValidators().get(builderIndex.intValue());
-        final UInt64 withdrawn = WithdrawalsHelpers.getTotalWithdrawn(withdrawals, builderIndex);
-        final UInt64 remainingBalance =
-            state.getBalances().get(builderIndex.intValue()).get().minusMinZero(withdrawn);
-        final UInt64 withdrawableBalance;
-        if (builder.isSlashed()) {
-          withdrawableBalance = remainingBalance.min(withdrawal.getAmount());
-        } else if (remainingBalance.isGreaterThan(specConfigElectra.getMinActivationBalance())) {
-          withdrawableBalance =
-              remainingBalance
-                  .minusMinZero(specConfigElectra.getMinActivationBalance())
-                  .min(withdrawal.getAmount());
-        } else {
-          withdrawableBalance = UInt64.ZERO;
-        }
-        if (withdrawableBalance.isGreaterThan(UInt64.ZERO)) {
-          withdrawals.add(
-              schemaDefinitions
-                  .getWithdrawalSchema()
-                  .create(
-                      withdrawalIndex,
-                      builderIndex,
-                      withdrawal.getFeeRecipient(),
-                      withdrawableBalance));
-          withdrawalIndex = withdrawalIndex.increment();
-        }
-      }
+      final UInt64 builderIndex = withdrawal.getBuilderIndex();
+      withdrawals.add(
+          schemaDefinitions
+              .getWithdrawalSchema()
+              .create(
+                  withdrawalIndex,
+                  miscHelpersGloas.convertBuilderIndexToValidatorIndex(builderIndex),
+                  withdrawal.getFeeRecipient(),
+                  withdrawal.getAmount()));
+
+      withdrawalIndex = withdrawalIndex.increment();
       processedBuilderWithdrawalsCount++;
     }
 
@@ -108,10 +93,65 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
   }
 
   @Override
-  protected int getBoundForPendingPartialWithdrawals(final List<Withdrawal> withdrawals) {
-    return Math.min(
-        withdrawals.size() + specConfigElectra.getMaxPendingPartialsPerWithdrawalsSweep(),
-        specConfig.getMaxWithdrawalsPerPayload() - 1);
+  protected int processBuildersSweepWithdrawals(
+      final BeaconState state, final List<Withdrawal> withdrawals) {
+    final BeaconStateGloas stateGloas = BeaconStateGloas.required(state);
+    final WithdrawalSchema withdrawalSchema = schemaDefinitions.getWithdrawalSchema();
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(state.getSlot());
+    final SszList<Builder> builders = stateGloas.getBuilders();
+    final int buildersCount = builders.size();
+
+    UInt64 withdrawalIndex = getNextWithdrawalIndex(state, withdrawals);
+    UInt64 builderIndex = stateGloas.getNextWithdrawalBuilderIndex();
+
+    int processedBuildersSweepCount = 0;
+
+    final int withdrawalsLimit = specConfig.getMaxWithdrawalsPerPayload();
+
+    final int buildersLimit =
+        Math.min(buildersCount, specConfigGloas.getMaxBuildersPerWithdrawalsSweep());
+
+    for (int i = 0; i < buildersLimit; i++) {
+      if (withdrawals.size() == withdrawalsLimit) {
+        break;
+      }
+      final Builder builder = builders.get(builderIndex.intValue());
+      if (builder.getWithdrawableEpoch().isLessThanOrEqualTo(epoch)
+          && builder.getBalance().isGreaterThan(UInt64.ZERO)) {
+        withdrawals.add(
+            withdrawalSchema.create(
+                withdrawalIndex,
+                miscHelpersGloas.convertBuilderIndexToValidatorIndex(builderIndex),
+                builder.getExecutionAddress(),
+                builder.getBalance()));
+        withdrawalIndex = withdrawalIndex.increment();
+      }
+
+      builderIndex = builderIndex.plus(1).mod(buildersCount);
+      processedBuildersSweepCount++;
+    }
+
+    return processedBuildersSweepCount;
+  }
+
+  @Override
+  protected void applyWithdrawals(
+      final MutableBeaconState state, final List<Withdrawal> withdrawals) {
+    for (final Withdrawal withdrawal : withdrawals) {
+      final UInt64 validatorIndex = withdrawal.getValidatorIndex();
+      if (predicatesGloas.isBuilderIndex(validatorIndex)) {
+        final UInt64 builderIndex =
+            miscHelpersGloas.convertValidatorIndexToBuilderIndex(validatorIndex);
+        final SszMutableList<Builder> builders =
+            MutableBeaconStateGloas.required(state).getBuilders();
+        final Builder builder = builders.get(builderIndex.intValue());
+        final UInt64 builderBalance = builder.getBalance();
+        state.set(builderIndex.intValue(), builder.copyWithNewBalance(builderBalance));
+      } else {
+        beaconStateMutators.decreaseBalance(
+            state, validatorIndex.intValue(), withdrawal.getAmount());
+      }
+    }
   }
 
   @Override
@@ -133,32 +173,22 @@ public class WithdrawalsHelpersGloas extends WithdrawalsHelpersElectra {
         stateGloas.getBuilderPendingWithdrawals().getSchema();
     final List<BuilderPendingWithdrawal> builderPendingWithdrawals =
         stateGloas.getBuilderPendingWithdrawals().asList();
-    if (stateGloas.getBuilderPendingWithdrawals().size() == processedBuilderWithdrawalsCount) {
-      final List<BuilderPendingWithdrawal> updatedBuilderPendingWithdrawals =
-          builderPendingWithdrawals.stream()
-              .filter(withdrawal -> !isBuilderPaymentWithdrawable(state, withdrawal))
-              .toList();
-      stateGloas.setBuilderPendingWithdrawals(
-          schema.createFromElements(updatedBuilderPendingWithdrawals));
-    } else {
-      final List<BuilderPendingWithdrawal> updatedBuilderPendingWithdrawals =
-          new ArrayList<>(
-              builderPendingWithdrawals.subList(0, processedBuilderWithdrawalsCount).stream()
-                  .filter(withdrawal -> !isBuilderPaymentWithdrawable(state, withdrawal))
-                  .toList());
-      updatedBuilderPendingWithdrawals.addAll(
-          builderPendingWithdrawals.subList(
-              processedBuilderWithdrawalsCount, builderPendingWithdrawals.size()));
-      stateGloas.setBuilderPendingWithdrawals(
-          schema.createFromElements(updatedBuilderPendingWithdrawals));
-    }
+    stateGloas.setBuilderPendingWithdrawals(
+        schema.createFromElements(
+            builderPendingWithdrawals.subList(
+                processedBuilderWithdrawalsCount, builderPendingWithdrawals.size())));
   }
 
-  private boolean isBuilderPaymentWithdrawable(
-      final BeaconState state, final BuilderPendingWithdrawal withdrawal) {
-    final Validator builder = state.getValidators().get(withdrawal.getBuilderIndex().intValue());
-    final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(state.getSlot());
-    return currentEpoch.isGreaterThanOrEqualTo(builder.getWithdrawableEpoch())
-        || !builder.isSlashed();
+  @Override
+  protected void updateNextWithdrawalBuilderIndex(
+      final MutableBeaconState state, final int processedBuildersSweepCount) {
+    final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
+    if (!stateGloas.getBuilders().isEmpty()) {
+      // Update the next builder index to start the next withdrawal sweep
+      final UInt64 nextIndex =
+          stateGloas.getNextWithdrawalBuilderIndex().plus(processedBuildersSweepCount);
+      final UInt64 nextBuilderIndex = nextIndex.mod(stateGloas.getBuilders().size());
+      stateGloas.setNextWithdrawalBuilderIndex(nextBuilderIndex);
+    }
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
@@ -121,7 +121,7 @@ public class VoluntaryExitValidator
 
     public static OperationInvalidReason pendingWithdrawalsInQueueForBuilder() {
       return () ->
-          "Builder cannot be exited while there are pending withdrawals in the withdrawal queue";
+          "Builder cannot be exited while it has pending withdrawals in the withdrawal queue";
     }
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
@@ -114,5 +114,14 @@ public class VoluntaryExitValidator
       return () ->
           "Validator cannot be exited while there are pending withdrawals in the withdrawal queue";
     }
+
+    public static OperationInvalidReason builderInactive() {
+      return () -> "Builder is not active";
+    }
+
+    public static OperationInvalidReason pendingWithdrawalsInQueueForBuilder() {
+      return () ->
+          "Builder cannot be exited while there are pending withdrawals in the withdrawal queue";
+    }
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BeaconStateAccessorsGloasTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final BeaconStateAccessorsGloas beaconStateAccessors =
+      BeaconStateAccessorsGloas.required(spec.getGenesisSpec().beaconStateAccessors());
+
+  @Test
+  void getBuilderIndex_shouldReturnBuilderIndex() {
+    final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
+    assertThat(state.getBuilders()).hasSizeGreaterThan(5);
+    for (int i = 0; i < 5; i++) {
+      final Builder builder = state.getBuilders().get(i);
+      assertThat(beaconStateAccessors.getBuilderIndex(state, builder.getPublicKey())).contains(i);
+    }
+  }
+
+  @Test
+  public void getBuilderIndex_shouldReturnEmptyWhenBuilderNotFound() {
+    final BeaconState state = dataStructureUtil.randomBeaconState();
+    final Optional<Integer> index =
+        beaconStateAccessors.getBuilderIndex(state, dataStructureUtil.randomPublicKey());
+    assertThat(index).isEmpty();
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+
+public class MiscHelpersGloasTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+
+  private final MiscHelpersGloas miscHelpers =
+      MiscHelpersGloas.required(spec.getGenesisSpec().miscHelpers());
+
+  @Test
+  public void roundTrip_convertBetweenBuilderIndexAndValidatorIndex() {
+    final UInt64 builderIndex = UInt64.valueOf(42);
+    final UInt64 validatorIndex = miscHelpers.convertBuilderIndexToValidatorIndex(builderIndex);
+    assertThat(miscHelpers.convertValidatorIndexToBuilderIndex(validatorIndex))
+        .isEqualTo(builderIndex);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
@@ -27,10 +27,14 @@ public class MiscHelpersGloasTest {
   private final MiscHelpersGloas miscHelpers =
       MiscHelpersGloas.required(spec.getGenesisSpec().miscHelpers());
 
+  private final PredicatesGloas predicates =
+      PredicatesGloas.required(spec.getGenesisSpec().predicates());
+
   @Test
-  public void roundTrip_convertBetweenBuilderIndexAndValidatorIndex() {
+  public void roundTrip_convertBuilderIndexToValidatorIndex() {
     final UInt64 builderIndex = UInt64.valueOf(42);
     final UInt64 validatorIndex = miscHelpers.convertBuilderIndexToValidatorIndex(builderIndex);
+    assertThat(predicates.isBuilderIndex(validatorIndex)).isTrue();
     assertThat(miscHelpers.convertValidatorIndexToBuilderIndex(validatorIndex))
         .isEqualTo(builderIndex);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.generator;
 
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -309,7 +311,7 @@ public class BlockProposalTestUtil {
                 executionPayloadProposalDataCache.put(newSlot, executionPayloadProposalData);
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(
-                        newSlot, blockSlotState, proposerIndex, executionPayloadProposalData));
+                        newSlot, blockSlotState, executionPayloadProposalData));
               }
               if (builder.supportsPayloadAttestations()) {
                 builder.payloadAttestations(
@@ -407,7 +409,7 @@ public class BlockProposalTestUtil {
                 executionPayloadProposalDataCache.put(newSlot, executionPayloadProposalData);
                 builder.signedExecutionPayloadBid(
                     createSignedExecutionPayloadBid(
-                        newSlot, blockSlotState, proposerIndex, executionPayloadProposalData));
+                        newSlot, blockSlotState, executionPayloadProposalData));
               }
               if (builder.supportsPayloadAttestations()) {
                 builder.payloadAttestations(
@@ -491,7 +493,6 @@ public class BlockProposalTestUtil {
   private SignedExecutionPayloadBid createSignedExecutionPayloadBid(
       final UInt64 newSlot,
       final BeaconState state,
-      final int proposerIndex,
       final ExecutionPayloadProposalData executionPayloadProposalData) {
     final SpecVersion specVersion = spec.atSlot(newSlot);
     final SchemaDefinitionsGloas schemaDefinitions =
@@ -508,7 +509,7 @@ public class BlockProposalTestUtil {
                 executionPayload.getPrevRandao(),
                 executionPayload.getFeeRecipient(),
                 executionPayload.getGasLimit(),
-                UInt64.valueOf(proposerIndex),
+                BUILDER_INDEX_SELF_BUILD,
                 newSlot,
                 UInt64.ZERO,
                 UInt64.ZERO,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -751,7 +751,6 @@ public class ChainBuilder {
                 executionPayloadProposalTestUtil.createExecutionPayload(
                     signer,
                     slot,
-                    UInt64.valueOf(proposerIndex),
                     nextBlockAndState.toUnsigned(),
                     executionPayloadProposalData.get(),
                     options.isSkipStateTransitionEnabled()));

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ExecutionPayloadProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ExecutionPayloadProposalTestUtil.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.generator;
 
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
+
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -35,7 +37,6 @@ public class ExecutionPayloadProposalTestUtil {
   public SafeFuture<SignedExecutionPayloadAndState> createExecutionPayload(
       final Signer signer,
       final UInt64 newSlot,
-      final UInt64 proposerIndex,
       final BeaconBlockAndState blockAndState,
       final ExecutionPayloadProposalData executionPayloadProposalData,
       final boolean skipStateTransition) {
@@ -48,7 +49,7 @@ public class ExecutionPayloadProposalTestUtil {
               .create(
                   executionPayloadProposalData.executionPayload(),
                   executionPayloadProposalData.executionRequests(),
-                  proposerIndex,
+                  BUILDER_INDEX_SELF_BUILD,
                   blockAndState.getRoot(),
                   newSlot,
                   executionPayloadProposalData.kzgCommitments(),
@@ -68,7 +69,7 @@ public class ExecutionPayloadProposalTestUtil {
     }
     return spec.createNewUnsignedExecutionPayload(
             newSlot,
-            proposerIndex,
+            BUILDER_INDEX_SELF_BUILD,
             blockAndState,
             SafeFuture.completedFuture(executionPayloadProposalData))
         .thenCompose(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/AbstractBeaconStateBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/AbstractBeaconStateBuilder.java
@@ -43,6 +43,7 @@ public abstract class AbstractBeaconStateBuilder<
     TBuilder extends AbstractBeaconStateBuilder<TState, TStateMutable, TBuilder>> {
   protected final DataStructureUtil dataStructureUtil;
   protected final int defaultValidatorCount;
+  protected final int defaultBuilderCount;
   protected final int defaultItemsInSSZLists;
   protected final SpecVersion spec;
 
@@ -74,6 +75,21 @@ public abstract class AbstractBeaconStateBuilder<
     this.spec = spec;
     this.dataStructureUtil = dataStructureUtil;
     this.defaultValidatorCount = defaultValidatorCount;
+    this.defaultBuilderCount = 0;
+    this.defaultItemsInSSZLists = defaultItemsInSSZLists;
+    initDefaults();
+  }
+
+  protected AbstractBeaconStateBuilder(
+      final SpecVersion spec,
+      final DataStructureUtil dataStructureUtil,
+      final int defaultValidatorCount,
+      final int defaultBuilderCount,
+      final int defaultItemsInSSZLists) {
+    this.spec = spec;
+    this.dataStructureUtil = dataStructureUtil;
+    this.defaultValidatorCount = defaultValidatorCount;
+    this.defaultBuilderCount = defaultBuilderCount;
     this.defaultItemsInSSZLists = defaultItemsInSSZLists;
     initDefaults();
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderGloas.java
@@ -68,8 +68,6 @@ public class BeaconStateBuilderGloas
   private SszUInt64Vector proposerLookahead;
 
   private ExecutionPayloadBid latestExecutionPayloadBid;
-  // same as defaultValidatorCount;
-  private int defaultBuilderCount = 10;
   private SszList<Builder> builders;
   private UInt64 nextWithdrawalBuilderIndex;
   private SszBitvector executionPayloadAvailability;
@@ -82,8 +80,14 @@ public class BeaconStateBuilderGloas
       final SpecVersion spec,
       final DataStructureUtil dataStructureUtil,
       final int defaultValidatorCount,
+      final int defaultBuilderCount,
       final int defaultItemsInSSZLists) {
-    super(spec, dataStructureUtil, defaultValidatorCount, defaultItemsInSSZLists);
+    super(
+        spec,
+        dataStructureUtil,
+        defaultValidatorCount,
+        defaultBuilderCount,
+        defaultItemsInSSZLists);
   }
 
   @Override
@@ -127,11 +131,13 @@ public class BeaconStateBuilderGloas
       final DataStructureUtil dataStructureUtil,
       final Spec spec,
       final int defaultValidatorCount,
+      final int defaultBuilderCount,
       final int defaultItemsInSSZLists) {
     return new BeaconStateBuilderGloas(
         spec.forMilestone(SpecMilestone.GLOAS),
         dataStructureUtil,
         defaultValidatorCount,
+        defaultBuilderCount,
         defaultItemsInSSZLists);
   }
 
@@ -197,12 +203,6 @@ public class BeaconStateBuilderGloas
       final ExecutionPayloadBid latestExecutionPayloadBid) {
     checkNotNull(latestExecutionPayloadBid);
     this.latestExecutionPayloadBid = latestExecutionPayloadBid;
-    return this;
-  }
-
-  public BeaconStateBuilderGloas defaultBuilderCount(final Integer defaultBuilderCount) {
-    checkNotNull(defaultBuilderCount);
-    this.defaultBuilderCount = defaultBuilderCount;
     return this;
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BuilderBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BuilderBuilder.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
 public class BuilderBuilder {
 
   private BLSPublicKey publicKey;
-  private Byte version;
+  private int version;
   private Eth1Address executionAddress;
   private UInt64 balance;
   private UInt64 depositEpoch = FAR_FUTURE_EPOCH;
@@ -32,7 +32,7 @@ public class BuilderBuilder {
 
   public BuilderBuilder(final Spec spec, final DataStructureUtil dataStructureUtil) {
     this.publicKey = dataStructureUtil.randomPublicKey();
-    this.version = dataStructureUtil.randomByte();
+    this.version = dataStructureUtil.randomPositiveInt(256);
     this.executionAddress = dataStructureUtil.randomEth1Address();
     this.balance = spec.getGenesisSpec().getConfig().getMaxEffectiveBalance();
   }
@@ -42,7 +42,7 @@ public class BuilderBuilder {
     return this;
   }
 
-  public BuilderBuilder version(final Byte version) {
+  public BuilderBuilder version(final int version) {
     this.version = version;
     return this;
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BuilderBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BuilderBuilder.java
@@ -32,7 +32,7 @@ public class BuilderBuilder {
 
   public BuilderBuilder(final Spec spec, final DataStructureUtil dataStructureUtil) {
     this.publicKey = dataStructureUtil.randomPublicKey();
-    this.version = dataStructureUtil.randomPositiveInt(256);
+    this.version = dataStructureUtil.randomUInt8();
     this.executionAddress = dataStructureUtil.randomEth1Address();
     this.balance = spec.getGenesisSpec().getConfig().getMaxEffectiveBalance();
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -306,6 +306,10 @@ public final class DataStructureUtil {
     return new Random(nextSeed()).nextBoolean();
   }
 
+  public int randomUInt8() {
+    return randomPositiveInt(256);
+  }
+
   public UInt64 randomUInt64() {
     return UInt64.fromLongBits(randomLong());
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -3149,7 +3149,7 @@ public final class DataStructureUtil {
   public BuilderPendingWithdrawal randomBuilderPendingWithdrawal() {
     return getGloasSchemaDefinitions()
         .getBuilderPendingWithdrawalSchema()
-        .create(randomEth1Address(), randomUInt64(), randomUInt64(), randomEpoch());
+        .create(randomEth1Address(), randomUInt64(), randomUInt64());
   }
 
   public BuilderPendingPayment randomBuilderPendingPayment() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2089,6 +2089,18 @@ public final class DataStructureUtil {
           ? extends AbstractBeaconStateBuilder<?, ?, ?>>
       stateBuilder(
           final SpecMilestone milestone, final int validatorCount, final int numItemsInSszLists) {
+    return stateBuilder(milestone, validatorCount, 10, numItemsInSszLists);
+  }
+
+  public AbstractBeaconStateBuilder<
+          ? extends BeaconState,
+          ? extends MutableBeaconState,
+          ? extends AbstractBeaconStateBuilder<?, ?, ?>>
+      stateBuilder(
+          final SpecMilestone milestone,
+          final int validatorCount,
+          final int builderCount,
+          final int numItemsInSszLists) {
     return switch (milestone) {
       case PHASE0 -> stateBuilderPhase0(validatorCount, numItemsInSszLists);
       case ALTAIR -> stateBuilderAltair(validatorCount, numItemsInSszLists);
@@ -2097,7 +2109,7 @@ public final class DataStructureUtil {
       case DENEB -> stateBuilderDeneb(validatorCount, numItemsInSszLists);
       case ELECTRA -> stateBuilderElectra(validatorCount, numItemsInSszLists);
       case FULU -> stateBuilderFulu(validatorCount, numItemsInSszLists);
-      case GLOAS -> stateBuilderGloas(validatorCount, numItemsInSszLists);
+      case GLOAS -> stateBuilderGloas(validatorCount, builderCount, numItemsInSszLists);
     };
   }
 
@@ -2154,9 +2166,11 @@ public final class DataStructureUtil {
   }
 
   public BeaconStateBuilderGloas stateBuilderGloas(
-      final int defaultValidatorCount, final int defaultItemsInSSZLists) {
+      final int defaultValidatorCount,
+      final int defaultBuilderCount,
+      final int defaultItemsInSSZLists) {
     return BeaconStateBuilderGloas.create(
-        this, spec, defaultValidatorCount, defaultItemsInSSZLists);
+        this, spec, defaultValidatorCount, defaultBuilderCount, defaultItemsInSSZLists);
   }
 
   public BeaconState randomBeaconState(final UInt64 slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -88,7 +88,7 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
             .getBlobKzgCommitmentsSchema()
             .createFromBlobsBundle(getPayloadResponse.getBlobsBundle().orElseThrow())
             .hashTreeRoot();
-    // for self-builds, use `BUILDER_INDEX_SELF_BUILD`
+    // For self-builds, use `BUILDER_INDEX_SELF_BUILD`
     final ExecutionPayloadBid bid =
         schemaDefinitions
             .getExecutionPayloadBidSchema()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
 import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatAbbreviatedHashRoot;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -87,13 +88,12 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
             .getBlobKzgCommitmentsSchema()
             .createFromBlobsBundle(getPayloadResponse.getBlobsBundle().orElseThrow())
             .hashTreeRoot();
-    // proposer is the builder
-    final UInt64 builderIndex = UInt64.valueOf(spec.getBeaconProposerIndex(state, slot));
+    // for self-builds, use `BUILDER_INDEX_SELF_BUILD`
     final ExecutionPayloadBid bid =
         schemaDefinitions
             .getExecutionPayloadBidSchema()
             .createLocalSelfBuiltBid(
-                builderIndex, slot, state, executionPayload, blobKzgCommitmentsRoot);
+                BUILDER_INDEX_SELF_BUILD, slot, state, executionPayload, blobKzgCommitmentsRoot);
     // Using G2_POINT_AT_INFINITY as signature for self-builds
     return schemaDefinitions
         .getSignedExecutionPayloadBidSchema()

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -24,7 +25,6 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
@@ -79,8 +79,6 @@ public class DefaultExecutionPayloadBidManagerTest {
 
     final ExecutionPayloadBid bid = signedBid.getMessage();
 
-    final UInt64 expectedBuilderIndex =
-        UInt64.valueOf(spec.getBeaconProposerIndex(state, state.getSlot()));
     final Bytes32 expectedBlobKzgCommitmentsRoot =
         schemaDefinitions
             .getBlobKzgCommitmentsSchema()
@@ -90,7 +88,7 @@ public class DefaultExecutionPayloadBidManagerTest {
         schemaDefinitions
             .getExecutionPayloadBidSchema()
             .createLocalSelfBuiltBid(
-                expectedBuilderIndex,
+                BUILDER_INDEX_SELF_BUILD,
                 state.getSlot(),
                 state,
                 executionPayload,

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/Cache.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/Cache.java
@@ -41,11 +41,6 @@ public interface Cache<K, V> {
   /** Creates independent copy of this Cache instance */
   Cache<K, V> copy();
 
-  /** Creates independent copy of this Cache instance while possibly clearing this cache content */
-  default Cache<K, V> transfer() {
-    return copy();
-  }
-
   /** Removes cache entry */
   void invalidate(K key);
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszByte.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszByte.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.infrastructure.ssz.primitive;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import tech.pegasys.teku.infrastructure.ssz.impl.AbstractSszPrimitive;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszPrimitiveSchema;
@@ -26,6 +28,7 @@ public class SszByte extends AbstractSszPrimitive<Byte> {
   }
 
   public static SszByte asUInt8(final int value) {
+    checkArgument(value >= 0 && value <= 255, "value must be in uint8 range (0–255)");
     return new SszByte((byte) value, SszPrimitiveSchemas.UINT8_SCHEMA);
   }
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -42,6 +42,10 @@ specrefs:
       - RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN
 
       # Not implemented: gloas
+      - PTC_TIMELINESS_INDEX#gloas
+      - NUM_BLOCK_TIMELINESS_DEADLINES#gloas
+      - DOMAIN_PROPOSER_PREFERENCES#gloas
+      - ATTESTATION_TIMELINESS_INDEX#gloas
       - PAYLOAD_STATUS_EMPTY#gloas
       - PAYLOAD_STATUS_FULL#gloas
       - PAYLOAD_STATUS_PENDING#gloas
@@ -59,6 +63,8 @@ specrefs:
 
       # Not implemented: gloas
       - ForkChoiceNode#gloas
+      - ProposerPreferences#gloas
+      - SignedProposerPreferences#gloas
 
     dataclasses:
       # Not defined, implemented differently
@@ -205,6 +211,11 @@ specrefs:
       - update_unrealized_checkpoints#phase0
       - validate_target_epoch_against_current_time#phase0
       - xor#phase0
+      - compute_proposer_score#phase0
+      - get_attestation_score#phase0
+      - is_proposer_equivocation#phase0
+      - record_block_timeliness#phase0
+      - update_proposer_boost_root#phase0
 
       # Not implemented: altair
       - compute_subnets_for_sync_committee#altair
@@ -252,6 +263,8 @@ specrefs:
       - prepare_execution_payload#electra
       - process_execution_payload#electra
       - process_voluntary_exit#electra
+      - is_eligible_for_partial_withdrawals#electra
+      - get_validators_sweep_withdrawals#electra
 
       # Not implemented: fulu
       - compute_matrix#fulu
@@ -300,3 +313,14 @@ specrefs:
       - validate_merge_block#gloas
       - validate_on_attestation#gloas
       - verify_data_column_sidecar#gloas
+      - get_attestation_score#gloas
+      - get_proposer_preferences_signature#gloas
+      - get_upcoming_proposal_slots#gloas
+      - is_head_late#gloas
+      - is_head_weak#gloas
+      - is_parent_strong#gloas
+      - is_valid_proposal_slot#gloas
+      - process_voluntary_exit#gloas
+      - record_block_timeliness#gloas
+      - should_apply_proposer_boost#gloas
+      - update_proposer_boost_root#gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.0
+version: v1.7.0-alpha.1
 style: full
 
 specrefs:

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.6.1
+version: v1.7.0-alpha.0
 style: full
 
 specrefs:
@@ -19,7 +19,6 @@ specrefs:
       - BASIS_POINTS#phase0
       - DOMAIN_APPLICATION_MASK
       - ENDIANNESS
-      - INTERVALS_PER_SLOT#phase0
 
       # Constants for max values, defined elsewhere
       - UINT256_MAX

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -478,6 +478,15 @@
     MESSAGE_DOMAIN_VALID_SNAPPY: DomainType = '0x01000000'
     </spec>
 
+- name: MIN_BUILDER_WITHDRAWABILITY_DELAY#gloas
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
+      search: "MIN_BUILDER_WITHDRAWABILITY_DELAY:"
+  spec: |
+    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="d378428f">
+    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 4096
+    </spec>
+
 - name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS#deneb
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -32,6 +32,24 @@
     BLS_WITHDRAWAL_PREFIX: Bytes1 = '0x00'
     </spec>
 
+- name: BUILDER_INDEX_FLAG#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
+      search: BUILDER_INDEX_FLAG =
+  spec: |
+    <spec constant_var="BUILDER_INDEX_FLAG" fork="gloas" hash="e9dca70d">
+    BUILDER_INDEX_FLAG: uint64 = 2**40
+    </spec>
+
+- name: BUILDER_INDEX_SELF_BUILD#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
+      search: BUILDER_INDEX_SELF_BUILD =
+  spec: |
+    <spec constant_var="BUILDER_INDEX_SELF_BUILD" fork="gloas" hash="622fd1b5">
+    BUILDER_INDEX_SELF_BUILD: BuilderIndex = UINT64_MAX
+    </spec>
+
 - name: BUILDER_PAYMENT_THRESHOLD_DENOMINATOR#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -1,3 +1,10 @@
+- name: ATTESTATION_TIMELINESS_INDEX#gloas
+  sources: []
+  spec: |
+    <spec constant_var="ATTESTATION_TIMELINESS_INDEX" fork="gloas" hash="7d373fc8">
+    ATTESTATION_TIMELINESS_INDEX = 0
+    </spec>
+
 - name: BASE_REWARDS_PER_EPOCH#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -208,6 +215,13 @@
     DOMAIN_DEPOSIT: DomainType = '0x03000000'
     </spec>
 
+- name: DOMAIN_PROPOSER_PREFERENCES#gloas
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_PROPOSER_PREFERENCES" fork="gloas" hash="9377ecfb">
+    DOMAIN_PROPOSER_PREFERENCES: DomainType = '0x0D000000'
+    </spec>
+
 - name: DOMAIN_PTC_ATTESTER#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -399,6 +413,13 @@
     NODE_ID_BITS = 256
     </spec>
 
+- name: NUM_BLOCK_TIMELINESS_DEADLINES#gloas
+  sources: []
+  spec: |
+    <spec constant_var="NUM_BLOCK_TIMELINESS_DEADLINES" fork="gloas" hash="c4e721d9">
+    NUM_BLOCK_TIMELINESS_DEADLINES = 2
+    </spec>
+
 - name: PARTICIPATION_FLAG_WEIGHTS#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/MiscHelpersAltair.java
@@ -443,6 +464,13 @@
   spec: |
     <spec constant_var="PROPOSER_WEIGHT" fork="altair" hash="4dcb6f6c">
     PROPOSER_WEIGHT: uint64 = 8
+    </spec>
+
+- name: PTC_TIMELINESS_INDEX#gloas
+  sources: []
+  spec: |
+    <spec constant_var="PTC_TIMELINESS_INDEX" fork="gloas" hash="ffca13bd">
+    PTC_TIMELINESS_INDEX = 1
     </spec>
 
 - name: RANDOM_CHALLENGE_KZG_BATCH_DOMAIN#deneb

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -150,8 +150,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: BEACON_BUILDER =
   spec: |
-    <spec constant_var="DOMAIN_BEACON_BUILDER" fork="gloas" hash="31821111">
-    DOMAIN_BEACON_BUILDER: DomainType = '0x1B000000'
+    <spec constant_var="DOMAIN_BEACON_BUILDER" fork="gloas" hash="76709e39">
+    DOMAIN_BEACON_BUILDER: DomainType = '0x0B000000'
     </spec>
 
 - name: DOMAIN_BEACON_PROPOSER#phase0
@@ -324,13 +324,6 @@
   spec: |
     <spec constant_var="GENESIS_SLOT" fork="phase0" hash="2d6f8884">
     GENESIS_SLOT: Slot = 0
-    </spec>
-
-- name: INTERVALS_PER_SLOT#phase0
-  sources: []
-  spec: |
-    <spec constant_var="INTERVALS_PER_SLOT" fork="phase0" hash="3352e419">
-    INTERVALS_PER_SLOT: uint64 = 3
     </spec>
 
 - name: JUSTIFICATION_BITS_LENGTH#phase0

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -615,7 +615,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloasImpl.java
   spec: |
-    <spec container="BeaconState" fork="gloas" hash="5da9e0b9">
+    <spec container="BeaconState" fork="gloas" hash="c33b0db2">
     class BeaconState(Container):
         genesis_time: uint64
         genesis_validators_root: Root
@@ -659,6 +659,10 @@
         pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
         proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
         # [New in Gloas:EIP7732]
+        builders: List[Builder, BUILDER_REGISTRY_LIMIT]
+        # [New in Gloas:EIP7732]
+        next_withdrawal_builder_index: BuilderIndex
+        # [New in Gloas:EIP7732]
         execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
         # [New in Gloas:EIP7732]
         builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
@@ -667,7 +671,7 @@
         # [New in Gloas:EIP7732]
         latest_block_hash: Hash32
         # [New in Gloas:EIP7732]
-        latest_withdrawals_root: Root
+        payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     </spec>
 
 - name: BlobIdentifier#deneb
@@ -711,12 +715,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingWithdrawal.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingWithdrawalSchema.java
   spec: |
-    <spec container="BuilderPendingWithdrawal" fork="gloas" hash="ead16c8b">
+    <spec container="BuilderPendingWithdrawal" fork="gloas" hash="0579f0ac">
     class BuilderPendingWithdrawal(Container):
         fee_recipient: ExecutionAddress
         amount: Gwei
-        builder_index: ValidatorIndex
-        withdrawable_epoch: Epoch
+        builder_index: BuilderIndex
     </spec>
 
 - name: Checkpoint#phase0
@@ -953,7 +956,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="aa04e425">
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="aa71ba16">
     class ExecutionPayloadBid(Container):
         parent_block_hash: Hash32
         parent_block_root: Root
@@ -961,7 +964,7 @@
         prev_randao: Bytes32
         fee_recipient: ExecutionAddress
         gas_limit: uint64
-        builder_index: ValidatorIndex
+        builder_index: BuilderIndex
         slot: Slot
         value: Gwei
         execution_payment: Gwei
@@ -973,11 +976,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelope.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelopeSchema.java
   spec: |
-    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="898d1db9">
+    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="cd522f7f">
     class ExecutionPayloadEnvelope(Container):
         payload: ExecutionPayload
         execution_requests: ExecutionRequests
-        builder_index: ValidatorIndex
+        builder_index: BuilderIndex
         beacon_block_root: Root
         slot: Slot
         blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -699,10 +699,24 @@
         kzg_commitment_inclusion_proof: Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]
     </spec>
 
+- name: Builder#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
+  spec: |
+    <spec container="Builder" fork="gloas" hash="ae177179">
+    class Builder(Container):
+        pubkey: BLSPubkey
+        version: uint8
+        execution_address: ExecutionAddress
+        balance: Gwei
+        deposit_epoch: Epoch
+        withdrawable_epoch: Epoch
+    </spec>
+
 - name: BuilderPendingPayment#gloas
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPayment.java
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingPaymentSchema.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingPayment.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingPaymentSchema.java
   spec: |
     <spec container="BuilderPendingPayment" fork="gloas" hash="73cf1649">
     class BuilderPendingPayment(Container):
@@ -712,8 +726,8 @@
 
 - name: BuilderPendingWithdrawal#gloas
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingWithdrawal.java
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BuilderPendingWithdrawalSchema.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingWithdrawal.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingWithdrawalSchema.java
   spec: |
     <spec container="BuilderPendingWithdrawal" fork="gloas" hash="0579f0ac">
     class BuilderPendingWithdrawal(Container):

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -1408,6 +1408,17 @@
         total_difficulty: uint256
     </spec>
 
+- name: ProposerPreferences#gloas
+  sources: []
+  spec: |
+    <spec container="ProposerPreferences" fork="gloas" hash="2a38b149">
+    class ProposerPreferences(Container):
+        proposal_slot: Slot
+        validator_index: ValidatorIndex
+        fee_recipient: ExecutionAddress
+        gas_limit: uint64
+    </spec>
+
 - name: ProposerSlashing#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashing.java
@@ -1502,6 +1513,15 @@
     <spec container="SignedExecutionPayloadEnvelope" fork="gloas" hash="ab8f3404">
     class SignedExecutionPayloadEnvelope(Container):
         message: ExecutionPayloadEnvelope
+        signature: BLSSignature
+    </spec>
+
+- name: SignedProposerPreferences#gloas
+  sources: []
+  spec: |
+    <spec container="SignedProposerPreferences" fork="gloas" hash="2142774c">
+    class SignedProposerPreferences(Container):
+        message: ProposerPreferences
         signature: BLSSignature
     </spec>
 

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -256,10 +256,17 @@
 - name: Store#gloas
   sources: []
   spec: |
-    <spec dataclass="Store" fork="gloas" style="diff" hash="d979eb1c">
+    <spec dataclass="Store" fork="gloas" style="diff" hash="4dbfec46">
     --- phase0
     +++ gloas
-    @@ -13,3 +13,5 @@
+    @@ -9,7 +9,11 @@
+         equivocating_indices: Set[ValidatorIndex]
+         blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
+         block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+    -    block_timeliness: Dict[Root, boolean] = field(default_factory=dict)
+    +    block_timeliness: Dict[Root, Vector[boolean, NUM_BLOCK_TIMELINESS_DEADLINES]] = field(
+    +        default_factory=dict
+    +    )
          checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
          latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
          unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -37,6 +37,46 @@
         blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     </spec>
 
+- name: ExpectedWithdrawals#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
+      search: record ExpectedWithdrawals(
+  spec: |
+    <spec dataclass="ExpectedWithdrawals" fork="capella" hash="73becb4c">
+    class ExpectedWithdrawals(object):
+        withdrawals: Sequence[Withdrawal]
+        processed_sweep_withdrawals_count: uint64
+    </spec>
+
+- name: ExpectedWithdrawals#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
+      search: record ExpectedWithdrawals(
+  spec: |
+    <spec dataclass="ExpectedWithdrawals" fork="electra" hash="a3827f01">
+    class ExpectedWithdrawals(object):
+        withdrawals: Sequence[Withdrawal]
+        # [New in Electra:EIP7251]
+        processed_partial_withdrawals_count: uint64
+        processed_sweep_withdrawals_count: uint64
+    </spec>
+
+- name: ExpectedWithdrawals#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
+      search: record ExpectedWithdrawals(
+  spec: |
+    <spec dataclass="ExpectedWithdrawals" fork="gloas" hash="b32cc9c9">
+    class ExpectedWithdrawals(object):
+        withdrawals: Sequence[Withdrawal]
+        # [New in Gloas:EIP7732]
+        processed_builder_withdrawals_count: uint64
+        processed_partial_withdrawals_count: uint64
+        # [New in Gloas:EIP7732]
+        processed_builders_sweep_count: uint64
+        processed_sweep_withdrawals_count: uint64
+    </spec>
+
 - name: GetPayloadResponse#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1049,7 +1049,7 @@
 - name: compute_matrix#fulu
   sources: []
   spec: |
-    <spec fn="compute_matrix" fork="fulu" hash="b39370ca">
+    <spec fn="compute_matrix" fork="fulu" hash="0b88eac1">
     def compute_matrix(blobs: Sequence[Blob]) -> Sequence[MatrixEntry]:
         """
         Return the full, flattened sequence of matrix entries.
@@ -1065,8 +1065,8 @@
                     MatrixEntry(
                         cell=cell,
                         kzg_proof=proof,
-                        row_index=blob_index,
                         column_index=cell_index,
+                        row_index=blob_index,
                     )
                 )
         return matrix
@@ -1093,7 +1093,7 @@
 - name: compute_on_chain_aggregate#electra
   sources: []
   spec: |
-    <spec fn="compute_on_chain_aggregate" fork="electra" hash="128055d6">
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="f020af4c">
     def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
         aggregates = sorted(
             network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0]
@@ -1114,8 +1114,8 @@
         return Attestation(
             aggregation_bits=aggregation_bits,
             data=data,
-            committee_bits=committee_bits,
             signature=signature,
+            committee_bits=committee_bits,
         )
     </spec>
 
@@ -1972,7 +1972,7 @@
 - name: evaluate_polynomial_in_evaluation_form#deneb
   sources: []
   spec: |
-    <spec fn="evaluate_polynomial_in_evaluation_form" fork="deneb" hash="d4c8a11a">
+    <spec fn="evaluate_polynomial_in_evaluation_form" fork="deneb" hash="7c1a70aa">
     def evaluate_polynomial_in_evaluation_form(
         polynomial: Polynomial, z: BLSFieldElement
     ) -> BLSFieldElement:
@@ -1981,7 +1981,7 @@
         - When ``z`` is in the domain, the evaluation can be found by indexing the polynomial at the
         position that ``z`` is in the domain.
         - When ``z`` is not in the domain, the barycentric formula is used:
-           f(z) = (z**WIDTH - 1) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (z - DOMAIN[i])
+           f(z) = (z**WIDTH - 1) / WIDTH  *  sum_(i=0)^(WIDTH-1) (f(DOMAIN[i]) * DOMAIN[i]) / (z - DOMAIN[i])
         """
         width = len(polynomial)
         assert width == FIELD_ELEMENTS_PER_BLOB
@@ -2243,7 +2243,7 @@
 - name: get_ancestor#gloas
   sources: []
   spec: |
-    <spec fn="get_ancestor" fork="gloas" hash="bc5140b8">
+    <spec fn="get_ancestor" fork="gloas" hash="95b7e8fe">
     def get_ancestor(store: Store, root: Root, slot: Slot) -> ForkChoiceNode:
         """
         Returns the beacon block root and the payload status of the ancestor of the beacon block
@@ -2255,13 +2255,14 @@
             return ForkChoiceNode(root=root, payload_status=PAYLOAD_STATUS_PENDING)
 
         parent = store.blocks[block.parent_root]
-        if parent.slot > slot:
-            return get_ancestor(store, block.parent_root, slot)
-        else:
-            return ForkChoiceNode(
-                root=block.parent_root,
-                payload_status=get_parent_payload_status(store, block),
-            )
+        while parent.slot > slot:
+            block = parent
+            parent = store.blocks[block.parent_root]
+
+        return ForkChoiceNode(
+            root=block.parent_root,
+            payload_status=get_parent_payload_status(store, block),
+        )
     </spec>
 
 - name: get_attestation_component_deltas#phase0
@@ -3427,40 +3428,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: public ExpectedWithdrawals getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="capella" hash="09191977">
-    def get_expected_withdrawals(state: BeaconState) -> Sequence[Withdrawal]:
-        epoch = get_current_epoch(state)
+    <spec fn="get_expected_withdrawals" fork="capella" hash="d6a98c14">
+    def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64]:
         withdrawal_index = state.next_withdrawal_index
-        validator_index = state.next_withdrawal_validator_index
         withdrawals: List[Withdrawal] = []
-        bound = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
-        for _ in range(bound):
-            validator = state.validators[validator_index]
-            balance = state.balances[validator_index]
-            if is_fully_withdrawable_validator(validator, balance, epoch):
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        amount=balance,
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
-            elif is_partially_withdrawable_validator(validator, balance):
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        amount=balance - MAX_EFFECTIVE_BALANCE,
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
-            if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
-                break
-            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
-        return withdrawals
+
+        # Get validators sweep withdrawals
+        validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
+            get_validators_sweep_withdrawals(state, withdrawal_index, withdrawals)
+        )
+        withdrawals.extend(validators_sweep_withdrawals)
+
+        return withdrawals, processed_validators_sweep_count
     </spec>
 
 - name: get_expected_withdrawals#electra
@@ -3468,194 +3447,71 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: public ExpectedWithdrawals getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="electra" hash="060932cd">
-    def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64]:
-        epoch = get_current_epoch(state)
+    <spec fn="get_expected_withdrawals" fork="electra" hash="cfce862b">
+    def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64, uint64]:
         withdrawal_index = state.next_withdrawal_index
-        validator_index = state.next_withdrawal_validator_index
         withdrawals: List[Withdrawal] = []
-        processed_partial_withdrawals_count = 0
 
         # [New in Electra:EIP7251]
-        # Consume pending partial withdrawals
-        for withdrawal in state.pending_partial_withdrawals:
-            if (
-                withdrawal.withdrawable_epoch > epoch
-                or len(withdrawals) == MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
-            ):
-                break
+        # Get partial withdrawals
+        partial_withdrawals, withdrawal_index, processed_partial_withdrawals_count = (
+            get_pending_partial_withdrawals(state, withdrawal_index, withdrawals)
+        )
+        withdrawals.extend(partial_withdrawals)
 
-            validator = state.validators[withdrawal.validator_index]
-            has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
-            total_withdrawn = sum(
-                w.amount for w in withdrawals if w.validator_index == withdrawal.validator_index
-            )
-            balance = state.balances[withdrawal.validator_index] - total_withdrawn
-            has_excess_balance = balance > MIN_ACTIVATION_BALANCE
-            if (
-                validator.exit_epoch == FAR_FUTURE_EPOCH
-                and has_sufficient_effective_balance
-                and has_excess_balance
-            ):
-                withdrawable_balance = min(balance - MIN_ACTIVATION_BALANCE, withdrawal.amount)
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=withdrawal.validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        amount=withdrawable_balance,
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
+        # Get validators sweep withdrawals
+        validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
+            get_validators_sweep_withdrawals(state, withdrawal_index, withdrawals)
+        )
+        withdrawals.extend(validators_sweep_withdrawals)
 
-            processed_partial_withdrawals_count += 1
-
-        # Sweep for remaining.
-        bound = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
-        for _ in range(bound):
-            validator = state.validators[validator_index]
-            # [Modified in Electra:EIP7251]
-            total_withdrawn = sum(w.amount for w in withdrawals if w.validator_index == validator_index)
-            balance = state.balances[validator_index] - total_withdrawn
-            if is_fully_withdrawable_validator(validator, balance, epoch):
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        amount=balance,
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
-            elif is_partially_withdrawable_validator(validator, balance):
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        # [Modified in Electra:EIP7251]
-                        amount=balance - get_max_effective_balance(validator),
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
-            if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
-                break
-            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
-        return withdrawals, processed_partial_withdrawals_count
+        # [Modified in Electra:EIP7251]
+        return withdrawals, processed_partial_withdrawals_count, processed_validators_sweep_count
     </spec>
 
 - name: get_expected_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_expected_withdrawals" fork="gloas" hash="5791eda3">
-    def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64, uint64]:
-        epoch = get_current_epoch(state)
+    <spec fn="get_expected_withdrawals" fork="gloas" hash="950fb815">
+    def get_expected_withdrawals(
+        state: BeaconState,
+    ) -> Tuple[Sequence[Withdrawal], uint64, uint64, uint64, uint64]:
         withdrawal_index = state.next_withdrawal_index
-        validator_index = state.next_withdrawal_validator_index
         withdrawals: List[Withdrawal] = []
-        processed_partial_withdrawals_count = 0
-        processed_builder_withdrawals_count = 0
 
         # [New in Gloas:EIP7732]
-        # Sweep for builder payments
-        for withdrawal in state.builder_pending_withdrawals:
-            if (
-                withdrawal.withdrawable_epoch > epoch
-                or len(withdrawals) + 1 == MAX_WITHDRAWALS_PER_PAYLOAD
-            ):
-                break
-            if is_builder_payment_withdrawable(state, withdrawal):
-                total_withdrawn = sum(
-                    w.amount for w in withdrawals if w.validator_index == withdrawal.builder_index
-                )
-                balance = state.balances[withdrawal.builder_index] - total_withdrawn
-                builder = state.validators[withdrawal.builder_index]
-                if builder.slashed:
-                    withdrawable_balance = min(balance, withdrawal.amount)
-                elif balance > MIN_ACTIVATION_BALANCE:
-                    withdrawable_balance = min(balance - MIN_ACTIVATION_BALANCE, withdrawal.amount)
-                else:
-                    withdrawable_balance = 0
-
-                if withdrawable_balance > 0:
-                    withdrawals.append(
-                        Withdrawal(
-                            index=withdrawal_index,
-                            validator_index=withdrawal.builder_index,
-                            address=withdrawal.fee_recipient,
-                            amount=withdrawable_balance,
-                        )
-                    )
-                    withdrawal_index += WithdrawalIndex(1)
-            processed_builder_withdrawals_count += 1
-
-        # Sweep for pending partial withdrawals
-        bound = min(
-            len(withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
-            MAX_WITHDRAWALS_PER_PAYLOAD - 1,
+        # Get builder withdrawals
+        builder_withdrawals, withdrawal_index, processed_builder_withdrawals_count = (
+            get_builder_withdrawals(state, withdrawal_index, withdrawals)
         )
-        for withdrawal in state.pending_partial_withdrawals:
-            if withdrawal.withdrawable_epoch > epoch or len(withdrawals) == bound:
-                break
+        withdrawals.extend(builder_withdrawals)
 
-            validator = state.validators[withdrawal.validator_index]
-            has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
-            total_withdrawn = sum(
-                w.amount for w in withdrawals if w.validator_index == withdrawal.validator_index
-            )
-            balance = state.balances[withdrawal.validator_index] - total_withdrawn
-            has_excess_balance = balance > MIN_ACTIVATION_BALANCE
-            if (
-                validator.exit_epoch == FAR_FUTURE_EPOCH
-                and has_sufficient_effective_balance
-                and has_excess_balance
-            ):
-                withdrawable_balance = min(balance - MIN_ACTIVATION_BALANCE, withdrawal.amount)
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=withdrawal.validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        amount=withdrawable_balance,
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
+        # Get partial withdrawals
+        partial_withdrawals, withdrawal_index, processed_partial_withdrawals_count = (
+            get_pending_partial_withdrawals(state, withdrawal_index, withdrawals)
+        )
+        withdrawals.extend(partial_withdrawals)
 
-            processed_partial_withdrawals_count += 1
+        # [New in Gloas:EIP7732]
+        # Get builders sweep withdrawals
+        builders_sweep_withdrawals, withdrawal_index, processed_builders_sweep_count = (
+            get_builders_sweep_withdrawals(state, withdrawal_index, withdrawals)
+        )
+        withdrawals.extend(builders_sweep_withdrawals)
 
-        # Sweep for remaining.
-        bound = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
-        for _ in range(bound):
-            validator = state.validators[validator_index]
-            total_withdrawn = sum(w.amount for w in withdrawals if w.validator_index == validator_index)
-            balance = state.balances[validator_index] - total_withdrawn
-            if is_fully_withdrawable_validator(validator, balance, epoch):
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        amount=balance,
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
-            elif is_partially_withdrawable_validator(validator, balance):
-                withdrawals.append(
-                    Withdrawal(
-                        index=withdrawal_index,
-                        validator_index=validator_index,
-                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                        amount=balance - get_max_effective_balance(validator),
-                    )
-                )
-                withdrawal_index += WithdrawalIndex(1)
-            if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
-                break
-            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+        # Get validators sweep withdrawals
+        validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
+            get_validators_sweep_withdrawals(state, withdrawal_index, withdrawals)
+        )
+        withdrawals.extend(validators_sweep_withdrawals)
+
+        # [Modified in Gloas:EIP7732]
         return (
             withdrawals,
             processed_builder_withdrawals_count,
             processed_partial_withdrawals_count,
+            processed_builders_sweep_count,
+            processed_validators_sweep_count,
         )
     </spec>
 
@@ -3749,7 +3605,7 @@
 - name: get_forkchoice_store#gloas
   sources: []
   spec: |
-    <spec fn="get_forkchoice_store" fork="gloas" hash="59983cbd">
+    <spec fn="get_forkchoice_store" fork="gloas" hash="40cb6fd0">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -3773,6 +3629,7 @@
             # [New in Gloas:EIP7732]
             execution_payload_states={anchor_root: copy(anchor_state)},
             ptc_vote={anchor_root: Vector[boolean, PTC_SIZE]()},
+            block_timeliness={anchor_root: [True, True]},
         )
     </spec>
 
@@ -3984,13 +3841,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public IndexedPayloadAttestation getIndexedPayloadAttestation(
   spec: |
-    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="91fab311">
+    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="0e516ffb">
     def get_indexed_payload_attestation(
-        state: BeaconState, slot: Slot, payload_attestation: PayloadAttestation
+        state: BeaconState, payload_attestation: PayloadAttestation
     ) -> IndexedPayloadAttestation:
         """
         Return the indexed payload attestation corresponding to ``payload_attestation``.
         """
+        slot = payload_attestation.data.slot
         ptc = get_ptc(state, slot)
         bits = payload_attestation.aggregation_bits
         attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
@@ -4347,26 +4205,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public UInt64 getPendingBalanceToWithdraw(
   spec: |
-    <spec fn="get_pending_balance_to_withdraw" fork="gloas" hash="e8e7fc8a">
+    <spec fn="get_pending_balance_to_withdraw" fork="gloas" hash="3960d28f">
     def get_pending_balance_to_withdraw(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
-        return (
-            sum(
-                withdrawal.amount
-                for withdrawal in state.pending_partial_withdrawals
-                if withdrawal.validator_index == validator_index
-            )
-            # [New in Gloas:EIP7732]
-            + sum(
-                withdrawal.amount
-                for withdrawal in state.builder_pending_withdrawals
-                if withdrawal.builder_index == validator_index
-            )
-            # [New in Gloas:EIP7732]
-            + sum(
-                payment.withdrawal.amount
-                for payment in state.builder_pending_payments
-                if payment.withdrawal.builder_index == validator_index
-            )
+        return sum(
+            withdrawal.amount
+            for withdrawal in state.pending_partial_withdrawals
+            if withdrawal.validator_index == validator_index
         )
     </spec>
 
@@ -4411,7 +4255,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
       search: public Bytes32 getProposerHead(
   spec: |
-    <spec fn="get_proposer_head" fork="phase0" hash="15d44290">
+    <spec fn="get_proposer_head" fork="phase0" hash="99e8fc05">
     def get_proposer_head(store: Store, head_root: Root, slot: Slot) -> Root:
         head_block = store.blocks[head_root]
         parent_root = head_block.parent_root
@@ -4442,7 +4286,10 @@
         head_weak = is_head_weak(store, head_root)
 
         # Check that the missing votes are assigned to the parent and not being hoarded.
-        parent_strong = is_parent_strong(store, parent_root)
+        parent_strong = is_parent_strong(store, head_root)
+
+        # Re-org more aggressively if there is a proposer equivocation in the previous slot.
+        proposer_equivocation = is_proposer_equivocation(store, head_root)
 
         if all(
             [
@@ -4457,6 +4304,8 @@
             ]
         ):
             # We can re-org the current head by building upon its parent block.
+            return parent_root
+        elif all([head_weak, current_time_ok, proposer_equivocation]):
             return parent_root
         else:
             return head_root
@@ -4489,11 +4338,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getProposerBoostAmount(
   spec: |
-    <spec fn="get_proposer_score" fork="phase0" hash="164b8de0">
+    <spec fn="get_proposer_score" fork="phase0" hash="2c8d8a27">
     def get_proposer_score(store: Store) -> Gwei:
         justified_checkpoint_state = store.checkpoint_states[store.justified_checkpoint]
-        committee_weight = get_total_active_balance(justified_checkpoint_state) // SLOTS_PER_EPOCH
-        return (committee_weight * PROPOSER_SCORE_BOOST) // 100
+        return compute_proposer_score(justified_checkpoint_state)
     </spec>
 
 - name: get_ptc#gloas
@@ -4949,26 +4797,10 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
       search: public Optional<UInt64> getWeight(
   spec: |
-    <spec fn="get_weight" fork="phase0" hash="f2e4e8ef">
+    <spec fn="get_weight" fork="phase0" hash="b18bf25c">
     def get_weight(store: Store, root: Root) -> Gwei:
         state = store.checkpoint_states[store.justified_checkpoint]
-        unslashed_and_active_indices = [
-            i
-            for i in get_active_validator_indices(state, get_current_epoch(state))
-            if not state.validators[i].slashed
-        ]
-        attestation_score = Gwei(
-            sum(
-                state.validators[i].effective_balance
-                for i in unslashed_and_active_indices
-                if (
-                    i in store.latest_messages
-                    and i not in store.equivocating_indices
-                    and get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot)
-                    == root
-                )
-            )
-        )
+        attestation_score = get_attestation_score(store, root, state)
         if store.proposer_boost_root == Root():
             # Return only attestation score if ``proposer_boost_root`` is not set
             return attestation_score
@@ -4984,31 +4816,20 @@
 - name: get_weight#gloas
   sources: []
   spec: |
-    <spec fn="get_weight" fork="gloas" hash="c16cb497">
-    def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
+    <spec fn="get_weight" fork="gloas" hash="10430b82">
+    def get_weight(
+        store: Store,
+        # [Modified in Gloas:EIP7732]
+        node: ForkChoiceNode,
+    ) -> Gwei:
         if node.payload_status == PAYLOAD_STATUS_PENDING or store.blocks[
             node.root
         ].slot + 1 != get_current_slot(store):
             state = store.checkpoint_states[store.justified_checkpoint]
-            unslashed_and_active_indices = [
-                i
-                for i in get_active_validator_indices(state, get_current_epoch(state))
-                if not state.validators[i].slashed
-            ]
-            attestation_score = Gwei(
-                sum(
-                    state.validators[i].effective_balance
-                    for i in unslashed_and_active_indices
-                    if (
-                        i in store.latest_messages
-                        and i not in store.equivocating_indices
-                        and is_supporting_vote(store, node, store.latest_messages[i])
-                    )
-                )
-            )
-
-            if store.proposer_boost_root == Root():
-                # Return only attestation score if `proposer_boost_root` is not set
+            attestation_score = get_attestation_score(store, node, state)
+            if not should_apply_proposer_boost(store):
+                # Return only attestation score if
+                # proposer boost should not apply
                 return attestation_score
 
             # Calculate proposer score if `proposer_boost_root` is set
@@ -5030,19 +4851,6 @@
             return Gwei(0)
     </spec>
 
-- name: has_builder_withdrawal_credential#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
-      search: public boolean hasBuilderWithdrawalCredential(
-  spec: |
-    <spec fn="has_builder_withdrawal_credential" fork="gloas" hash="5376d784">
-    def has_builder_withdrawal_credential(validator: Validator) -> bool:
-        """
-        Check if ``validator`` has an 0x03 prefixed "builder" withdrawal credential.
-        """
-        return is_builder_withdrawal_credential(validator.withdrawal_credentials)
-    </spec>
-
 - name: has_compounding_withdrawal_credential#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
@@ -5061,16 +4869,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
       search: public boolean hasCompoundingWithdrawalCredential(
   spec: |
-    <spec fn="has_compounding_withdrawal_credential" fork="gloas" hash="2d37ec04">
+    <spec fn="has_compounding_withdrawal_credential" fork="gloas" hash="a83f0327">
     def has_compounding_withdrawal_credential(validator: Validator) -> bool:
         """
-        Check if ``validator`` has an 0x02 or 0x03 prefixed withdrawal credential.
+        Check if ``validator`` has an 0x02 prefixed "compounding" withdrawal credential.
         """
-        if is_compounding_withdrawal_credential(validator.withdrawal_credentials):
-            return True
-        if is_builder_withdrawal_credential(validator.withdrawal_credentials):
-            return True
-        return False
+        return is_compounding_withdrawal_credential(validator.withdrawal_credentials)
     </spec>
 
 - name: has_eth1_withdrawal_credential#capella
@@ -5147,7 +4951,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
       search: public BeaconState initializeBeaconStateFromEth1(
   spec: |
-    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="c69537d6">
+    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="d3a0ddd4">
     def initialize_beacon_state_from_eth1(
         eth1_block_hash: Hash32, eth1_timestamp: uint64, deposits: Sequence[Deposit]
     ) -> BeaconState:
@@ -5159,7 +4963,7 @@
         state = BeaconState(
             genesis_time=eth1_timestamp + GENESIS_DELAY,
             fork=fork,
-            eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=uint64(len(deposits))),
+            eth1_data=Eth1Data(deposit_count=uint64(len(deposits)), block_hash=eth1_block_hash),
             latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
             randao_mixes=[eth1_block_hash]
             * EPOCHS_PER_HISTORICAL_VECTOR,  # Seed RANDAO with Eth1 entropy
@@ -5456,23 +5260,6 @@
 
         # Tiebreaker 3: Prefer updates with earlier signature slots
         return new_update.signature_slot < old_update.signature_slot
-    </spec>
-
-- name: is_builder_payment_withdrawable#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
-      search: private boolean isBuilderPaymentWithdrawable(
-  spec: |
-    <spec fn="is_builder_payment_withdrawable" fork="gloas" hash="2a0397c1">
-    def is_builder_payment_withdrawable(
-        state: BeaconState, withdrawal: BuilderPendingWithdrawal
-    ) -> bool:
-        """
-        Check if the builder is slashed and not yet withdrawable.
-        """
-        builder = state.validators[withdrawal.builder_index]
-        current_epoch = compute_epoch_at_slot(state.slot)
-        return builder.withdrawable_epoch >= current_epoch or not builder.slashed
     </spec>
 
 - name: is_builder_withdrawal_credential#gloas
@@ -5793,10 +5580,11 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
       search: boolean isParentStrong(
   spec: |
-    <spec fn="is_parent_strong" fork="phase0" hash="e06641a8">
-    def is_parent_strong(store: Store, parent_root: Root) -> bool:
+    <spec fn="is_parent_strong" fork="phase0" hash="02a3fd0b">
+    def is_parent_strong(store: Store, root: Root) -> bool:
         justified_state = store.checkpoint_states[store.justified_checkpoint]
         parent_threshold = calculate_committee_fraction(justified_state, REORG_PARENT_WEIGHT_THRESHOLD)
+        parent_root = store.blocks[root].parent_root
         parent_weight = get_weight(store, parent_root)
         return parent_weight > parent_threshold
     </spec>
@@ -5943,7 +5731,7 @@
 - name: is_supporting_vote#gloas
   sources: []
   spec: |
-    <spec fn="is_supporting_vote" fork="gloas" hash="c65a637a">
+    <spec fn="is_supporting_vote" fork="gloas" hash="87dd2faf">
     def is_supporting_vote(store: Store, node: ForkChoiceNode, message: LatestMessage) -> bool:
         """
         Returns whether a vote for ``message.root`` supports the chain containing the beacon block ``node.root`` with the
@@ -5959,7 +5747,6 @@
                 return node.payload_status == PAYLOAD_STATUS_FULL
             else:
                 return node.payload_status == PAYLOAD_STATUS_EMPTY
-
         else:
             ancestor = get_ancestor(store, message.root, block.slot)
             return node.root == ancestor.root and (
@@ -6352,7 +6139,7 @@
 - name: notify_ptc_messages#gloas
   sources: []
   spec: |
-    <spec fn="notify_ptc_messages" fork="gloas" hash="2245929f">
+    <spec fn="notify_ptc_messages" fork="gloas" hash="f28f190f">
     def notify_ptc_messages(
         store: Store, state: BeaconState, payload_attestations: Sequence[PayloadAttestation]
     ) -> None:
@@ -6363,9 +6150,7 @@
         if state.slot == 0:
             return
         for payload_attestation in payload_attestations:
-            indexed_payload_attestation = get_indexed_payload_attestation(
-                state, Slot(state.slot - 1), payload_attestation
-            )
+            indexed_payload_attestation = get_indexed_payload_attestation(state, payload_attestation)
             for idx in indexed_payload_attestation.attesting_indices:
                 on_payload_attestation_message(
                     store,
@@ -6432,7 +6217,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="phase0" hash="aff24b59">
+    <spec fn="on_block" fork="phase0" hash="5f45947a">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         block = signed_block.message
         # Parent block must be known
@@ -6462,19 +6247,8 @@
         # Add new state for this block to the store
         store.block_states[block_root] = state
 
-        # Add block timeliness to the store
-        seconds_since_genesis = store.time - store.genesis_time
-        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-        epoch = get_current_store_epoch(store)
-        attestation_threshold_ms = get_attestation_due_ms(epoch)
-        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
-        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
-        store.block_timeliness[hash_tree_root(block)] = is_timely
-
-        # Add proposer score boost if the block is timely and not conflicting with an existing block
-        is_first_block = store.proposer_boost_root == Root()
-        if is_timely and is_first_block:
-            store.proposer_boost_root = hash_tree_root(block)
+        record_block_timeliness(store, block_root)
+        update_proposer_boost_root(store, block_root)
 
         # Update checkpoints in store if necessary
         update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
@@ -6488,7 +6262,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="bellatrix" hash="a3193d92">
+    <spec fn="on_block" fork="bellatrix" hash="e81d01c3">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
@@ -6529,19 +6303,8 @@
         # Add new state for this block to the store
         store.block_states[block_root] = state
 
-        # Add block timeliness to the store
-        seconds_since_genesis = store.time - store.genesis_time
-        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-        epoch = get_current_store_epoch(store)
-        attestation_threshold_ms = get_attestation_due_ms(epoch)
-        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
-        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
-        store.block_timeliness[hash_tree_root(block)] = is_timely
-
-        # Add proposer score boost if the block is timely and not conflicting with an existing block
-        is_first_block = store.proposer_boost_root == Root()
-        if is_timely and is_first_block:
-            store.proposer_boost_root = hash_tree_root(block)
+        record_block_timeliness(store, block_root)
+        update_proposer_boost_root(store, block_root)
 
         # Update checkpoints in store if necessary
         update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
@@ -6555,7 +6318,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="capella" hash="560056ad">
+    <spec fn="on_block" fork="capella" hash="7450531c">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
@@ -6588,19 +6351,8 @@
         # Add new state for this block to the store
         store.block_states[block_root] = state
 
-        # Add block timeliness to the store
-        seconds_since_genesis = store.time - store.genesis_time
-        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-        epoch = get_current_store_epoch(store)
-        attestation_threshold_ms = get_attestation_due_ms(epoch)
-        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
-        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
-        store.block_timeliness[hash_tree_root(block)] = is_timely
-
-        # Add proposer score boost if the block is timely and not conflicting with an existing block
-        is_first_block = store.proposer_boost_root == Root()
-        if is_timely and is_first_block:
-            store.proposer_boost_root = hash_tree_root(block)
+        record_block_timeliness(store, block_root)
+        update_proposer_boost_root(store, block_root)
 
         # Update checkpoints in store if necessary
         update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
@@ -6614,7 +6366,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="deneb" hash="9565acee">
+    <spec fn="on_block" fork="deneb" hash="bbad196e">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
@@ -6652,19 +6404,8 @@
         # Add new state for this block to the store
         store.block_states[block_root] = state
 
-        # Add block timeliness to the store
-        seconds_since_genesis = store.time - store.genesis_time
-        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-        epoch = get_current_store_epoch(store)
-        attestation_threshold_ms = get_attestation_due_ms(epoch)
-        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
-        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
-        store.block_timeliness[hash_tree_root(block)] = is_timely
-
-        # Add proposer score boost if the block is timely and not conflicting with an existing block
-        is_first_block = store.proposer_boost_root == Root()
-        if is_timely and is_first_block:
-            store.proposer_boost_root = hash_tree_root(block)
+        record_block_timeliness(store, block_root)
+        update_proposer_boost_root(store, block_root)
 
         # Update checkpoints in store if necessary
         update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
@@ -6678,7 +6419,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="fulu" hash="4f955de9">
+    <spec fn="on_block" fork="fulu" hash="b8f279b9">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
@@ -6716,19 +6457,8 @@
         # Add new state for this block to the store
         store.block_states[block_root] = state
 
-        # Add block timeliness to the store
-        seconds_since_genesis = store.time - store.genesis_time
-        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-        epoch = get_current_store_epoch(store)
-        attestation_threshold_ms = get_attestation_due_ms(epoch)
-        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
-        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
-        store.block_timeliness[hash_tree_root(block)] = is_timely
-
-        # Add proposer score boost if the block is timely and not conflicting with an existing block
-        is_first_block = store.proposer_boost_root == Root()
-        if is_timely and is_first_block:
-            store.proposer_boost_root = hash_tree_root(block)
+        record_block_timeliness(store, block_root)
+        update_proposer_boost_root(store, block_root)
 
         # Update checkpoints in store if necessary
         update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
@@ -6740,7 +6470,7 @@
 - name: on_block#gloas
   sources: []
   spec: |
-    <spec fn="on_block" fork="gloas" hash="690a9aa0">
+    <spec fn="on_block" fork="gloas" hash="0a135554">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
@@ -6789,19 +6519,9 @@
 
         # Notify the store about the payload_attestations in the block
         notify_ptc_messages(store, state, block.body.payload_attestations)
-        # Add proposer score boost if the block is timely
-        seconds_since_genesis = store.time - store.genesis_time
-        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-        epoch = get_current_store_epoch(store)
-        attestation_threshold_ms = get_attestation_due_ms(epoch)
-        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
-        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
-        store.block_timeliness[hash_tree_root(block)] = is_timely
 
-        # Add proposer score boost if the block is timely and not conflicting with an existing block
-        is_first_block = store.proposer_boost_root == Root()
-        if is_timely and is_first_block:
-            store.proposer_boost_root = hash_tree_root(block)
+        record_block_timeliness(store, block_root)
+        update_proposer_boost_root(store, block_root)
 
         # Update checkpoints in store if necessary
         update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
@@ -6839,12 +6559,13 @@
 - name: on_payload_attestation_message#gloas
   sources: []
   spec: |
-    <spec fn="on_payload_attestation_message" fork="gloas" hash="71fe48d3">
+    <spec fn="on_payload_attestation_message" fork="gloas" hash="e801d849">
     def on_payload_attestation_message(
         store: Store, ptc_message: PayloadAttestationMessage, is_from_block: bool = False
     ) -> None:
         """
-        Run ``on_payload_attestation_message`` upon receiving a new ``ptc_message`` directly on the wire.
+        Run ``on_payload_attestation_message`` upon receiving a new ``ptc_message`` from
+        either within a block or directly on the wire.
         """
         # The beacon block root must be known
         data = ptc_message.data
@@ -6978,10 +6699,10 @@
 - name: prepare_execution_payload#capella
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="capella" style="diff" hash="28db1590">
+    <spec fn="prepare_execution_payload" fork="capella" style="diff" hash="c258893e">
     --- bellatrix
     +++ capella
-    @@ -4,28 +4,14 @@
+    @@ -4,28 +4,16 @@
          finalized_block_hash: Hash32,
          suggested_fee_recipient: ExecutionAddress,
          execution_engine: ExecutionEngine,
@@ -6995,20 +6716,21 @@
     -        )
     -        if is_terminal_block_hash_set and not is_activation_epoch_reached:
     -            return None
-    -
+    +    parent_hash = state.latest_execution_payload_header.block_hash
+
     -        terminal_pow_block = get_terminal_pow_block(pow_chain)
     -        if terminal_pow_block is None:
     -            return None
     -        parent_hash = terminal_pow_block.block_hash
     -    else:
     -        parent_hash = state.latest_execution_payload_header.block_hash
-    +    parent_hash = state.latest_execution_payload_header.block_hash
+    +    withdrawals, _ = get_expected_withdrawals(state)
 
          payload_attributes = PayloadAttributes(
              timestamp=compute_time_at_slot(state, state.slot),
              prev_randao=get_randao_mix(state, get_current_epoch(state)),
              suggested_fee_recipient=suggested_fee_recipient,
-    +        withdrawals=get_expected_withdrawals(state),
+    +        withdrawals=withdrawals,
          )
          return execution_engine.notify_forkchoice_updated(
              head_block_hash=parent_hash,
@@ -7017,13 +6739,13 @@
 - name: prepare_execution_payload#deneb
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="deneb" style="diff" hash="f3387ec6">
+    <spec fn="prepare_execution_payload" fork="deneb" style="diff" hash="59f61f3a">
     --- capella
     +++ deneb
-    @@ -12,6 +12,7 @@
+    @@ -14,6 +14,7 @@
              prev_randao=get_randao_mix(state, get_current_epoch(state)),
              suggested_fee_recipient=suggested_fee_recipient,
-             withdrawals=get_expected_withdrawals(state),
+             withdrawals=withdrawals,
     +        parent_beacon_block_root=hash_tree_root(state.latest_block_header),
          )
          return execution_engine.notify_forkchoice_updated(
@@ -7033,30 +6755,24 @@
 - name: prepare_execution_payload#electra
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="electra" style="diff" hash="567b3739">
+    <spec fn="prepare_execution_payload" fork="electra" style="diff" hash="5414b883">
     --- deneb
     +++ electra
-    @@ -7,11 +7,13 @@
+    @@ -7,7 +7,7 @@
      ) -> Optional[PayloadId]:
          parent_hash = state.latest_execution_payload_header.block_hash
 
-    +    withdrawals, _ = get_expected_withdrawals(state)
-    +
+    -    withdrawals, _ = get_expected_withdrawals(state)
+    +    withdrawals, _, _ = get_expected_withdrawals(state)
+
          payload_attributes = PayloadAttributes(
              timestamp=compute_time_at_slot(state, state.slot),
-             prev_randao=get_randao_mix(state, get_current_epoch(state)),
-             suggested_fee_recipient=suggested_fee_recipient,
-    -        withdrawals=get_expected_withdrawals(state),
-    +        withdrawals=withdrawals,
-             parent_beacon_block_root=hash_tree_root(state.latest_block_header),
-         )
-         return execution_engine.notify_forkchoice_updated(
     </spec>
 
 - name: prepare_execution_payload#gloas
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="gloas" hash="3e12a9e7">
+    <spec fn="prepare_execution_payload" fork="gloas" hash="8fdad5cf">
     def prepare_execution_payload(
         state: BeaconState,
         safe_block_hash: Hash32,
@@ -7069,7 +6785,7 @@
 
         # [Modified in Gloas:EIP7732]
         # Set the forkchoice head and initiate the payload build process
-        withdrawals, _, _ = get_expected_withdrawals(state)
+        withdrawals, _, _, _, _ = get_expected_withdrawals(state)
 
         payload_attributes = PayloadAttributes(
             timestamp=compute_time_at_slot(state, state.slot),
@@ -7092,7 +6808,7 @@
       search: protected void processAttestation(
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/AttestationDataValidatorPhase0.java
   spec: |
-    <spec fn="process_attestation" fork="phase0" hash="6ac78cd0">
+    <spec fn="process_attestation" fork="phase0" hash="d8e86aa9">
     def process_attestation(state: BeaconState, attestation: Attestation) -> None:
         data = attestation.data
         assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
@@ -7104,8 +6820,8 @@
         assert len(attestation.aggregation_bits) == len(committee)
 
         pending_attestation = PendingAttestation(
-            data=data,
             aggregation_bits=attestation.aggregation_bits,
+            data=data,
             inclusion_delay=state.slot - data.slot,
             proposer_index=get_beacon_proposer_index(state),
         )
@@ -7556,18 +7272,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/statetransition/epoch/EpochProcessorGloas.java
       search: public void processBuilderPendingPayments(
   spec: |
-    <spec fn="process_builder_pending_payments" fork="gloas" hash="04362ccc">
+    <spec fn="process_builder_pending_payments" fork="gloas" hash="10da48dd">
     def process_builder_pending_payments(state: BeaconState) -> None:
         """
         Processes the builder pending payments from the previous epoch.
         """
         quorum = get_builder_payment_quorum_threshold(state)
         for payment in state.builder_pending_payments[:SLOTS_PER_EPOCH]:
-            if payment.weight > quorum:
-                amount = payment.withdrawal.amount
-                exit_queue_epoch = compute_exit_epoch_and_update_churn(state, amount)
-                withdrawable_epoch = exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
-                payment.withdrawal.withdrawable_epoch = Epoch(withdrawable_epoch)
+            if payment.weight >= quorum:
                 state.builder_pending_withdrawals.append(payment.withdrawal)
 
         old_payments = state.builder_pending_payments[SLOTS_PER_EPOCH:]
@@ -8227,7 +7939,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
       search: public void processUnsignedExecutionPayload(
   spec: |
-    <spec fn="process_execution_payload" fork="gloas" hash="b1cc7efc">
+    <spec fn="process_execution_payload" fork="gloas" hash="98cceb7d">
     def process_execution_payload(
         state: BeaconState,
         # [Modified in Gloas:EIP7732]
@@ -8260,8 +7972,8 @@
         assert committed_bid.blob_kzg_commitments_root == hash_tree_root(envelope.blob_kzg_commitments)
         assert committed_bid.prev_randao == payload.prev_randao
 
-        # Verify the withdrawals root
-        assert hash_tree_root(payload.withdrawals) == state.latest_withdrawals_root
+        # Verify consistency with expected withdrawals
+        assert hash_tree_root(payload.withdrawals) == hash_tree_root(state.payload_expected_withdrawals)
 
         # Verify the gas_limit
         assert committed_bid.gas_limit == payload.gas_limit
@@ -8302,10 +8014,6 @@
         payment = state.builder_pending_payments[SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH]
         amount = payment.withdrawal.amount
         if amount > 0:
-            exit_queue_epoch = compute_exit_epoch_and_update_churn(state, amount)
-            payment.withdrawal.withdrawable_epoch = Epoch(
-                exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
-            )
             state.builder_pending_withdrawals.append(payment.withdrawal)
         state.builder_pending_payments[SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH] = (
             BuilderPendingPayment()
@@ -8325,42 +8033,24 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void processExecutionPayloadBid(
   spec: |
-    <spec fn="process_execution_payload_bid" fork="gloas" hash="d8bba25d">
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="6dc696bb">
     def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> None:
         signed_bid = block.body.signed_execution_payload_bid
         bid = signed_bid.message
         builder_index = bid.builder_index
-        builder = state.validators[builder_index]
-
         amount = bid.value
+
         # For self-builds, amount must be zero regardless of withdrawal credential prefix
-        if builder_index == block.proposer_index:
+        if builder_index == BUILDER_INDEX_SELF_BUILD:
             assert amount == 0
             assert signed_bid.signature == bls.G2_POINT_AT_INFINITY
         else:
-            # Non-self builds require builder withdrawal credential
-            assert has_builder_withdrawal_credential(builder)
+            # Verify that the builder is active
+            assert is_active_builder(state, builder_index)
+            # Verify that the builder has funds to cover the bid
+            assert can_builder_cover_bid(state, builder_index, amount)
+            # Verify that the bid signature is valid
             assert verify_execution_payload_bid_signature(state, signed_bid)
-
-        assert is_active_validator(builder, get_current_epoch(state))
-        assert not builder.slashed
-
-        # Check that the builder is active, non-slashed, and has funds to cover the bid
-        pending_payments = sum(
-            payment.withdrawal.amount
-            for payment in state.builder_pending_payments
-            if payment.withdrawal.builder_index == builder_index
-        )
-        pending_withdrawals = sum(
-            withdrawal.amount
-            for withdrawal in state.builder_pending_withdrawals
-            if withdrawal.builder_index == builder_index
-        )
-        assert (
-            amount == 0
-            or state.balances[builder_index]
-            >= amount + pending_payments + pending_withdrawals + MIN_ACTIVATION_BALANCE
-        )
 
         # Verify that the bid is for the current slot
         assert bid.slot == block.slot
@@ -8377,7 +8067,6 @@
                     fee_recipient=bid.fee_recipient,
                     amount=amount,
                     builder_index=builder_index,
-                    withdrawable_epoch=FAR_FUTURE_EPOCH,
                 ),
             )
             state.builder_pending_payments[SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH] = (
@@ -8704,7 +8393,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void processOperationsNoValidation(
   spec: |
-    <spec fn="process_operations" fork="gloas" hash="ba4ce754">
+    <spec fn="process_operations" fork="gloas" hash="05a7a4ea">
     def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
         # Disable former deposit mechanism once all prior deposits are processed
         eth1_deposit_index_limit = min(
@@ -8727,6 +8416,7 @@
         # [Modified in Gloas:EIP7732]
         for_ops(body.attestations, process_attestation)
         for_ops(body.deposits, process_deposit)
+        # [Modified in Gloas:EIP7732]
         for_ops(body.voluntary_exits, process_voluntary_exit)
         for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
         # [Modified in Gloas:EIP7732]
@@ -8769,7 +8459,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void processPayloadAttestations(
   spec: |
-    <spec fn="process_payload_attestation" fork="gloas" hash="a299be3b">
+    <spec fn="process_payload_attestation" fork="gloas" hash="f46bf0b0">
     def process_payload_attestation(
         state: BeaconState, payload_attestation: PayloadAttestation
     ) -> None:
@@ -8780,9 +8470,7 @@
         # Check that the attestation is for the previous slot
         assert data.slot + 1 == state.slot
         # Verify signature
-        indexed_payload_attestation = get_indexed_payload_attestation(
-            state, data.slot, payload_attestation
-        )
+        indexed_payload_attestation = get_indexed_payload_attestation(state, payload_attestation)
         assert is_valid_indexed_payload_attestation(state, indexed_payload_attestation)
     </spec>
 
@@ -9526,31 +9214,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="capella" hash="ed6a9c5a">
+    <spec fn="process_withdrawals" fork="capella" hash="901f9fc4">
     def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
-        expected_withdrawals = get_expected_withdrawals(state)
-        assert payload.withdrawals == expected_withdrawals
+        # Get expected withdrawals
+        withdrawals, processed_validators_sweep_count = get_expected_withdrawals(state)
+        assert payload.withdrawals == withdrawals
 
-        for withdrawal in expected_withdrawals:
-            decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
+        # Apply expected withdrawals
+        apply_withdrawals(state, withdrawals)
 
-        # Update the next withdrawal index if this block contained withdrawals
-        if len(expected_withdrawals) != 0:
-            latest_withdrawal = expected_withdrawals[-1]
-            state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
-
-        # Update the next validator index to start the next withdrawal sweep
-        if len(expected_withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
-            # Next sweep starts after the latest withdrawal's validator index
-            next_validator_index = ValidatorIndex(
-                (expected_withdrawals[-1].validator_index + 1) % len(state.validators)
-            )
-            state.next_withdrawal_validator_index = next_validator_index
-        else:
-            # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
-            next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
-            next_validator_index = ValidatorIndex(next_index % len(state.validators))
-            state.next_withdrawal_validator_index = next_validator_index
+        # Update withdrawals fields in the state
+        update_next_withdrawal_index(state, withdrawals)
+        update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
     </spec>
 
 - name: process_withdrawals#electra
@@ -9558,39 +9233,23 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="electra" hash="dd99a91f">
+    <spec fn="process_withdrawals" fork="electra" hash="67870972">
     def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
         # [Modified in Electra:EIP7251]
-        expected_withdrawals, processed_partial_withdrawals_count = get_expected_withdrawals(state)
+        # Get expected withdrawals
+        withdrawals, processed_partial_withdrawals_count, processed_validators_sweep_count = (
+            get_expected_withdrawals(state)
+        )
+        assert payload.withdrawals == withdrawals
 
-        assert payload.withdrawals == expected_withdrawals
+        # Apply expected withdrawals
+        apply_withdrawals(state, withdrawals)
 
-        for withdrawal in expected_withdrawals:
-            decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
-
+        # Update withdrawals fields in the state
+        update_next_withdrawal_index(state, withdrawals)
         # [New in Electra:EIP7251]
-        # Update pending partial withdrawals
-        state.pending_partial_withdrawals = state.pending_partial_withdrawals[
-            processed_partial_withdrawals_count:
-        ]
-
-        # Update the next withdrawal index if this block contained withdrawals
-        if len(expected_withdrawals) != 0:
-            latest_withdrawal = expected_withdrawals[-1]
-            state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
-
-        # Update the next validator index to start the next withdrawal sweep
-        if len(expected_withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
-            # Next sweep starts after the latest withdrawal's validator index
-            next_validator_index = ValidatorIndex(
-                (expected_withdrawals[-1].validator_index + 1) % len(state.validators)
-            )
-            state.next_withdrawal_validator_index = next_validator_index
-        else:
-            # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
-            next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
-            next_validator_index = ValidatorIndex(next_index % len(state.validators))
-            state.next_withdrawal_validator_index = next_validator_index
+        update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)
+        update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
     </spec>
 
 - name: process_withdrawals#gloas
@@ -9598,7 +9257,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="gloas" hash="505dadda">
+    <spec fn="process_withdrawals" fork="gloas" hash="3caee596">
     def process_withdrawals(
         state: BeaconState,
         # [Modified in Gloas:EIP7732]
@@ -9610,45 +9269,28 @@
             return
 
         # [Modified in Gloas:EIP7732]
-        # Get information about the expected withdrawals
-        withdrawals, processed_builder_withdrawals_count, processed_partial_withdrawals_count = (
-            get_expected_withdrawals(state)
-        )
-        withdrawals_list = List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](withdrawals)
-        state.latest_withdrawals_root = hash_tree_root(withdrawals_list)
-        for withdrawal in withdrawals:
-            decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
+        # Get expected withdrawals
+        (
+            withdrawals,
+            processed_builder_withdrawals_count,
+            processed_partial_withdrawals_count,
+            processed_builders_sweep_count,
+            processed_validators_sweep_count,
+        ) = get_expected_withdrawals(state)
 
+        # Apply expected withdrawals
+        apply_withdrawals(state, withdrawals)
+
+        # Update withdrawals fields in the state
+        update_next_withdrawal_index(state, withdrawals)
         # [New in Gloas:EIP7732]
-        # Update the pending builder withdrawals
-        state.builder_pending_withdrawals = [
-            w
-            for w in state.builder_pending_withdrawals[:processed_builder_withdrawals_count]
-            if not is_builder_payment_withdrawable(state, w)
-        ] + state.builder_pending_withdrawals[processed_builder_withdrawals_count:]
-
-        # Update pending partial withdrawals
-        state.pending_partial_withdrawals = state.pending_partial_withdrawals[
-            processed_partial_withdrawals_count:
-        ]
-
-        # Update the next withdrawal index if this block contained withdrawals
-        if len(withdrawals) != 0:
-            latest_withdrawal = withdrawals[-1]
-            state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
-
-        # Update the next validator index to start the next withdrawal sweep
-        if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
-            # Next sweep starts after the latest withdrawal's validator index
-            next_validator_index = ValidatorIndex(
-                (withdrawals[-1].validator_index + 1) % len(state.validators)
-            )
-            state.next_withdrawal_validator_index = next_validator_index
-        else:
-            # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
-            next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
-            next_validator_index = ValidatorIndex(next_index % len(state.validators))
-            state.next_withdrawal_validator_index = next_validator_index
+        update_payload_expected_withdrawals(state, withdrawals)
+        # [New in Gloas:EIP7732]
+        update_builder_pending_withdrawals(state, processed_builder_withdrawals_count)
+        update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)
+        # [New in Gloas:EIP7732]
+        update_next_withdrawal_builder_index(state, processed_builders_sweep_count)
+        update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
     </spec>
 
 - name: queue_excess_active_balance#electra
@@ -9722,7 +9364,7 @@
 - name: recover_matrix#fulu
   sources: []
   spec: |
-    <spec fn="recover_matrix" fork="fulu" hash="9b01f005">
+    <spec fn="recover_matrix" fork="fulu" hash="3db21f50">
     def recover_matrix(
         partial_matrix: Sequence[MatrixEntry], blob_count: uint64
     ) -> Sequence[MatrixEntry]:
@@ -9742,8 +9384,8 @@
                     MatrixEntry(
                         cell=cell,
                         kzg_proof=proof,
-                        row_index=blob_index,
                         column_index=cell_index,
+                        row_index=blob_index,
                     )
                 )
         return matrix
@@ -9892,7 +9534,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/client/LateBlockReorgLogic.java
       search: public boolean shouldOverrideForkChoiceUpdate(
   spec: |
-    <spec fn="should_override_forkchoice_update" fork="bellatrix" hash="9a8043af">
+    <spec fn="should_override_forkchoice_update" fork="bellatrix" hash="c055d92a">
     def should_override_forkchoice_update(store: Store, head_root: Root) -> bool:
         head_block = store.blocks[head_root]
         parent_root = head_block.parent_root
@@ -9933,7 +9575,7 @@
         # `store.time` early, or by counting queued attestations during the head block's slot.
         if current_slot > head_block.slot:
             head_weak = is_head_weak(store, head_root)
-            parent_strong = is_parent_strong(store, parent_root)
+            parent_strong = is_parent_strong(store, head_root)
         else:
             head_weak = True
             parent_strong = True
@@ -10949,7 +10591,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: public BeaconStateGloas upgrade(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="d2c34d52">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="855ad3f7">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -11003,6 +10645,10 @@
             pending_consolidations=pre.pending_consolidations,
             proposer_lookahead=pre.proposer_lookahead,
             # [New in Gloas:EIP7732]
+            builders=[],
+            # [New in Gloas:EIP7732]
+            next_withdrawal_builder_index=BuilderIndex(0),
+            # [New in Gloas:EIP7732]
             execution_payload_availability=[0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)],
             # [New in Gloas:EIP7732]
             builder_pending_payments=[BuilderPendingPayment() for _ in range(2 * SLOTS_PER_EPOCH)],
@@ -11011,7 +10657,7 @@
             # [New in Gloas:EIP7732]
             latest_block_hash=pre.latest_execution_payload_header.block_hash,
             # [New in Gloas:EIP7732]
-            latest_withdrawals_root=Root(),
+            payload_expected_withdrawals=[],
         )
 
         return post
@@ -11151,7 +10797,7 @@
 - name: validate_merge_block#gloas
   sources: []
   spec: |
-    <spec fn="validate_merge_block" fork="gloas" hash="1b577110">
+    <spec fn="validate_merge_block" fork="gloas" hash="d51209cc">
     def validate_merge_block(block: BeaconBlock) -> None:
         """
         Check the parent PoW block of execution payload is a valid terminal PoW block.
@@ -11163,12 +10809,10 @@
         if TERMINAL_BLOCK_HASH != Hash32():
             # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
             assert compute_epoch_at_slot(block.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
-            assert (
-                block.body.signed_execution_payload_bid.message.parent_block_hash == TERMINAL_BLOCK_HASH
-            )
+            assert block.body.execution_payload.parent_hash == TERMINAL_BLOCK_HASH
             return
 
-        pow_block = get_pow_block(block.body.signed_execution_payload_bid.message.parent_block_hash)
+        pow_block = get_pow_block(block.body.execution_payload.parent_hash)
         # Check if `pow_block` is available
         assert pow_block is not None
         pow_parent = get_pow_block(pow_block.parent_hash)
@@ -11647,11 +11291,11 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
       search: public boolean verifyExecutionPayloadBidSignature(
   spec: |
-    <spec fn="verify_execution_payload_bid_signature" fork="gloas" hash="cbe813b1">
+    <spec fn="verify_execution_payload_bid_signature" fork="gloas" hash="8a3e3a8d">
     def verify_execution_payload_bid_signature(
         state: BeaconState, signed_bid: SignedExecutionPayloadBid
     ) -> bool:
-        builder = state.validators[signed_bid.message.builder_index]
+        builder = state.builders[signed_bid.message.builder_index]
         signing_root = compute_signing_root(
             signed_bid.message, get_domain(state, DOMAIN_BEACON_BUILDER)
         )
@@ -11663,15 +11307,21 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionPayloadProcessorGloas.java
       search: private boolean verifyExecutionPayloadEnvelopeSignature(
   spec: |
-    <spec fn="verify_execution_payload_envelope_signature" fork="gloas" hash="a85e73c3">
+    <spec fn="verify_execution_payload_envelope_signature" fork="gloas" hash="49483ae2">
     def verify_execution_payload_envelope_signature(
         state: BeaconState, signed_envelope: SignedExecutionPayloadEnvelope
     ) -> bool:
-        builder = state.validators[signed_envelope.message.builder_index]
+        builder_index = signed_envelope.message.builder_index
+        if builder_index == BUILDER_INDEX_SELF_BUILD:
+            validator_index = state.latest_block_header.proposer_index
+            pubkey = state.validators[validator_index].pubkey
+        else:
+            pubkey = state.builders[builder_index].pubkey
+
         signing_root = compute_signing_root(
             signed_envelope.message, get_domain(state, DOMAIN_BEACON_BUILDER)
         )
-        return bls.Verify(builder.pubkey, signing_root, signed_envelope.signature)
+        return bls.Verify(pubkey, signing_root, signed_envelope.signature)
     </spec>
 
 - name: verify_kzg_proof#deneb

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -17,6 +17,20 @@
         return o
     </spec>
 
+- name: add_builder_to_registry#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+      search: public void addBuilderToRegistry(
+  spec: |
+    <spec fn="add_builder_to_registry" fork="gloas" hash="938224ec">
+    def add_builder_to_registry(
+        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+    ) -> None:
+        index = get_index_for_new_builder(state)
+        builder = get_builder_from_deposit(state, pubkey, withdrawal_credentials, amount)
+        set_or_append_list(state.builders, index, builder)
+    </spec>
+
 - name: add_flag#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/MiscHelpersAltair.java
@@ -152,6 +166,30 @@
         )
     </spec>
 
+- name: apply_deposit_for_builder#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+      search: public void applyDepositForBuilder(
+  spec: |
+    <spec fn="apply_deposit_for_builder" fork="gloas" hash="eae84bc2">
+    def apply_deposit_for_builder(
+        state: BeaconState,
+        pubkey: BLSPubkey,
+        withdrawal_credentials: Bytes32,
+        amount: uint64,
+        signature: BLSSignature,
+    ) -> None:
+        builder_pubkeys = [b.pubkey for b in state.builders]
+        if pubkey not in builder_pubkeys:
+            # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
+            if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
+                add_builder_to_registry(state, pubkey, withdrawal_credentials, amount)
+        else:
+            # Increase balance by deposit amount
+            builder_index = builder_pubkeys.index(pubkey)
+            state.builders[builder_index].balance += amount
+    </spec>
+
 - name: apply_light_client_update#altair
   sources: []
   spec: |
@@ -197,6 +235,34 @@
         else:
             validator_index = ValidatorIndex(validator_pubkeys.index(deposit.pubkey))
             increase_balance(state, validator_index, deposit.amount)
+    </spec>
+
+- name: apply_withdrawals#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+      search: protected void applyWithdrawals(
+  spec: |
+    <spec fn="apply_withdrawals" fork="capella" hash="fa29f504">
+    def apply_withdrawals(state: BeaconState, withdrawals: Sequence[Withdrawal]) -> None:
+        for withdrawal in withdrawals:
+            decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
+    </spec>
+
+- name: apply_withdrawals#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: protected void applyWithdrawals(
+  spec: |
+    <spec fn="apply_withdrawals" fork="gloas" hash="4231861d">
+    def apply_withdrawals(state: BeaconState, withdrawals: Sequence[Withdrawal]) -> None:
+        for withdrawal in withdrawals:
+            # [Modified in Gloas:EIP7732]
+            if is_builder_index(withdrawal.validator_index):
+                builder_index = convert_validator_index_to_builder_index(withdrawal.validator_index)
+                builder_balance = state.builders[builder_index].balance
+                state.builders[builder_index].balance -= min(withdrawal.amount, builder_balance)
+            else:
+                decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
     </spec>
 
 - name: bit_reversal_permutation#deneb
@@ -393,6 +459,23 @@
     def calculate_committee_fraction(state: BeaconState, committee_percent: uint64) -> Gwei:
         committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
         return Gwei((committee_weight * committee_percent) // 100)
+    </spec>
+
+- name: can_builder_cover_bid#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public boolean canBuilderCoverBid(
+  spec: |
+    <spec fn="can_builder_cover_bid" fork="gloas" hash="9e3f2d7c">
+    def can_builder_cover_bid(
+        state: BeaconState, builder_index: BuilderIndex, bid_amount: Gwei
+    ) -> bool:
+        builder_balance = state.builders[builder_index].balance
+        pending_withdrawals_amount = get_pending_balance_to_withdraw_for_builder(state, builder_index)
+        min_balance = MIN_DEPOSIT_AMOUNT + pending_withdrawals_amount
+        if builder_balance < min_balance:
+            return False
+        return builder_balance - min_balance >= bid_amount
     </spec>
 
 - name: cell_to_coset_evals#fulu
@@ -1657,6 +1740,26 @@
         return zero_poly_coeff
     </spec>
 
+- name: convert_builder_index_to_validator_index#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public UInt64 convertBuilderIndexToValidatorIndex(
+  spec: |
+    <spec fn="convert_builder_index_to_validator_index" fork="gloas" hash="c416de6c">
+    def convert_builder_index_to_validator_index(builder_index: BuilderIndex) -> ValidatorIndex:
+        return ValidatorIndex(builder_index | BUILDER_INDEX_FLAG)
+    </spec>
+
+- name: convert_validator_index_to_builder_index#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+      search: public UInt64 convertValidatorIndexToBuilderIndex(
+  spec: |
+    <spec fn="convert_validator_index_to_builder_index" fork="gloas" hash="2fea5b47">
+    def convert_validator_index_to_builder_index(validator_index: ValidatorIndex) -> BuilderIndex:
+        return BuilderIndex(validator_index & ~BUILDER_INDEX_FLAG)
+    </spec>
+
 - name: coset_evals_to_cell#fulu
   sources: []
   spec: |
@@ -2551,6 +2654,25 @@
         return output
     </spec>
 
+- name: get_balance_after_withdrawals#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+      search: protected UInt64 getBalanceAfterWithdrawals(
+  spec: |
+    <spec fn="get_balance_after_withdrawals" fork="capella" hash="d01eedbb">
+    def get_balance_after_withdrawals(
+        state: BeaconState,
+        validator_index: ValidatorIndex,
+        withdrawals: Sequence[Withdrawal],
+    ) -> Gwei:
+        withdrawn = sum(
+            withdrawal.amount
+            for withdrawal in withdrawals
+            if withdrawal.validator_index == validator_index
+        )
+        return state.balances[validator_index] - withdrawn
+    </spec>
+
 - name: get_balance_churn_limit#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
@@ -2760,6 +2882,25 @@
         return bls.Sign(privkey, signing_root)
     </spec>
 
+- name: get_builder_from_deposit#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public Builder getBuilderFromDeposit(
+  spec: |
+    <spec fn="get_builder_from_deposit" fork="gloas" hash="7f914af6">
+    def get_builder_from_deposit(
+        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+    ) -> Builder:
+        return Builder(
+            pubkey=pubkey,
+            version=uint8(withdrawal_credentials[0]),
+            execution_address=ExecutionAddress(withdrawal_credentials[12:]),
+            balance=amount,
+            deposit_epoch=get_current_epoch(state),
+            withdrawable_epoch=FAR_FUTURE_EPOCH,
+        )
+    </spec>
+
 - name: get_builder_payment_quorum_threshold#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -2773,6 +2914,84 @@
         per_slot_balance = get_total_active_balance(state) // SLOTS_PER_EPOCH
         quorum = per_slot_balance * BUILDER_PAYMENT_THRESHOLD_NUMERATOR
         return uint64(quorum // BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
+    </spec>
+
+- name: get_builder_withdrawals#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: protected int processBuilderWithdrawals(
+  spec: |
+    <spec fn="get_builder_withdrawals" fork="gloas" hash="35cd32cd">
+    def get_builder_withdrawals(
+        state: BeaconState,
+        withdrawal_index: WithdrawalIndex,
+        prior_withdrawals: Sequence[Withdrawal],
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+
+        processed_count: uint64 = 0
+        withdrawals: List[Withdrawal] = []
+        for withdrawal in state.builder_pending_withdrawals:
+            all_withdrawals = prior_withdrawals + withdrawals
+            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            if has_reached_limit:
+                break
+
+            builder_index = withdrawal.builder_index
+            withdrawals.append(
+                Withdrawal(
+                    index=withdrawal_index,
+                    validator_index=convert_builder_index_to_validator_index(builder_index),
+                    address=withdrawal.fee_recipient,
+                    amount=withdrawal.amount,
+                )
+            )
+            withdrawal_index += WithdrawalIndex(1)
+            processed_count += 1
+
+        return withdrawals, withdrawal_index, processed_count
+    </spec>
+
+- name: get_builders_sweep_withdrawals#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: protected int processBuildersSweepWithdrawals(
+  spec: |
+    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="028d161d">
+    def get_builders_sweep_withdrawals(
+        state: BeaconState,
+        withdrawal_index: WithdrawalIndex,
+        prior_withdrawals: Sequence[Withdrawal],
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+        epoch = get_current_epoch(state)
+        builders_limit = min(len(state.builders), MAX_BUILDERS_PER_WITHDRAWALS_SWEEP)
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+
+        processed_count: uint64 = 0
+        withdrawals: List[Withdrawal] = []
+        builder_index = state.next_withdrawal_builder_index
+        for _ in range(builders_limit):
+            all_withdrawals = prior_withdrawals + withdrawals
+            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            if has_reached_limit:
+                break
+
+            builder = state.builders[builder_index]
+            if builder.withdrawable_epoch <= epoch and builder.balance > 0:
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=convert_builder_index_to_validator_index(builder_index),
+                        address=builder.execution_address,
+                        amount=builder.balance,
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+
+            builder_index = BuilderIndex((builder_index + 1) % len(state.builders))
+            processed_count += 1
+
+        return withdrawals, withdrawal_index, processed_count
     </spec>
 
 - name: get_checkpoint_block#phase0
@@ -3809,6 +4028,19 @@
         return rewards, penalties
     </spec>
 
+- name: get_index_for_new_builder#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+      search: public UInt64 getIndexForNewBuilder(
+  spec: |
+    <spec fn="get_index_for_new_builder" fork="gloas" hash="82dfbdb5">
+    def get_index_for_new_builder(state: BeaconState) -> BuilderIndex:
+        for index, builder in enumerate(state.builders):
+            if builder.withdrawable_epoch <= get_current_epoch(state) and builder.balance == 0:
+                return BuilderIndex(index)
+        return BuilderIndex(len(state.builders))
+    </spec>
+
 - name: get_index_for_new_validator#altair
   sources: []
   spec: |
@@ -4200,18 +4432,70 @@
         )
     </spec>
 
-- name: get_pending_balance_to_withdraw#gloas
+- name: get_pending_balance_to_withdraw_for_builder#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
-      search: public UInt64 getPendingBalanceToWithdraw(
+      search: public UInt64 getPendingBalanceToWithdrawForBuilder(
   spec: |
-    <spec fn="get_pending_balance_to_withdraw" fork="gloas" hash="3960d28f">
-    def get_pending_balance_to_withdraw(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
+    <spec fn="get_pending_balance_to_withdraw_for_builder" fork="gloas" hash="a5d10dc1">
+    def get_pending_balance_to_withdraw_for_builder(
+        state: BeaconState, builder_index: BuilderIndex
+    ) -> Gwei:
         return sum(
             withdrawal.amount
-            for withdrawal in state.pending_partial_withdrawals
-            if withdrawal.validator_index == validator_index
+            for withdrawal in state.builder_pending_withdrawals
+            if withdrawal.builder_index == builder_index
+        ) + sum(
+            payment.withdrawal.amount
+            for payment in state.builder_pending_payments
+            if payment.withdrawal.builder_index == builder_index
         )
+    </spec>
+
+- name: get_pending_partial_withdrawals#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+      search: protected int processPendingPartialWithdrawals(
+  spec: |
+    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="b53b25d7">
+    def get_pending_partial_withdrawals(
+        state: BeaconState,
+        withdrawal_index: WithdrawalIndex,
+        prior_withdrawals: Sequence[Withdrawal],
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+        epoch = get_current_epoch(state)
+        withdrawals_limit = min(
+            len(prior_withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
+            MAX_WITHDRAWALS_PER_PAYLOAD - 1,
+        )
+
+        processed_count: uint64 = 0
+        withdrawals: List[Withdrawal] = []
+        for withdrawal in state.pending_partial_withdrawals:
+            all_withdrawals = prior_withdrawals + withdrawals
+            is_withdrawable = withdrawal.withdrawable_epoch <= epoch
+            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            if not is_withdrawable or has_reached_limit:
+                break
+
+            validator_index = withdrawal.validator_index
+            validator = state.validators[validator_index]
+            balance = get_balance_after_withdrawals(state, validator_index, all_withdrawals)
+            if is_eligible_for_partial_withdrawals(validator, balance):
+                withdrawal_amount = min(balance - MIN_ACTIVATION_BALANCE, withdrawal.amount)
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        amount=withdrawal_amount,
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+
+            processed_count += 1
+
+        return withdrawals, withdrawal_index, processed_count
     </spec>
 
 - name: get_pow_block_at_terminal_total_difficulty#bellatrix
@@ -4772,6 +5056,111 @@
         return min(max(count, VALIDATOR_CUSTODY_REQUIREMENT), NUMBER_OF_CUSTODY_GROUPS)
     </spec>
 
+- name: get_validators_sweep_withdrawals#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+      search: protected int processValidatorsSweepWithdrawals(
+  spec: |
+    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="81868c81">
+    def get_validators_sweep_withdrawals(
+        state: BeaconState,
+        withdrawal_index: WithdrawalIndex,
+        prior_withdrawals: Sequence[Withdrawal],
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+        epoch = get_current_epoch(state)
+        validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+
+        processed_count: uint64 = 0
+        withdrawals: List[Withdrawal] = []
+        validator_index = state.next_withdrawal_validator_index
+        for _ in range(validators_limit):
+            all_withdrawals = prior_withdrawals + withdrawals
+            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            if has_reached_limit:
+                break
+
+            validator = state.validators[validator_index]
+            balance = get_balance_after_withdrawals(state, validator_index, all_withdrawals)
+            if is_fully_withdrawable_validator(validator, balance, epoch):
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        amount=balance,
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+            elif is_partially_withdrawable_validator(validator, balance):
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        amount=balance - MAX_EFFECTIVE_BALANCE,
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+
+            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+            processed_count += 1
+
+        return withdrawals, withdrawal_index, processed_count
+    </spec>
+
+- name: get_validators_sweep_withdrawals#electra
+  sources: []
+  spec: |
+    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="74bbd437">
+    def get_validators_sweep_withdrawals(
+        state: BeaconState,
+        withdrawal_index: WithdrawalIndex,
+        prior_withdrawals: Sequence[Withdrawal],
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+        epoch = get_current_epoch(state)
+        validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+
+        processed_count: uint64 = 0
+        withdrawals: List[Withdrawal] = []
+        validator_index = state.next_withdrawal_validator_index
+        for _ in range(validators_limit):
+            all_withdrawals = prior_withdrawals + withdrawals
+            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            if has_reached_limit:
+                break
+
+            validator = state.validators[validator_index]
+            balance = get_balance_after_withdrawals(state, validator_index, all_withdrawals)
+            if is_fully_withdrawable_validator(validator, balance, epoch):
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        amount=balance,
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+            elif is_partially_withdrawable_validator(validator, balance):
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=validator_index,
+                        address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                        # [Modified in Electra:EIP7251]
+                        amount=balance - get_max_effective_balance(validator),
+                    )
+                )
+                withdrawal_index += WithdrawalIndex(1)
+
+            validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+            processed_count += 1
+
+        return withdrawals, withdrawal_index, processed_count
+    </spec>
+
 - name: get_voting_source#phase0
   sources: []
   spec: |
@@ -4857,19 +5246,6 @@
       search: public boolean hasCompoundingWithdrawalCredential(
   spec: |
     <spec fn="has_compounding_withdrawal_credential" fork="electra" hash="a83f0327">
-    def has_compounding_withdrawal_credential(validator: Validator) -> bool:
-        """
-        Check if ``validator`` has an 0x02 prefixed "compounding" withdrawal credential.
-        """
-        return is_compounding_withdrawal_credential(validator.withdrawal_credentials)
-    </spec>
-
-- name: has_compounding_withdrawal_credential#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
-      search: public boolean hasCompoundingWithdrawalCredential(
-  spec: |
-    <spec fn="has_compounding_withdrawal_credential" fork="gloas" hash="a83f0327">
     def has_compounding_withdrawal_credential(validator: Validator) -> bool:
         """
         Check if ``validator`` has an 0x02 prefixed "compounding" withdrawal credential.
@@ -5040,6 +5416,25 @@
         return lookahead
     </spec>
 
+- name: initiate_builder_exit#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+      search: public void initiateBuilderExit(
+  spec: |
+    <spec fn="initiate_builder_exit" fork="gloas" hash="3da938d5">
+    def initiate_builder_exit(state: BeaconState, builder_index: BuilderIndex) -> None:
+        """
+        Initiate the exit of the builder with index ``index``.
+        """
+        # Return if builder already initiated exit
+        builder = state.builders[builder_index]
+        if builder.withdrawable_epoch != FAR_FUTURE_EPOCH:
+            return
+
+        # Set builder exit epoch
+        builder.withdrawable_epoch = get_current_epoch(state) + MIN_BUILDER_WITHDRAWABILITY_DELAY
+    </spec>
+
 - name: initiate_validator_exit#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -5134,6 +5529,25 @@
                     )
             r = add_polynomialcoeff(r, summand)
         return r
+    </spec>
+
+- name: is_active_builder#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+      search: public boolean isActiveBuilder(final BeaconState state, final UInt64 builderIndex)
+  spec: |
+    <spec fn="is_active_builder" fork="gloas" hash="1a599fb2">
+    def is_active_builder(state: BeaconState, builder_index: BuilderIndex) -> bool:
+        """
+        Check if the builder at ``builder_index`` is active for the given ``state``.
+        """
+        builder = state.builders[builder_index]
+        return (
+            # Placement in builder list is finalized
+            builder.deposit_epoch < state.finalized_checkpoint.epoch
+            # Has not initiated exit
+            and builder.withdrawable_epoch == FAR_FUTURE_EPOCH
+        )
     </spec>
 
 - name: is_active_validator#phase0
@@ -5260,6 +5674,16 @@
 
         # Tiebreaker 3: Prefer updates with earlier signature slots
         return new_update.signature_slot < old_update.signature_slot
+    </spec>
+
+- name: is_builder_index#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
+      search: public boolean isBuilderIndex(
+  spec: |
+    <spec fn="is_builder_index" fork="gloas" hash="2fbd46e9">
+    def is_builder_index(validator_index: ValidatorIndex) -> bool:
+        return (validator_index & BUILDER_INDEX_FLAG) != 0
     </spec>
 
 - name: is_builder_withdrawal_credential#gloas
@@ -7430,7 +7854,7 @@
 - name: process_deposit_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
-      search: public void processDepositRequests(
+      search: protected void processDepositRequest(
   spec: |
     <spec fn="process_deposit_request" fork="electra" hash="547c4a35">
     def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
@@ -7439,6 +7863,46 @@
             state.deposit_requests_start_index = deposit_request.index
 
         # Create pending deposit
+        state.pending_deposits.append(
+            PendingDeposit(
+                pubkey=deposit_request.pubkey,
+                withdrawal_credentials=deposit_request.withdrawal_credentials,
+                amount=deposit_request.amount,
+                signature=deposit_request.signature,
+                slot=state.slot,
+            )
+        )
+    </spec>
+
+- name: process_deposit_request#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+      search: protected void processDepositRequest(
+  spec: |
+    <spec fn="process_deposit_request" fork="gloas" hash="50ffbd27">
+    def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
+        # [New in Gloas:EIP7732]
+        builder_pubkeys = [b.pubkey for b in state.builders]
+        validator_pubkeys = [v.pubkey for v in state.validators]
+
+        # [New in Gloas:EIP7732]
+        # Regardless of the withdrawal credentials prefix, if a builder/validator
+        # already exists with this pubkey, apply the deposit to their balance
+        is_builder = deposit_request.pubkey in builder_pubkeys
+        is_validator = deposit_request.pubkey in validator_pubkeys
+        is_builder_prefix = is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
+        if is_builder or (is_builder_prefix and not is_validator):
+            # Apply builder deposits immediately
+            apply_deposit_for_builder(
+                state,
+                deposit_request.pubkey,
+                deposit_request.withdrawal_credentials,
+                deposit_request.amount,
+                deposit_request.signature,
+            )
+            return
+
+        # Add validator deposits to the queue
         state.pending_deposits.append(
             PendingDeposit(
                 pubkey=deposit_request.pubkey,
@@ -9134,6 +9598,49 @@
          )
     </spec>
 
+- name: process_voluntary_exit#gloas
+  sources: []
+  spec: |
+    <spec fn="process_voluntary_exit" fork="gloas" hash="2a22a698">
+    def process_voluntary_exit(state: BeaconState, signed_voluntary_exit: SignedVoluntaryExit) -> None:
+        voluntary_exit = signed_voluntary_exit.message
+        domain = compute_domain(
+            DOMAIN_VOLUNTARY_EXIT, CAPELLA_FORK_VERSION, state.genesis_validators_root
+        )
+        signing_root = compute_signing_root(voluntary_exit, domain)
+
+        # Exits must specify an epoch when they become valid; they are not valid before then
+        assert get_current_epoch(state) >= voluntary_exit.epoch
+
+        # [New in Gloas:EIP7732]
+        if is_builder_index(voluntary_exit.validator_index):
+            builder_index = convert_validator_index_to_builder_index(voluntary_exit.validator_index)
+            # Verify the builder is active
+            assert is_active_builder(state, builder_index)
+            # Only exit builder if it has no pending withdrawals in the queue
+            assert get_pending_balance_to_withdraw_for_builder(state, builder_index) == 0
+            # Verify signature
+            pubkey = state.builders[builder_index].pubkey
+            assert bls.Verify(pubkey, signing_root, signed_voluntary_exit.signature)
+            # Initiate exit
+            initiate_builder_exit(state, builder_index)
+            return
+
+        validator = state.validators[voluntary_exit.validator_index]
+        # Verify the validator is active
+        assert is_active_validator(validator, get_current_epoch(state))
+        # Verify exit has not been initiated
+        assert validator.exit_epoch == FAR_FUTURE_EPOCH
+        # Verify the validator has been active long enough
+        assert get_current_epoch(state) >= validator.activation_epoch + SHARD_COMMITTEE_PERIOD
+        # Only exit validator if it has no pending withdrawals in the queue
+        assert get_pending_balance_to_withdraw(state, voluntary_exit.validator_index) == 0
+        # Verify signature
+        assert bls.Verify(validator.pubkey, signing_root, signed_voluntary_exit.signature)
+        # Initiate exit
+        initiate_validator_exit(state, voluntary_exit.validator_index)
+    </spec>
+
 - name: process_withdrawal_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -9316,6 +9823,41 @@
                     slot=GENESIS_SLOT,
                 )
             )
+    </spec>
+
+- name: record_block_timeliness#phase0
+  sources: []
+  spec: |
+    <spec fn="record_block_timeliness" fork="phase0" hash="5c584f56">
+    def record_block_timeliness(store: Store, root: Root) -> None:
+        block = store.blocks[root]
+        seconds_since_genesis = store.time - store.genesis_time
+        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
+        epoch = get_current_store_epoch(store)
+        attestation_threshold_ms = get_attestation_due_ms(epoch)
+        is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
+        is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
+        store.block_timeliness[root] = is_timely
+    </spec>
+
+- name: record_block_timeliness#gloas
+  sources: []
+  spec: |
+    <spec fn="record_block_timeliness" fork="gloas" hash="f4bc2c5a">
+    def record_block_timeliness(store: Store, root: Root) -> None:
+        block = store.blocks[root]
+        seconds_since_genesis = store.time - store.genesis_time
+        time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
+        epoch = get_current_store_epoch(store)
+        attestation_threshold_ms = get_attestation_due_ms(epoch)
+        # [New in Gloas:EIP7732]
+        is_current_slot = get_current_slot(store) == block.slot
+        ptc_threshold_ms = get_payload_attestation_due_ms(epoch)
+        # [Modified in Gloas:EIP7732]
+        store.block_timeliness[root] = [
+            is_current_slot and time_into_slot_ms < threshold
+            for threshold in [attestation_threshold_ms, ptc_threshold_ms]
+        ]
     </spec>
 
 - name: recover_cells_and_kzg_proofs#fulu
@@ -9513,6 +10055,43 @@
             list.append(value)
         else:
             list[index] = value
+    </spec>
+
+- name: should_apply_proposer_boost#gloas
+  sources: []
+  spec: |
+    <spec fn="should_apply_proposer_boost" fork="gloas" hash="a18e5701">
+    def should_apply_proposer_boost(store: Store) -> bool:
+        if store.proposer_boost_root == Root():
+            return False
+
+        block = store.blocks[store.proposer_boost_root]
+        parent_root = block.parent_root
+        parent = store.blocks[parent_root]
+        slot = block.slot
+
+        # Apply proposer boost if `parent` is not from the previous slot
+        if parent.slot + 1 < slot:
+            return True
+
+        # Apply proposer boost if `parent` is not weak
+        if not is_head_weak(store, parent_root):
+            return True
+
+        # If `parent` is weak and from the previous slot, apply
+        # proposer boost if there are no early equivocations
+        equivocations = [
+            root
+            for root, block in store.blocks.items()
+            if (
+                store.block_timeliness[root][PTC_TIMELINESS_INDEX]
+                and block.proposer_index == parent.proposer_index
+                and block.slot + 1 == slot
+                and root != parent_root
+            )
+        ]
+
+        return len(equivocations) == 0
     </spec>
 
 - name: should_extend_payload#gloas
@@ -9814,6 +10393,20 @@
                     epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
     </spec>
 
+- name: update_builder_pending_withdrawals#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: protected void updateBuilderPendingWithdrawals(
+  spec: |
+    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="0cbba9bd">
+    def update_builder_pending_withdrawals(
+        state: BeaconState, processed_builder_withdrawals_count: uint64
+    ) -> None:
+        state.builder_pending_withdrawals = state.builder_pending_withdrawals[
+            processed_builder_withdrawals_count:
+        ]
+    </spec>
+
 - name: update_checkpoints#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -9870,6 +10463,119 @@
                 store.latest_messages[i] = LatestMessage(
                     slot=slot, root=beacon_block_root, payload_present=payload_present
                 )
+    </spec>
+
+- name: update_next_withdrawal_builder_index#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: protected void updateNextWithdrawalBuilderIndex(
+  spec: |
+    <spec fn="update_next_withdrawal_builder_index" fork="gloas" hash="652c72b5">
+    def update_next_withdrawal_builder_index(
+        state: BeaconState, processed_builders_sweep_count: uint64
+    ) -> None:
+        if len(state.builders) > 0:
+            # Update the next builder index to start the next withdrawal sweep
+            next_index = state.next_withdrawal_builder_index + processed_builders_sweep_count
+            next_builder_index = BuilderIndex(next_index % len(state.builders))
+            state.next_withdrawal_builder_index = next_builder_index
+    </spec>
+
+- name: update_next_withdrawal_index#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+      search: protected void updateNextWithdrawalIndex(
+  spec: |
+    <spec fn="update_next_withdrawal_index" fork="capella" hash="a9e9baa5">
+    def update_next_withdrawal_index(state: BeaconState, withdrawals: Sequence[Withdrawal]) -> None:
+        # Update the next withdrawal index if this block contained withdrawals
+        if len(withdrawals) != 0:
+            latest_withdrawal = withdrawals[-1]
+            state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
+    </spec>
+
+- name: update_next_withdrawal_validator_index#capella
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+      search: protected void updateNextWithdrawalValidatorIndex(
+  spec: |
+    <spec fn="update_next_withdrawal_validator_index" fork="capella" hash="98095ea6">
+    def update_next_withdrawal_validator_index(
+        state: BeaconState, processed_validators_sweep_count: uint64
+    ) -> None:
+        # Update the next validator index to start the next withdrawal sweep
+        next_index = state.next_withdrawal_validator_index + processed_validators_sweep_count
+        next_validator_index = ValidatorIndex(next_index % len(state.validators))
+        state.next_withdrawal_validator_index = next_validator_index
+    </spec>
+
+- name: update_payload_expected_withdrawals#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
+      search: protected void updatePayloadExpectedWithdrawals(
+  spec: |
+    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="6a3810b9">
+    def update_payload_expected_withdrawals(
+        state: BeaconState, withdrawals: Sequence[Withdrawal]
+    ) -> None:
+        state.payload_expected_withdrawals = List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](withdrawals)
+    </spec>
+
+- name: update_pending_partial_withdrawals#electra
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+      search: protected void updatePendingPartialWithdrawals(
+  spec: |
+    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="dcdd6c8f">
+    def update_pending_partial_withdrawals(
+        state: BeaconState, processed_partial_withdrawals_count: uint64
+    ) -> None:
+        state.pending_partial_withdrawals = state.pending_partial_withdrawals[
+            processed_partial_withdrawals_count:
+        ]
+    </spec>
+
+- name: update_proposer_boost_root#phase0
+  sources: []
+  spec: |
+    <spec fn="update_proposer_boost_root" fork="phase0" hash="f037a32d">
+    def update_proposer_boost_root(store: Store, root: Root) -> None:
+        is_first_block = store.proposer_boost_root == Root()
+        is_timely = store.block_timeliness[root]
+
+        # Add proposer score boost if the block is timely, not conflicting with an
+        # existing block, with the same the proposer as the canonical chain.
+        if is_timely and is_first_block:
+            head_state = copy(store.block_states[get_head(store)])
+            slot = get_current_slot(store)
+            if head_state.slot < slot:
+                process_slots(head_state, slot)
+            block = store.blocks[root]
+            # Only update if the proposer is the same as on the canonical chain
+            if block.proposer_index == get_beacon_proposer_index(head_state):
+                store.proposer_boost_root = root
+    </spec>
+
+- name: update_proposer_boost_root#gloas
+  sources: []
+  spec: |
+    <spec fn="update_proposer_boost_root" fork="gloas" hash="d813a162">
+    def update_proposer_boost_root(store: Store, root: Root) -> None:
+        is_first_block = store.proposer_boost_root == Root()
+        # [Modified in Gloas:EIP7732]
+        is_timely = store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]
+
+        # Add proposer score boost if the block is the first timely block
+        # for this slot, with the same proposer as the canonical chain.
+        if is_timely and is_first_block:
+            head_state = copy(store.block_states[get_head(store).root])
+            slot = get_current_slot(store)
+            if head_state.slot < slot:
+                process_slots(head_state, slot)
+            block = store.blocks[root]
+            # Only update if the proposer is the same as on the canonical chain
+            if block.proposer_index == get_beacon_proposer_index(head_state):
+                store.proposer_boost_root = root
     </spec>
 
 - name: update_unrealized_checkpoints#phase0

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3711,8 +3711,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: public ExpectedWithdrawals getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="capella" hash="d6a98c14">
-    def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64]:
+    <spec fn="get_expected_withdrawals" fork="capella" hash="12088347">
+    def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
         withdrawals: List[Withdrawal] = []
 
@@ -3722,7 +3722,10 @@
         )
         withdrawals.extend(validators_sweep_withdrawals)
 
-        return withdrawals, processed_validators_sweep_count
+        return ExpectedWithdrawals(
+            withdrawals,
+            processed_validators_sweep_count,
+        )
     </spec>
 
 - name: get_expected_withdrawals#electra
@@ -3730,8 +3733,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: public ExpectedWithdrawals getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="electra" hash="cfce862b">
-    def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64, uint64]:
+    <spec fn="get_expected_withdrawals" fork="electra" hash="254541e3">
+    def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
         withdrawals: List[Withdrawal] = []
 
@@ -3748,17 +3751,19 @@
         )
         withdrawals.extend(validators_sweep_withdrawals)
 
-        # [Modified in Electra:EIP7251]
-        return withdrawals, processed_partial_withdrawals_count, processed_validators_sweep_count
+        return ExpectedWithdrawals(
+            withdrawals,
+            # [New in Electra:EIP7251]
+            processed_partial_withdrawals_count,
+            processed_validators_sweep_count,
+        )
     </spec>
 
 - name: get_expected_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_expected_withdrawals" fork="gloas" hash="950fb815">
-    def get_expected_withdrawals(
-        state: BeaconState,
-    ) -> Tuple[Sequence[Withdrawal], uint64, uint64, uint64, uint64]:
+    <spec fn="get_expected_withdrawals" fork="gloas" hash="8d0675cb">
+    def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
         withdrawals: List[Withdrawal] = []
 
@@ -3788,11 +3793,12 @@
         )
         withdrawals.extend(validators_sweep_withdrawals)
 
-        # [Modified in Gloas:EIP7732]
-        return (
+        return ExpectedWithdrawals(
             withdrawals,
+            # [New in Gloas:EIP7732]
             processed_builder_withdrawals_count,
             processed_partial_withdrawals_count,
+            # [New in Gloas:EIP7732]
             processed_builders_sweep_count,
             processed_validators_sweep_count,
         )
@@ -7314,10 +7320,10 @@
 - name: prepare_execution_payload#capella
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="capella" style="diff" hash="c258893e">
+    <spec fn="prepare_execution_payload" fork="capella" style="diff" hash="998e8b92">
     --- bellatrix
     +++ capella
-    @@ -4,28 +4,16 @@
+    @@ -4,28 +4,14 @@
          finalized_block_hash: Hash32,
          suggested_fee_recipient: ExecutionAddress,
          execution_engine: ExecutionEngine,
@@ -7331,21 +7337,20 @@
     -        )
     -        if is_terminal_block_hash_set and not is_activation_epoch_reached:
     -            return None
-    +    parent_hash = state.latest_execution_payload_header.block_hash
-
+    -
     -        terminal_pow_block = get_terminal_pow_block(pow_chain)
     -        if terminal_pow_block is None:
     -            return None
     -        parent_hash = terminal_pow_block.block_hash
     -    else:
     -        parent_hash = state.latest_execution_payload_header.block_hash
-    +    withdrawals, _ = get_expected_withdrawals(state)
+    +    parent_hash = state.latest_execution_payload_header.block_hash
 
          payload_attributes = PayloadAttributes(
              timestamp=compute_time_at_slot(state, state.slot),
              prev_randao=get_randao_mix(state, get_current_epoch(state)),
              suggested_fee_recipient=suggested_fee_recipient,
-    +        withdrawals=withdrawals,
+    +        withdrawals=get_expected_withdrawals(state).withdrawals,
          )
          return execution_engine.notify_forkchoice_updated(
              head_block_hash=parent_hash,
@@ -7354,13 +7359,13 @@
 - name: prepare_execution_payload#deneb
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="deneb" style="diff" hash="59f61f3a">
+    <spec fn="prepare_execution_payload" fork="deneb" style="diff" hash="c617aa1b">
     --- capella
     +++ deneb
-    @@ -14,6 +14,7 @@
+    @@ -12,6 +12,7 @@
              prev_randao=get_randao_mix(state, get_current_epoch(state)),
              suggested_fee_recipient=suggested_fee_recipient,
-             withdrawals=withdrawals,
+             withdrawals=get_expected_withdrawals(state).withdrawals,
     +        parent_beacon_block_root=hash_tree_root(state.latest_block_header),
          )
          return execution_engine.notify_forkchoice_updated(
@@ -7370,24 +7375,23 @@
 - name: prepare_execution_payload#electra
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="electra" style="diff" hash="5414b883">
-    --- deneb
+    <spec fn="prepare_execution_payload" fork="electra" style="diff" hash="c617aa1b">
+    --- capella
     +++ electra
-    @@ -7,7 +7,7 @@
-     ) -> Optional[PayloadId]:
-         parent_hash = state.latest_execution_payload_header.block_hash
-
-    -    withdrawals, _ = get_expected_withdrawals(state)
-    +    withdrawals, _, _ = get_expected_withdrawals(state)
-
-         payload_attributes = PayloadAttributes(
-             timestamp=compute_time_at_slot(state, state.slot),
+    @@ -12,6 +12,7 @@
+             prev_randao=get_randao_mix(state, get_current_epoch(state)),
+             suggested_fee_recipient=suggested_fee_recipient,
+             withdrawals=get_expected_withdrawals(state).withdrawals,
+    +        parent_beacon_block_root=hash_tree_root(state.latest_block_header),
+         )
+         return execution_engine.notify_forkchoice_updated(
+             head_block_hash=parent_hash,
     </spec>
 
 - name: prepare_execution_payload#gloas
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="gloas" hash="8fdad5cf">
+    <spec fn="prepare_execution_payload" fork="gloas" hash="c617aa1b">
     def prepare_execution_payload(
         state: BeaconState,
         safe_block_hash: Hash32,
@@ -7395,18 +7399,16 @@
         suggested_fee_recipient: ExecutionAddress,
         execution_engine: ExecutionEngine,
     ) -> Optional[PayloadId]:
-        # Verify consistency of the parent hash with respect to the previous execution payload bid
-        parent_hash = state.latest_execution_payload_bid.block_hash
+        # Verify consistency of the parent hash with respect to the previous execution payload header
+        parent_hash = state.latest_execution_payload_header.block_hash
 
-        # [Modified in Gloas:EIP7732]
         # Set the forkchoice head and initiate the payload build process
-        withdrawals, _, _, _, _ = get_expected_withdrawals(state)
-
         payload_attributes = PayloadAttributes(
             timestamp=compute_time_at_slot(state, state.slot),
             prev_randao=get_randao_mix(state, get_current_epoch(state)),
             suggested_fee_recipient=suggested_fee_recipient,
-            withdrawals=withdrawals,
+            withdrawals=get_expected_withdrawals(state).withdrawals,
+            # [New in Deneb:EIP4788]
             parent_beacon_block_root=hash_tree_root(state.latest_block_header),
         )
         return execution_engine.notify_forkchoice_updated(
@@ -9912,18 +9914,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="capella" hash="901f9fc4">
+    <spec fn="process_withdrawals" fork="capella" hash="47327ef6">
     def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
         # Get expected withdrawals
-        withdrawals, processed_validators_sweep_count = get_expected_withdrawals(state)
-        assert payload.withdrawals == withdrawals
+        expected = get_expected_withdrawals(state)
+        assert payload.withdrawals == expected.withdrawals
 
         # Apply expected withdrawals
-        apply_withdrawals(state, withdrawals)
+        apply_withdrawals(state, expected.withdrawals)
 
         # Update withdrawals fields in the state
-        update_next_withdrawal_index(state, withdrawals)
-        update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
+        update_next_withdrawal_index(state, expected.withdrawals)
+        update_next_withdrawal_validator_index(state, expected.withdrawals)
     </spec>
 
 - name: process_withdrawals#electra
@@ -9931,23 +9933,20 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="electra" hash="67870972">
+    <spec fn="process_withdrawals" fork="electra" hash="24a50daa">
     def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
-        # [Modified in Electra:EIP7251]
         # Get expected withdrawals
-        withdrawals, processed_partial_withdrawals_count, processed_validators_sweep_count = (
-            get_expected_withdrawals(state)
-        )
-        assert payload.withdrawals == withdrawals
+        expected = get_expected_withdrawals(state)
+        assert payload.withdrawals == expected.withdrawals
 
         # Apply expected withdrawals
-        apply_withdrawals(state, withdrawals)
+        apply_withdrawals(state, expected.withdrawals)
 
         # Update withdrawals fields in the state
-        update_next_withdrawal_index(state, withdrawals)
+        update_next_withdrawal_index(state, expected.withdrawals)
         # [New in Electra:EIP7251]
-        update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)
-        update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
+        update_pending_partial_withdrawals(state, expected.processed_partial_withdrawals_count)
+        update_next_withdrawal_validator_index(state, expected.withdrawals)
     </spec>
 
 - name: process_withdrawals#gloas
@@ -9955,7 +9954,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: public void processWithdrawals(
   spec: |
-    <spec fn="process_withdrawals" fork="gloas" hash="3caee596">
+    <spec fn="process_withdrawals" fork="gloas" hash="16d9ad2a">
     def process_withdrawals(
         state: BeaconState,
         # [Modified in Gloas:EIP7732]
@@ -9966,29 +9965,22 @@
         if not is_parent_block_full(state):
             return
 
-        # [Modified in Gloas:EIP7732]
         # Get expected withdrawals
-        (
-            withdrawals,
-            processed_builder_withdrawals_count,
-            processed_partial_withdrawals_count,
-            processed_builders_sweep_count,
-            processed_validators_sweep_count,
-        ) = get_expected_withdrawals(state)
+        expected = get_expected_withdrawals(state)
 
         # Apply expected withdrawals
-        apply_withdrawals(state, withdrawals)
+        apply_withdrawals(state, expected.withdrawals)
 
         # Update withdrawals fields in the state
-        update_next_withdrawal_index(state, withdrawals)
+        update_next_withdrawal_index(state, expected.withdrawals)
         # [New in Gloas:EIP7732]
-        update_payload_expected_withdrawals(state, withdrawals)
+        update_payload_expected_withdrawals(state, expected.withdrawals)
         # [New in Gloas:EIP7732]
-        update_builder_pending_withdrawals(state, processed_builder_withdrawals_count)
-        update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)
+        update_builder_pending_withdrawals(state, expected.processed_builder_withdrawals_count)
+        update_pending_partial_withdrawals(state, expected.processed_partial_withdrawals_count)
         # [New in Gloas:EIP7732]
-        update_next_withdrawal_builder_index(state, processed_builders_sweep_count)
-        update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
+        update_next_withdrawal_builder_index(state, expected.processed_builders_sweep_count)
+        update_next_withdrawal_validator_index(state, expected.withdrawals)
     </spec>
 
 - name: queue_excess_active_balance#electra
@@ -10690,14 +10682,22 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: protected void updateNextWithdrawalValidatorIndex(
   spec: |
-    <spec fn="update_next_withdrawal_validator_index" fork="capella" hash="98095ea6">
+    <spec fn="update_next_withdrawal_validator_index" fork="capella" hash="4a3ee635">
     def update_next_withdrawal_validator_index(
-        state: BeaconState, processed_validators_sweep_count: uint64
+        state: BeaconState, withdrawals: Sequence[Withdrawal]
     ) -> None:
         # Update the next validator index to start the next withdrawal sweep
-        next_index = state.next_withdrawal_validator_index + processed_validators_sweep_count
-        next_validator_index = ValidatorIndex(next_index % len(state.validators))
-        state.next_withdrawal_validator_index = next_validator_index
+        if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
+            # Next sweep starts after the latest withdrawal's validator index
+            next_validator_index = ValidatorIndex(
+                (withdrawals[-1].validator_index + 1) % len(state.validators)
+            )
+            state.next_withdrawal_validator_index = next_validator_index
+        else:
+            # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
+            next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
+            next_validator_index = ValidatorIndex(next_index % len(state.validators))
+            state.next_withdrawal_validator_index = next_validator_index
     </spec>
 
 - name: update_payload_expected_withdrawals#gloas

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1311,6 +1311,15 @@
         ]
     </spec>
 
+- name: compute_proposer_score#phase0
+  sources: []
+  spec: |
+    <spec fn="compute_proposer_score" fork="phase0" hash="43ff8b01">
+    def compute_proposer_score(state: BeaconState) -> Gwei:
+        committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
+        return (committee_weight * PROPOSER_SCORE_BOOST) // 100
+    </spec>
+
 - name: compute_pulled_up_tip#phase0
   sources: []
   spec: |
@@ -2585,6 +2594,61 @@
             participation_flag_indices.append(TIMELY_HEAD_FLAG_INDEX)
 
         return participation_flag_indices
+    </spec>
+
+- name: get_attestation_score#phase0
+  sources: []
+  spec: |
+    <spec fn="get_attestation_score" fork="phase0" hash="da969f50">
+    def get_attestation_score(store: Store, root: Root, state: BeaconState) -> Gwei:
+        unslashed_and_active_indices = [
+            i
+            for i in get_active_validator_indices(state, get_current_epoch(state))
+            if not state.validators[i].slashed
+        ]
+        return Gwei(
+            sum(
+                state.validators[i].effective_balance
+                for i in unslashed_and_active_indices
+                if (
+                    i in store.latest_messages
+                    and i not in store.equivocating_indices
+                    and get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot)
+                    == root
+                )
+            )
+        )
+    </spec>
+
+- name: get_attestation_score#gloas
+  sources: []
+  spec: |
+    <spec fn="get_attestation_score" fork="gloas" hash="8a2e4701">
+    def get_attestation_score(
+        store: Store,
+        # [Modified in Gloas:EIP7732]
+        # Removed `root`
+        # [New in Gloas:EIP7732]
+        node: ForkChoiceNode,
+        state: BeaconState,
+    ) -> Gwei:
+        unslashed_and_active_indices = [
+            i
+            for i in get_active_validator_indices(state, get_current_epoch(state))
+            if not state.validators[i].slashed
+        ]
+        return Gwei(
+            sum(
+                state.validators[i].effective_balance
+                for i in unslashed_and_active_indices
+                if (
+                    i in store.latest_messages
+                    and i not in store.equivocating_indices
+                    # [Modified in Gloas:EIP7732]
+                    and is_supporting_vote(store, node, store.latest_messages[i])
+                )
+            )
+        )
     </spec>
 
 - name: get_attestation_signature#phase0
@@ -4595,6 +4659,20 @@
             return head_root
     </spec>
 
+- name: get_proposer_preferences_signature#gloas
+  sources: []
+  spec: |
+    <spec fn="get_proposer_preferences_signature" fork="gloas" hash="6a34cb73">
+    def get_proposer_preferences_signature(
+        state: BeaconState, preferences: ProposerPreferences, privkey: int
+    ) -> BLSSignature:
+        domain = get_domain(
+            state, DOMAIN_PROPOSER_PREFERENCES, compute_epoch_at_slot(preferences.proposal_slot)
+        )
+        signing_root = compute_signing_root(preferences, domain)
+        return bls.Sign(privkey, signing_root)
+    </spec>
+
 - name: get_proposer_reorg_cutoff_ms#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -4957,6 +5035,23 @@
             i for i in active_validator_indices if has_flag(epoch_participation[i], flag_index)
         ]
         return set(filter(lambda index: not state.validators[index].slashed, participating_indices))
+    </spec>
+
+- name: get_upcoming_proposal_slots#gloas
+  sources: []
+  spec: |
+    <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="802ba480">
+    def get_upcoming_proposal_slots(
+        state: BeaconState, validator_index: ValidatorIndex
+    ) -> Sequence[Slot]:
+        """
+        Get the slots in the next epoch for which ``validator_index`` is proposing.
+        """
+        return [
+            Slot(compute_start_slot_at_epoch(get_current_epoch(state) + Epoch(1)) + offset)
+            for offset, proposer_index in enumerate(state.proposer_lookahead[SLOTS_PER_EPOCH:])
+            if validator_index == proposer_index
+        ]
     </spec>
 
 - name: get_validator_activation_churn_limit#deneb
@@ -5804,6 +5899,23 @@
         )
     </spec>
 
+- name: is_eligible_for_partial_withdrawals#electra
+  sources: []
+  spec: |
+    <spec fn="is_eligible_for_partial_withdrawals" fork="electra" hash="c8d29720">
+    def is_eligible_for_partial_withdrawals(validator: Validator, balance: Gwei) -> bool:
+        """
+        Check if ``validator`` can process a pending partial withdrawal.
+        """
+        has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
+        has_excess_balance = balance > MIN_ACTIVATION_BALANCE
+        return (
+            validator.exit_epoch == FAR_FUTURE_EPOCH
+            and has_sufficient_effective_balance
+            and has_excess_balance
+        )
+    </spec>
+
 - name: is_execution_block#bellatrix
   sources: []
   spec: |
@@ -5896,6 +6008,14 @@
         return not store.block_timeliness[head_root]
     </spec>
 
+- name: is_head_late#gloas
+  sources: []
+  spec: |
+    <spec fn="is_head_late" fork="gloas" hash="dd4c9308">
+    def is_head_late(store: Store, head_root: Root) -> bool:
+        return not store.block_timeliness[head_root][ATTESTATION_TIMELINESS_INDEX]
+    </spec>
+
 - name: is_head_weak#phase0
   sources:
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -5906,6 +6026,34 @@
         justified_state = store.checkpoint_states[store.justified_checkpoint]
         reorg_threshold = calculate_committee_fraction(justified_state, REORG_HEAD_WEIGHT_THRESHOLD)
         head_weight = get_weight(store, head_root)
+        return head_weight < reorg_threshold
+    </spec>
+
+- name: is_head_weak#gloas
+  sources: []
+  spec: |
+    <spec fn="is_head_weak" fork="gloas" hash="a763a3db">
+    def is_head_weak(store: Store, head_root: Root) -> bool:
+        # Calculate weight threshold for weak head
+        justified_state = store.checkpoint_states[store.justified_checkpoint]
+        reorg_threshold = calculate_committee_fraction(justified_state, REORG_HEAD_WEIGHT_THRESHOLD)
+
+        # Compute head weight including equivocations
+        head_state = store.block_states[head_root]
+        head_block = store.blocks[head_root]
+        epoch = compute_epoch_at_slot(head_block.slot)
+        head_node = ForkChoiceNode(root=head_root, payload_status=PAYLOAD_STATUS_PENDING)
+        head_weight = get_attestation_score(store, head_node, justified_state)
+        for index in range(get_committee_count_per_slot(head_state, epoch)):
+            committee = get_beacon_committee(head_state, head_block.slot, CommitteeIndex(index))
+            head_weight += Gwei(
+                sum(
+                    justified_state.validators[i].effective_balance
+                    for i in committee
+                    if i in store.equivocating_indices
+                )
+            )
+
         return head_weight < reorg_threshold
     </spec>
 
@@ -6013,6 +6161,20 @@
         return parent_weight > parent_threshold
     </spec>
 
+- name: is_parent_strong#gloas
+  sources: []
+  spec: |
+    <spec fn="is_parent_strong" fork="gloas" hash="37089462">
+    def is_parent_strong(store: Store, root: Root) -> bool:
+        justified_state = store.checkpoint_states[store.justified_checkpoint]
+        parent_threshold = calculate_committee_fraction(justified_state, REORG_PARENT_WEIGHT_THRESHOLD)
+        block = store.blocks[root]
+        parent_payload_status = get_parent_payload_status(store, block)
+        parent_node = ForkChoiceNode(root=block.parent_root, payload_status=parent_payload_status)
+        parent_weight = get_attestation_score(store, parent_node, justified_state)
+        return parent_weight > parent_threshold
+    </spec>
+
 - name: is_partially_withdrawable_validator#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/PredicatesElectra.java
@@ -6092,6 +6254,23 @@
     <spec fn="is_proposer" fork="phase0" hash="d9e66d76">
     def is_proposer(state: BeaconState, validator_index: ValidatorIndex) -> bool:
         return get_beacon_proposer_index(state) == validator_index
+    </spec>
+
+- name: is_proposer_equivocation#phase0
+  sources: []
+  spec: |
+    <spec fn="is_proposer_equivocation" fork="phase0" hash="8e90bb33">
+    def is_proposer_equivocation(store: Store, root: Root) -> bool:
+        block = store.blocks[root]
+        proposer_index = block.proposer_index
+        slot = block.slot
+        # roots from the same slot and proposer
+        matching_roots = [
+            root
+            for root, block in store.blocks.items()
+            if (block.proposer_index == proposer_index and block.slot == slot)
+        ]
+        return len(matching_roots) > 1
     </spec>
 
 - name: is_proposing_on_time#phase0
@@ -6376,6 +6555,18 @@
             if branch[i] != Bytes32():
                 return False
         return is_valid_merkle_branch(leaf, branch[num_extra:], depth, index, root)
+    </spec>
+
+- name: is_valid_proposal_slot#gloas
+  sources: []
+  spec: |
+    <spec fn="is_valid_proposal_slot" fork="gloas" hash="55b8762f">
+    def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
+        """
+        Check if the validator is the proposer for the given slot in the next epoch.
+        """
+        index = SLOTS_PER_EPOCH + preferences.proposal_slot % SLOTS_PER_EPOCH
+        return state.proposer_lookahead[index] == preferences.validator_index
     </spec>
 
 - name: is_valid_switch_to_compounding_request#electra

--- a/specrefs/presets.yml
+++ b/specrefs/presets.yml
@@ -16,6 +16,15 @@
     BUILDER_PENDING_WITHDRAWALS_LIMIT: uint64 = 1048576
     </spec>
 
+- name: BUILDER_REGISTRY_LIMIT#gloas
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
+      search: "BUILDER_REGISTRY_LIMIT:"
+  spec: |
+    <spec preset_var="BUILDER_REGISTRY_LIMIT" fork="gloas" hash="e951ff73">
+    BUILDER_REGISTRY_LIMIT: uint64 = 1099511627776
+    </spec>
+
 - name: BYTES_PER_LOGS_BLOOM#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
@@ -239,6 +248,15 @@
   spec: |
     <spec preset_var="MAX_BLS_TO_EXECUTION_CHANGES" fork="capella" hash="1eee2f2f">
     MAX_BLS_TO_EXECUTION_CHANGES = 16
+    </spec>
+
+- name: MAX_BUILDERS_PER_WITHDRAWALS_SWEEP#gloas
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
+      search: "MAX_BUILDERS_PER_WITHDRAWALS_SWEEP:"
+  spec: |
+    <spec preset_var="MAX_BUILDERS_PER_WITHDRAWALS_SWEEP" fork="gloas" hash="1556b314">
+    MAX_BUILDERS_PER_WITHDRAWALS_SWEEP = 16384
     </spec>
 
 - name: MAX_BYTES_PER_TRANSACTION#bellatrix

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.duties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.logging.Converter.weiToEth;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
@@ -224,8 +225,8 @@ public class BlockProductionDuty implements Duty {
 
   private void notifyExecutionPayloadBidEventsSubscribers(
       final SignedExecutionPayloadBid signedBid, final ForkInfo forkInfo) {
-    // G2_POINT_AT_INFINITY signature indicates a self-built bid
-    if (signedBid.getSignature().isInfinity()) {
+    // BUILDER_INDEX_SELF_BUILD indicates a self-built bid
+    if (signedBid.getMessage().getBuilderIndex().equals(BUILDER_INDEX_SELF_BUILD)) {
       executionPayloadBidEventsChannelPublisher.onSelfBuiltBidIncludedInBlock(
           validator, forkInfo, signedBid.getMessage());
     }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -26,6 +26,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 
 import java.util.List;
 import java.util.Optional;
@@ -626,16 +627,15 @@ class BlockProductionDutyTest {
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
     final BLSSignature blockSignature = dataStructureUtil.randomSignature();
 
-    final ExecutionPayloadBid bid = dataStructureUtil.randomExecutionPayloadBid();
+    final ExecutionPayloadBid bid =
+        dataStructureUtil.randomExecutionPayloadBid(slot, BUILDER_INDEX_SELF_BUILD);
     final BeaconBlockBody blockBody =
         dataStructureUtil.randomBeaconBlockBody(
             builder ->
                 builder.signedExecutionPayloadBid(
                     SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
                         .getSignedExecutionPayloadBidSchema()
-                        .create(
-                            // mimicking self-built bid
-                            bid, BLSSignature.infinity())));
+                        .create(bid, dataStructureUtil.randomSignature())));
 
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/pull/4788

Also enabling back al the Gloas consensus-specs reference tests from: https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.1

The major change TLDR is that we track builders in the state separate from validators and process their deposits/withdrawals separate 

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements builders as non-validating staked actors and aligns with consensus-specs v1.7.0-alpha.1.
> 
> - Add `Builder` SSZ container and registry in `BeaconState` with caches (`buildersPubKeys`, `builderIndexCache`); add `next_withdrawal_builder_index` and `payload_expected_withdrawals`
> - Replace validator-based builder fields with `BuilderIndex` (incl. `BUILDER_INDEX_SELF_BUILD`), update `ExecutionPayloadBid/Envelope` and signature checks to use builder pubkeys; special handling for self-builds
> - Rework withdrawals: queue/process builder pending withdrawals and a builders sweep; apply withdrawals to builder balances; advance `next_withdrawal_*` indices; extend `ExpectedWithdrawals`
> - Handle deposits for builders immediately and add builder exits (`initiateBuilderExit`); map builder/validator indices via new helpers
> - Update predicates/accessors/mutators for builders (balance checks, active status, index/pubkey lookups); adjust SSZ schemas (`Builder.version` uint8; remove `withdrawable_epoch` from `BuilderPendingWithdrawal`)
> - Enable Gloas `ssz_*`, fork-choice tests; update test fixtures/utilities to use `BUILDER_INDEX_SELF_BUILD`; bump specrefs to v1.7.0-alpha.1
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbd46704782fe31bd9d06d0558b872ce7fb37344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->