### PR TITLE
Improve reference tests filtering for ignoring tests

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -18,12 +18,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import tech.pegasys.teku.ethtests.TestFork;
-import tech.pegasys.teku.ethtests.TestSpecConfig;
-import tech.pegasys.teku.ethtests.finder.PyspecTestFinder.ForkAndConfig;
 import tech.pegasys.teku.infrastructure.async.ExceptionThrowingFunction;
 
 @SuppressWarnings("MustBeClosedChecker")
@@ -72,49 +69,20 @@ public class ReferenceTestFinder {
                       new SszTestFinder("ssz_static"),
                       new ShufflingTestFinder(),
                       new PyspecTestFinder(
-                          Map.of(),
-                          // TODO: https://github.com/Consensys/teku/issues/10320 ignoring tests
-                          // which fail because of the proposer boost changes added in
-                          // https://github.com/ethereum/consensus-specs/pull/4807
-                          Map.of(
-                              new ForkAndConfig(TestFork.ALTAIR, TestSpecConfig.MINIMAL),
-                              List.of(
-                                  "fork_choice/get_head - voting_source_beyond_two_epoch",
-                                  "fork_choice/on_block - justified_update_always_if_better",
-                                  "fork_choice/on_block - justified_update_not_realized_finality"),
-                              new ForkAndConfig(TestFork.BELLATRIX, TestSpecConfig.MINIMAL),
-                              List.of(
-                                  "fork_choice/get_head - voting_source_beyond_two_epoch",
-                                  "fork_choice/on_block - justified_update_always_if_better",
-                                  "fork_choice/on_block - justified_update_not_realized_finality"),
-                              new ForkAndConfig(TestFork.CAPELLA, TestSpecConfig.MINIMAL),
-                              List.of(
-                                  "fork_choice/get_head - voting_source_beyond_two_epoch",
-                                  "fork_choice/on_block - justified_update_always_if_better",
-                                  "fork_choice/on_block - justified_update_not_realized_finality"),
-                              new ForkAndConfig(TestFork.DENEB, TestSpecConfig.MINIMAL),
-                              List.of(
-                                  "fork_choice/get_head - voting_source_beyond_two_epoch",
-                                  "fork_choice/on_block - justified_update_always_if_better",
-                                  "fork_choice/on_block - justified_update_not_realized_finality"),
-                              new ForkAndConfig(TestFork.ELECTRA, TestSpecConfig.MINIMAL),
-                              List.of(
-                                  "fork_choice/get_head - voting_source_beyond_two_epoch",
-                                  "fork_choice/on_block - justified_update_always_if_better",
-                                  "fork_choice/on_block - justified_update_not_realized_finality"),
-                              new ForkAndConfig(TestFork.FULU, TestSpecConfig.MINIMAL),
-                              List.of(
-                                  "fork_choice/get_head - voting_source_beyond_two_epoch",
-                                  "fork_choice/on_block - justified_update_always_if_better",
-                                  "fork_choice/on_block - justified_update_not_realized_finality"),
+                          List.of(),
+                          List.of(
+                              // TODO: https://github.com/Consensys/teku/issues/10320 ignoring tests
+                              // which fail because of the proposer boost changes added in
+                              // https://github.com/ethereum/consensus-specs/pull/4807
+                              "minimal - fork_choice/get_head - voting_source_beyond_two_epoch",
+                              "minimal - fork_choice/on_block - justified_update_always_if_better",
+                              "minimal - fork_choice/on_block - justified_update_not_realized_finality",
                               // TODO-GLOAS: Limit what tests we run for Gloas while it is
                               // under development. This is temporary and should be removed once we
                               // are up-to-date with Gloas specs (see
                               // https://github.com/Consensys/teku-internal/issues/221)
-                              new ForkAndConfig(TestFork.GLOAS, TestSpecConfig.MAINNET),
-                              List.of("fork_choice/"),
-                              new ForkAndConfig(TestFork.GLOAS, TestSpecConfig.MINIMAL),
-                              List.of("fork_choice/"))),
+                              "gloas - minimal - fork_choice/",
+                              "gloas - mainnet - fork_choice/")),
                       new MerkleProofTestFinder())
                   .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
             });


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Improve filtering of ignoring specific reference tests

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test discovery/filtering logic changes only; main risk is accidentally skipping or re-enabling reference tests due to broader `contains` matching semantics.
> 
> **Overview**
> Pyspec reference test filtering is simplified to use two global string lists (`onlyTestsToRun`, `testsToIgnore`) instead of per-`ForkAndConfig` maps, removing the `ForkAndConfig` record entirely.
> 
> Filtering now matches against each test’s full `TestDefinition.getDisplayName()` using substring (`contains`) semantics, and `ReferenceTestFinder`’s hard-coded ignore rules are updated to the new `{fork} - {config} - {test-type} - {test-name}`-style identifiers (including minimal fork-choice exclusions and Gloas fork-choice limiting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9ad238a927212861cf8e3e8bfe0f3b89abaa00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->