### PR TITLE
Remove SidecarUpdateChannel.onNewNonCanonicalSidecar(sidecar)

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/DataColumnSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/DataColumnSidecarsByRangeIntegrationTest.java
@@ -126,7 +126,7 @@ public class DataColumnSidecarsByRangeIntegrationTest extends AbstractRpcMethodI
           nonCanonicalDataColumnSidecars.addAll(dataColumnSidecars);
           peerStorage.chainUpdater().saveBlock(signedBlockAndState);
           dataColumnSidecars.forEach(
-              sidecar -> safeJoin(peerStorage.chainStorage().onNewNonCanonicalSidecar(sidecar)));
+              sidecar -> peerStorage.database().addNonCanonicalSidecar(sidecar));
         });
 
     // make sure canonical head is the canonical head

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
@@ -25,6 +25,4 @@ public interface SidecarUpdateChannel extends ChannelInterface {
   SafeFuture<Void> onEarliestAvailableDataColumnSlot(UInt64 slot);
 
   SafeFuture<Void> onNewSidecar(DataColumnSidecar sidecar);
-
-  SafeFuture<Void> onNewNonCanonicalSidecar(DataColumnSidecar sidecar);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -478,9 +478,4 @@ public class ChainStorage
   public SafeFuture<Void> onNewSidecar(final DataColumnSidecar sidecar) {
     return SafeFuture.fromRunnable(() -> database.addSidecar(sidecar));
   }
-
-  @Override
-  public SafeFuture<Void> onNewNonCanonicalSidecar(final DataColumnSidecar sidecar) {
-    return SafeFuture.fromRunnable(() -> database.addNonCanonicalSidecar(sidecar));
-  }
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This method is not used in production and was accidentally added for test support, though there is a way to do the test without adding confusing interface.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **API cleanup**
> 
> - Removes `onNewNonCanonicalSidecar` from `storage/api/.../SidecarUpdateChannel` and its implementation in `ChainStorage`
> - Updates `DataColumnSidecarsByRangeIntegrationTest` to insert non-canonical sidecars via `database().addNonCanonicalSidecar(...)`
> - Retains existing `onNewSidecar` handling for canonical data
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a56d7518792953b30bd981893542e6fba9bd6013. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->