### PR TITLE
downgrade snappy-java to 1.1.10.7 because of the musl detection issue

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -135,7 +135,7 @@ dependencyManagement {
       entry 'utils'
     }
 
-    dependency 'org.xerial.snappy:snappy-java:1.1.10.8'
+    dependency 'org.xerial.snappy:snappy-java:1.1.10.7'
 
     dependency 'io.prometheus:prometheus-metrics-bom:1.3.10'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Downgrade snappy-java to `1.1.10.7` until https://github.com/xerial/snappy-java/issues/692 is fixed and https://github.com/xerial/snappy-java/pull/694 is merged and released.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Downgrades `org.xerial.snappy:snappy-java` from `1.1.10.8` to `1.1.10.7` in `gradle/versions.gradle` to work around a musl detection issue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09ca84393abe65a8ae03080d055ecd2a42a7a856. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->