### PR TITLE
Updated discovery to 26.1.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -155,7 +155,7 @@ dependencyManagement {
       entry "junit-jupiter"
     }
 
-    dependency 'tech.pegasys.discovery:discovery:25.4.0'
+    dependency 'tech.pegasys.discovery:discovery:26.1.0'
 
     dependencySet(group: 'org.jupnp', version: '3.0.3') {
       entry "org.jupnp"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches peer discovery/ENR signing and a core dependency bump; regressions could impact node discovery/advertisement behavior at runtime.
> 
> **Overview**
> Upgrades `tech.pegasys.discovery:discovery` from `25.4.0` to `26.1.0`.
> 
> Updates `DiscV5Service` to match the new discovery signing API by replacing direct `SecretKey` usage with a `Signer` (`DefaultSigner`) when building the local node record, configuring the `DiscoverySystemBuilder`, and updating ENR address changes (`withNewAddress` signature change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96918ed76a72e745b4c631f0e2a9722040cb550f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->