### PR TITLE
[Gloas] State selection during block production

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -146,7 +146,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   private final ChainDataProvider chainDataProvider;
   private final NodeDataProvider nodeDataProvider;
   private final NetworkDataProvider networkDataProvider;
-  private final CombinedChainDataClient combinedChainDataClient;
+  protected final CombinedChainDataClient combinedChainDataClient;
   private final SyncStateProvider syncStateProvider;
   private final BlockFactory blockFactory;
   private final AggregatingAttestationPool attestationPool;
@@ -155,8 +155,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   private final ActiveValidatorTracker activeValidatorTracker;
   private final DutyMetrics dutyMetrics;
   private final PerformanceTracker performanceTracker;
-  private final Spec spec;
-  private final ForkChoiceTrigger forkChoiceTrigger;
+  protected final Spec spec;
+  protected final ForkChoiceTrigger forkChoiceTrigger;
   private final SyncCommitteeMessagePool syncCommitteeMessagePool;
   private final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager;
   private final SyncCommitteeContributionPool syncCommitteeContributionPool;
@@ -445,23 +445,26 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   private BlockProductionPreparationContext prepareBlockProductionInternal(final UInt64 slot) {
     return blockProductionPreparationContextBySlotCache.computeIfAbsent(
         slot,
-        keySlot -> {
-          LOG.info("Preparing block production for slot {}", keySlot);
+        __ -> {
+          LOG.info("Preparing block production for slot {}", slot);
           final BlockProductionPerformance productionPerformance =
-              blockProductionAndPublishingPerformanceFactory.createForProduction(keySlot);
+              blockProductionAndPublishingPerformanceFactory.createForProduction(slot);
           final SafeFuture<Optional<BeaconState>> state =
               forkChoiceTrigger
-                  .prepareForBlockProduction(keySlot, productionPerformance)
-                  .thenCompose(
-                      ignored ->
-                          combinedChainDataClient.getStateForBlockProduction(
-                              keySlot,
-                              forkChoiceTrigger.isForkChoiceOverrideLateBlockEnabled(),
-                              productionPerformance::lateBlockReorgPreparationCompleted))
-                  .thenPeek(__ -> productionPerformance.getState());
+                  .prepareForBlockProduction(slot, productionPerformance)
+                  .thenCompose(___ -> getStateForBlockProduction(slot, productionPerformance))
+                  .thenPeek(___ -> productionPerformance.getState());
 
           return new BlockProductionPreparationContext(state, productionPerformance);
         });
+  }
+
+  protected SafeFuture<Optional<BeaconState>> getStateForBlockProduction(
+      final UInt64 slot, final BlockProductionPerformance productionPerformance) {
+    return combinedChainDataClient.getStateForBlockProduction(
+        slot,
+        forkChoiceTrigger.isForkChoiceOverrideLateBlockEnabled(),
+        productionPerformance::lateBlockReorgPreparationCompleted);
   }
 
   private SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlockInternal(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
@@ -100,8 +100,8 @@ public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
   @Override
   protected SafeFuture<Optional<BeaconState>> getStateForBlockProduction(
       final UInt64 slot, final BlockProductionPerformance productionPerformance) {
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10352 this is naive state selection
-    // (good enough for devnet-0) and needs to be revisited
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10352 this is very simple and naïve
+    // state selection (possibly good enough for devnet-0) that needs to be revisited
     final Optional<BeaconState> executionPayloadState =
         combinedChainDataClient
             .getRecentChainData()
@@ -111,7 +111,8 @@ public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
                     combinedChainDataClient
                         .getStore()
                         // no state will be present for slots before the Gloas fork
-                        .getExecutionPayloadStateIfAvailable(blockRoot));
+                        .getExecutionPayloadStateIfAvailable(blockRoot))
+            .flatMap(state -> combinedChainDataClient.regenerateBeaconState(state, slot));
     if (executionPayloadState.isPresent()) {
       return SafeFuture.completedFuture(executionPayloadState);
     }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import java.util.Optional;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.NetworkDataProvider;
+import tech.pegasys.teku.api.NodeDataProvider;
+import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionAndPublishingPerformanceFactory;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.gossip.subnets.AttestationTopicSubscriber;
+import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubscriptionManager;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.attestation.AttestationManager;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.executionproofs.ExecutionProofManager;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
+import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
+import tech.pegasys.teku.validator.coordinator.publisher.BlockPublisher;
+import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisher;
+
+public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
+
+  public ValidatorApiHandlerGloas(
+      final ChainDataProvider chainDataProvider,
+      final NodeDataProvider nodeDataProvider,
+      final NetworkDataProvider networkDataProvider,
+      final CombinedChainDataClient combinedChainDataClient,
+      final SyncStateProvider syncStateProvider,
+      final BlockFactory blockFactory,
+      final AggregatingAttestationPool attestationPool,
+      final AttestationManager attestationManager,
+      final AttestationTopicSubscriber attestationTopicSubscriber,
+      final ActiveValidatorTracker activeValidatorTracker,
+      final DutyMetrics dutyMetrics,
+      final PerformanceTracker performanceTracker,
+      final Spec spec,
+      final ForkChoiceTrigger forkChoiceTrigger,
+      final ProposersDataManager proposersDataManager,
+      final SyncCommitteeMessagePool syncCommitteeMessagePool,
+      final SyncCommitteeContributionPool syncCommitteeContributionPool,
+      final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager,
+      final BlockProductionAndPublishingPerformanceFactory
+          blockProductionAndPublishingPerformanceFactory,
+      final BlockPublisher blockPublisher,
+      final PayloadAttestationPool payloadAttestationPool,
+      final ExecutionPayloadManager executionPayloadManager,
+      final ExecutionPayloadFactory executionPayloadFactory,
+      final ExecutionPayloadPublisher executionPayloadPublisher,
+      final ExecutionProofManager executionProofManager) {
+    super(
+        chainDataProvider,
+        nodeDataProvider,
+        networkDataProvider,
+        combinedChainDataClient,
+        syncStateProvider,
+        blockFactory,
+        attestationPool,
+        attestationManager,
+        attestationTopicSubscriber,
+        activeValidatorTracker,
+        dutyMetrics,
+        performanceTracker,
+        spec,
+        forkChoiceTrigger,
+        proposersDataManager,
+        syncCommitteeMessagePool,
+        syncCommitteeContributionPool,
+        syncCommitteeSubscriptionManager,
+        blockProductionAndPublishingPerformanceFactory,
+        blockPublisher,
+        payloadAttestationPool,
+        executionPayloadManager,
+        executionPayloadFactory,
+        executionPayloadPublisher,
+        executionProofManager);
+  }
+
+  @Override
+  protected SafeFuture<Optional<BeaconState>> getStateForBlockProduction(
+      final UInt64 slot, final BlockProductionPerformance productionPerformance) {
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10352 this is naive state selection
+    // (good enough for devnet-0) and needs to be revisited
+    final Optional<BeaconState> executionPayloadState =
+        combinedChainDataClient
+            .getRecentChainData()
+            .getBlockRootInEffectBySlot(slot)
+            .flatMap(
+                blockRoot ->
+                    combinedChainDataClient
+                        .getStore()
+                        // no state will be present for slots before the Gloas fork
+                        .getExecutionPayloadStateIfAvailable(blockRoot));
+    if (executionPayloadState.isPresent()) {
+      return SafeFuture.completedFuture(executionPayloadState);
+    }
+    return combinedChainDataClient.getStateForBlockProduction(
+        slot,
+        forkChoiceTrigger.isForkChoiceOverrideLateBlockEnabled(),
+        productionPerformance::lateBlockReorgPreparationCompleted);
+  }
+}

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateAtSlotTask.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateAtSlotTask.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -123,7 +124,7 @@ public class StateAtSlotTask implements CacheableTask<SlotAndBlockRoot, BeaconSt
   @FunctionalInterface
   public interface AsyncStateProvider {
     static AsyncStateProvider fromBlockAndState(final SignedBlockAndState blockAndState) {
-      return (Bytes32 root) -> {
+      return (root) -> {
         if (Objects.equals(root, blockAndState.getRoot())) {
           return SafeFuture.completedFuture(Optional.of(blockAndState.getState()));
         } else {
@@ -132,8 +133,19 @@ public class StateAtSlotTask implements CacheableTask<SlotAndBlockRoot, BeaconSt
       };
     }
 
+    static AsyncStateProvider fromExecutionPayloadAndState(
+        final SignedExecutionPayloadAndState executionPayloadAndState) {
+      return (root) -> {
+        if (Objects.equals(root, executionPayloadAndState.getBeaconBlockRoot())) {
+          return SafeFuture.completedFuture(Optional.of(executionPayloadAndState.state()));
+        } else {
+          return SafeFuture.completedFuture(Optional.empty());
+        }
+      };
+    }
+
     static AsyncStateProvider fromAnchor(final AnchorPoint anchor) {
-      return (Bytes32 root) -> {
+      return (root) -> {
         if (Objects.equals(root, anchor.getRoot())) {
           return SafeFuture.completedFuture(Optional.of(anchor.getState()));
         } else {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/SignedExecutionPayloadAndState.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.epbs;
 
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -24,5 +25,9 @@ public record SignedExecutionPayloadAndState(
     SignedExecutionPayloadEnvelope executionPayload, BeaconState state) {
   public UInt64 getSlot() {
     return executionPayload.getMessage().getSlot();
+  }
+
+  public Bytes32 getBeaconBlockRoot() {
+    return executionPayload.getBeaconBlockRoot();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/PayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/PayloadStatus.java
@@ -14,19 +14,19 @@
 package tech.pegasys.teku.spec.datastructures.forkchoice;
 
 /**
- * Represents the payload status for Gloas fork choice.
+ * Possible status of a payload in the fork-choice
  *
  * <p>Spec reference:
- * https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/gloas/fork-choice.md
+ * hhttps://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md
  */
-public enum PayloadStatusGloas {
+public enum PayloadStatus {
   PAYLOAD_STATUS_PENDING(0),
   PAYLOAD_STATUS_EMPTY(1),
   PAYLOAD_STATUS_FULL(2);
 
   private final int value;
 
-  PayloadStatusGloas(final int value) {
+  PayloadStatus(final int value) {
     this.value = value;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/PayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/PayloadStatus.java
@@ -17,7 +17,7 @@ package tech.pegasys.teku.spec.datastructures.forkchoice;
  * Possible status of a payload in the fork-choice
  *
  * <p>Spec reference:
- * hhttps://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md
  */
 public enum PayloadStatus {
   PAYLOAD_STATUS_PENDING(0),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
@@ -400,6 +399,11 @@ public class ForkChoiceUtil {
         signedBlock, postState, blockCheckpoints, blobSidecars, earliestBlobSidecarsSlot);
   }
 
+  public SafeFuture<Optional<BeaconState>> retrievePreStateRequiredOnBlock(
+      final ReadOnlyStore store, final SignedBeaconBlock block) {
+    return store.retrieveBlockState(block.getSlotAndBlockRoot());
+  }
+
   public void applyExecutionPayloadToStore(
       final MutableStore store,
       final SignedExecutionPayloadEnvelope signedEnvelope,
@@ -410,13 +414,6 @@ public class ForkChoiceUtil {
   private UInt64 getFinalizedCheckpointStartSlot(final ReadOnlyStore store) {
     final UInt64 finalizedEpoch = store.getFinalizedCheckpoint().getEpoch();
     return miscHelpers.computeStartSlotAtEpoch(finalizedEpoch);
-  }
-
-  public SafeFuture<Optional<BeaconState>> retrieveBlockState(
-      final ReadOnlyStore store, final SignedBeaconBlock block) {
-    final SlotAndBlockRoot slotAndBlockRoot =
-        new SlotAndBlockRoot(block.getSlot(), block.getParentRoot());
-    return store.retrieveBlockState(slotAndBlockRoot);
   }
 
   public BlockImportResult checkOnBlockConditions(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
@@ -401,7 +402,9 @@ public class ForkChoiceUtil {
 
   public SafeFuture<Optional<BeaconState>> retrievePreStateRequiredOnBlock(
       final ReadOnlyStore store, final SignedBeaconBlock block) {
-    return store.retrieveBlockState(block.getSlotAndBlockRoot());
+    final SlotAndBlockRoot slotAndBlockRoot =
+        new SlotAndBlockRoot(block.getSlot(), block.getParentRoot());
+    return store.retrieveBlockState(slotAndBlockRoot);
   }
 
   public void applyExecutionPayloadToStore(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.spec.logic.versions.gloas.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
-import static tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatusGloas.PAYLOAD_STATUS_EMPTY;
+import static tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatus.PAYLOAD_STATUS_EMPTY;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -28,7 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
-import tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatusGloas;
+import tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
@@ -64,16 +64,11 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> retrieveBlockState(
+  public SafeFuture<Optional<BeaconState>> retrievePreStateRequiredOnBlock(
       final ReadOnlyStore store, final SignedBeaconBlock block) {
-    final SlotAndBlockRoot slotAndBlockRoot =
-        new SlotAndBlockRoot(block.getSlot(), block.getParentRoot());
-    // From Gloas, there are 3 states available in a given slot
-    // pre-state: State at the slot before block applied
-    // block-state: State at slot after consensus block applied
-    // execution-state: State at slot after consensus and execution has been applied
-    // The state to build on for the next slot is the best available of this list
-    // (execution-state > block-state > pre-state)
+    final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
+    // the `on_block` is modified to consider the pre-state of the given consensus beacon block
+    // depending not only on the parent block root, but also on the parent blockhash.
     if (isParentNodeFull(store, block.getMessage().getBlock())) {
       return store.retrieveExecutionPayloadState(slotAndBlockRoot);
     } else {
@@ -108,15 +103,14 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
    * Determines the payload status of the parent block.
    *
    * <p>Spec reference:
-   * https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/gloas/fork-choice.md#get_parent_payload_status
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-get_parent_payload_status
    *
    * @param store the fork choice store
    * @param block the current block
    * @return PAYLOAD_STATUS_FULL if parent has full payload, PAYLOAD_STATUS_EMPTY otherwise
    */
   // get_parent_payload_status
-  public PayloadStatusGloas getParentPayloadStatus(
-      final ReadOnlyStore store, final BeaconBlock block) {
+  PayloadStatus getParentPayloadStatus(final ReadOnlyStore store, final BeaconBlock block) {
     final SignedBeaconBlock parent =
         store
             .getBlockIfAvailable(block.getParentRoot())
@@ -124,7 +118,7 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
                 () ->
                     new IllegalStateException("Parent block not found: " + block.getParentRoot()));
 
-    // TODO-gloas #10341
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10341
     // if the parent is pre-gloas, we'd use the block state,
     // there would be no payload state
     if (parent.getSlot().isLessThan(earliestGloasSlot)) {
@@ -141,7 +135,7 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
         parentBody.getSignedExecutionPayloadBid().getMessage().getBlockHash();
 
     return parentBlockHash.equals(messageBlockHash)
-        ? PayloadStatusGloas.PAYLOAD_STATUS_FULL
+        ? PayloadStatus.PAYLOAD_STATUS_FULL
         : PAYLOAD_STATUS_EMPTY;
   }
 
@@ -149,14 +143,14 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
    * Checks if the parent node has a full payload.
    *
    * <p>Spec reference:
-   * https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/gloas/fork-choice.md#is_parent_node_full
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_parent_node_full
    *
    * @param store the fork choice store
    * @param block the current block
    * @return true if parent has full payload status
    */
   // is_parent_node_full
-  public boolean isParentNodeFull(final ReadOnlyStore store, final BeaconBlock block) {
-    return getParentPayloadStatus(store, block) == PayloadStatusGloas.PAYLOAD_STATUS_FULL;
+  boolean isParentNodeFull(final ReadOnlyStore store, final BeaconBlock block) {
+    return getParentPayloadStatus(store, block) == PayloadStatus.PAYLOAD_STATUS_FULL;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -68,8 +68,12 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
       final ReadOnlyStore store, final SignedBeaconBlock block) {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(block.getSlot(), block.getParentRoot());
-    // the `on_block` is modified to consider the pre-state of the given consensus beacon block
-    // depending not only on the parent block root, but also on the parent blockhash.
+    // From Gloas, there are 3 states available in a given slot
+    // pre-state: State at the slot before block applied
+    // block-state: State at slot after consensus block applied
+    // execution-state: State at slot after consensus and execution has been applied
+    // The state to build on for the next slot is the best available of this list
+    // (execution-state > block-state > pre-state)
     if (isParentNodeFull(store, block.getMessage().getBlock())) {
       return store.retrieveExecutionPayloadState(slotAndBlockRoot);
     } else {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -66,7 +66,8 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
   @Override
   public SafeFuture<Optional<BeaconState>> retrievePreStateRequiredOnBlock(
       final ReadOnlyStore store, final SignedBeaconBlock block) {
-    final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
+    final SlotAndBlockRoot slotAndBlockRoot =
+        new SlotAndBlockRoot(block.getSlot(), block.getParentRoot());
     // the `on_block` is modified to consider the pre-state of the given consensus beacon block
     // depending not only on the parent block root, but also on the parent blockhash.
     if (isParentNodeFull(store, block.getMessage().getBlock())) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
-import tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatusGloas;
+import tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -44,7 +44,7 @@ class ForkChoiceUtilGloasTest {
   void setUp() {
     spec = TestSpecFactory.createMinimalGloas();
     dataStructureUtil = new DataStructureUtil(spec);
-    forkChoiceUtil = (ForkChoiceUtilGloas) spec.getGenesisSpec().getForkChoiceUtil();
+    forkChoiceUtil = ForkChoiceUtilGloas.required(spec.getGenesisSpec().getForkChoiceUtil());
   }
 
   @Test
@@ -63,10 +63,10 @@ class ForkChoiceUtilGloasTest {
         .thenReturn(Optional.of(parentBlock));
 
     // Test
-    final PayloadStatusGloas result =
+    final PayloadStatus result =
         forkChoiceUtil.getParentPayloadStatus(store, currentBlock.getMessage());
 
-    assertThat(result).isEqualTo(PayloadStatusGloas.PAYLOAD_STATUS_FULL);
+    assertThat(result).isEqualTo(PayloadStatus.PAYLOAD_STATUS_FULL);
   }
 
   @Test
@@ -86,10 +86,10 @@ class ForkChoiceUtilGloasTest {
         .thenReturn(Optional.of(parentBlock));
 
     // Test
-    final PayloadStatusGloas result =
+    final PayloadStatus result =
         forkChoiceUtil.getParentPayloadStatus(store, currentBlock.getMessage());
 
-    assertThat(result).isEqualTo(PayloadStatusGloas.PAYLOAD_STATUS_EMPTY);
+    assertThat(result).isEqualTo(PayloadStatus.PAYLOAD_STATUS_EMPTY);
   }
 
   @Test

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -250,15 +249,13 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public SafeFuture<Optional<BeaconState>> retrieveExecutionPayloadState(
       final SlotAndBlockRoot slotAndBlockRoot) {
-    // TODO-gloas
-    return SafeFuture.failedFuture(
-        new NotImplementedException("TODO-Gloas - fetch execution payload state"));
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not implemented"));
   }
 
   @Override
   public SafeFuture<Optional<BeaconState>> retrieveBlockState(
       final SlotAndBlockRoot slotAndBlockRoot) {
-    throw new UnsupportedOperationException("Not implemented");
+    return SafeFuture.failedFuture(new UnsupportedOperationException("Not implemented"));
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.validation;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
@@ -86,6 +87,10 @@ public class GossipValidationHelper {
       final UInt64 builderIndex,
       final BLSSignature signature,
       final BeaconState state) {
+    if (builderIndex.equals(BUILDER_INDEX_SELF_BUILD)) {
+      return isSignatureValidWithRespectToProposerIndex(
+          signingRoot, state.getLatestBlockHeader().getProposerIndex(), signature, state);
+    }
     return spec.getBuilderPubKey(state, builderIndex)
         .map(publicKey -> BLS.verify(publicKey, signingRoot, signature))
         .orElse(false);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -286,6 +286,7 @@ import tech.pegasys.teku.validator.coordinator.GraffitiBuilder;
 import tech.pegasys.teku.validator.coordinator.MilestoneBasedBlockFactory;
 import tech.pegasys.teku.validator.coordinator.StoredLatestCanonicalBlockUpdater;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandlerGloas;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.NoOpPerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
@@ -1718,33 +1719,64 @@ public class BeaconChainController extends Service implements BeaconChainControl
       executionPayloadPublisher = ExecutionPayloadPublisher.NOOP;
     }
 
-    this.validatorApiHandler =
-        new ValidatorApiHandler(
-            dataProvider.getChainDataProvider(),
-            dataProvider.getNodeDataProvider(),
-            dataProvider.getNetworkDataProvider(),
-            combinedChainDataClient,
-            syncService,
-            blockFactory,
-            attestationPool,
-            attestationManager,
-            attestationTopicSubscriber,
-            activeValidatorTracker,
-            dutyMetrics,
-            performanceTracker,
-            spec,
-            forkChoiceTrigger,
-            proposersDataManager,
-            syncCommitteeMessagePool,
-            syncCommitteeContributionPool,
-            syncCommitteeSubscriptionManager,
-            blockProductionPerformanceFactory,
-            blockPublisher,
-            payloadAttestationPool,
-            executionPayloadManager,
-            executionPayloadFactory,
-            executionPayloadPublisher,
-            executionProofManager);
+    if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      this.validatorApiHandler =
+          new ValidatorApiHandlerGloas(
+              dataProvider.getChainDataProvider(),
+              dataProvider.getNodeDataProvider(),
+              dataProvider.getNetworkDataProvider(),
+              combinedChainDataClient,
+              syncService,
+              blockFactory,
+              attestationPool,
+              attestationManager,
+              attestationTopicSubscriber,
+              activeValidatorTracker,
+              dutyMetrics,
+              performanceTracker,
+              spec,
+              forkChoiceTrigger,
+              proposersDataManager,
+              syncCommitteeMessagePool,
+              syncCommitteeContributionPool,
+              syncCommitteeSubscriptionManager,
+              blockProductionPerformanceFactory,
+              blockPublisher,
+              payloadAttestationPool,
+              executionPayloadManager,
+              executionPayloadFactory,
+              executionPayloadPublisher,
+              executionProofManager);
+    } else {
+      this.validatorApiHandler =
+          new ValidatorApiHandler(
+              dataProvider.getChainDataProvider(),
+              dataProvider.getNodeDataProvider(),
+              dataProvider.getNetworkDataProvider(),
+              combinedChainDataClient,
+              syncService,
+              blockFactory,
+              attestationPool,
+              attestationManager,
+              attestationTopicSubscriber,
+              activeValidatorTracker,
+              dutyMetrics,
+              performanceTracker,
+              spec,
+              forkChoiceTrigger,
+              proposersDataManager,
+              syncCommitteeMessagePool,
+              syncCommitteeContributionPool,
+              syncCommitteeSubscriptionManager,
+              blockProductionPerformanceFactory,
+              blockPublisher,
+              payloadAttestationPool,
+              executionPayloadManager,
+              executionPayloadFactory,
+              executionPayloadPublisher,
+              executionProofManager);
+    }
+
     eventChannels
         .subscribe(SlotEventsChannel.class, activeValidatorTracker)
         .subscribe(ExecutionClientEventsChannel.class, executionClientVersionProvider)

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -4435,7 +4435,7 @@
 - name: get_parent_payload_status#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
-      search: public PayloadStatusGloas getParentPayloadStatus(
+      search: PayloadStatus getParentPayloadStatus(
   spec: |
     <spec fn="get_parent_payload_status" fork="gloas" hash="4ab82d16">
     def get_parent_payload_status(store: Store, block: BeaconBlock) -> PayloadStatus:
@@ -6173,7 +6173,7 @@
 - name: is_parent_node_full#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
-      search: public boolean isParentNodeFull(final ReadOnlyStore store, final BeaconBlock block) {
+      search: boolean isParentNodeFull(final ReadOnlyStore store, final BeaconBlock block) {
   spec: |
     <spec fn="is_parent_node_full" fork="gloas" hash="4fc2d12c">
     def is_parent_node_full(store: Store, block: BeaconBlock) -> bool:

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -829,11 +829,6 @@ public class CombinedChainDataClient {
     return historicalChainData.getDataColumnIdentifiers(slot);
   }
 
-  public SafeFuture<List<DataColumnSlotAndIdentifier>> getNonCanonicalDataColumnIdentifiers(
-      final UInt64 slot) {
-    return historicalChainData.getNonCanonicalDataColumnIdentifiers(slot);
-  }
-
   public SafeFuture<List<DataColumnSlotAndIdentifier>> getDataColumnIdentifiers(
       final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
     return historicalChainData.getDataColumnIdentifiers(startSlot, endSlot, limit);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -30,7 +30,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -848,10 +847,24 @@ public class CombinedChainDataClient {
     return historicalChainData.getEarliestDataColumnSidecarSlot();
   }
 
-  public SafeFuture<List<List<KZGProof>>> getDataColumnSidecarProofs(final UInt64 slot) {
-    return historicalChainData
-        .getDataColumnSidecarsProofs(slot)
-        .thenApply(maybeProofs -> maybeProofs.orElseGet(List::of));
+  public Optional<BeaconState> regenerateBeaconState(
+      final BeaconState preState, final UInt64 slot) {
+    if (preState.getSlot().equals(slot)) {
+      return Optional.of(preState);
+    } else if (slot.compareTo(getCurrentSlot()) > 0) {
+      LOG.debug("Attempted to wind forward to a future state: {}", slot.toString());
+      return Optional.empty();
+    }
+    try {
+      LOG.debug(
+          "Processing slots to regenerate state from slot {}, target slot {}",
+          preState::getSlot,
+          () -> slot);
+      return Optional.of(spec.processSlots(preState, slot));
+    } catch (SlotProcessingException | EpochProcessingException | IllegalArgumentException e) {
+      LOG.debug("State Transition error", e);
+      return Optional.empty();
+    }
   }
 
   private SafeFuture<Optional<BeaconState>> getStateFromSlotAndBlock(
@@ -885,26 +898,6 @@ public class CombinedChainDataClient {
             maybeState ->
                 maybeState.flatMap(
                     preState -> regenerateBeaconState(preState, slotAndBlockRoot.getSlot())));
-  }
-
-  private Optional<BeaconState> regenerateBeaconState(
-      final BeaconState preState, final UInt64 slot) {
-    if (preState.getSlot().equals(slot)) {
-      return Optional.of(preState);
-    } else if (slot.compareTo(getCurrentSlot()) > 0) {
-      LOG.debug("Attempted to wind forward to a future state: {}", slot.toString());
-      return Optional.empty();
-    }
-    try {
-      LOG.debug(
-          "Processing slots to regenerate state from slot {}, target slot {}",
-          preState::getSlot,
-          () -> slot);
-      return Optional.of(spec.processSlots(preState, slot));
-    } catch (SlotProcessingException | EpochProcessingException | IllegalArgumentException e) {
-      LOG.debug("State Transition error", e);
-      return Optional.empty();
-    }
   }
 
   private SafeFuture<Optional<SignedBlockAndState>> getStateForBlock(

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -720,8 +720,15 @@ class Store extends CacheableStore {
   @Override
   public SafeFuture<Optional<BeaconState>> retrieveExecutionPayloadState(
       final SlotAndBlockRoot slotAndBlockRoot) {
-    return SafeFuture.completedFuture(
-        getExecutionPayloadStateIfAvailable(slotAndBlockRoot.getBlockRoot()));
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 implement caching similar to
+    // retrieveBlockState/retrieveCheckpointState
+    return new StateAtSlotTask(
+            spec,
+            slotAndBlockRoot,
+            __ ->
+                SafeFuture.completedFuture(
+                    getExecutionPayloadStateIfAvailable(slotAndBlockRoot.getBlockRoot())))
+        .performTask();
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This is very simple implementation for the moment.

- Created `ValidatorApiHandlerGloas` to not affect current flow with an if statement
- Modified `Store` and `StoreTransaction` to process slots required in fork choice for execution payload states (using StateAtSlotTask pattern)
- I also renamed `PayloadStatusGloas` to `PayloadStatus` just to align with specs (we can distinguish between the two from the package)
- Also fixed signature checking during gossip validation


## Fixed Issue(s)
related to #10352

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-choice pre-state retrieval, block production state selection, and state regeneration paths; mistakes could cause incorrect state selection or failed imports/production around the Gloas fork, but changes are largely gated to Gloas and add tests/compat fallbacks.
> 
> **Overview**
> Enables *Gloas-aware state selection* in validator block production by introducing `ValidatorApiHandlerGloas` and routing `BeaconChainController` to use it when `SpecMilestone.GLOAS` is supported; the handler can prefer an execution-payload-derived state (regenerated to the target slot) before falling back to the existing `getStateForBlockProduction` path.
> 
> Updates fork-choice to retrieve the *correct pre-state* via a new `ForkChoiceUtil.retrievePreStateRequiredOnBlock` hook, with the Gloas implementation choosing between block state vs execution payload state based on parent payload fullness; storage (`Store`/`StoreTransaction`/`StateAtSlotTask`) is extended to regenerate execution payload states to a requested slot using the existing `StateAtSlotTask` pattern.
> 
> Also renames `PayloadStatusGloas` to `PayloadStatus` (and updates call sites/spec refs/tests) and fixes gossip signature verification to treat the `SELF_BUILD` builder index as proposer-signed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9af6a93370ea1c8e7991d77ad29ca3276393271e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->