### PR TITLE
Column sidecar batching and inflight retrievable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,8 @@ Each module has its own test suite under `src/test/java` and test fixtures under
 - **Async operations**: Use `SafeFuture` and `AsyncRunner` instead of raw CompletableFuture
 - **Immutability**: Prefer immutable data structures (record types, SszData implementations)
 - **Error handling**: Use checked exceptions for recoverable errors, unchecked for programming errors
-- **Testing**: All code must have automated test coverage (no manual tests)
+- **Testing**: All code must have automated test coverage (no manual tests). All code changes must include corresponding unit tests.
+- **Logging**: Add appropriate LOG lines for new code paths, following the Hyperledger Besu Coding Conventions.
 - **Commit messages**: Imperative mood, present tense ("Add feature" not "Added feature")
 
 See [Hyperledger Besu Coding Conventions](https://wiki.hyperledger.org/display/BESU/Coding+Conventions) for additional guidelines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ Each module has its own test suite under `src/test/java` and test fixtures under
 - **Async operations**: Use `SafeFuture` and `AsyncRunner` instead of raw CompletableFuture
 - **Immutability**: Prefer immutable data structures (record types, SszData implementations)
 - **Error handling**: Use checked exceptions for recoverable errors, unchecked for programming errors
-- **Testing**: All code must have automated test coverage (no manual tests). All code changes must include corresponding unit tests.
+- **Testing**: All code must have automated test coverage (no manual tests).
 - **Logging**: Add appropriate LOG lines for new code paths, following the Hyperledger Besu Coding Conventions.
 - **Commit messages**: Imperative mood, present tense ("Add feature" not "Added feature")
 
@@ -353,10 +353,12 @@ Circular dependencies are prevented by build-time dependency checks (DepCheckPlu
 ## Development Workflow
 
 1. Make changes to relevant module(s)
-2. Run `./gradlew spotlessApply` to format code
-3. Run `./gradlew test` to run unit tests
-4. Run module-specific tests: `./gradlew :<module>:test`
-5. Run `./gradlew build` for full verification before committing
+2. Write unit tests for all code changes
+3. Run `./gradlew spotlessApply` to format code
+4. Verify compilation: `./gradlew compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava compilePropertyTestJava`
+5. Run unit tests: `./gradlew test`
+6. Run module-specific tests: `./gradlew :<module>:test`
+7. Run full build before committing: `./gradlew build`
 
 ## Running Teku Locally
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
@@ -58,12 +58,12 @@ public class DataColumnSidecarDbAccessorBuilder {
   }
 
   public DataColumnSidecarDbAccessor build() {
-    final ColumnIdCachingDasDb columnIdCachingDasDb =
-        new ColumnIdCachingDasDb(
+    final CachingDataColumnSidecarDB cachingDataColumnSidecarDB =
+        new CachingDataColumnSidecarDB(
             db,
             this::getNumberOfColumnsForSlot,
             columnIdReadCacheSlotCount,
             columnIdWriteCacheCount);
-    return new DasDb(columnIdCachingDasDb);
+    return new DasDb(cachingDataColumnSidecarDB);
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1418,6 +1418,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
           new DataColumnSidecarNetworkRetrieverImpl(
               simpleSidecarRetriever.get()::retrieve,
               simpleSidecarRetriever.get()::flush,
+              // intentionally bypassing CachingDataColumnSidecarDB to avoid
+              // getGlobs API calls polluting caches
               sidecarDB.orElseThrow()::addSidecar,
               beaconConfig.beaconRestApiConfig().getGetBlobsSidecarsDownloadTimeoutSeconds());
     } else {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.api;
 
+import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -25,4 +26,6 @@ public interface SidecarUpdateChannel extends ChannelInterface {
   SafeFuture<Void> onEarliestAvailableDataColumnSlot(UInt64 slot);
 
   SafeFuture<Void> onNewSidecar(DataColumnSidecar sidecar);
+
+  SafeFuture<Void> onNewSidecars(List<DataColumnSidecar> sidecars);
 }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -399,10 +399,9 @@ public class DatabaseTest {
             dataStructureUtil.randomSignedBeaconBlockHeader(UInt64.valueOf(3)), UInt64.valueOf(3));
 
     // add blobs out of order
-    database.addSidecar(dataColumnSidecarSlot1);
-    database.addSidecar(dataColumnSidecarSlot0);
-    database.addSidecar(dataColumnSidecarSlot3);
-    database.addSidecar(dataColumnSidecarSlot2);
+    database.addSidecars(List.of(dataColumnSidecarSlot1));
+    database.addSidecars(List.of(dataColumnSidecarSlot0));
+    database.addSidecars(List.of(dataColumnSidecarSlot3, dataColumnSidecarSlot2));
 
     assertThat(database.getSidecarColumnCount()).isEqualTo(4L);
 
@@ -2387,7 +2386,7 @@ public class DatabaseTest {
         DataColumnSlotAndIdentifier.fromDataColumn(dataColumnSidecar);
     assertThat(database.getSidecar(columnSlotAndIdentifier).isEmpty()).isTrue();
 
-    database.addSidecar(dataColumnSidecar);
+    database.addSidecars(List.of(dataColumnSidecar));
     assertThat(database.getSidecar(columnSlotAndIdentifier)).contains(dataColumnSidecar);
   }
 
@@ -2439,9 +2438,7 @@ public class DatabaseTest {
     final DataColumnSlotAndIdentifier block2Column0 =
         DataColumnSlotAndIdentifier.fromDataColumn(block2Sidecar0);
 
-    database.addSidecar(block1Sidecar0);
-    database.addSidecar(block1Sidecar1);
-    database.addSidecar(block2Sidecar0);
+    database.addSidecars(List.of(block1Sidecar0, block1Sidecar1, block2Sidecar0));
 
     try (final Stream<DataColumnSlotAndIdentifier> dataColumnIdentifiersStream =
         database.streamDataColumnIdentifiers(block1Sidecar0.getSlot().plus(1))) {
@@ -2485,9 +2482,7 @@ public class DatabaseTest {
     final DataColumnSlotAndIdentifier block2Column0 =
         DataColumnSlotAndIdentifier.fromDataColumn(block2Sidecar0);
 
-    database.addSidecar(block1Sidecar0);
-    database.addSidecar(block1Sidecar1);
-    database.addSidecar(block2Sidecar0);
+    database.addSidecars(List.of(block1Sidecar0, block1Sidecar1, block2Sidecar0));
 
     database.pruneAllSidecars(ZERO, 10);
     try (final Stream<DataColumnSlotAndIdentifier> dataColumnIdentifiersStream =
@@ -2544,11 +2539,8 @@ public class DatabaseTest {
     final DataColumnSlotAndIdentifier block3Column0 =
         DataColumnSlotAndIdentifier.fromDataColumn(block3Sidecar0);
 
-    database.addSidecar(block1Sidecar0);
-    database.addSidecar(block1Sidecar1);
-    database.addSidecar(block1Sidecar2);
-    database.addSidecar(block2Sidecar0);
-    database.addSidecar(block3Sidecar0);
+    database.addSidecars(
+        List.of(block1Sidecar0, block1Sidecar1, block1Sidecar2, block2Sidecar0, block3Sidecar0));
 
     // not pruned yet should contain all sidecars
     try (final Stream<DataColumnSlotAndIdentifier> dataColumnIdentifiersStream =
@@ -2612,9 +2604,7 @@ public class DatabaseTest {
     final DataColumnSlotAndIdentifier block3Column0 =
         DataColumnSlotAndIdentifier.fromDataColumn(block3Sidecar0);
 
-    database.addSidecar(block1Sidecar0);
-    database.addSidecar(block1Sidecar1);
-    database.addSidecar(block1Sidecar2);
+    database.addSidecars(List.of(block1Sidecar0, block1Sidecar1, block1Sidecar2));
     database.addNonCanonicalSidecar(block2Sidecar0);
     database.addNonCanonicalSidecar(block3Sidecar0);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannel.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
+
+public class BatchingSidecarUpdateChannel implements SidecarUpdateChannel {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private static final int DEFAULT_BATCH_SIZE = 100;
+  private static final Duration DEFAULT_MAX_DELAY = Duration.ofMillis(100);
+
+  private record PendingItem(DataColumnSidecar sidecar, SafeFuture<Void> future) {}
+
+  private final SidecarUpdateChannel delegate;
+  private final AsyncRunner asyncRunner;
+  private final int maxBatchSize;
+  private final Duration maxDelay;
+
+  private final Object lock = new Object();
+  private final List<PendingItem> pendingItems = new ArrayList<>();
+  private boolean flushScheduled = false;
+
+  public BatchingSidecarUpdateChannel(
+      final SidecarUpdateChannel delegate, final AsyncRunner asyncRunner) {
+    this(delegate, asyncRunner, DEFAULT_BATCH_SIZE, DEFAULT_MAX_DELAY);
+  }
+
+  public BatchingSidecarUpdateChannel(
+      final SidecarUpdateChannel delegate,
+      final AsyncRunner asyncRunner,
+      final int maxBatchSize,
+      final Duration maxDelay) {
+    this.delegate = delegate;
+    this.asyncRunner = asyncRunner;
+    this.maxBatchSize = maxBatchSize;
+    this.maxDelay = maxDelay;
+  }
+
+  @Override
+  public SafeFuture<Void> onFirstCustodyIncompleteSlot(final UInt64 slot) {
+    return delegate.onFirstCustodyIncompleteSlot(slot);
+  }
+
+  @Override
+  public SafeFuture<Void> onEarliestAvailableDataColumnSlot(final UInt64 slot) {
+    return delegate.onEarliestAvailableDataColumnSlot(slot);
+  }
+
+  @Override
+  public SafeFuture<Void> onNewSidecar(final DataColumnSidecar sidecar) {
+    final SafeFuture<Void> result = new SafeFuture<>();
+    synchronized (lock) {
+      pendingItems.add(new PendingItem(sidecar, result));
+      if (pendingItems.size() >= maxBatchSize) {
+        flushBatch();
+      } else if (!flushScheduled) {
+        flushScheduled = true;
+        asyncRunner.runAfterDelay(this::flushBatch, maxDelay).finishStackTrace();
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public SafeFuture<Void> onNewSidecars(final List<DataColumnSidecar> sidecars) {
+    return delegate.onNewSidecars(sidecars);
+  }
+
+  @Override
+  public SafeFuture<Void> onNewNonCanonicalSidecar(final DataColumnSidecar sidecar) {
+    return delegate.onNewNonCanonicalSidecar(sidecar);
+  }
+
+  private void flushBatch() {
+    final List<DataColumnSidecar> batch;
+    final List<SafeFuture<Void>> futures;
+
+    synchronized (lock) {
+      if (pendingItems.isEmpty()) {
+        flushScheduled = false;
+        return;
+      }
+
+      batch = new ArrayList<>(pendingItems.size());
+      futures = new ArrayList<>(pendingItems.size());
+
+      pendingItems.removeIf(
+          item -> {
+            batch.add(item.sidecar);
+            futures.add(item.future);
+            return true;
+          });
+
+      flushScheduled = false;
+    }
+
+    LOG.info("Executing a batch of size {}", batch.size());
+
+    delegate
+        .onNewSidecars(batch)
+        .finish(
+            () -> futures.forEach(f -> f.complete(null)),
+            error -> futures.forEach(f -> f.completeExceptionally(error)));
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannel.java
@@ -91,11 +91,6 @@ public class BatchingSidecarUpdateChannel implements SidecarUpdateChannel {
     return delegate.onNewSidecars(sidecars);
   }
 
-  @Override
-  public SafeFuture<Void> onNewNonCanonicalSidecar(final DataColumnSidecar sidecar) {
-    return delegate.onNewNonCanonicalSidecar(sidecar);
-  }
-
   private void flushBatch() {
     final List<DataColumnSidecar> batch;
     final List<SafeFuture<Void>> futures;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -476,6 +476,11 @@ public class ChainStorage
 
   @Override
   public SafeFuture<Void> onNewSidecar(final DataColumnSidecar sidecar) {
-    return SafeFuture.fromRunnable(() -> database.addSidecar(sidecar));
+    return SafeFuture.fromRunnable(() -> database.addSidecars(List.of(sidecar)));
+  }
+
+  @Override
+  public SafeFuture<Void> onNewSidecars(final List<DataColumnSidecar> sidecars) {
+    return SafeFuture.fromRunnable(() -> database.addSidecars(sidecars));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -293,7 +293,7 @@ public interface Database extends AutoCloseable {
 
   void setFirstCustodyIncompleteSlot(UInt64 slot);
 
-  void addSidecar(DataColumnSidecar sidecar);
+  void addSidecars(List<DataColumnSidecar> sidecars);
 
   void addNonCanonicalSidecar(DataColumnSidecar sidecar);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1190,9 +1190,12 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public void addSidecar(final DataColumnSidecar sidecar) {
+  public void addSidecars(final List<DataColumnSidecar> sidecars) {
+    if (sidecars.isEmpty()) {
+      return;
+    }
     try (final FinalizedUpdater updater = finalizedUpdater()) {
-      updater.addSidecar(sidecar);
+      sidecars.forEach(updater::addSidecar);
       updater.commit();
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -418,7 +418,7 @@ public class NoOpDatabase implements Database {
   public void setFirstCustodyIncompleteSlot(final UInt64 slot) {}
 
   @Override
-  public void addSidecar(final DataColumnSidecar sidecar) {}
+  public void addSidecars(final List<DataColumnSidecar> sidecars) {}
 
   @Override
   public void addNonCanonicalSidecar(final DataColumnSidecar sidecar) {}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannelTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannelTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Consensys Software Inc., 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
+
+class BatchingSidecarUpdateChannelTest {
+  private static final int BATCH_SIZE = 3;
+  private static final Duration MAX_DELAY = Duration.ofMillis(50);
+
+  private final SidecarUpdateChannel delegate = mock(SidecarUpdateChannel.class);
+  private final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();
+
+  private BatchingSidecarUpdateChannel channel;
+
+  @BeforeEach
+  void setUp() {
+    channel = new BatchingSidecarUpdateChannel(delegate, stubAsyncRunner, BATCH_SIZE, MAX_DELAY);
+    when(delegate.onNewSidecars(anyList())).thenReturn(SafeFuture.COMPLETE);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldScheduleExecutionForFirstSidecar() {
+    final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
+    channel.onNewSidecar(sidecar);
+
+    assertExecutionScheduled();
+    triggerBatchExecution(List.of(sidecar));
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldBatchMultipleSidecarsReceivedBeforeExecution() {
+    final DataColumnSidecar sidecar1 = mock(DataColumnSidecar.class);
+    final DataColumnSidecar sidecar2 = mock(DataColumnSidecar.class);
+
+    channel.onNewSidecar(sidecar1);
+    assertExecutionScheduled();
+
+    channel.onNewSidecar(sidecar2);
+
+    triggerBatchExecution(List.of(sidecar1, sidecar2));
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldFlushImmediatelyWhenBatchSizeReached() {
+    final DataColumnSidecar sidecar1 = mock(DataColumnSidecar.class);
+    final DataColumnSidecar sidecar2 = mock(DataColumnSidecar.class);
+    final DataColumnSidecar sidecar3 = mock(DataColumnSidecar.class);
+
+    // First sidecar - schedules execution
+    channel.onNewSidecar(sidecar1);
+    assertExecutionScheduled();
+
+    // Second sidecar - still accumulating
+    channel.onNewSidecar(sidecar2);
+
+    // Third sidecar - hits batch size, should flush immediately
+    channel.onNewSidecar(sidecar3);
+
+    // Verify that the delegate was called immediately with all 3 sidecars
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<DataColumnSidecar>> captor = ArgumentCaptor.forClass(List.class);
+    verify(delegate).onNewSidecars(captor.capture());
+    assertThat(captor.getValue()).containsExactly(sidecar1, sidecar2, sidecar3);
+  }
+
+  @Test
+  @SuppressWarnings({"FutureReturnValueIgnored"})
+  void shouldScheduleNewBatchAfterPreviousCompletes() {
+    final DataColumnSidecar sidecar1 = mock(DataColumnSidecar.class);
+    final DataColumnSidecar sidecar2 = mock(DataColumnSidecar.class);
+
+    channel.onNewSidecar(sidecar1);
+    assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
+
+    // Process first batch
+    stubAsyncRunner.executeQueuedActions();
+    verify(delegate, times(1)).onNewSidecars(List.of(sidecar1));
+
+    // Add second sidecar, should schedule new execution
+    channel.onNewSidecar(sidecar2);
+    assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
+
+    // Process second batch
+    stubAsyncRunner.executeQueuedActions();
+    verify(delegate, times(1)).onNewSidecars(List.of(sidecar2));
+  }
+
+  @Test
+  void shouldNotCompleteFuturesUntilDelegateCompletes() {
+    final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
+    final SafeFuture<Void> delegateFuture = new SafeFuture<>();
+    when(delegate.onNewSidecars(anyList())).thenReturn(delegateFuture);
+
+    final SafeFuture<Void> result = channel.onNewSidecar(sidecar);
+    assertThat(result).isNotDone();
+
+    // Trigger batch flush
+    stubAsyncRunner.executeQueuedActions();
+
+    // Caller future should still be pending - delegate hasn't completed yet
+    assertThat(result).isNotDone();
+
+    // Now complete the delegate
+    delegateFuture.complete(null);
+
+    // Caller future should now be completed
+    assertThat(result).isCompleted();
+  }
+
+  @Test
+  void shouldCompleteFuturesExceptionallyOnDelegateError() {
+    final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
+    final RuntimeException error = new RuntimeException("Test error");
+    when(delegate.onNewSidecars(anyList())).thenReturn(SafeFuture.failedFuture(error));
+
+    final SafeFuture<Void> result = channel.onNewSidecar(sidecar);
+    assertThat(result).isNotDone();
+
+    stubAsyncRunner.executeQueuedActions();
+
+    assertThat(result).isCompletedExceptionally();
+    assertThat(result.exceptionNow()).isSameAs(error);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldDelegateOnFirstCustodyIncompleteSlotDirectly() {
+    final UInt64 slot = UInt64.valueOf(100);
+    when(delegate.onFirstCustodyIncompleteSlot(slot)).thenReturn(SafeFuture.COMPLETE);
+
+    channel.onFirstCustodyIncompleteSlot(slot);
+
+    verify(delegate).onFirstCustodyIncompleteSlot(slot);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldDelegateOnEarliestAvailableDataColumnSlotDirectly() {
+    final UInt64 slot = UInt64.valueOf(100);
+    when(delegate.onEarliestAvailableDataColumnSlot(slot)).thenReturn(SafeFuture.COMPLETE);
+
+    channel.onEarliestAvailableDataColumnSlot(slot);
+
+    verify(delegate).onEarliestAvailableDataColumnSlot(slot);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldDelegateOnNewNonCanonicalSidecarDirectly() {
+    final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
+    when(delegate.onNewNonCanonicalSidecar(sidecar)).thenReturn(SafeFuture.COMPLETE);
+
+    channel.onNewNonCanonicalSidecar(sidecar);
+
+    verify(delegate).onNewNonCanonicalSidecar(sidecar);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldDelegateOnNewSidecarsListDirectly() {
+    final DataColumnSidecar sidecar1 = mock(DataColumnSidecar.class);
+    final DataColumnSidecar sidecar2 = mock(DataColumnSidecar.class);
+    final List<DataColumnSidecar> sidecars = List.of(sidecar1, sidecar2);
+
+    channel.onNewSidecars(sidecars);
+
+    verify(delegate).onNewSidecars(sidecars);
+  }
+
+  @Test
+  @SuppressWarnings({"FutureReturnValueIgnored", "unchecked"})
+  void shouldFlushAfterDelayEvenWhenBatchNotFull() {
+    final DataColumnSidecar sidecar1 = mock(DataColumnSidecar.class);
+    final DataColumnSidecar sidecar2 = mock(DataColumnSidecar.class);
+
+    // Add sidecars without reaching batch size
+    channel.onNewSidecar(sidecar1);
+    channel.onNewSidecar(sidecar2);
+
+    // Should not flush immediately since batch size (3) not reached
+    verify(delegate, never()).onNewSidecars(any());
+    assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
+
+    // Simulate delay expiring - should trigger flush
+    stubAsyncRunner.executeQueuedActions();
+
+    // Verify batch was flushed with the 2 sidecars
+    final ArgumentCaptor<List<DataColumnSidecar>> captor = ArgumentCaptor.forClass(List.class);
+    verify(delegate).onNewSidecars(captor.capture());
+    assertThat(captor.getValue()).containsExactly(sidecar1, sidecar2);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void shouldRespectMaxDelayBeforeFlushing() {
+    final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+    final BatchingSidecarUpdateChannel channelWithTimeProvider =
+        new BatchingSidecarUpdateChannel(delegate, asyncRunner, BATCH_SIZE, MAX_DELAY);
+
+    final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
+    channelWithTimeProvider.onNewSidecar(sidecar);
+
+    // Advance time by less than MAX_DELAY (49ms < 50ms)
+    timeProvider.advanceTimeByMillis(49);
+    asyncRunner.executeDueActions();
+
+    // Should NOT have flushed yet
+    verify(delegate, never()).onNewSidecars(any());
+
+    // Advance time to reach MAX_DELAY (now at 50ms)
+    timeProvider.advanceTimeByMillis(1);
+    asyncRunner.executeDueActions();
+
+    // Should have flushed now
+    verify(delegate).onNewSidecars(List.of(sidecar));
+  }
+
+  private void assertExecutionScheduled() {
+    assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
+    verify(delegate, never()).onNewSidecars(any());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void triggerBatchExecution(final List<DataColumnSidecar> expectedBatch) {
+    stubAsyncRunner.executeQueuedActions();
+    ArgumentCaptor<List<DataColumnSidecar>> captor = ArgumentCaptor.forClass(List.class);
+    verify(delegate, times(1)).onNewSidecars(captor.capture());
+    assertThat(captor.getValue()).containsExactlyElementsOf(expectedBatch);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannelTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/BatchingSidecarUpdateChannelTest.java
@@ -180,17 +180,6 @@ class BatchingSidecarUpdateChannelTest {
 
   @Test
   @SuppressWarnings("FutureReturnValueIgnored")
-  void shouldDelegateOnNewNonCanonicalSidecarDirectly() {
-    final DataColumnSidecar sidecar = mock(DataColumnSidecar.class);
-    when(delegate.onNewNonCanonicalSidecar(sidecar)).thenReturn(SafeFuture.COMPLETE);
-
-    channel.onNewNonCanonicalSidecar(sidecar);
-
-    verify(delegate).onNewNonCanonicalSidecar(sidecar);
-  }
-
-  @Test
-  @SuppressWarnings("FutureReturnValueIgnored")
   void shouldDelegateOnNewSidecarsListDirectly() {
     final DataColumnSidecar sidecar1 = mock(DataColumnSidecar.class);
     final DataColumnSidecar sidecar2 = mock(DataColumnSidecar.class);


### PR DESCRIPTION
supersedes #10233

this PR implements:
1. column sidecar write batching
2. inflight write tracking


Feature 1. reduce the amount of transactions against DB (columns will be batched and written within the same transaction)
Feature 2. allows to immediately respond to getSidecar, so reading classes do not need to wait for the DB write to complete. This addresses some additional latency (100ms) introduced by 1. The inflight will be also considered on the columnId caching functionality

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces batched persistence and inflight-aware caching for data column sidecars to cut DB transactions and read latency.
> 
> - **Storage/API changes**: Add `onNewSidecars(List<DataColumnSidecar>)` to `SidecarUpdateChannel`; replace `Database.addSidecar` with `Database.addSidecars(List)` and update `ChainStorage`, `KvStoreDatabase`, `NoOpDatabase`, and integration tests
> - **Batching**: New `BatchingSidecarUpdateChannel` buffers `onNewSidecar` calls (size/time based) and flushes via `onNewSidecars`; wired in `StorageService`
> - **Caching**: Replace `ColumnIdCachingDasDb` with `CachingDataColumnSidecarDB` tracking inflight writes to (a) immediately serve `getSidecar` and (b) merge inflight IDs into `getColumnIdentifiers`; builder updated; comprehensive unit tests added
> - **Controller**: `BeaconChainController` explicitly bypasses the cache for REST `getBlobs` downloads to avoid polluting caches
> - **Docs**: Minor `CLAUDE.md` updates (testing/logging, workflow steps)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39e9f7c60ac227416ff902e2095afe66a1642f72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->