### PR TITLE
Added tests for validation on executionPayloadEnvelopesByRange

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIds.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodIds.java
@@ -77,6 +77,11 @@ public class BeaconChainMethodIds {
     return getMethodId(EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT, version, encoding);
   }
 
+  public static String getExecutionPayloadEnvelopesByRangeMethodId(
+      final int version, final RpcEncoding encoding) {
+    return getMethodId(EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE, version, encoding);
+  }
+
   public static String getStatusMethodId(final int version, final RpcEncoding encoding) {
     return getMethodId(STATUS, version, encoding);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
-import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -613,7 +612,7 @@ public class BeaconChainMethods {
     final ExecutionPayloadEnvelopesByRangeMessageHandler
         executionPayloadEnvelopesByRangeMessageHandler =
             new ExecutionPayloadEnvelopesByRangeMessageHandler(
-                getSpecConfigGloas(spec), metricsSystem);
+                spec, metricsSystem, recentChainData);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(
@@ -738,10 +737,6 @@ public class BeaconChainMethods {
 
   private static SpecConfigFulu getSpecConfigFulu(final Spec spec) {
     return SpecConfigFulu.required(spec.forMilestone(SpecMilestone.FULU).getConfig());
-  }
-
-  private static SpecConfigGloas getSpecConfigGloas(final Spec spec) {
-    return SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig());
   }
 
   public Collection<RpcMethod<?, ?, ?>> all() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
@@ -22,14 +22,18 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.RequestKey;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRangeRequestMessage;
+import tech.pegasys.teku.storage.client.RecentChainData;
 
 // TODO-GLOAS: https://github.com/Consensys/teku/issues/9974
 /**
@@ -43,12 +47,19 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
   private static final Logger LOG = LogManager.getLogger();
 
   private final SpecConfigGloas config;
+  private final Spec spec;
   private final LabelledMetric<Counter> requestCounter;
+
+  @SuppressWarnings("unused")
+  private final RecentChainData recentChainData;
+
   private final Counter totalExecutionPayloadEnvelopesRequestedCounter;
 
   public ExecutionPayloadEnvelopesByRangeMessageHandler(
-      final SpecConfigGloas config, final MetricsSystem metricsSystem) {
-    this.config = config;
+      final Spec spec, final MetricsSystem metricsSystem, final RecentChainData recentChainData) {
+    this.spec = spec;
+    this.config = SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig());
+    this.recentChainData = recentChainData;
     requestCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.NETWORK,
@@ -73,6 +84,14 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
               String.format(
                   "Only a maximum of %s execution payload envelopes can be requested per request",
                   config.getMaxRequestBlocksDeneb())));
+    }
+    final UInt64 finalizedEpoch = recentChainData.getFinalizedEpoch();
+    if (spec.computeEpochAtSlot(request.getStartSlot()).isLessThan(finalizedEpoch)) {
+      requestCounter.labels("start_slot_invalid").inc();
+      return Optional.of(
+          new RpcException(
+              INVALID_REQUEST_CODE,
+              String.format("Start slot is prior to finalized epoch %s", finalizedEpoch)));
     }
     return Optional.empty();
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.NETWORK;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
+import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRangeRequestMessage;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class ExecutionPayloadEnvelopesByRangeMessageHandlerTest {
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private static final RpcEncoding RPC_ENCODING =
+      RpcEncoding.createSszSnappyEncoding(
+          TestSpecFactory.createDefault().getNetworkingConfig().getMaxPayloadSize());
+
+  private static final String PROTOCOL_ID =
+      BeaconChainMethodIds.getExecutionPayloadEnvelopesByRangeMethodId(1, RPC_ENCODING);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+
+  @Test
+  void validateRequest_countTooBig() {
+    final ExecutionPayloadEnvelopesByRangeMessageHandler handler =
+        new ExecutionPayloadEnvelopesByRangeMessageHandler(spec, metricsSystem, recentChainData);
+    final Optional<RpcException> response =
+        handler.validateRequest(
+            PROTOCOL_ID,
+            new ExecutionPayloadEnvelopesByRangeRequestMessage(UInt64.ONE, UInt64.valueOf(256)));
+    assertThat(response).isNotEmpty();
+    assertThat(response.get().getMessage())
+        .containsIgnoringCase("maximum of 128 execution payload envelopes");
+    assertThat(getLabelledCounterValue("count_too_big")).isEqualTo(1);
+    assertThat(getLabelledCounterValue("start_slot_invalid")).isEqualTo(0);
+    verifyNoInteractions(recentChainData);
+  }
+
+  @Test
+  void validateRequest_maxCount() {
+    final ExecutionPayloadEnvelopesByRangeMessageHandler handler =
+        new ExecutionPayloadEnvelopesByRangeMessageHandler(spec, metricsSystem, recentChainData);
+    when(recentChainData.getFinalizedEpoch()).thenReturn(UInt64.ZERO);
+    final Optional<RpcException> response =
+        handler.validateRequest(
+            PROTOCOL_ID,
+            new ExecutionPayloadEnvelopesByRangeRequestMessage(UInt64.ONE, UInt64.valueOf(128)));
+    assertThat(response).isEmpty();
+    assertThat(getLabelledCounterValue("count_too_big")).isEqualTo(0);
+    assertThat(getLabelledCounterValue("start_slot_invalid")).isEqualTo(0);
+    verify(recentChainData).getFinalizedEpoch();
+  }
+
+  @Test
+  void validateRequest_startSlotTooEarly() {
+    final ExecutionPayloadEnvelopesByRangeMessageHandler handler =
+        new ExecutionPayloadEnvelopesByRangeMessageHandler(spec, metricsSystem, recentChainData);
+    when(recentChainData.getFinalizedEpoch()).thenReturn(UInt64.ONE);
+    final Optional<RpcException> response =
+        handler.validateRequest(
+            PROTOCOL_ID,
+            new ExecutionPayloadEnvelopesByRangeRequestMessage(UInt64.ONE, UInt64.valueOf(128)));
+    assertThat(response).isNotEmpty();
+    assertThat(response.get().getMessage()).containsIgnoringCase("prior to finalized");
+    assertThat(getLabelledCounterValue("count_too_big")).isEqualTo(0);
+    assertThat(getLabelledCounterValue("start_slot_invalid")).isEqualTo(1);
+    verify(recentChainData).getFinalizedEpoch();
+  }
+
+  private long getLabelledCounterValue(final String label) {
+    return metricsSystem.getLabelledCounterValue(
+        NETWORK, "rpc_execution_payload_envelopes_by_range_requests_total", label);
+  }
+}


### PR DESCRIPTION
Covered a minimal set of validations in test cases for payload envelopes.

partially addresses #10301

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request validation for the Gloas `ExecutionPayloadEnvelopesByRange` RPC to reject ranges starting before the finalized epoch, which could affect peer interoperability if assumptions are wrong. Scope is limited and covered by new unit tests.
> 
> **Overview**
> Strengthens Gloas `ExecutionPayloadEnvelopesByRange` RPC request validation by deriving `SpecConfigGloas` from `Spec`, injecting `RecentChainData`, and rejecting requests whose `start_slot` is before the finalized epoch (with new metrics labels).
> 
> Adds `ExecutionPayloadEnvelopesByRangeMessageHandlerTest` covering oversize counts, max-count acceptance, and too-early `start_slot`, and introduces `BeaconChainMethodIds.getExecutionPayloadEnvelopesByRangeMethodId` while updating `BeaconChainMethods` wiring accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21941f37c8ba74c6c984ccb96a58998509d7c562. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->