### PR TITLE
Typo and clarifications

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/DataColumnSidecarPruner.java
@@ -106,6 +106,10 @@ public class DataColumnSidecarPruner extends Service {
     return SafeFuture.COMPLETE;
   }
 
+  /**
+   * NOTE: the column pruning must not update earliestAvailableDataColumnSlot db variable. That
+   * variable is fully maintained by DasCustodyBackfiller
+   */
   private void pruneDataColumnSidecars() {
 
     final Optional<UInt64> genesisTime = getGenesisTime();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.storage.server.Database;
 
 public class FinalizedStateCache {
 
-  private static final long MAX_REGENERATE_LOTS = 10_000L;
+  private static final long MAX_REGENERATE_SLOTS = 10_000L;
 
   /**
    * Note this is a best effort basis to track what states are cached. Slots are added here slightly
@@ -52,7 +52,7 @@ public class FinalizedStateCache {
         maximumCacheSize,
         useSoftReferences,
         stateRebuildTimeoutSeconds,
-        MAX_REGENERATE_LOTS);
+        MAX_REGENERATE_SLOTS);
   }
 
   FinalizedStateCache(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification plus a non-functional constant rename; no behavioral changes expected.
> 
> **Overview**
> Clarifies in `DataColumnSidecarPruner` that pruning **must not** update the `earliestAvailableDataColumnSlot` DB variable because it is maintained by `DasCustodyBackfiller`.
> 
> Fixes a typo in `FinalizedStateCache` by renaming `MAX_REGENERATE_LOTS` to `MAX_REGENERATE_SLOTS` and updating the constructor default to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2679dc869ba085ba1565b7677a2f381cb7c91316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->