### PR TITLE
reduced backfill default batch size to 3

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -58,7 +58,7 @@ public class P2PConfig {
   public static final int DEFAULT_DOWNLOAD_TIMEOUT_MS = 240_000;
 
   public static final int DEFAULT_COLUMN_CUSTODY_BACKFILLER_POLL_PERIOD_SECONDS = 30;
-  public static final int DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE = 10;
+  public static final int DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE = 3;
   public static final boolean DEFAULT_REWORKED_COLUMN_CUSTODY_BACKFILLER = true;
 
   // RocksDB is configured with 6 background jobs and threads (DEFAULT_MAX_BACKGROUND_JOBS and


### PR DESCRIPTION
After testing on a supernode this looks like a more sane default batch size. It'll slow down backfill but give us space to perform duties.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant tweak to a default tuning parameter; main impact is slower backfill/initial sync but reduced resource contention.
> 
> **Overview**
> Reduces the default `DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE` in `P2PConfig` from `10` to `3`, lowering the default work per backfill cycle for the reworked column custody/sidecar sync backfiller.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4905bdc44469ea1cbde00079ba972feb1f35bc9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->