### PR TITLE
Move error encountered on stream abort to DEBUG level

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2OutgoingRequestHandler.java
@@ -240,7 +240,9 @@ public class Eth2OutgoingRequestHandler<
     // releasing any resources
     try {
       responseDecoder.close();
-      rpcStream.closeAbruptly().finishStackTrace();
+      rpcStream.closeAbruptly().finishDebug(LOG);
+    } catch (Exception ex) {
+      LOG.debug("Encountered error while aborting outgoing request", ex);
     } finally {
       getResponseProcessor(rpcStream)
           .finishProcessing()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Issues when closing stream are not very rare and shouldn't lead to INFO log poisoning.
User reported following logs:
```
2026-01-22 21:32:06.905 ERROR - PLEASE FIX OR REPORT | Unexpected exception thrown for p2p-async-8
io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:74) ~[netty-common-4.2.7.Final.jar:4.2.7.Final]
at io.netty.util.internal.ReferenceCountUpdater.retryRelease0(ReferenceCountUpdater.java:157) ~[netty-common-4.2.7.Final.jar:4.2.7.Final]
at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:131) ~[netty-common-4.2.7.Final.jar:4.2.7.Final]
at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:141) ~[netty-buffer-4.2.7.Final.jar:4.2.7.Final]
at tech.pegasys.teku.networking.eth2.rpc.core.encodings.AbstractByteBufDecoder.close(AbstractByteBufDecoder.java:84) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.snappy.SnappyFramedCompressor$SnappyFramedDecompressor.close(SnappyFramedCompressor.java:122) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at java.base/java.util.Optional.ifPresent(Unknown Source) ~[?:?]
at tech.pegasys.teku.networking.eth2.rpc.core.encodings.LengthPrefixedPayloadDecoder.close(LengthPrefixedPayloadDecoder.java:134) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at java.base/java.util.Optional.ifPresent(Unknown Source) ~[?:?]
at tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseDecoder.close(RpcResponseDecoder.java:140) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHandler.abortRequest(Eth2OutgoingRequestHandler.java:242) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHandler.abortRequest(Eth2OutgoingRequestHandler.java:230) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHandler.lambda$ensureNextResponseChunkArrivesInTime$6(Eth2OutgoingRequestHandler.java:259) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.SafeFuture.fromRunnable(SafeFuture.java:157) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.AsyncRunner.lambda$runAfterDelay$1(AsyncRunner.java:32) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:74) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner.lambda$createRunnableForAction$1(ScheduledExecutorAsyncRunner.java:124) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
at java.base/java.lang.Thread.run(Unknown Source) [?:?]
2026-01-22 21:32:06.909 ERROR - PLEASE FIX OR REPORT | Unexpected exception thrown for p2p-async-4
io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:74) ~[netty-common-4.2.7.Final.jar:4.2.7.Final]
at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:132) ~[netty-common-4.2.7.Final.jar:4.2.7.Final]
at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:141) ~[netty-buffer-4.2.7.Final.jar:4.2.7.Final]
at tech.pegasys.teku.networking.eth2.rpc.core.encodings.AbstractByteBufDecoder.close(AbstractByteBufDecoder.java:84) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at java.base/java.util.Optional.ifPresent(Unknown Source) ~[?:?]
at tech.pegasys.teku.networking.eth2.rpc.core.encodings.LengthPrefixedPayloadDecoder.close(LengthPrefixedPayloadDecoder.java:133) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at java.base/java.util.Optional.ifPresent(Unknown Source) ~[?:?]
at tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseDecoder.close(RpcResponseDecoder.java:140) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHandler.abortRequest(Eth2OutgoingRequestHandler.java:242) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHandler.abortRequest(Eth2OutgoingRequestHandler.java:230) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.networking.eth2.rpc.core.Eth2OutgoingRequestHandler.lambda$ensureNextResponseChunkArrivesInTime$6(Eth2OutgoingRequestHandler.java:259) ~[teku-networking-eth2-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.SafeFuture.fromRunnable(SafeFuture.java:157) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.AsyncRunner.lambda$runAfterDelay$1(AsyncRunner.java:32) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:74) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner.lambda$createRunnableForAction$1(ScheduledExecutorAsyncRunner.java:124) ~[teku-infrastructure-async-25.12.0.jar:25.12.0]
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
at java.base/java.lang.Thread.run(Unknown Source) [?:?]
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces log noise during outgoing RPC aborts by downgrading close errors and safely handling abort cleanup.
> 
> - In `Eth2OutgoingRequestHandler.abortRequest`, replaced `rpcStream.closeAbruptly().finishStackTrace()` with `finishDebug(LOG)`
> - Wrapped `responseDecoder.close()` and stream close in try/catch; logs exceptions at DEBUG
> - No changes to request/response processing flow outside the abort path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e220a7f68c43872cb9b89d5da78ebe68ae5efe88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->