### PR TITLE
added missing variable in get-variables debug tool

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -480,7 +480,10 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
         .put(
             "OPTIMISTIC_TRANSITION_BLOCK_SLOT",
             getOptimisticTransitionBlockSlot().map(Objects::toString))
-        .put("CUSTODY_GROUP_COUNT", getCustodyGroupCount().map(Objects::toString));
+        .put("CUSTODY_GROUP_COUNT", getCustodyGroupCount().map(Objects::toString))
+        .put(
+            "EARLIEST_AVAILABLE_DATA_COLUMN_SLOT",
+            getEarliestAvailableDataColumnSlot().map(Objects::toString));
 
     // get a list of the known keys, so that we can add missing variables
     final Map<String, Optional<String>> knownVariables = knownVariablesBuilder.build();


### PR DESCRIPTION
will be helpful in release.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only extends the `getVariables()` debug/diagnostic output to include one additional existing DB variable, without changing storage logic or persistence format.
> 
> **Overview**
> `CombinedKvStoreDao.getVariables()` now includes the missing `EARLIEST_AVAILABLE_DATA_COLUMN_SLOT` entry so the variables debug tool exports this value alongside the other known KV-store variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7cb6ceec96b55367a5b76ef2056f9551eaca24c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->