### PR TITLE
[Gloas] Initial changes to cache execution payload state

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -226,7 +226,7 @@ public abstract class AbstractBlockFactoryTest {
     final Bytes32 bestBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final BeaconState blockSlotState =
         recentChainData
-            .retrieveStateAtSlot(new SlotAndBlockRoot(UInt64.valueOf(blockSlot), bestBlockRoot))
+            .retrieveBlockState(new SlotAndBlockRoot(UInt64.valueOf(blockSlot), bestBlockRoot))
             .join()
             .orElseThrow();
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -445,7 +445,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     // a sync where the attestation weighting is almost certainly useless.
     final BeaconState preState =
         safeJoin(
-                recentChainData.retrieveStateAtSlot(
+                recentChainData.retrieveBlockState(
                     new SlotAndBlockRoot(block.getSlot(), block.getParentRoot())))
             .orElseThrow();
     final VoteUpdater voteUpdater = recentChainData.startVoteUpdate();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -99,6 +99,14 @@ public interface ReadOnlyStore extends TimeProvider {
   Optional<BeaconState> getBlockStateIfAvailable(Bytes32 blockRoot);
 
   /**
+   * Returns an execution payload state only if it is immediately available (not pruned).
+   *
+   * @param blockRoot The block root corresponding to the execution payload state to retrieve
+   * @return The execution payload state if available.
+   */
+  Optional<BeaconState> getExecutionPayloadStateIfAvailable(Bytes32 blockRoot);
+
+  /**
    * Returns a block only if it is immediately available (not pruned).
    *
    * @param blockRoot The block root of the block to retrieve
@@ -120,9 +128,9 @@ public interface ReadOnlyStore extends TimeProvider {
 
   SafeFuture<Optional<BeaconState>> retrieveBlockState(Bytes32 blockRoot);
 
-  SafeFuture<Optional<BeaconState>> retrieveCheckpointState(Checkpoint checkpoint);
+  SafeFuture<Optional<BeaconState>> retrieveBlockState(SlotAndBlockRoot slotAndBlockRoot);
 
-  SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(SlotAndBlockRoot checkpoint);
+  SafeFuture<Optional<BeaconState>> retrieveCheckpointState(Checkpoint checkpoint);
 
   SafeFuture<Optional<UInt64>> retrieveEarliestBlobSidecarSlot();
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -200,6 +200,10 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     return Optional.ofNullable(checkpointStates.get(checkpoint));
   }
 
+  private BeaconState getExecutionPayloadState(final Bytes32 blockRoot) {
+    return executionPayloadStates.get(blockRoot);
+  }
+
   @Override
   public UInt64 getHighestVotedValidatorIndex() {
     return votes.keySet().stream().max(Comparator.naturalOrder()).orElse(UInt64.ZERO);
@@ -209,6 +213,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public Optional<BeaconState> getBlockStateIfAvailable(final Bytes32 blockRoot) {
     return Optional.ofNullable(getBlockState(blockRoot));
+  }
+
+  @Override
+  public Optional<BeaconState> getExecutionPayloadStateIfAvailable(final Bytes32 blockRoot) {
+    return Optional.ofNullable(getExecutionPayloadState(blockRoot));
   }
 
   @Override
@@ -238,14 +247,14 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
-    return SafeFuture.completedFuture(getCheckpointState(checkpoint));
+  public SafeFuture<Optional<BeaconState>> retrieveBlockState(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(
-      final SlotAndBlockRoot slotAndBlockRoot) {
-    throw new UnsupportedOperationException("Not implemented");
+  public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
+    return SafeFuture.completedFuture(getCheckpointState(checkpoint));
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -365,12 +365,13 @@ public class ChainBuilder {
     return resultToState(getBlockAndStateAtSlot(slot));
   }
 
-  public SignedExecutionPayloadAndState getExecutionPayloadAndStateAtSlot(final UInt64 slot) {
-    return executionPayloads.get(slot);
+  public Optional<SignedExecutionPayloadAndState> getExecutionPayloadAndStateAtSlot(
+      final UInt64 slot) {
+    return Optional.ofNullable(executionPayloads.get(slot));
   }
 
-  public BeaconState getExecutionPayloadStateAtSlot(final UInt64 slot) {
-    return resultToState(getExecutionPayloadAndStateAtSlot(slot));
+  public Optional<BeaconState> getExecutionPayloadStateAtSlot(final UInt64 slot) {
+    return getExecutionPayloadAndStateAtSlot(slot).map(SignedExecutionPayloadAndState::state);
   }
 
   public SignedBlockAndState getLatestBlockAndStateAtSlot(final long slot) {
@@ -682,7 +683,7 @@ public class ChainBuilder {
     final SignedBlockAndState latestBlockAndState = getLatestBlockAndState();
     final BeaconState preState =
         // build on top of the execution payload state if an execution payload has been processed
-        Optional.ofNullable(getExecutionPayloadStateAtSlot(latestBlockAndState.getSlot()))
+        getExecutionPayloadStateAtSlot(latestBlockAndState.getSlot())
             .orElse(latestBlockAndState.getState());
     final Bytes32 parentRoot = latestBlockAndState.getBlock().getMessage().hashTreeRoot();
 
@@ -1016,10 +1017,6 @@ public class ChainBuilder {
 
   private SignedBeaconBlock resultToBlock(final SignedBlockAndState result) {
     return Optional.ofNullable(result).map(SignedBlockAndState::getBlock).orElse(null);
-  }
-
-  private BeaconState resultToState(final SignedExecutionPayloadAndState result) {
-    return Optional.ofNullable(result).map(SignedExecutionPayloadAndState::state).orElse(null);
   }
 
   public SignedContributionAndProofTestBuilder createValidSignedContributionAndProofBuilder() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
@@ -58,7 +58,7 @@ public class EpochCachePrimer {
   private void primeCacheForBlockAtSlot(
       final MinimalBeaconBlockSummary headBlock, final UInt64 firstSlotOfEpoch) {
     recentChainData
-        .retrieveStateAtSlot(new SlotAndBlockRoot(firstSlotOfEpoch, headBlock.getRoot()))
+        .retrieveBlockState(new SlotAndBlockRoot(firstSlotOfEpoch, headBlock.getRoot()))
         .finish(
             maybeState -> maybeState.ifPresent(this::primeEpochStateCaches),
             error -> LOG.warn("Failed to precompute epoch transition", error));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -214,7 +214,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final ExecutionLayerChannel executionLayer) {
     recentChainData.setBlockTimelinessIfEmpty(block);
     return recentChainData
-        .retrieveStateAtSlot(new SlotAndBlockRoot(block.getSlot(), block.getParentRoot()))
+        .retrieveBlockState(new SlotAndBlockRoot(block.getSlot(), block.getParentRoot()))
         .thenPeek(__ -> blockImportPerformance.ifPresent(BlockImportPerformance::preStateRetrieved))
         .thenCompose(
             blockSlotState ->
@@ -231,7 +231,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final SignedExecutionPayloadEnvelope signedEnvelope,
       final ExecutionLayerChannel executionLayer) {
     return recentChainData
-        .retrieveStateAtSlot(signedEnvelope.getSlotAndBlockRoot())
+        .retrieveBlockState(signedEnvelope.getSlotAndBlockRoot())
         .thenCompose(blockState -> onExecutionPayload(signedEnvelope, blockState, executionLayer));
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -289,7 +289,7 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
     if (spec.computeEpochAtSlot(head.getSlot()).equals(requiredEpoch)) {
       return head.getState().thenApply(Optional::of);
     } else {
-      return recentChainData.retrieveStateAtSlot(
+      return recentChainData.retrieveBlockState(
           new SlotAndBlockRoot(spec.computeStartSlotAtEpoch(requiredEpoch), head.getRoot()));
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtils.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtils.java
@@ -65,7 +65,7 @@ public class SyncCommitteeStateUtils {
       return SafeFuture.completedFuture(Optional.empty());
     }
     return recentChainData
-        .retrieveStateAtSlot(
+        .retrieveBlockState(
             new SlotAndBlockRoot(chainHeadSlot.max(requiredSlot), chainHead.getRoot()))
         .thenApply(maybeState -> maybeState.flatMap(BeaconState::toVersionAltair));
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -112,7 +112,7 @@ public class GossipValidationHelper {
 
   public SafeFuture<Optional<BeaconState>> getStateAtSlotAndBlockRoot(
       final SlotAndBlockRoot slotAndBlockRoot) {
-    return recentChainData.retrieveStateAtSlot(slotAndBlockRoot);
+    return recentChainData.retrieveBlockState(slotAndBlockRoot);
   }
 
   public boolean currentFinalizedCheckpointIsAncestorOfBlock(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -105,7 +105,7 @@ public class GossipValidationHelper {
     final UInt64 firstSlotInBlockEpoch =
         spec.computeStartSlotAtEpoch(spec.computeEpochAtSlot(slot));
     return parentBlockSlot.isLessThan(firstSlotInBlockEpoch)
-        ? recentChainData.retrieveStateAtSlot(
+        ? recentChainData.retrieveBlockState(
             new SlotAndBlockRoot(firstSlotInBlockEpoch, parentBlockRoot))
         : recentChainData.retrieveBlockState(parentBlockRoot);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
@@ -179,7 +179,7 @@ class EpochCachePrimerTest {
   private BeaconState getStateForEpoch(final UInt64 epoch) {
     final Bytes32 headBlock = recentChainData.getBestBlockRoot().orElseThrow();
     final SafeFuture<Optional<BeaconState>> stateFuture =
-        recentChainData.retrieveStateAtSlot(
+        recentChainData.retrieveBlockState(
             new SlotAndBlockRoot(realSpec.computeStartSlotAtEpoch(epoch), headBlock));
     assertThatSafeFuture(stateFuture).isCompletedWithNonEmptyOptional();
     return stateFuture.getNow(null).orElseThrow();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -1040,7 +1040,7 @@ class ForkChoiceNotifierTest {
     final Bytes32 bestBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final BeaconState state =
         recentChainData
-            .retrieveStateAtSlot(new SlotAndBlockRoot(blockSlot, bestBlockRoot))
+            .retrieveBlockState(new SlotAndBlockRoot(blockSlot, bestBlockRoot))
             .join()
             .orElseThrow();
     return withProposerForSlot(getCurrentForkChoiceState(), state, blockSlot);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
@@ -93,7 +94,7 @@ class ProposersDataManagerTest {
     when(chainHead.getSlot()).thenReturn(UInt64.ONE);
     when(chainHead.getState()).thenReturn(SafeFuture.completedFuture(mock(BeaconState.class)));
 
-    when(recentChainData.retrieveStateAtSlot(any()))
+    when(recentChainData.retrieveBlockState(any(SlotAndBlockRoot.class)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(mock(BeaconState.class))));
     when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
   }
@@ -127,7 +128,7 @@ class ProposersDataManagerTest {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.ONE)).isCompletedWithValue(false);
-    verify(recentChainData, never()).retrieveStateAtSlot(any());
+    verify(recentChainData, never()).retrieveBlockState(any(SlotAndBlockRoot.class));
   }
 
   @TestTemplate
@@ -136,7 +137,7 @@ class ProposersDataManagerTest {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.ONE)).isCompletedWithValue(true);
-    verify(recentChainData, never()).retrieveStateAtSlot(any());
+    verify(recentChainData, never()).retrieveBlockState(any(SlotAndBlockRoot.class));
   }
 
   @TestTemplate
@@ -145,7 +146,7 @@ class ProposersDataManagerTest {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.valueOf(10))).isCompletedWithValue(false);
-    verify(recentChainData).retrieveStateAtSlot(any());
+    verify(recentChainData).retrieveBlockState(any(SlotAndBlockRoot.class));
   }
 
   @TestTemplate
@@ -154,6 +155,6 @@ class ProposersDataManagerTest {
     manager.updatePreparedProposers(proposers, UInt64.ONE);
 
     assertThat(manager.isBlockProposerConnected(UInt64.valueOf(10))).isCompletedWithValue(true);
-    verify(recentChainData).retrieveStateAtSlot(any());
+    verify(recentChainData).retrieveBlockState(any(SlotAndBlockRoot.class));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
@@ -147,7 +147,7 @@ class SyncCommitteeStateUtilsTest {
     when(recentChainData.getSlotForBlockRoot(blockRoot)).thenReturn(Optional.of(blockSlot));
 
     assertThatSafeFuture(stateUtils.getStateForSyncCommittee(slot)).isCompletedWithEmptyOptional();
-    verify(recentChainData, never()).retrieveBlockState(any());
+    verify(recentChainData, never()).retrieveBlockState(any(SlotAndBlockRoot.class));
   }
 
   private void assertRetrievedStateIsSuitable(final UInt64 slot, final BeaconState state) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
@@ -126,7 +126,7 @@ class SyncCommitteeStateUtilsTest {
 
     final BeaconStateAltair generatedState =
         dataStructureUtil.stateBuilderAltair().slot(generatedStateSlot).build();
-    when(recentChainData.retrieveStateAtSlot(
+    when(recentChainData.retrieveBlockState(
             new SlotAndBlockRoot(generatedStateSlot, chainHead.getRoot())))
         .thenReturn(SafeFuture.completedFuture(Optional.of(generatedState)));
 
@@ -147,7 +147,7 @@ class SyncCommitteeStateUtilsTest {
     when(recentChainData.getSlotForBlockRoot(blockRoot)).thenReturn(Optional.of(blockSlot));
 
     assertThatSafeFuture(stateUtils.getStateForSyncCommittee(slot)).isCompletedWithEmptyOptional();
-    verify(recentChainData, never()).retrieveStateAtSlot(any());
+    verify(recentChainData, never()).retrieveBlockState(any());
   }
 
   private void assertRetrievedStateIsSuitable(final UInt64 slot, final BeaconState state) {

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.networks.Eth2Network;
@@ -407,7 +408,8 @@ public class SlotProcessorTest {
     final Optional<MinimalBeaconBlockSummary> headBlock =
         storageSystem.recentChainData().getHeadBlock();
     when(recentChainData.getHeadBlock()).thenReturn(headBlock);
-    when(recentChainData.retrieveBlockState(any())).thenReturn(new SafeFuture<>());
+    when(recentChainData.retrieveBlockState(any(SlotAndBlockRoot.class)))
+        .thenReturn(new SafeFuture<>());
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
 
     final Spec spec = TestSpecFactory.create(SpecMilestone.PHASE0, eth2Network);
@@ -446,7 +448,7 @@ public class SlotProcessorTest {
         nextEpochSlotMinusOne.plus(oneThirdMillis(millisPerSlot)), Optional.empty());
 
     // Shouldn't have precomputed epoch transition yet.
-    verify(recentChainData, never()).retrieveBlockState(any());
+    verify(recentChainData, never()).retrieveBlockState(any(SlotAndBlockRoot.class));
 
     // But just before the last slot of the epoch ends, we should precompute the next epoch
     slotProcessor.onTick(
@@ -458,7 +460,7 @@ public class SlotProcessorTest {
         nextEpochSlotMinusOne.plus(oneThirdMillis(millisPerSlot) * 2 + 1000), Optional.empty());
     slotProcessor.onTick(
         nextEpochSlotMinusOne.plus(oneThirdMillis(millisPerSlot) * 2 + 2000), Optional.empty());
-    verify(recentChainData, atMostOnce()).retrieveBlockState(any());
+    verify(recentChainData, atMostOnce()).retrieveBlockState(any(SlotAndBlockRoot.class));
   }
 
   @ParameterizedTest

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -407,7 +407,7 @@ public class SlotProcessorTest {
     final Optional<MinimalBeaconBlockSummary> headBlock =
         storageSystem.recentChainData().getHeadBlock();
     when(recentChainData.getHeadBlock()).thenReturn(headBlock);
-    when(recentChainData.retrieveStateAtSlot(any())).thenReturn(new SafeFuture<>());
+    when(recentChainData.retrieveBlockState(any())).thenReturn(new SafeFuture<>());
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
 
     final Spec spec = TestSpecFactory.create(SpecMilestone.PHASE0, eth2Network);
@@ -446,7 +446,7 @@ public class SlotProcessorTest {
         nextEpochSlotMinusOne.plus(oneThirdMillis(millisPerSlot)), Optional.empty());
 
     // Shouldn't have precomputed epoch transition yet.
-    verify(recentChainData, never()).retrieveStateAtSlot(any());
+    verify(recentChainData, never()).retrieveBlockState(any());
 
     // But just before the last slot of the epoch ends, we should precompute the next epoch
     slotProcessor.onTick(
@@ -458,7 +458,7 @@ public class SlotProcessorTest {
         nextEpochSlotMinusOne.plus(oneThirdMillis(millisPerSlot) * 2 + 1000), Optional.empty());
     slotProcessor.onTick(
         nextEpochSlotMinusOne.plus(oneThirdMillis(millisPerSlot) * 2 + 2000), Optional.empty());
-    verify(recentChainData, atMostOnce()).retrieveStateAtSlot(any());
+    verify(recentChainData, atMostOnce()).retrieveBlockState(any());
   }
 
   @ParameterizedTest

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -251,7 +251,7 @@ public class CombinedChainDataClient {
     final Optional<Bytes32> recentBlockRoot = recentChainData.getBlockRootInEffectBySlot(slot);
     if (recentBlockRoot.isPresent()) {
       return getStore()
-          .retrieveStateAtSlot(new SlotAndBlockRoot(slot, recentBlockRoot.get()))
+          .retrieveBlockState(new SlotAndBlockRoot(slot, recentBlockRoot.get()))
           .thenCompose(
               maybeState ->
                   maybeState.isPresent()
@@ -309,7 +309,7 @@ public class CombinedChainDataClient {
         recentChainData.getBlockRootInEffectBySlot(slot, chainHead);
     if (recentBlockRoot.isPresent()) {
       return getStore()
-          .retrieveStateAtSlot(new SlotAndBlockRoot(slot, recentBlockRoot.get()))
+          .retrieveBlockState(new SlotAndBlockRoot(slot, recentBlockRoot.get()))
           .thenCompose(
               maybeState ->
                   maybeState.isPresent()
@@ -863,7 +863,7 @@ public class CombinedChainDataClient {
       return STATE_NOT_AVAILABLE;
     }
     return store
-        .retrieveStateAtSlot(slotAndBlockRoot)
+        .retrieveBlockState(slotAndBlockRoot)
         .thenCompose(
             maybeState -> {
               if (maybeState.isPresent()) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -664,7 +664,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
     return store.retrieveBlockState(blockRoot);
   }
 
-  public SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(
+  public SafeFuture<Optional<BeaconState>> retrieveBlockState(
       final SlotAndBlockRoot slotAndBlockRoot) {
     if (store == null) {
       return EmptyStoreResults.EMPTY_STATE_FUTURE;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -669,7 +669,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
     if (store == null) {
       return EmptyStoreResults.EMPTY_STATE_FUTURE;
     }
-    return store.retrieveStateAtSlot(slotAndBlockRoot);
+    return store.retrieveBlockState(slotAndBlockRoot);
   }
 
   public SafeFuture<Optional<BeaconState>> retrieveStateInEffectAtSlot(final UInt64 slot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 
@@ -38,7 +39,7 @@ public abstract class CacheableStore implements UpdatableStore {
 
   abstract void cacheBlocks(Collection<BlockAndCheckpoints> blockAndCheckpoints);
 
-  abstract void cacheStates(Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries);
+  abstract void cacheBlockStates(Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries);
 
   abstract void cacheBlobSidecars(Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsMap);
 
@@ -50,4 +51,7 @@ public abstract class CacheableStore implements UpdatableStore {
   abstract void setHighestVotedValidatorIndex(UInt64 highestVotedValidatorIndex);
 
   abstract void setVote(int index, VoteTracker voteTracker);
+
+  abstract void cacheExecutionPayloadAndStates(
+      Map<Bytes32, SignedExecutionPayloadAndState> executionPayloadAndStates);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -1103,18 +1103,24 @@ class Store extends CacheableStore {
     return maybeEpochStates;
   }
 
-  void removeStateAndBlock(final Bytes32 root) {
-    blocks.remove(root);
-    blockStates.remove(root);
+  void removeBlockAndState(final Bytes32 blockRoot) {
+    blocks.remove(blockRoot);
+    blockStates.remove(blockRoot);
     maybeEpochStates.ifPresent(
         epochStates -> {
-          if (!finalizedAnchor.getRoot().equals(root)) {
-            final StateAndBlockSummary stateAndBlockSummary = epochStates.remove(root);
+          if (!finalizedAnchor.getRoot().equals(blockRoot)) {
+            final StateAndBlockSummary stateAndBlockSummary = epochStates.remove(blockRoot);
             if (stateAndBlockSummary != null) {
               LOG.trace("epochCache REM {}", stateAndBlockSummary::getSlot);
             }
           }
         });
+  }
+
+  void removeExecutionPayloadAndState(final Bytes32 blockRoot) {
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 remove execution payload when we
+    // implement storing it
+    executionPayloadStates.remove(blockRoot);
   }
 
   void updateFinalizedAnchor(final AnchorPoint latestFinalized) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.dataproviders.lookup.BlockProvider.fromDynamicMa
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,6 +60,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -102,7 +104,7 @@ class Store extends CacheableStore {
   private final ForkChoiceStrategy forkChoiceStrategy;
 
   private final Optional<Checkpoint> initialCheckpoint;
-  private final CachingTaskQueue<Bytes32, StateAndBlockSummary> states;
+  private final CachingTaskQueue<Bytes32, StateAndBlockSummary> blockStates;
   private final Map<Bytes32, SignedBeaconBlock> blocks;
   private final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates;
   private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
@@ -116,6 +118,7 @@ class Store extends CacheableStore {
   private VoteTracker[] votes;
   private UInt64 highestVotedValidatorIndex;
   private Optional<UInt64> custodyGroupCount = Optional.empty();
+  private final CachingTaskQueue<Bytes32, BeaconState> executionPayloadStates;
 
   private UInt64 reorgThreshold = UInt64.ZERO;
   private UInt64 parentThreshold = UInt64.ZERO;
@@ -127,7 +130,7 @@ class Store extends CacheableStore {
       final BlockProvider blockProvider,
       final StateAndBlockSummaryProvider stateProvider,
       final EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider,
-      final CachingTaskQueue<Bytes32, StateAndBlockSummary> states,
+      final CachingTaskQueue<Bytes32, StateAndBlockSummary> blockStates,
       final Optional<Checkpoint> initialCheckpoint,
       final UInt64 time,
       final UInt64 genesisTime,
@@ -141,7 +144,8 @@ class Store extends CacheableStore {
       final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates,
       final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates,
       final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
-      final Optional<UInt64> custodyGroupCount) {
+      final Optional<UInt64> custodyGroupCount,
+      final CachingTaskQueue<Bytes32, BeaconState> executionPayloadStates) {
     checkArgument(
         time.isGreaterThanOrEqualTo(genesisTime),
         "Time must be greater than or equal to genesisTime");
@@ -154,7 +158,7 @@ class Store extends CacheableStore {
     // Set up metrics
     this.metricsSystem = metricsSystem;
     this.spec = spec;
-    this.states = states;
+    this.blockStates = blockStates;
     this.checkpointStates = checkpointStates;
 
     // Store instance variables
@@ -175,7 +179,7 @@ class Store extends CacheableStore {
     // Track latest finalized block
     this.finalizedAnchor = finalizedAnchor;
     this.maybeEpochStates = maybeEpochStates;
-    states.cache(finalizedAnchor.getRoot(), finalizedAnchor);
+    blockStates.cache(finalizedAnchor.getRoot(), finalizedAnchor);
     this.finalizedOptimisticTransitionPayload = finalizedOptimisticTransitionPayload;
 
     // Set up block provider to draw from in-memory blocks
@@ -192,6 +196,8 @@ class Store extends CacheableStore {
 
     this.earliestBlobSidecarSlotProvider = earliestBlobSidecarSlotProvider;
     this.custodyGroupCount = custodyGroupCount;
+
+    this.executionPayloadStates = executionPayloadStates;
   }
 
   private BlockProvider createBlockProviderFromMapWhileLocked(
@@ -223,7 +229,6 @@ class Store extends CacheableStore {
       final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint bestJustifiedCheckpoint,
-      final Map<Bytes32, StoredBlockMetadata> blockInfoByRoot,
       final Map<UInt64, VoteTracker> votes,
       final StoreConfig config,
       final ForkChoiceStrategy forkChoiceStrategy,
@@ -236,7 +241,7 @@ class Store extends CacheableStore {
             metricsSystem,
             "memory_checkpoint_states",
             config.getCheckpointStateCacheSize());
-    final CachingTaskQueue<Bytes32, StateAndBlockSummary> stateTaskQueue =
+    final CachingTaskQueue<Bytes32, StateAndBlockSummary> blockStateTaskQueue =
         CachingTaskQueue.create(
             asyncRunner, metricsSystem, "memory_states", config.getStateCacheSize());
     final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates =
@@ -245,6 +250,12 @@ class Store extends CacheableStore {
             : Optional.empty();
     final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars =
         LimitedMap.createSynchronizedNatural(config.getBlockCacheSize());
+    final CachingTaskQueue<Bytes32, BeaconState> executionPayloadStateTaskQueue =
+        CachingTaskQueue.create(
+            asyncRunner,
+            metricsSystem,
+            "memory_execution_payload_states",
+            config.getStateCacheSize());
 
     return new Store(
         metricsSystem,
@@ -253,7 +264,7 @@ class Store extends CacheableStore {
         blockProvider,
         stateAndBlockProvider,
         earliestBlobSidecarSlotProvider,
-        stateTaskQueue,
+        blockStateTaskQueue,
         initialCheckpoint,
         time,
         genesisTime,
@@ -267,7 +278,8 @@ class Store extends CacheableStore {
         checkpointStateTaskQueue,
         maybeEpochStates,
         blobSidecars,
-        custodyGroupCount);
+        custodyGroupCount,
+        executionPayloadStateTaskQueue);
   }
 
   static UpdatableStore create(
@@ -316,7 +328,6 @@ class Store extends CacheableStore {
         finalizedOptimisticTransitionPayload,
         justifiedCheckpoint,
         bestJustifiedCheckpoint,
-        blockInfoByRoot,
         votes,
         config,
         forkChoiceStrategy,
@@ -411,8 +422,9 @@ class Store extends CacheableStore {
                     "memory_epoch_states_cache_size",
                     "Number of Epoch aligned states held in the in-memory store"));
       }
-      states.startMetrics();
+      blockStates.startMetrics();
       checkpointStates.startMetrics();
+      executionPayloadStates.startMetrics();
     } finally {
       votesLock.writeLock().unlock();
       lock.writeLock().unlock();
@@ -427,9 +439,10 @@ class Store extends CacheableStore {
   @Override
   @VisibleForTesting
   public void clearCaches() {
-    states.clear();
+    blockStates.clear();
     checkpointStates.clear();
     blocks.clear();
+    executionPayloadStates.clear();
   }
 
   @Override
@@ -578,7 +591,12 @@ class Store extends CacheableStore {
 
   @Override
   public Optional<BeaconState> getBlockStateIfAvailable(final Bytes32 blockRoot) {
-    return states.getIfAvailable(blockRoot).map(StateAndBlockSummary::getState);
+    return blockStates.getIfAvailable(blockRoot).map(StateAndBlockSummary::getState);
+  }
+
+  @Override
+  public Optional<BeaconState> getExecutionPayloadStateIfAvailable(final Bytes32 blockRoot) {
+    return executionPayloadStates.getIfAvailable(blockRoot);
   }
 
   @Override
@@ -700,16 +718,16 @@ class Store extends CacheableStore {
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
-    return checkpointStates.perform(
-        new StateAtSlotTask(spec, checkpoint.toSlotAndBlockRoot(spec), this::retrieveBlockState));
-  }
-
-  @Override
-  public SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(
+  public SafeFuture<Optional<BeaconState>> retrieveBlockState(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return checkpointStates.perform(
         new StateAtSlotTask(spec, slotAndBlockRoot, this::retrieveBlockState));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
+    return checkpointStates.perform(
+        new StateAtSlotTask(spec, checkpoint.toSlotAndBlockRoot(spec), this::retrieveBlockState));
   }
 
   @Override
@@ -794,8 +812,8 @@ class Store extends CacheableStore {
 
   /** Non-synchronized, no lock, unsafe if Store is not locked externally */
   @Override
-  void cacheStates(final Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries) {
-    states.cacheAll(stateAndBlockSummaries);
+  void cacheBlockStates(final Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries) {
+    blockStates.cacheAll(stateAndBlockSummaries);
   }
 
   /** Non-synchronized, no lock, unsafe if Store is not locked externally */
@@ -837,6 +855,14 @@ class Store extends CacheableStore {
   @Override
   void setVote(final int index, final VoteTracker voteTracker) {
     votes[index] = voteTracker;
+  }
+
+  @Override
+  void cacheExecutionPayloadAndStates(
+      final Map<Bytes32, SignedExecutionPayloadAndState> executionPayloadAndStates) {
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 store the execution payload
+    executionPayloadStates.cacheAll(
+        Maps.transformValues(executionPayloadAndStates, SignedExecutionPayloadAndState::state));
   }
 
   UInt64 getHighestVotedValidatorIndex() {
@@ -883,7 +909,7 @@ class Store extends CacheableStore {
   private SafeFuture<Optional<StateAndBlockSummary>> getOrRegenerateBlockAndState(
       final Bytes32 blockRoot) {
     // Avoid generating the hash tree to rebuild if the state is already available.
-    final Optional<StateAndBlockSummary> cachedResult = states.getIfAvailable(blockRoot);
+    final Optional<StateAndBlockSummary> cachedResult = blockStates.getIfAvailable(blockRoot);
     if (cachedResult.isPresent()) {
       return SafeFuture.completedFuture(cachedResult).thenPeek(this::cacheIfEpochState);
     }
@@ -918,7 +944,7 @@ class Store extends CacheableStore {
         .thenCompose(
             maybeTask ->
                 maybeTask.isPresent()
-                    ? states.perform(maybeTask.get()).thenPeek(this::cacheIfEpochState)
+                    ? blockStates.perform(maybeTask.get()).thenPeek(this::cacheIfEpochState)
                     : EmptyStoreResults.EMPTY_STATE_AND_BLOCK_SUMMARY_FUTURE);
   }
 
@@ -935,7 +961,7 @@ class Store extends CacheableStore {
         // pre-epoch transition state
         // This will be referenced during epoch transition if the first slot of the epoch is empty
         final Optional<StateAndBlockSummary> maybeParentStateAndBlockSummary =
-            states.getIfAvailable(stateAndBlockSummary.getParentRoot());
+            blockStates.getIfAvailable(stateAndBlockSummary.getParentRoot());
         maybeParentStateAndBlockSummary.ifPresent(
             parentStateAndBlockSummary -> {
               if (epochStates.put(parentStateAndBlockSummary.getRoot(), parentStateAndBlockSummary)
@@ -1079,7 +1105,7 @@ class Store extends CacheableStore {
 
   void removeStateAndBlock(final Bytes32 root) {
     blocks.remove(root);
-    states.remove(root);
+    blockStates.remove(root);
     maybeEpochStates.ifPresent(
         epochStates -> {
           if (!finalizedAnchor.getRoot().equals(root)) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -129,7 +129,6 @@ public class StoreBuilder {
           finalizedOptimisticTransitionPayload,
           justifiedCheckpoint,
           bestJustifiedCheckpoint,
-          blockInfoByRoot,
           votes,
           storeConfig,
           forkChoiceStrategy,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -76,6 +77,8 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Optional<UInt64> maybeEarliestBlobSidecarTransactionSlot = Optional.empty();
   Optional<Bytes32> maybeLatestCanonicalBlockRoot = Optional.empty();
   Optional<UInt64> maybeCustodyGroupCount = Optional.empty();
+  Map<Bytes32, SignedExecutionPayloadAndState> executionPayloadData = new HashMap<>();
+
   private final UpdatableStore.StoreUpdateHandler updateHandler;
 
   StoreTransaction(
@@ -110,7 +113,9 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public void putExecutionPayloadAndState(
       final SignedExecutionPayloadEnvelope executionPayload, final BeaconState state) {
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878
+    executionPayloadData.put(
+        executionPayload.getBeaconBlockRoot(),
+        new SignedExecutionPayloadAndState(executionPayload, state));
   }
 
   private boolean needToUpdateEarliestBlobSidecarSlot(
@@ -125,11 +130,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
     }
     // New value is smaller than an old one - true
     final UInt64 newEarliestBlobSidecarSlot = maybeNewEarliestBlobSidecarSlot.get();
-    if (newEarliestBlobSidecarSlot.isLessThan(maybeEarliestBlobSidecarTransactionSlot.get())) {
-      return true;
-    } else {
-      return false;
-    }
+    return newEarliestBlobSidecarSlot.isLessThan(maybeEarliestBlobSidecarTransactionSlot.get());
   }
 
   @Override
@@ -378,6 +379,13 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public Optional<BeaconState> getExecutionPayloadStateIfAvailable(final Bytes32 blockRoot) {
+    return Optional.ofNullable(executionPayloadData.get(blockRoot))
+        .map(SignedExecutionPayloadAndState::state)
+        .or(() -> store.getExecutionPayloadStateIfAvailable(blockRoot));
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> retrieveSignedBlock(final Bytes32 blockRoot) {
     if (blockData.containsKey(blockRoot)) {
       return SafeFuture.completedFuture(
@@ -415,6 +423,21 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public SafeFuture<Optional<BeaconState>> retrieveBlockState(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    SignedBlockAndState inMemoryCheckpointBlockState =
+        blockData.get(slotAndBlockRoot.getBlockRoot());
+    if (inMemoryCheckpointBlockState != null) {
+      // Not executing the task via the task queue to avoid caching the result before the tx is
+      // committed
+      return new StateAtSlotTask(
+              spec, slotAndBlockRoot, fromBlockAndState(inMemoryCheckpointBlockState))
+          .performTask();
+    }
+    return store.retrieveBlockState(slotAndBlockRoot);
+  }
+
+  @Override
   public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
     SignedBlockAndState inMemoryCheckpointBlockState = blockData.get(checkpoint.getRoot());
     if (inMemoryCheckpointBlockState != null) {
@@ -427,21 +450,6 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
           .performTask();
     }
     return store.retrieveCheckpointState(checkpoint);
-  }
-
-  @Override
-  public SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(
-      final SlotAndBlockRoot slotAndBlockRoot) {
-    SignedBlockAndState inMemoryCheckpointBlockState =
-        blockData.get(slotAndBlockRoot.getBlockRoot());
-    if (inMemoryCheckpointBlockState != null) {
-      // Not executing the task via the task queue to avoid caching the result before the tx is
-      // committed
-      return new StateAtSlotTask(
-              spec, slotAndBlockRoot, fromBlockAndState(inMemoryCheckpointBlockState))
-          .performTask();
-    }
-    return store.retrieveStateAtSlot(slotAndBlockRoot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -140,8 +140,14 @@ class StoreTransactionUpdates {
     finalizedChainData.ifPresent(
         finalizedData -> store.updateFinalizedAnchor(finalizedData.getLatestFinalized()));
 
-    // Prune blocks and states
-    prunedHotBlockRoots.keySet().forEach(store::removeStateAndBlock);
+    // Prune blocks, execution payloads and states
+    prunedHotBlockRoots
+        .keySet()
+        .forEach(
+            blockRoot -> {
+              store.removeBlockAndState(blockRoot);
+              store.removeExecutionPayloadAndState(blockRoot);
+            });
 
     store.cleanupCheckpointStates(
         slotAndBlockRoot -> prunedHotBlockRoots.containsKey(slotAndBlockRoot.getBlockRoot()));

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.api.FinalizedChainData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
@@ -49,6 +50,7 @@ class StoreTransactionUpdates {
   private final Optional<UInt64> custodyGroupCount;
   private final boolean blobSidecarsEnabled;
   private final boolean dataColumnSidecarsEnabled;
+  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
 
   StoreTransactionUpdates(
       final StoreTransaction tx,
@@ -65,11 +67,12 @@ class StoreTransactionUpdates {
       final Optional<Bytes32> latestCanonicalBlockRoot,
       final Optional<UInt64> custodyGroupCount,
       final boolean blobSidecarsEnabled,
-      final boolean dataColumnSidecarsEnabled) {
+      final boolean dataColumnSidecarsEnabled,
+      final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates) {
     checkNotNull(tx, "Transaction is required");
     checkNotNull(finalizedChainData, "Finalized data is required");
     checkNotNull(hotBlocks, "Hot blocks are required");
-    checkNotNull(hotBlockAndStates, "Hot states are required");
+    checkNotNull(hotBlockAndStates, "Hot block states are required");
     checkNotNull(hotStatesToPersist, "Hot states to persist are required");
     checkNotNull(blobSidecars, "BlobSidecars are required");
     checkNotNull(maybeEarliestBlobSidecarSlot, "Hot maybe earliest blobSidecar slot is required");
@@ -78,6 +81,7 @@ class StoreTransactionUpdates {
     checkNotNull(optimisticTransitionBlockRoot, "Optimistic transition block root is required");
     checkNotNull(latestCanonicalBlockRoot, "Latest canonical block root is required");
     checkNotNull(custodyGroupCount, "Current custody group count is required");
+    checkNotNull(hotExecutionPayloadAndStates, "Hot execution payload states are required");
 
     this.tx = tx;
     this.finalizedChainData = finalizedChainData;
@@ -94,6 +98,7 @@ class StoreTransactionUpdates {
     this.custodyGroupCount = custodyGroupCount;
     this.blobSidecarsEnabled = blobSidecarsEnabled;
     this.dataColumnSidecarsEnabled = dataColumnSidecarsEnabled;
+    this.hotExecutionPayloadAndStates = hotExecutionPayloadAndStates;
   }
 
   public StorageUpdate createStorageUpdate() {
@@ -124,7 +129,7 @@ class StoreTransactionUpdates {
     tx.bestJustifiedCheckpoint.ifPresent(store::updateBestJustifiedCheckpoint);
     tx.getCustodyGroupCount().ifPresent(store::updateCustodyGroupCount);
     store.cacheBlocks(hotBlocks.values());
-    store.cacheStates(Maps.transformValues(hotBlockAndStates, this::blockAndStateAsSummary));
+    store.cacheBlockStates(Maps.transformValues(hotBlockAndStates, this::blockAndStateAsSummary));
     store.cacheBlobSidecars(blobSidecars);
     if (optimisticTransitionBlockRootSet) {
       store.cacheFinalizedOptimisticTransitionPayload(
@@ -144,6 +149,8 @@ class StoreTransactionUpdates {
     if (tx.proposerBoostRootSet) {
       store.cacheProposerBoostRoot(tx.proposerBoostRoot);
     }
+
+    store.cacheExecutionPayloadAndStates(hotExecutionPayloadAndStates);
 
     store
         .getForkChoiceStrategy()

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -54,6 +55,7 @@ class StoreTransactionUpdatesFactory {
   private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
   private final AnchorPoint latestFinalized;
   private final Map<Bytes32, UInt64> prunedHotBlockRoots = new ConcurrentHashMap<>();
+  private final Map<Bytes32, SignedExecutionPayloadAndState> hotExecutionPayloadAndStates;
 
   public StoreTransactionUpdatesFactory(
       final Spec spec,
@@ -76,6 +78,7 @@ class StoreTransactionUpdatesFactory {
     maybeEarliestBlobSidecarSlot = tx.maybeEarliestBlobSidecarTransactionSlot;
     maybeLatestCanonicalBlockRoot = tx.maybeLatestCanonicalBlockRoot;
     maybeCustodyGroupCount = tx.maybeCustodyGroupCount;
+    hotExecutionPayloadAndStates = new ConcurrentHashMap<>(tx.executionPayloadData);
   }
 
   public static StoreTransactionUpdates create(
@@ -134,6 +137,7 @@ class StoreTransactionUpdatesFactory {
     calculatePrunedHotBlockRoots();
     prunedHotBlockRoots.forEach(hotBlocks::remove);
     prunedHotBlockRoots.forEach(hotBlockAndStates::remove);
+    prunedHotBlockRoots.forEach(hotExecutionPayloadAndStates::remove);
 
     final Optional<FinalizedChainData> finalizedChainData =
         Optional.of(
@@ -264,6 +268,7 @@ class StoreTransactionUpdatesFactory {
         maybeLatestCanonicalBlockRoot,
         maybeCustodyGroupCount,
         spec.isMilestoneSupported(SpecMilestone.DENEB),
-        spec.isMilestoneSupported(SpecMilestone.FULU));
+        spec.isMilestoneSupported(SpecMilestone.FULU),
+        hotExecutionPayloadAndStates);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -167,7 +167,7 @@ class CombinedChainDataClientTest {
     final Runnable onLateBlockReorgPreparationCompleted = mock(Runnable.class);
     when(recentChainData.getBlockRootInEffectBySlot(UInt64.ONE)).thenReturn(recentBlockRoot);
     when(recentChainData.getStore()).thenReturn(store);
-    when(store.retrieveStateAtSlot(slotAndBlockRoot))
+    when(store.retrieveBlockState(slotAndBlockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
     final SafeFuture<Optional<BeaconState>> future =
         client.getStateForBlockProduction(UInt64.ONE, false, onLateBlockReorgPreparationCompleted);
@@ -175,7 +175,7 @@ class CombinedChainDataClientTest {
     verify(onLateBlockReorgPreparationCompleted, never()).run();
     // getStateAtSlotExact
     verify(recentChainData).getBlockRootInEffectBySlot(UInt64.ONE);
-    verify(store).retrieveStateAtSlot(slotAndBlockRoot);
+    verify(store).retrieveBlockState(slotAndBlockRoot);
   }
 
   @Test
@@ -191,7 +191,7 @@ class CombinedChainDataClientTest {
 
     when(recentChainData.getBestBlockRoot()).thenReturn(Optional.empty());
     when(recentChainData.getBlockRootInEffectBySlot(UInt64.ONE)).thenReturn(recentBlockRoot);
-    when(store.retrieveStateAtSlot(slotAndBlockRoot))
+    when(store.retrieveBlockState(slotAndBlockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
 
     final SafeFuture<Optional<BeaconState>> future =
@@ -200,7 +200,7 @@ class CombinedChainDataClientTest {
     verify(onLateBlockReorgPreparationCompleted, never()).run();
     // getStateAtSlotExact
     verify(recentChainData).getBlockRootInEffectBySlot(UInt64.ONE);
-    verify(store).retrieveStateAtSlot(slotAndBlockRoot);
+    verify(store).retrieveBlockState(slotAndBlockRoot);
   }
 
   @Test
@@ -221,7 +221,7 @@ class CombinedChainDataClientTest {
     when(recentChainData.getProposerHead(any(), any())).thenReturn(recentBlockRoot);
     when(recentChainData.getBlockRootInEffectBySlot(UInt64.ONE))
         .thenReturn(Optional.of(recentBlockRoot));
-    when(store.retrieveStateAtSlot(slotAndBlockRoot))
+    when(store.retrieveBlockState(slotAndBlockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
 
     final SafeFuture<Optional<BeaconState>> future =
@@ -230,7 +230,7 @@ class CombinedChainDataClientTest {
     verify(onLateBlockReorgPreparationCompleted, never()).run();
     // getStateAtSlotExact
     verify(recentChainData).getBlockRootInEffectBySlot(UInt64.ONE);
-    verify(store).retrieveStateAtSlot(slotAndBlockRoot);
+    verify(store).retrieveBlockState(slotAndBlockRoot);
   }
 
   @Test
@@ -259,7 +259,7 @@ class CombinedChainDataClientTest {
     when(lateBlockReorgPreparationHandler.onLateBlockReorgPreparation(UInt64.ZERO, recentBlockRoot))
         .thenReturn(lateBlockReorgPreparationFuture);
 
-    when(store.retrieveStateAtSlot(slotAndBlockRoot))
+    when(store.retrieveBlockState(slotAndBlockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
 
     final SafeFuture<Optional<BeaconState>> future =
@@ -276,7 +276,7 @@ class CombinedChainDataClientTest {
 
     assertThat(future.get()).contains(proposerState);
 
-    verify(store, never()).retrieveStateAtSlot(slotAndBlockRoot);
+    verify(store, never()).retrieveBlockState(slotAndBlockRoot);
   }
 
   @Test
@@ -334,7 +334,7 @@ class CombinedChainDataClientTest {
     when(store.getFinalizedCheckpoint()).thenReturn(finalized);
     when(recentChainData.getBlockRootInEffectBySlot(any()))
         .thenReturn(Optional.of(state.getLatestBlockHeader().getBodyRoot()));
-    when(store.retrieveStateAtSlot(any()))
+    when(store.retrieveBlockState(any(SlotAndBlockRoot.class)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
 
     final SafeFuture<Optional<BeaconState>> maybeFinalizedState = client.getBestFinalizedState();

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -45,12 +45,16 @@ import tech.pegasys.teku.storage.api.StubStorageUpdateChannel;
 import tech.pegasys.teku.storage.protoarray.ForkChoiceStrategy;
 
 public abstract class AbstractStoreTest {
-  protected final Spec spec = TestSpecFactory.createMinimalDeneb();
+  protected final Spec spec = getSpec();
   protected final StorageUpdateChannel storageUpdateChannel = new StubStorageUpdateChannel();
   protected final ChainBuilder chainBuilder = ChainBuilder.create(spec);
   protected final StoreConfig defaultStoreConfig = StoreConfig.createDefault();
 
   protected final ForkChoiceStrategy dummyForkChoiceStrategy = mock(ForkChoiceStrategy.class);
+
+  protected Spec getSpec() {
+    return TestSpecFactory.createMinimalDeneb();
+  }
 
   protected void processChainWithLimitedCache(
       final BiConsumer<UpdatableStore, SignedBlockAndState> chainProcessor) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -494,9 +494,9 @@ class StoreTest extends AbstractStoreTest {
     tx.commit().join();
 
     final Store s = (Store) store;
-    assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(16, chainBuilder))).isCompleted();
-    assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(24, chainBuilder))).isCompleted();
-    assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(8, chainBuilder))).isCompleted();
+    assertThat(store.retrieveBlockState(stateAndBlockAtSlot(16, chainBuilder))).isCompleted();
+    assertThat(store.retrieveBlockState(stateAndBlockAtSlot(24, chainBuilder))).isCompleted();
+    assertThat(store.retrieveBlockState(stateAndBlockAtSlot(8, chainBuilder))).isCompleted();
     assertThat(
             s.getEpochStates().orElseThrow().values().stream()
                 .map(StateAndBlockSummary::getSlot)

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionGloasTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public class StoreTransactionGloasTest extends AbstractStoreTest {
+
+  @Override
+  protected Spec getSpec() {
+    return TestSpecFactory.createMinimalGloas();
+  }
+
+  @Test
+  public void getExecutionPayloadStateIfAvailable_fromTx() {
+    final UpdatableStore store = createGenesisStore();
+    final SignedBlockAndState blockAndState = chainBuilder.generateNextBlock();
+    final Optional<SignedExecutionPayloadAndState> maybeExecutionPayloadAndState =
+        chainBuilder.getExecutionPayloadAndStateAtSlot(blockAndState.getSlot());
+    assertThat(maybeExecutionPayloadAndState).isPresent();
+    final SignedExecutionPayloadAndState executionPayloadAndState =
+        maybeExecutionPayloadAndState.get();
+    final UpdatableStore.StoreTransaction tx = store.startTransaction(storageUpdateChannel);
+    tx.putExecutionPayloadAndState(
+        executionPayloadAndState.executionPayload(), executionPayloadAndState.state());
+
+    final Optional<BeaconState> result =
+        tx.getExecutionPayloadStateIfAvailable(blockAndState.getRoot());
+    assertThat(result).hasValue(executionPayloadAndState.state());
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
@@ -415,18 +415,6 @@ public class StoreTransactionTest extends AbstractStoreTest {
             mainChainBlock4.getRoot());
   }
 
-  @Test
-  public void getExecutionPayloadStateIfAvailable_fromTx() {
-    final UpdatableStore store = createGenesisStore();
-    final SignedBlockAndState blockAndState = chainBuilder.generateNextBlock();
-    UpdatableStore.StoreTransaction tx = store.startTransaction(storageUpdateChannel);
-    tx.putBlockAndState(blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
-
-    SafeFuture<Optional<SignedBlockAndState>> result =
-        tx.retrieveBlockAndState(blockAndState.getRoot());
-    assertThat(result).isCompletedWithValue(Optional.of(blockAndState));
-  }
-
   private void setTime(final UpdatableStore store, final UInt64 newTime) {
     final StoreTransaction tx = store.startTransaction(storageUpdateChannel);
     tx.setTimeMillis(newTime);

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
@@ -415,6 +415,18 @@ public class StoreTransactionTest extends AbstractStoreTest {
             mainChainBlock4.getRoot());
   }
 
+  @Test
+  public void getExecutionPayloadStateIfAvailable_fromTx() {
+    final UpdatableStore store = createGenesisStore();
+    final SignedBlockAndState blockAndState = chainBuilder.generateNextBlock();
+    UpdatableStore.StoreTransaction tx = store.startTransaction(storageUpdateChannel);
+    tx.putBlockAndState(blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
+
+    SafeFuture<Optional<SignedBlockAndState>> result =
+        tx.retrieveBlockAndState(blockAndState.getRoot());
+    assertThat(result).isCompletedWithValue(Optional.of(blockAndState));
+  }
+
   private void setTime(final UpdatableStore store, final UInt64 newTime) {
     final StoreTransaction tx = store.startTransaction(storageUpdateChannel);
     tx.setTimeMillis(newTime);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -33,7 +34,6 @@ import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
-// TODO-GLOAS: https://github.com/Consensys/teku/issues/10071
 public class ChainUpdater {
 
   public final RecentChainData recentChainData;
@@ -181,12 +181,28 @@ public class ChainUpdater {
   }
 
   public void syncWith(final ChainBuilder otherChain) {
-    otherChain.streamBlocksAndStates().forEach(this::saveBlock);
+    otherChain
+        .streamBlocksAndStates()
+        .forEach(
+            block -> {
+              saveBlock(block);
+              otherChain
+                  .getExecutionPayloadAndStateAtSlot(block.getSlot())
+                  .ifPresent(this::saveExecutionPayload);
+            });
     updateBestBlock(otherChain.getLatestBlockAndState());
   }
 
   public void syncWithUpToSlot(final ChainBuilder otherChain, final long slot) {
-    otherChain.streamBlocksAndStates(0, slot).forEach(this::saveBlock);
+    otherChain
+        .streamBlocksAndStates(0, slot)
+        .forEach(
+            block -> {
+              saveBlock(block);
+              otherChain
+                  .getExecutionPayloadAndStateAtSlot(block.getSlot())
+                  .ifPresent(this::saveExecutionPayload);
+            });
     updateBestBlock(otherChain.getLatestBlockAndStateAtSlot(slot));
   }
 
@@ -255,6 +271,7 @@ public class ChainUpdater {
     } else {
       saveBlock(block, blobSidecars);
     }
+    chainBuilder.getExecutionPayloadAndStateAtSlot(slot).ifPresent(this::saveExecutionPayload);
     return block;
   }
 
@@ -318,6 +335,12 @@ public class ChainUpdater {
     if (blockTime.compareTo(recentChainData.getStore().getTimeSeconds()) > 0) {
       setTime(blockTime);
     }
+  }
+
+  public void saveExecutionPayload(final SignedExecutionPayloadAndState executionPayload) {
+    final StoreTransaction tx = recentChainData.startStoreTransaction();
+    tx.putExecutionPayloadAndState(executionPayload.executionPayload(), executionPayload.state());
+    assertThat(tx.commit()).isCompleted();
   }
 
   protected UInt64 getSlotTime(final UInt64 slot) {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -51,14 +51,15 @@ public class StoreAssertions {
             "checkpointStateRequestRegenerateCounter",
             "checkpointStateRequestMissCounter",
             "metricsSystem",
-            "states",
+            "blockStates",
             "stateProvider",
             "checkpointStates",
             "forkChoiceStrategy",
             "maybeEpochStates",
             "epochStatesCountGauge",
             "blobSidecars",
-            "blobSidecarsBlocksCountGauge")
+            "blobSidecarsBlocksCountGauge",
+            "executionPayloadStates")
         .isEqualTo(expectedState);
     assertThat(actualState.getOrderedBlockRoots())
         .containsExactlyElementsOf(expectedState.getOrderedBlockRoots());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Changes to `Store` interface to cache the execution payload state. This won't be the final design necessarily, but is good enough for devnet-0

## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/9878 and https://github.com/Consensys/teku/issues/10098

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Store`/`RecentChainData` state-retrieval APIs and adds a new cached state type, which could affect forkchoice and block import if mis-cached or pruned incorrectly.
> 
> **Overview**
> Adds a new in-memory cache for *execution payload states* alongside existing block state caching, exposing it via `ReadOnlyStore.getExecutionPayloadStateIfAvailable` and wiring transaction commits to persist/prune these payload states.
> 
> Refactors slot-based state retrieval by renaming `retrieveStateAtSlot(SlotAndBlockRoot)` to `retrieveBlockState(SlotAndBlockRoot)` across storage, forkchoice/statetransition, and tests, and updates test utilities (`ChainBuilder`, `ChainUpdater`) to optionally produce/store execution payload state. 
> 
> Introduces new Gloas-focused coverage (`StoreTransactionGloasTest`) to verify payload-state visibility from uncommitted transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 207eeaa1a512b8314e423ca2ccacac95e962c6d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->