### PR TITLE
Prune hot collections correctly

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -135,9 +135,14 @@ class StoreTransactionUpdatesFactory {
 
     // Prune collections
     calculatePrunedHotBlockRoots();
-    prunedHotBlockRoots.forEach(hotBlocks::remove);
-    prunedHotBlockRoots.forEach(hotBlockAndStates::remove);
-    prunedHotBlockRoots.forEach(hotExecutionPayloadAndStates::remove);
+    prunedHotBlockRoots
+        .keySet()
+        .forEach(
+            blockRoot -> {
+              hotBlocks.remove(blockRoot);
+              hotBlockAndStates.remove(blockRoot);
+              hotExecutionPayloadAndStates.remove(blockRoot);
+            });
 
     final Optional<FinalizedChainData> finalizedChainData =
         Optional.of(

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactoryTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
+import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
+import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.storage.api.StorageUpdate;
+import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+import tech.pegasys.teku.storage.api.UpdateResult;
+import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
+
+class StoreTransactionUpdatesFactoryTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
+
+  @Test
+  void hotBlocksShouldNotContainPrunedRoots() {
+    final SignedBlockAndState genesis = chainBuilder.generateGenesis();
+    final Checkpoint genesisCheckpoint = chainBuilder.getCurrentCheckpointForEpoch(0);
+
+    final UpdatableStore store =
+        StoreBuilder.create()
+            .asyncRunner(SYNC_RUNNER)
+            .metricsSystem(new StubMetricsSystem())
+            .specProvider(spec)
+            .blockProvider(roots -> SafeFuture.completedFuture(Collections.emptyMap()))
+            .earliestBlobSidecarSlotProvider(EarliestBlobSidecarSlotProvider.NOOP)
+            .stateProvider(StateAndBlockSummaryProvider.NOOP)
+            .anchor(Optional.empty())
+            .genesisTime(genesis.getState().getGenesisTime())
+            .time(genesis.getState().getGenesisTime())
+            .latestFinalized(AnchorPoint.create(spec, genesisCheckpoint, genesis))
+            .justifiedCheckpoint(genesisCheckpoint)
+            .bestJustifiedCheckpoint(genesisCheckpoint)
+            .blockInformation(
+                Map.of(
+                    genesis.getRoot(),
+                    new StoredBlockMetadata(
+                        genesis.getSlot(),
+                        genesis.getRoot(),
+                        genesis.getParentRoot(),
+                        genesis.getStateRoot(),
+                        genesis.getExecutionBlockNumber(),
+                        genesis.getExecutionBlockHash(),
+                        Optional.of(spec.calculateBlockCheckpoints(genesis.getState())))))
+            .storeConfig(StoreConfig.createDefault())
+            .votes(Collections.emptyMap())
+            .latestCanonicalBlockRoot(Optional.empty())
+            .build();
+
+    // Generate blocks for multiple epochs to trigger finalization
+    final UInt64 epoch3Slot = spec.computeStartSlotAtEpoch(UInt64.valueOf(3));
+    chainBuilder.generateBlocksUpToSlot(epoch3Slot);
+
+    final CapturingStorageUpdateChannel capturingChannel = new CapturingStorageUpdateChannel();
+
+    // Start a transaction and add all blocks
+    final UpdatableStore.StoreTransaction tx = store.startTransaction(capturingChannel);
+    chainBuilder
+        .streamBlocksAndStates(1, chainBuilder.getLatestSlot().longValue())
+        .forEach(
+            blockAndState ->
+                tx.putBlockAndState(
+                    blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState())));
+
+    // Set finalized checkpoint to epoch 2
+    final Checkpoint finalizedCheckpoint =
+        chainBuilder.getCurrentCheckpointForEpoch(UInt64.valueOf(2));
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
+
+    tx.commit().join();
+
+    // Verify we captured a storage update
+    assertThat(capturingChannel.getLastStorageUpdate()).isNotNull();
+    final StorageUpdate storageUpdate = capturingChannel.getLastStorageUpdate();
+
+    // Get the finalized block
+    final SignedBlockAndState finalizedBlockAndState =
+        chainBuilder.getBlockAndState(finalizedCheckpoint.getRoot()).orElseThrow();
+
+    // Collect all block roots that should have been pruned (blocks at or before finalized slot,
+    // except the finalized block itself)
+    final UInt64 finalizedSlot = finalizedBlockAndState.getSlot();
+    final List<Bytes32> rootsThatShouldBePruned =
+        chainBuilder
+            .streamBlocksAndStates(1, finalizedSlot.longValue())
+            .map(SignedBlockAndState::getRoot)
+            .filter(root -> !root.equals(finalizedBlockAndState.getRoot()))
+            .toList();
+
+    // Verify that the pruned roots are really pruned
+    assertThat(rootsThatShouldBePruned).isNotEmpty();
+    for (final Bytes32 prunedRoot : rootsThatShouldBePruned) {
+      assertThat(storageUpdate.getHotBlocks())
+          .describedAs("Hot blocks should not contain pruned root %s", prunedRoot)
+          .doesNotContainKey(prunedRoot);
+    }
+
+    // Also verify the pruned roots are actually recorded in the deleted hot blocks
+    assertThat(storageUpdate.getDeletedHotBlocks().keySet()).containsAll(rootsThatShouldBePruned);
+  }
+
+  /** A StorageUpdateChannel that captures StorageUpdate for testing */
+  private static class CapturingStorageUpdateChannel implements StorageUpdateChannel {
+    private StorageUpdate lastStorageUpdate;
+
+    @Override
+    public SafeFuture<UpdateResult> onStorageUpdate(final StorageUpdate event) {
+      this.lastStorageUpdate = event;
+      return SafeFuture.completedFuture(UpdateResult.EMPTY);
+    }
+
+    @Override
+    public SafeFuture<Void> onFinalizedBlocks(
+        final Collection<SignedBeaconBlock> finalizedBlocks,
+        final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+        final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
+      return SafeFuture.COMPLETE;
+    }
+
+    @Override
+    public SafeFuture<Void> onReconstructedFinalizedState(
+        final BeaconState finalizedState, final Bytes32 blockRoot) {
+      return SafeFuture.COMPLETE;
+    }
+
+    @Override
+    public SafeFuture<Void> onWeakSubjectivityUpdate(
+        final WeakSubjectivityUpdate weakSubjectivityUpdate) {
+      return SafeFuture.COMPLETE;
+    }
+
+    @Override
+    public SafeFuture<Void> onFinalizedDepositSnapshot(
+        final DepositTreeSnapshot depositTreeSnapshot) {
+      return SafeFuture.COMPLETE;
+    }
+
+    @Override
+    public void onChainInitialized(final AnchorPoint initialAnchor) {}
+
+    public StorageUpdate getLastStorageUpdate() {
+      return lastStorageUpdate;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We changed `prunedHotBlockRoots` from `Set` to `Map` in https://github.com/Consensys/teku/pull/6636 but didn't modify the usage of it when pruning hot collections

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot block pruning during finalization; incorrect behavior here could drop needed in-memory blocks or keep too much data, though the change is small and covered by a new test.
> 
> **Overview**
> Fixes hot-collection pruning in `StoreTransactionUpdatesFactory` by removing entries based on `prunedHotBlockRoots` *keys* (now a `Map`) so `hotBlocks`, `hotBlockAndStates`, and `hotExecutionPayloadAndStates` are actually pruned.
> 
> Adds `StoreTransactionUpdatesFactoryTest` to assert finalized-driven pruning removes expected roots from `StorageUpdate.getHotBlocks()` and records them in `getDeletedHotBlocks()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358f7b357153e0e1b047725a13b19069a1b94fd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->