### PR TITLE
Refactored bls_to_execution validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,5 @@
 
 ### Bug Fixes
 
-- added `DOMAIN_BLS_TO_EXECUTION_CHANGE` to spec api output.
+- Added `DOMAIN_BLS_TO_EXECUTION_CHANGE` to spec api output.
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -165,7 +165,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       }
 
       // Process_block
-      BeaconState postState =
+      final BeaconState postState =
           processUnsignedBlock(
               blockSlotState,
               signedBlock.getMessage(),
@@ -173,7 +173,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
               signatureVerifier,
               payloadExecutor);
 
-      BlockValidationResult blockValidationResult =
+      final BlockValidationResult blockValidationResult =
           validateBlockPostProcessing(
               blockSlotState, signedBlock, postState, indexedAttestationCache, signatureVerifier);
 
@@ -229,8 +229,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       final SignedBeaconBlock block,
       final IndexedAttestationCache indexedAttestationCache,
       final BLSSignatureVerifier signatureVerifier) {
-    BeaconBlock blockMessage = block.getMessage();
-    BeaconBlockBody blockBody = blockMessage.getBody();
+    final BeaconBlock blockMessage = block.getMessage();
+    final BeaconBlockBody blockBody = blockMessage.getBody();
 
     return BlockValidationResult.allOf(
         () -> verifyBlockSignature(preState, block, signatureVerifier),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
@@ -125,8 +125,7 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
                 () ->
                     new BlockProcessingException(
                         "BlsToExecutionChanges was not found during block processing.")),
-        signatureVerifier,
-        false);
+        signatureVerifier);
   }
 
   @Override
@@ -157,7 +156,7 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
       throws BlockProcessingException {
     final BlockValidationResult result =
         verifyBlsToExecutionChangesPreProcessing(
-            state, blsToExecutionChanges, BLSSignatureVerifier.SIMPLE, true);
+            state, blsToExecutionChanges, BLSSignatureVerifier.SIMPLE);
     if (!result.isValid()) {
       throw new BlockProcessingException(result.getFailureReason());
     }
@@ -166,7 +165,7 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
   }
 
   // process_bls_to_execution_change
-  public void processBlsToExecutionChangesNoValidation(
+  private void processBlsToExecutionChangesNoValidation(
       final MutableBeaconStateCapella state,
       final SszList<SignedBlsToExecutionChange> signedBlsToExecutionChanges) {
 
@@ -201,8 +200,7 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
   BlockValidationResult verifyBlsToExecutionChangesPreProcessing(
       final BeaconState genericState,
       final SszList<SignedBlsToExecutionChange> signedBlsToExecutionChanges,
-      final BLSSignatureVerifier signatureVerifier,
-      final boolean executeValidationRules) {
+      final BLSSignatureVerifier signatureVerifier) {
 
     final Set<UInt64> validatorsSeenInBlock = new HashSet<>();
     for (SignedBlsToExecutionChange signedBlsToExecutionChange : signedBlsToExecutionChanges) {
@@ -213,13 +211,11 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
             "Duplicated BlsToExecutionChange for validator " + addressChange.getValidatorIndex());
       }
 
-      if (executeValidationRules) {
-        final Optional<OperationInvalidReason> operationInvalidReason =
-            operationValidator.validateBlsToExecutionChange(
-                genericState.getFork(), genericState, addressChange);
-        if (operationInvalidReason.isPresent()) {
-          return BlockValidationResult.failed(operationInvalidReason.get().describe());
-        }
+      final Optional<OperationInvalidReason> operationInvalidReason =
+          operationValidator.validateBlsToExecutionChange(
+              genericState.getFork(), genericState, addressChange);
+      if (operationInvalidReason.isPresent()) {
+        return BlockValidationResult.failed(operationInvalidReason.get().describe());
       }
 
       boolean signatureValid =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
@@ -140,7 +140,7 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
 
     safelyProcess(
         () ->
-            processBlsToExecutionChangesNoValidation(
+            processBlsToExecutionChanges(
                 MutableBeaconStateCapella.required(state),
                 body.getOptionalBlsToExecutionChanges()
                     .orElseThrow(
@@ -149,6 +149,7 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
                                 "BlsToExecutionChanges was not found during block processing."))));
   }
 
+  // process_bls_to_execution_change
   @Override
   public void processBlsToExecutionChanges(
       final MutableBeaconState state,
@@ -160,16 +161,8 @@ public class BlockProcessorCapella extends BlockProcessorBellatrix {
     if (!result.isValid()) {
       throw new BlockProcessingException(result.getFailureReason());
     }
-    processBlsToExecutionChangesNoValidation(
-        MutableBeaconStateCapella.required(state), blsToExecutionChanges);
-  }
 
-  // process_bls_to_execution_change
-  private void processBlsToExecutionChangesNoValidation(
-      final MutableBeaconStateCapella state,
-      final SszList<SignedBlsToExecutionChange> signedBlsToExecutionChanges) {
-
-    for (SignedBlsToExecutionChange signedBlsToExecutionChange : signedBlsToExecutionChanges) {
+    for (SignedBlsToExecutionChange signedBlsToExecutionChange : blsToExecutionChanges) {
       BlsToExecutionChange addressChange = signedBlsToExecutionChange.getMessage();
       final int validatorIndex = addressChange.getValidatorIndex().intValue();
       Validator validator = state.getValidators().get(validatorIndex);

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -7857,7 +7857,7 @@
 - name: process_bls_to_execution_change#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
-      search: public void processBlsToExecutionChangesNoValidation(
+      search: public void processBlsToExecutionChanges(
   spec: |
     <spec fn="process_bls_to_execution_change" fork="capella" hash="1fade4f1">
     def process_bls_to_execution_change(


### PR DESCRIPTION
Added some unit tests and refactored pre-processing function.

fixes #10309

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Capella block pre-processing and `processBlsToExecutionChanges` validation, which can affect block import/consensus behavior if the new deposit-aware revalidation has edge cases.
> 
> **Overview**
> Refactors Capella `bls_to_execution_change` handling so validation is always enforced via `verifyBlsToExecutionChangesPreProcessing`, and the legacy no-validation path is removed.
> 
> `validateBlockPreProcessing` now retries BLS-to-execution-change validation after temporarily applying block deposits when the first validation fails, to handle changes referencing validators introduced via pending deposits.
> 
> Adds unit tests covering invalid changes, invalid signatures, and valid changes; updates `specrefs/functions.yml` to point at the new entrypoint and includes minor style/wording tweaks in `AbstractBlockProcessor` and the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9e45ea2510fe70f2a05300d3cae9f00ce62f174. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->