### PR TITLE
Fork choice changes to align with `v1.7.0-alpha.1`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.6.1"
+def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.1"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -788,9 +788,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                 }
               }
               // Only update if the proposer is the same as on the canonical chain
-              System.out.println(
-                  block.getProposerIndex().intValue()
-                      == spec.getBeaconProposerIndex(headState, currentSlot));
               return block.getProposerIndex().intValue()
                   == spec.getBeaconProposerIndex(headState, currentSlot);
             })

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -764,7 +764,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       return false;
     }
     // in the edge cases when the chain head is not present or the head state future is not
-    // immediately available, we will set the proposer boost root to maintain backwards
+    // immediately available, the proposer boost root will be set to maintain backwards
     // compatibility (see: https://github.com/ethereum/consensus-specs/pull/4807/)
     return recentChainData
         .getChainHead()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -764,8 +764,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       return false;
     }
     // in the edge cases when the chain head is not present or the head state future is not
-    // immediately available, we will set the proposer boost root (see:
-    // https://github.com/ethereum/consensus-specs/pull/4807/)
+    // immediately available, we will set the proposer boost root to maintain backwards
+    // compatibility (see: https://github.com/ethereum/consensus-specs/pull/4807/)
     return recentChainData
         .getChainHead()
         .map(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.forkchoice;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.logging.P2PLogger.P2P_LOG;
-import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.statetransition.forkchoice.StateRootCollector.addParentStateRoots;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -67,6 +66,8 @@ import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
@@ -663,8 +664,9 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         blobSidecars,
         earliestBlobSidecarsSlot);
 
-    final boolean shouldApplyProposerBoost = shouldApplyProposerBoost(block, transaction);
-    if (shouldApplyProposerBoost) {
+    final boolean shouldUpdateProposerBoostRoot = shouldUpdateProposerBoostRoot(block, transaction);
+
+    if (shouldUpdateProposerBoostRoot) {
       transaction.setProposerBoostRoot(block.getRoot());
     }
 
@@ -694,7 +696,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     } else {
       result = BlockImportResult.optimisticallySuccessful(block);
     }
-    updateForkChoiceForImportedBlock(block, shouldApplyProposerBoost, result, forkChoiceStrategy);
+    updateForkChoiceForImportedBlock(
+        block, shouldUpdateProposerBoostRoot, result, forkChoiceStrategy);
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
     return result;
   }
@@ -747,20 +750,51 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   }
 
   // from consensus-specs/fork-choice:
-  private boolean shouldApplyProposerBoost(
+  //
+  // Add proposer score boost if the block is timely, not conflicting with an existing block, with
+  // the same the proposer as the canonical chain.
+  private boolean shouldUpdateProposerBoostRoot(
       final SignedBeaconBlock block, final StoreTransaction transaction) {
-    // get_current_slot(store) == block.slot
-    if (!spec.getCurrentSlot(transaction).equals(block.getSlot())) {
-      return false;
-    }
-    // is_before_attesting_interval
-    final UInt64 timeIntoSlotMillis =
-        getMillisIntoSlot(transaction, spec.getSlotDurationMillis(block.getSlot()));
-    if (!timeIntoSlotMillis.isLessThan(spec.getAttestationDueMillis(block.getSlot()))) {
-      return false;
-    }
     // is_first_block
-    return transaction.getProposerBoostRoot().isEmpty();
+    if (transaction.getProposerBoostRoot().isPresent()) {
+      return false;
+    }
+    // is_timely
+    if (recentChainData.isBlockLate(block.getRoot())) {
+      return false;
+    }
+    // in the edge cases when the chain head is not present or the head state future is not
+    // immediately available, we will set the proposer boost root (see:
+    // https://github.com/ethereum/consensus-specs/pull/4807/)
+    return recentChainData
+        .getChainHead()
+        .map(
+            chainHead -> {
+              final SafeFuture<BeaconState> headStateFuture = chainHead.getState();
+              if (!headStateFuture.isCompletedNormally()) {
+                return true;
+              }
+              BeaconState headState = headStateFuture.join();
+              final UInt64 currentSlot = spec.getCurrentSlot(transaction);
+              if (headState.getSlot().isLessThan(currentSlot)) {
+                try {
+                  headState = spec.processSlots(headState, currentSlot);
+                } catch (final SlotProcessingException | EpochProcessingException ex) {
+                  throw new RuntimeException(
+                      String.format(
+                          "Can't progress head state from slot %s to slot %s",
+                          headState.getSlot(), currentSlot),
+                      ex);
+                }
+              }
+              // Only update if the proposer is the same as on the canonical chain
+              System.out.println(
+                  block.getProposerIndex().intValue()
+                      == spec.getBeaconProposerIndex(headState, currentSlot));
+              return block.getProposerIndex().intValue()
+                  == spec.getBeaconProposerIndex(headState, currentSlot);
+            })
+        .orElse(true);
   }
 
   private Optional<List<BlobSidecar>> extractBlobSidecarsFromValidationResults(
@@ -812,13 +846,6 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             earliestAvailabilityWindowSlotBeforeBlock.max(earliestAffectedSlot));
   }
 
-  private UInt64 getMillisIntoSlot(final StoreTransaction transaction, final int millisPerSlot) {
-    return transaction
-        .getTimeInMillis()
-        .minus(secondsToMillis(transaction.getGenesisTime()))
-        .mod(millisPerSlot);
-  }
-
   private void onExecutionPayloadResult(
       final Bytes32 blockRoot, final PayloadStatus payloadResult) {
     final SafeFuture<PayloadValidationResult> transitionValidatedStatus;
@@ -859,7 +886,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
   private void updateForkChoiceForImportedBlock(
       final SignedBeaconBlock block,
-      final boolean shouldApplyProposerBoost,
+      final boolean shouldUpdateProposerBoostRoot,
       final BlockImportResult result,
       final ForkChoiceStrategy forkChoiceStrategy) {
 
@@ -873,7 +900,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       }
     }
 
-    if (!result.isBlockOnCanonicalChain() && shouldApplyProposerBoost) {
+    if (!result.isBlockOnCanonicalChain() && shouldUpdateProposerBoostRoot) {
       // This is likely a reorging block that requires a full processHead to update the head.
       // Running processHead here will ensure:
       //

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -779,6 +779,10 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
     lateBlockReorgLogic.setBlockTimelinessFromArrivalTime(block, store.getTimeInMillis());
   }
 
+  public boolean isBlockLate(final Bytes32 root) {
+    return lateBlockReorgLogic.isBlockLate(root);
+  }
+
   public Optional<UInt64> getCustodyGroupCount() {
     return store.getCustodyGroupCount();
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
There is a proposer boost change required in fork choice to align with new specs as per https://github.com/ethereum/consensus-specs/pull/4807 . There is also a refactor to `is_parent_strong` to cater for Gloas reusing this method, but we can tackle this when we work on the Gloas fork choice changes.

This is prerequisite for all tests to pass in https://github.com/Consensys/teku/pull/10261

There is discussion on Discord: https://discordapp.com/channels/595666850260713488/598292067260825641/1458453736417394791

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns fork choice with the v1.7.0-alpha.1 consensus spec and adjusts reference tests.
> 
> - Updates proposer boost handling: replace `shouldApplyProposerBoost` with `shouldUpdateProposerBoostRoot` to boost only when the block is timely (via `recentChainData.isBlockLate`), is the first in slot, and the proposer matches the canonical chain’s proposer; processes head state as needed to determine proposer index
> - Removes time-into-slot calculation and related import; adds handling for slot/epoch processing exceptions during head state progression
> - Calls to update fork choice now use the new proposer-boost flag; retains reorg handling via `processHead()` when appropriate
> - Adds `RecentChainData.isBlockLate(Bytes32)` to surface lateness from `LateBlockReorgLogic`
> - Bumps consensus-spec reference tests in `build.gradle` to `v1.7.0-alpha.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82a4ef4828ce7b59d58709b420e1528e43ddce09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->