### PR TITLE
Add completed slots cache in recovering custody

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -309,17 +309,18 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
   @Override
   public SafeFuture<Void> onNewValidatedDataColumnSidecar(
       final DataColumnSidecar dataColumnSidecar, final RemoteOrigin remoteOrigin) {
+    if (completedSlots.contains(dataColumnSidecar.getSlotAndBlockRoot())) {
+      return SafeFuture.COMPLETE;
+    }
     // Recovery is not needed for locally produced or recovered data,
     // we will get everything for it in custody w/o reconstruction
     if (remoteOrigin.equals(RemoteOrigin.RPC) || remoteOrigin.equals(RemoteOrigin.GOSSIP)) {
-      if (!completedSlots.contains(dataColumnSidecar.getSlotAndBlockRoot())) {
-        LOG.debug(
-            "sidecar: {} {} - remoteOrigin: {}",
-            dataColumnSidecar::getSlotAndBlockRoot,
-            dataColumnSidecar::getIndex,
-            () -> remoteOrigin);
-        createOrUpdateRecoveryTaskForDataColumnSidecar(dataColumnSidecar);
-      }
+      LOG.debug(
+          "sidecar: {} {} - remoteOrigin: {}",
+          dataColumnSidecar::getSlotAndBlockRoot,
+          dataColumnSidecar::getIndex,
+          () -> remoteOrigin);
+      createOrUpdateRecoveryTaskForDataColumnSidecar(dataColumnSidecar);
     }
     return delegate.onNewValidatedDataColumnSidecar(dataColumnSidecar, remoteOrigin);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyImpl.java
@@ -170,8 +170,11 @@ public class DataColumnSidecarRecoveringCustodyImpl implements DataColumnSidecar
   }
 
   private void pruneCompletedSlots() {
-    while (completedSlots.size() >= completedSlotsSizeTarget) {
-      completedSlots.removeFirst();
+    final int slotsToPrune = completedSlots.size() - completedSlotsSizeTarget;
+    if (slotsToPrune >= 0) {
+      for (int i = 0; i <= slotsToPrune; i++) {
+        completedSlots.removeFirst();
+      }
     }
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -50,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
@@ -330,10 +332,18 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
   @Test
   public void shouldPreserveTaskIsStartedWhenSuccess() {
+    final Map<DataColumnSlotAndIdentifier, DataColumnSidecar> sidecars =
+        columnIndices
+            .get()
+            .limit(64)
+            .map(i -> dataStructureUtil.randomDataColumnSidecar(signedBeaconBlock.asHeader(), i))
+            .collect(
+                Collectors.toMap(DataColumnSlotAndIdentifier::fromDataColumn, sidecar -> sidecar));
+
     final DataColumnSidecarRecoveringCustodyImpl.RecoveryTask task =
         new DataColumnSidecarRecoveringCustodyImpl.RecoveryTask(
             new SlotAndBlockRoot(UInt64.ZERO, Bytes32.ZERO),
-            Collections.emptyMap(),
+            sidecars,
             new AtomicBoolean(true),
             new AtomicBoolean(true));
 
@@ -387,5 +397,106 @@ public class DataColumnSidecarRecoveringCustodyTest {
 
     verifyNoInteractions(miscHelpersFulu);
     verify(dataColumnSidecarPublisher, never()).accept(any(), eq(RemoteOrigin.RECOVERED));
+  }
+
+  @Test
+  public void shouldAddToCompletedSlotsWhenCompleted() {
+    custody.onSlot(slot);
+    assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
+
+    final Map<UInt64, DataColumnSidecar> sidecars =
+        columnIndices
+            .get()
+            .map(i -> dataStructureUtil.randomDataColumnSidecar(signedBeaconBlock.asHeader(), i))
+            .collect(Collectors.toMap(DataColumnSidecar::getIndex, sidecar -> sidecar));
+    sidecars
+        .values()
+        .forEach(sidecar -> custody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC));
+
+    assertThat(custody.getCompletedSlots()).isEmpty();
+
+    stubAsyncRunner.executeDueActionsRepeatedly();
+    stubTimeProvider.advanceTimeBySeconds(1);
+    stubAsyncRunner.executeDueActionsRepeatedly();
+    stubTimeProvider.advanceTimeBySeconds(1);
+    stubAsyncRunner.executeDueActionsRepeatedly();
+
+    assertThat(custody.getCompletedSlots()).contains(signedBeaconBlock.getSlotAndBlockRoot());
+  }
+
+  @Test
+  public void shouldPruneRecoveryTasks() {
+    // recovery tasks size target is slots per epoch, minimal is 8, so adding 9, 1st should gone
+    for (UInt64 slot = UInt64.ONE;
+        slot.isLessThanOrEqualTo(UInt64.valueOf(9));
+        slot = slot.increment()) {
+      custody.onSlot(slot);
+      assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
+
+      final SignedBeaconBlock signedBeaconBlock = dataStructureUtil.randomSignedBeaconBlock(slot);
+      final Map<UInt64, DataColumnSidecar> sidecars =
+          columnIndices
+              .get()
+              .map(i -> dataStructureUtil.randomDataColumnSidecar(signedBeaconBlock.asHeader(), i))
+              .collect(Collectors.toMap(DataColumnSidecar::getIndex, sidecar -> sidecar));
+      sidecars
+          .values()
+          .forEach(sidecar -> custody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC));
+    }
+
+    assertThat(custody.getCompletedSlots()).isEmpty();
+    assertThat(custody.getRecoveryTasks().size()).isEqualTo(8);
+    // replaced with 2nd because prune target is 8
+    assertThat(
+            custody.getRecoveryTasks().keySet().stream()
+                .map(SlotAndBlockRoot::getSlot)
+                .collect(Collectors.toSet()))
+        .doesNotContain(UInt64.ONE);
+
+    stubAsyncRunner.executeDueActionsRepeatedly();
+    stubTimeProvider.advanceTimeBySeconds(1);
+    stubAsyncRunner.executeDueActionsRepeatedly();
+    stubTimeProvider.advanceTimeBySeconds(1);
+    stubAsyncRunner.executeDueActionsRepeatedly();
+
+    assertThat(custody.getCompletedSlots().size()).isEqualTo(8);
+  }
+
+  @Test
+  @Disabled("This test is slow for CI, run it locally")
+  public void shouldPruneCompletedSlots() {
+    final int slotsPerEpoch = spec.getGenesisSpec().getSlotsPerEpoch();
+    // completed slots size target is slots per epoch * 64, we have minimal spec with 8 slots
+    for (long j = 0; j <= 64; ++j) {
+      for (UInt64 slot = UInt64.ONE.plus(slotsPerEpoch * j);
+          slot.isLessThanOrEqualTo(UInt64.valueOf(8).plus(slotsPerEpoch * j));
+          slot = slot.increment()) {
+        custody.onSlot(slot);
+        assertThat(stubAsyncRunner.hasDelayedActions()).isTrue();
+
+        final SignedBeaconBlock signedBeaconBlock = dataStructureUtil.randomSignedBeaconBlock(slot);
+        final Map<UInt64, DataColumnSidecar> sidecars =
+            columnIndices
+                .get()
+                .map(
+                    i -> dataStructureUtil.randomDataColumnSidecar(signedBeaconBlock.asHeader(), i))
+                .collect(Collectors.toMap(DataColumnSidecar::getIndex, sidecar -> sidecar));
+        sidecars
+            .values()
+            .forEach(sidecar -> custody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC));
+      }
+
+      stubAsyncRunner.executeDueActionsRepeatedly();
+      stubTimeProvider.advanceTimeBySeconds(1);
+      stubAsyncRunner.executeDueActionsRepeatedly();
+      stubTimeProvider.advanceTimeBySeconds(1);
+      stubAsyncRunner.executeDueActionsRepeatedly();
+    }
+    // we didn't have onSlot (which fires prune) after last 8 recovery tasks execution
+    custody.onSlot(UInt64.valueOf(65 * 8 + 1));
+
+    assertThat(custody.getCompletedSlots().size()).isEqualTo(8 * 64 - 1);
+    assertThat(custody.getCompletedSlots().getFirst().getSlot()).isEqualTo(UInt64.valueOf(10));
+    assertThat(custody.getCompletedSlots().getLast().getSlot()).isEqualTo(UInt64.valueOf(8 * 65));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarRecoveringCustodyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.statetransition.datacolumns.DasCustodyStand.createCustodyGroupCountManager;
 
@@ -412,6 +413,7 @@ public class DataColumnSidecarRecoveringCustodyTest {
     sidecars
         .values()
         .forEach(sidecar -> custody.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC));
+    verify(delegate, times(sidecars.size())).onNewValidatedDataColumnSidecar(any(), any());
 
     assertThat(custody.getCompletedSlots()).isEmpty();
 
@@ -422,6 +424,11 @@ public class DataColumnSidecarRecoveringCustodyTest {
     stubAsyncRunner.executeDueActionsRepeatedly();
 
     assertThat(custody.getCompletedSlots()).contains(signedBeaconBlock.getSlotAndBlockRoot());
+
+    // doesn't pass sidecars further when it's proved as completed
+    custody.onNewValidatedDataColumnSidecar(
+        sidecars.values().stream().findFirst().get(), RemoteOrigin.RPC);
+    verifyNoMoreInteractions(delegate);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We had documented cases when sidecars are submitted to recovering custody for 2 times in a row. For example with failed sync batch submission, which retries the same range after a while. If there are misses in the second retry, recovering custody will try to recover sidecars which are already in DB. I've added small light cache to `DataColumnSidecarRecoveringCustodyImpl` to avoid such behavior and skip creation of recovery task for the second time. 

Regarding the disabled test: it takes locally om m4 like 10 seconds, so it will take on CI 30+ seconds, which I think is too much for single unit test. If some could suggest a lighter way to check the same, I'd appreciate and will change the test.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a lightweight in-memory cache of completed `SlotAndBlockRoot`s to skip duplicate recovery and sidecar handling, populated when all columns are present or after reconstruction.
> 
> - New `completedSlots` set with pruning (`completedSlotsSizeTarget`); pruned each `onSlot`
> - Early-return in `onNewValidatedDataColumnSidecar` when slot is completed
> - Recovery flow updates: mark slot completed when all columns already present or after recovery; clear task sidecars
> - New constructor enabling configurable `recoveryTasksSizeTarget` and `completedSlotsSizeTarget` (public ctor retains sensible defaults); minor visibility/test helpers added
> - Tests added/updated for completion, pruning, and task behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ea69aa37aff960a055ae0fa752f99a14e92a329. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->