### PR TITLE
third party update sweep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 plugins {
   id 'com.diffplug.spotless' version '7.2.1'
-  id 'com.github.ben-manes.versions' version '0.52.0'
+  id 'com.github.ben-manes.versions' version '0.53.0'
   id 'com.github.jk1.dependency-license-report' version '2.9'
   id 'io.spring.dependency-management' version '1.1.7'
   id 'net.ltgt.errorprone' version '4.3.0' apply false

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,7 +1,7 @@
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.20.1'
-    dependencySet(group: 'com.fasterxml.jackson.dataformat', version: '2.20.1') {
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.21.0'
+    dependencySet(group: 'com.fasterxml.jackson.dataformat', version: '2.21.0') {
       entry 'jackson-dataformat-yaml'
       entry 'jackson-dataformat-toml'
     }
@@ -20,9 +20,9 @@ dependencyManagement {
 
     dependency 'org.yaml:snakeyaml:2.5'
 
-    dependency 'org.jsoup:jsoup:1.21.2'
+    dependency 'org.jsoup:jsoup:1.22.1'
 
-    dependency 'com.launchdarkly:okhttp-eventsource:4.1.1'
+    dependency 'com.launchdarkly:okhttp-eventsource:4.2.0'
 
     dependencySet(group: 'com.squareup.okhttp3', version: '4.12.0') {
       entry 'okhttp'
@@ -55,7 +55,7 @@ dependencyManagement {
     }
 
     // On update don't forget to change version in tech.pegasys.teku.infrastructure.restapi.SwaggerUIBuilder
-    dependency 'org.webjars:swagger-ui:5.27.1'
+    dependency 'org.webjars:swagger-ui:5.31.0'
 
     dependency 'org.thymeleaf:thymeleaf:3.1.3.RELEASE'
     dependency 'io.github.classgraph:classgraph:4.8.184'
@@ -64,7 +64,7 @@ dependencyManagement {
       entry 'oshi-core-java11'
     }
 
-    dependencySet(group: 'io.netty', version: '4.2.9.Final') {
+    dependencySet(group: 'io.netty', version: '4.2.10.Final') {
       entry 'netty-handler'
       entry 'netty-codec-http'
     }
@@ -94,7 +94,7 @@ dependencyManagement {
 
     dependency 'org.apiguardian:apiguardian-api:1.1.2'
 
-    dependency 'org.assertj:assertj-core:3.27.4'
+    dependency 'org.assertj:assertj-core:3.27.7'
 
     dependency 'org.awaitility:awaitility:4.3.0'
 
@@ -113,7 +113,7 @@ dependencyManagement {
 
     dependency 'net.java.dev.jna:jna:5.18.1'
 
-    dependencySet(group: 'org.mockito', version: '5.19.0') {
+    dependencySet(group: 'org.mockito', version: '5.21.0') {
       entry 'mockito-core'
       entry 'mockito-junit-jupiter'
     }
@@ -150,14 +150,14 @@ dependencyManagement {
       entry 'besu-plugin-api'
     }
 
-    dependencySet(group: 'org.testcontainers', version: '1.21.3') {
+    dependencySet(group: 'org.testcontainers', version: '1.21.4') {
       entry "testcontainers"
       entry "junit-jupiter"
     }
 
     dependency 'tech.pegasys.discovery:discovery:25.4.0'
 
-    dependencySet(group: 'org.jupnp', version: '3.0.3') {
+    dependencySet(group: 'org.jupnp', version: '3.0.4') {
       entry "org.jupnp"
       entry "org.jupnp.support"
     }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@ dependencyManagement {
       entry 'jackson-dataformat-yaml'
       entry 'jackson-dataformat-toml'
     }
-    dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.20.1'
+    dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.21.0'
 
     dependencySet(group: 'com.google.errorprone', version: '2.45.0') {
       entry 'error_prone_annotation'

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.infrastructure.restapi.openapi.OpenApiDocBuilder;
 
 public class SwaggerUIBuilder {
   // Version here MUST match `swagger-ui` library version
-  private static final String SWAGGER_UI_VERSION = "5.27.1";
+  private static final String SWAGGER_UI_VERSION = "5.31.0";
 
   private static final String SWAGGER_UI_PATH = "/swagger-ui";
   private static final String SWAGGER_HOSTED_PATH = "/webjars/swagger-ui/" + SWAGGER_UI_VERSION;

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -309,7 +309,6 @@ specrefs:
       - update_latest_messages#gloas
       - validate_merge_block#gloas
       - validate_on_attestation#gloas
-      - verify_data_column_sidecar#gloas
       - get_attestation_score#gloas
       - get_proposer_preferences_signature#gloas
       - get_upcoming_proposal_slots#gloas
@@ -322,4 +321,3 @@ specrefs:
       - should_apply_proposer_boost#gloas
       - update_proposer_boost_root#gloas
       - is_data_available#gloas
-      - verify_data_column_sidecar_kzg_proofs#gloas


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly version bumps, but updates to core libraries like Jackson and Netty can introduce runtime/compatibility regressions; Swagger UI version sync is low risk but affects API docs UI paths.
> 
> **Overview**
> Primarily a dependency refresh: bumps the Gradle `com.github.ben-manes.versions` plugin and updates several pinned library versions in `gradle/versions.gradle` (notably Jackson 2.21.0, `swagger-ui` 5.31.0, Netty 4.2.10.Final, Mockito 5.21.0, plus smaller bumps like jsoup, LaunchDarkly eventsource, AssertJ, Testcontainers, and JUPnP).
> 
> Keeps the REST API Swagger UI hosting in sync by updating `SwaggerUIBuilder.SWAGGER_UI_VERSION` to match the new `swagger-ui` webjar, and removes two `gloas` function exclusions from `specrefs/.ethspecify.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99ab9e00fcb5061f69fbbd7b1e5379c9bea87d57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->