### PR TITLE
Close decoder on dropped incoming RPC requests

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -95,7 +95,9 @@ public class Eth2IncomingRequestHandler<
   }
 
   @Override
-  public void closed(final NodeId nodeId, final RpcStream rpcStream) {}
+  public void closed(final NodeId nodeId, final RpcStream rpcStream) {
+    requestDecoder.close();
+  }
 
   private void handleRequest(
       final Optional<Eth2Peer> peer,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcRequestDecoder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcRequestDecoder.java
@@ -71,4 +71,8 @@ public final class RpcRequestDecoder<T extends RpcRequest & SszData> {
     }
     return maybeRequest;
   }
+
+  public void close() {
+    decoder.close();
+  }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -144,7 +144,7 @@ public class Eth2IncomingRequestHandlerTest
   }
 
   @Test
-  public void shouldReleaseBuffersWhenStreamClosedWithoutAnyData() {
+  public void shouldReleaseBuffersWhenHandlerIsClosedWithNoProcessedData() {
     // Close without any data being processed - should not throw
     reqHandler.closed(nodeId, rpcStream);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.netty.buffer.ByteBuf;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,6 +109,46 @@ public class Eth2IncomingRequestHandlerTest
     asyncRunner.executeQueuedActions();
     asyncRunner.executeQueuedActions();
     verify(rpcStream, never()).closeAbruptly();
+  }
+
+  @Test
+  public void shouldReleaseBuffersWhenStreamClosedAfterPartialData() {
+    // Send partial data (incomplete request) - this will cause the decoder to retain the buffer
+    final ByteBuf partialData = Utils.toByteBuf(requestData.slice(0, requestData.size() / 2));
+    final int initialRefCnt = partialData.refCnt();
+
+    reqHandler.processData(nodeId, rpcStream, partialData);
+
+    // Buffer should have been retained by the decoder's CompositeByteBuf
+    assertThat(partialData.refCnt()).isGreaterThanOrEqualTo(initialRefCnt);
+
+    // Close the stream - this should release the retained buffers
+    reqHandler.closed(nodeId, rpcStream);
+
+    // After close, the buffer's reference count should be back to initial
+    // (the retained slice should have been released)
+    assertThat(partialData.refCnt()).isEqualTo(initialRefCnt);
+  }
+
+  @Test
+  public void shouldHandleClosedCalledMultipleTimes() {
+    // Send partial data
+    final ByteBuf partialData = Utils.toByteBuf(requestData.slice(0, requestData.size() / 2));
+    reqHandler.processData(nodeId, rpcStream, partialData);
+
+    // Close should be idempotent and not throw
+    reqHandler.closed(nodeId, rpcStream);
+    reqHandler.closed(nodeId, rpcStream);
+
+    // Should not throw any exceptions
+  }
+
+  @Test
+  public void shouldReleaseBuffersWhenStreamClosedWithoutAnyData() {
+    // Close without any data being processed - should not throw
+    reqHandler.closed(nodeId, rpcStream);
+
+    // Should complete without exceptions
   }
 
   @Override


### PR DESCRIPTION
When an RPC stream is closed abnormally (peer disconnect, timeout, abort), the `Eth2IncomingRequestHandler.closed()` callback was empty and didn't clean up the decoder's internal buffers.

note that `responseDecoder.close();` seems to be called in `Eth2OutgoingRequestHandler::abortRequest`

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix resource cleanup on dropped incoming RPC requests**
> 
> - Call `requestDecoder.close()` in `Eth2IncomingRequestHandler.closed()` to release retained buffers
> - Add `close()` to `RpcRequestDecoder` delegating to the underlying decoder
> - New tests assert buffer release after partial data, idempotent `closed()` behavior, and safe close with no data
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdcb7982fbe8c933c38793dfd5839e2473ea6501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->