### PR TITLE
Add AT test for `--rest-api-getblobs-sidecars-download-enabled`

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -145,7 +145,7 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
 
     secondaryNode.start();
 
-    // late joining full node without validators without
+    // late joining node without validators without
     // --rest-api-getblobs-sidecars-download-enabled
     // this mean that when we try to blob sidecars it will 404
 
@@ -178,7 +178,7 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
     final int columnsFromThirdNode = thirdNode.getDataColumnSidecarCount("head");
     assertThat(columnsFromThirdNode).isGreaterThan(0);
 
-    // 404 are casted into optional empty
+    // third node should not have blobs as get blobs download is not enabled
     assertThat(thirdNode.getBlobsAtSlot(headSlot)).isEmpty();
   }
 

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -14,21 +14,28 @@
 package tech.pegasys.teku.test.acceptance.das;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
 import tech.pegasys.teku.test.acceptance.dsl.TekuBeaconNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
 
 public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
+
   @Test
   public void shouldBeAbleToCheckpointSyncAndBackfillCustody() throws Exception {
     // supernode with validators
@@ -42,6 +49,7 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
 
     primaryNode.start();
     final UInt64 genesisTime = primaryNode.getGenesisTime();
+
     primaryNode.waitForNewFinalization();
     final SignedBeaconBlock checkpointFinalizedBlock = primaryNode.getFinalizedBlock();
     // We expect at least 1 full epoch in Fulu before checkpoint, so it's greater without equal
@@ -54,19 +62,39 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
                 .isGreaterThan(specConfigFulu.getFuluForkEpoch()))
         .isTrue();
 
-    // late joining full node without validators
+
+    // late joining full node without validators with --rest-api-getblobs-sidecars-download-enabled
     final TekuBeaconNode secondaryNode =
-        createTekuBeaconNode(
-            createConfigBuilder()
-                .withRealNetwork()
-                .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
-                .withGenesisTime(genesisTime.intValue())
-                .withPeers(primaryNode)
-                .withInteropValidators(0, 0)
-                .build());
+            createTekuBeaconNode(
+                    createConfigBuilder()
+                            .withRealNetwork()
+                            .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
+                            .withGenesisTime(genesisTime.intValue())
+                            .withGetBlobsSidecarsDownloadApiEnabled()
+                            .withPeers(primaryNode)
+                            .withInteropValidators(0, 0)
+                            .build());
 
     secondaryNode.start();
+
+    // late joining full node without validators without --rest-api-getblobs-sidecars-download-enabled
+    //this mean that when we try to blob sidecars it will 404
+
+    final TekuBeaconNode thirdNode =
+            createTekuBeaconNode(
+                    createConfigBuilder()
+                            .withRealNetwork()
+                            .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
+                            .withGenesisTime(genesisTime.intValue())
+                            .withPeers(primaryNode)
+                            .withInteropValidators(0, 0)
+                            .build());
+
+    thirdNode.start();
+
     secondaryNode.waitUntilInSyncWith(primaryNode);
+    thirdNode.waitUntilInSyncWith(primaryNode);
+
 
     final UInt64 firstFuluSlot =
         primaryNode.getSpec().computeStartSlotAtEpoch(specConfigFulu.getFuluForkEpoch());
@@ -100,6 +128,25 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
             .mapToInt(i -> i)
             .sum();
     assertThat(beforeCheckpointSidecars).isGreaterThan(0);
+
+    //get a slot to get blobs from
+    final UInt64 headSlot = secondaryNode.getHeadBlock().getSlot();
+
+    final Optional<List<Blob>> blobsForBlockNode1 = primaryNode.getBlobsAtSlot(headSlot);
+    final int columnsFromSecondNode = secondaryNode.getDataColumnSidecarCount("head");
+    assertThat(columnsFromSecondNode).isGreaterThan(0);
+    final Optional<List<Blob>> blobsForBlockNode2 = secondaryNode.getBlobsAtSlot(headSlot);
+
+    //assert that blobs obtained from node 1 and node 2 are the same
+    assertThat(blobsForBlockNode1).isPresent();
+    assertThat(blobsForBlockNode1).isEqualTo(blobsForBlockNode2);
+
+    final int columnsFromThirdNode = thirdNode.getDataColumnSidecarCount("head");
+    assertThat(columnsFromThirdNode).isGreaterThan(0);
+
+    //404 are casted into optional empty
+    assertThat(thirdNode.getBlobsAtSlot(headSlot)).isEmpty();
+
   }
 
   private int getAndAssertDasCustody(

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -58,7 +58,7 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
                 .isGreaterThan(specConfigFulu.getFuluForkEpoch()))
         .isTrue();
 
-    // late joining full node without validators with --rest-api-getblobs-sidecars-download-enabled
+    // late joining full node without validators
     final TekuBeaconNode secondaryNode =
         createTekuBeaconNode(
             createConfigBuilder()
@@ -119,7 +119,6 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
 
     primaryNode.start();
     final UInt64 genesisTime = primaryNode.getGenesisTime();
-
     primaryNode.waitForNewFinalization();
     final SignedBeaconBlock checkpointFinalizedBlock = primaryNode.getFinalizedBlock();
     // We expect at least 1 full epoch in Fulu before checkpoint, so it's greater without equal

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -103,7 +103,6 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
             .mapToInt(i -> i)
             .sum();
     assertThat(beforeCheckpointSidecars).isGreaterThan(0);
-
   }
 
   @Test
@@ -111,12 +110,12 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
 
     // supernode with validators
     final TekuBeaconNode primaryNode =
-            createTekuBeaconNode(
-                    createConfigBuilder()
-                            .withRealNetwork()
-                            .withSubscribeAllCustodySubnetsEnabled()
-                            .withInteropValidators(0, 64)
-                            .build());
+        createTekuBeaconNode(
+            createConfigBuilder()
+                .withRealNetwork()
+                .withSubscribeAllCustodySubnetsEnabled()
+                .withInteropValidators(0, 64)
+                .build());
 
     primaryNode.start();
     final UInt64 genesisTime = primaryNode.getGenesisTime();
@@ -125,25 +124,25 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
     final SignedBeaconBlock checkpointFinalizedBlock = primaryNode.getFinalizedBlock();
     // We expect at least 1 full epoch in Fulu before checkpoint, so it's greater without equal
     final SpecConfigFulu specConfigFulu =
-            SpecConfigFulu.required(primaryNode.getSpec().forMilestone(SpecMilestone.FULU).getConfig());
+        SpecConfigFulu.required(primaryNode.getSpec().forMilestone(SpecMilestone.FULU).getConfig());
     assertThat(
             primaryNode
-                    .getSpec()
-                    .computeEpochAtSlot(checkpointFinalizedBlock.getSlot())
-                    .isGreaterThan(specConfigFulu.getFuluForkEpoch()))
-            .isTrue();
+                .getSpec()
+                .computeEpochAtSlot(checkpointFinalizedBlock.getSlot())
+                .isGreaterThan(specConfigFulu.getFuluForkEpoch()))
+        .isTrue();
 
     // late joining full node without validators with --rest-api-getblobs-sidecars-download-enabled
     final TekuBeaconNode secondaryNode =
-            createTekuBeaconNode(
-                    createConfigBuilder()
-                            .withRealNetwork()
-                            .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
-                            .withGenesisTime(genesisTime.intValue())
-                            .withGetBlobsSidecarsDownloadApiEnabled()
-                            .withPeers(primaryNode)
-                            .withInteropValidators(0, 0)
-                            .build());
+        createTekuBeaconNode(
+            createConfigBuilder()
+                .withRealNetwork()
+                .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
+                .withGenesisTime(genesisTime.intValue())
+                .withGetBlobsSidecarsDownloadApiEnabled()
+                .withPeers(primaryNode)
+                .withInteropValidators(0, 0)
+                .build());
 
     secondaryNode.start();
 
@@ -152,14 +151,14 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
     // this mean that when we try to blob sidecars it will 404
 
     final TekuBeaconNode thirdNode =
-            createTekuBeaconNode(
-                    createConfigBuilder()
-                            .withRealNetwork()
-                            .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
-                            .withGenesisTime(genesisTime.intValue())
-                            .withPeers(primaryNode)
-                            .withInteropValidators(0, 0)
-                            .build());
+        createTekuBeaconNode(
+            createConfigBuilder()
+                .withRealNetwork()
+                .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
+                .withGenesisTime(genesisTime.intValue())
+                .withPeers(primaryNode)
+                .withInteropValidators(0, 0)
+                .build());
 
     thirdNode.start();
 
@@ -182,8 +181,8 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
 
     // 404 are casted into optional empty
     assertThat(thirdNode.getBlobsAtSlot(headSlot)).isEmpty();
-
   }
+
   private int getAndAssertDasCustody(
       final TekuBeaconNode node, final UInt64 fuluSlot, final int expectedCustodyCount) {
     try {

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/DasCheckpointSyncAcceptanceTest.java
@@ -14,16 +14,12 @@
 package tech.pegasys.teku.test.acceptance.das;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -62,39 +58,38 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
                 .isGreaterThan(specConfigFulu.getFuluForkEpoch()))
         .isTrue();
 
-
     // late joining full node without validators with --rest-api-getblobs-sidecars-download-enabled
     final TekuBeaconNode secondaryNode =
-            createTekuBeaconNode(
-                    createConfigBuilder()
-                            .withRealNetwork()
-                            .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
-                            .withGenesisTime(genesisTime.intValue())
-                            .withGetBlobsSidecarsDownloadApiEnabled()
-                            .withPeers(primaryNode)
-                            .withInteropValidators(0, 0)
-                            .build());
+        createTekuBeaconNode(
+            createConfigBuilder()
+                .withRealNetwork()
+                .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
+                .withGenesisTime(genesisTime.intValue())
+                .withGetBlobsSidecarsDownloadApiEnabled()
+                .withPeers(primaryNode)
+                .withInteropValidators(0, 0)
+                .build());
 
     secondaryNode.start();
 
-    // late joining full node without validators without --rest-api-getblobs-sidecars-download-enabled
-    //this mean that when we try to blob sidecars it will 404
+    // late joining full node without validators without
+    // --rest-api-getblobs-sidecars-download-enabled
+    // this mean that when we try to blob sidecars it will 404
 
     final TekuBeaconNode thirdNode =
-            createTekuBeaconNode(
-                    createConfigBuilder()
-                            .withRealNetwork()
-                            .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
-                            .withGenesisTime(genesisTime.intValue())
-                            .withPeers(primaryNode)
-                            .withInteropValidators(0, 0)
-                            .build());
+        createTekuBeaconNode(
+            createConfigBuilder()
+                .withRealNetwork()
+                .withCheckpointSyncUrl(primaryNode.getBeaconRestApiUrl())
+                .withGenesisTime(genesisTime.intValue())
+                .withPeers(primaryNode)
+                .withInteropValidators(0, 0)
+                .build());
 
     thirdNode.start();
 
     secondaryNode.waitUntilInSyncWith(primaryNode);
     thirdNode.waitUntilInSyncWith(primaryNode);
-
 
     final UInt64 firstFuluSlot =
         primaryNode.getSpec().computeStartSlotAtEpoch(specConfigFulu.getFuluForkEpoch());
@@ -129,7 +124,7 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
             .sum();
     assertThat(beforeCheckpointSidecars).isGreaterThan(0);
 
-    //get a slot to get blobs from
+    // get a slot to get blobs from
     final UInt64 headSlot = secondaryNode.getHeadBlock().getSlot();
 
     final Optional<List<Blob>> blobsForBlockNode1 = primaryNode.getBlobsAtSlot(headSlot);
@@ -137,16 +132,15 @@ public class DasCheckpointSyncAcceptanceTest extends AcceptanceTestBase {
     assertThat(columnsFromSecondNode).isGreaterThan(0);
     final Optional<List<Blob>> blobsForBlockNode2 = secondaryNode.getBlobsAtSlot(headSlot);
 
-    //assert that blobs obtained from node 1 and node 2 are the same
+    // assert that blobs obtained from node 1 and node 2 are the same
     assertThat(blobsForBlockNode1).isPresent();
     assertThat(blobsForBlockNode1).isEqualTo(blobsForBlockNode2);
 
     final int columnsFromThirdNode = thirdNode.getDataColumnSidecarCount("head");
     assertThat(columnsFromThirdNode).isGreaterThan(0);
 
-    //404 are casted into optional empty
+    // 404 are casted into optional empty
     assertThat(thirdNode.getBlobsAtSlot(headSlot)).isEmpty();
-
   }
 
   private int getAndAssertDasCustody(

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -750,9 +750,10 @@ public class TekuBeaconNode extends TekuNode {
 
   public Optional<List<Blob>> getBlobsAtSlot(final UInt64 slot) throws IOException {
     final Bytes result =
-            httpClient.getAsBytes(getRestApiUrl(),
-                            "/eth/v1/beacon/blobs/" + slot,
-                            Map.of("Accept", "application/octet-stream"));
+        httpClient.getAsBytes(
+            getRestApiUrl(),
+            "/eth/v1/beacon/blobs/" + slot,
+            Map.of("Accept", "application/octet-stream"));
     if (result.isEmpty()) {
       return Optional.empty();
     } else {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -65,6 +65,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -745,6 +746,18 @@ public class TekuBeaconNode extends TekuNode {
         httpClient.get(getRestApiUrl(), "/eth/v1/debug/beacon/data_column_sidecars/" + blockId);
     final JsonNode jsonNode = OBJECT_MAPPER.readTree(result);
     return jsonNode.get("data").size();
+  }
+
+  public Optional<List<Blob>> getBlobsAtSlot(final UInt64 slot) throws IOException {
+    final Bytes result =
+            httpClient.getAsBytes(getRestApiUrl(),
+                            "/eth/v1/beacon/blobs/" + slot,
+                            Map.of("Accept", "application/octet-stream"));
+    if (result.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(spec.deserializeBlobsInBlock(result, slot).asList());
+    }
   }
 
   public void waitForCustodyBackfill(final UInt64 slot, final int expectedCustodyCount) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -691,6 +691,12 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
+  public TekuNodeConfigBuilder withGetBlobsSidecarsDownloadApiEnabled(){
+    LOG.debug("--rest-api-getblobs-sidecars-download-enabled: {}", true);
+    configMap.put("rest-api-getblobs-sidecars-download-enabled", true);
+    return this;
+  }
+
   public TekuNodeConfigBuilder withReworkedRecoveryTimeouts(
       final int recoveryTimeout, final int downloadTimeout) {
     LOG.debug("Xp2p-sidecar-cancel-timeout-ms: {}", recoveryTimeout);

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -691,7 +691,7 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
-  public TekuNodeConfigBuilder withGetBlobsSidecarsDownloadApiEnabled(){
+  public TekuNodeConfigBuilder withGetBlobsSidecarsDownloadApiEnabled() {
     LOG.debug("--rest-api-getblobs-sidecars-download-enabled: {}", true);
     configMap.put("rest-api-getblobs-sidecars-download-enabled", true);
     return this;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR modifies the existing `DasCheckpointSyncAcceptanceTest` to ensure the flag `--rest-api-getblobs-sidecars-download-enabled` works as intended and reconstructs the blobs from a peer that can provide the columns

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10252 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validates blob retrieval via REST when blob-sidecar download is enabled, and ensures nodes without the flag do not serve blobs.
> 
> - Adds `shouldBeAbleToRetrieveBlobsWhenGetBlobsDownloadIsEnabled` in `DasCheckpointSyncAcceptanceTest` that compares blobs between a provider and a consumer node, and confirms a third node without the flag returns empty
> - Extends `TekuBeaconNode` with `getBlobsAtSlot(slot)` (binary `Accept` handling and SSZ deserialization) and uses `getDataColumnSidecarCount` to assert custody availability
> - Extends `TekuNodeConfigBuilder` with `withGetBlobsSidecarsDownloadApiEnabled()` to set `rest-api-getblobs-sidecars-download-enabled`
> - Minor: removes unnecessary sync wait in the existing custody backfill test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d93fb53479ac105d7768bd89881fccb2bfa791c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->