### PR TITLE
Defaults TRUE faster block import when 50% of all sidecar columns ava…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Additions and Improvements
 
 - Use jemalloc in our docker images to improve memory allocation
+- Nodes with >50% custody requirements will be able to import blocks after downloading 50% of the sidecars, and the remaining sidecars will be handled as a background task. This includes nodes servicing validators in excess of 2048 eth effective balance, as well as voluntary supernodes. 
 
 ### Bug Fixes
 

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/das/Das50PercentRecoveryAcceptanceTest.java
@@ -65,6 +65,9 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
                 .withSubscribeAllCustodySubnetsEnabled()
                 .withInteropValidators(0, 0)
                 .withDasDisableElRecovery()
+                // need to disable this feature or node will go forward not waiting for
+                // reconstruction
+                .withColumnsDataAvailabilityHalfCheckDisabled()
                 .withReworkedRecoveryTimeouts(recoveryTimeout, downloadTimeout)
                 .build());
 
@@ -140,6 +143,9 @@ public class Das50PercentRecoveryAcceptanceTest extends AcceptanceTestBase {
                 .withSubscribeAllCustodySubnetsEnabled()
                 .withInteropValidators(0, 0)
                 .withDasDisableElRecovery()
+                // need to disable this feature or node will go forward not waiting for
+                // reconstruction
+                .withColumnsDataAvailabilityHalfCheckDisabled()
                 .withReworkedRecoveryTimeouts(recoveryTimeout, downloadTimeout)
                 .build());
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -685,6 +685,12 @@ public class TekuNodeConfigBuilder {
     return this;
   }
 
+  public TekuNodeConfigBuilder withColumnsDataAvailabilityHalfCheckDisabled() {
+    LOG.debug("Xcolumns-data-availability-half-check-enabled: {}", false);
+    configMap.put("Xcolumns-data-availability-half-check-enabled", false);
+    return this;
+  }
+
   public TekuNodeConfigBuilder withGetBlobsSidecarsDownloadApiEnabled() {
     LOG.debug("--rest-api-getblobs-sidecars-download-enabled: {}", true);
     configMap.put("rest-api-getblobs-sidecars-download-enabled", true);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -318,7 +318,8 @@ public class P2PConfig {
     private Integer reworkedSidecarDownloadTimeout = DEFAULT_DOWNLOAD_TIMEOUT_MS;
 
     private boolean reworkedSidecarSyncEnabled = DEFAULT_REWORKED_COLUMN_CUSTODY_BACKFILLER;
-    private boolean columnsDataAvailabilityHalfCheckEnabled = false;
+    private boolean columnsDataAvailabilityHalfCheckEnabled =
+        DEFAULT_COLUMNS_DATA_AVAILABILITY_HALF_CHECK_ENABLED;
     private Integer reworkedSidecarSyncBatchSize = DEFAULT_COLUMN_CUSTODY_BACKFILLER_BATCH_SIZE;
     private Integer reworkedSidecarSyncPollPeriod =
         DEFAULT_COLUMN_CUSTODY_BACKFILLER_POLL_PERIOD_SECONDS;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -45,7 +45,7 @@ public class P2PConfig {
   public static final boolean DEFAULT_GOSSIP_SCORING_ENABLED = true;
   public static final boolean DEFAULT_GOSSIP_BLOBS_AFTER_BLOCK_ENABLED = true;
   public static final boolean DEFAULT_DAS_DISABLE_EL_RECOVERY = false;
-  public static final boolean DEFAULT_COLUMNS_DATA_AVAILABILITY_HALF_CHECK_ENABLED = false;
+  public static final boolean DEFAULT_COLUMNS_DATA_AVAILABILITY_HALF_CHECK_ENABLED = true;
   public static final int DEFAULT_BATCH_VERIFY_MAX_THREADS =
       Math.max(4, Runtime.getRuntime().availableProcessors() / 2);
   public static final int DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY = 30_000;

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
@@ -241,15 +241,8 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
   }
 
   @Test
-  void columnsDataAvailabilityHalfCheckEnabled_disabledByDefault() {
+  void columnsDataAvailabilityHalfCheckEnabled_enabledByDefault() {
     TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
-    assertThat(tekuConfiguration.p2p().isColumnsDataAvailabilityHalfCheckEnabled()).isFalse();
-  }
-
-  @Test
-  void columnsDataAvailabilityHalfCheckEnabled_toggles() {
-    TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--Xcolumns-data-availability-half-check-enabled");
     assertThat(tekuConfiguration.p2p().isColumnsDataAvailabilityHalfCheckEnabled()).isTrue();
   }
 }


### PR DESCRIPTION
…ilable on supernodes

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Feature was implemented in #10248, I think we could activate it now by default.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a default in the P2P/DAS block-import path, which can affect sync/import timing and background recovery behavior on high-custody nodes; coverage is updated but regressions could impact network performance or correctness if edge cases exist.
> 
> **Overview**
> Enables the `Xcolumns-data-availability-half-check-enabled` behavior by default (via `P2PConfig`), allowing high-custody nodes/supernodes to import blocks once ~50% of sidecar columns are available and backfill the remainder in the background.
> 
> Updates acceptance tests to explicitly *disable* the feature when validating reconstruction/waiting behavior, adds a test-fixture config helper for that toggle, and adjusts the CLI/options test to assert the new default. A changelog entry documents the behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7caefb42b9aba6bc25db9daf1d611447cd7b10ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->