### PR TITLE
Use current date when CI triggered manually

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -118,6 +118,11 @@ jobs:
           cosign sign --yes $IMAGE
       - name: Generate provenance file
         run: |
+          BUILD_STARTED_ON="${{ github.event.head_commit.timestamp }}"
+          # Fallback to current time if head_commit.timestamp is not available (e.g., in workflow_call events)
+          if [ -z "$BUILD_STARTED_ON" ]; then
+            BUILD_STARTED_ON=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          fi
           BUILD_FINISHED_ON=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           cat > provenance.json <<'EOF'
           {
@@ -134,7 +139,7 @@ jobs:
               }
             },
             "metadata": {
-              "buildStartedOn": "${{ github.event.head_commit.timestamp }}",
+              "buildStartedOn": "__BUILD_STARTED_ON__",
               "buildFinishedOn": "__BUILD_FINISHED_ON__"
             },
             "source": {
@@ -143,6 +148,7 @@ jobs:
             }
           }
           EOF
+          sed -i "s/__BUILD_STARTED_ON__/$BUILD_STARTED_ON/" provenance.json
           sed -i "s/__BUILD_FINISHED_ON__/$BUILD_FINISHED_ON/" provenance.json
       - name: Attest cosign provenance 
         run: |


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The `publish-docker` workflow fails when triggered manually with this error:
`Error: unmarshal Provenance predicate: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"`

Example: https://github.com/Consensys/teku/actions/runs/21670357205 (ci triggered manually for master) 

This happens because It  uses `${{ github.event.head_commit.timestamp }}` for the `buildStartedOn` field and this value is only available in push events but is empty `workflow_dispatch` events (manual runs) resulting in an empty string that  cannot be parses as a valid timestamp.

This PR adds a fallback mechanism that checks if `BUILD_STARTED_ON` is empty and generates a valid timestamp using `date -u +"%Y-%m-%dT%H:%M:%SZ"` when the event context doesn't provide one.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just fills `buildStartedOn` with a valid UTC timestamp when `github.event.head_commit.timestamp` is missing, preventing provenance generation/attestation failures on manual or `workflow_call` triggers.
> 
> **Overview**
> Fixes `publish-docker` provenance generation for non-push triggers by **falling back to the current UTC time** when `github.event.head_commit.timestamp` is empty.
> 
> The workflow now writes placeholders into `provenance.json` and `sed`-substitutes both `buildStartedOn` and `buildFinishedOn`, ensuring cosign provenance attestation always has valid timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed3c5a48e232544a7c75176c4f4ed9ec5c64d9f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>ed3c5a4</u></sup><!-- /BUGBOT_STATUS -->