### PR TITLE
[Gloas] Envelopes by range impl + tests

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSelectorFactoryTest.java
@@ -59,8 +59,7 @@ import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-// TODO-GLOAS Fix test https://github.com/Consensys/teku/issues/9833
-@TestSpecContext(allMilestones = true, ignoredMilestones = SpecMilestone.GLOAS)
+@TestSpecContext(allMilestones = true)
 public class BlobSelectorFactoryTest {
 
   private final CombinedChainDataClient client = mock(CombinedChainDataClient.class);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodyGloas.java
@@ -52,11 +52,6 @@ public interface BeaconBlockBodyGloas extends BeaconBlockBodyElectra {
   }
 
   @Override
-  default Optional<SszList<SszKZGCommitment>> getOptionalBlobKzgCommitments() {
-    return Optional.empty();
-  }
-
-  @Override
   default Optional<SignedExecutionPayloadBid> getOptionalSignedExecutionPayloadBid() {
     return Optional.of(getSignedExecutionPayloadBid());
   }
@@ -73,7 +68,7 @@ public interface BeaconBlockBodyGloas extends BeaconBlockBodyElectra {
 
   @Override
   default SszList<SszKZGCommitment> getBlobKzgCommitments() {
-    throw new UnsupportedOperationException("blob_kzg_commitments field was removed in Gloas");
+    return getSignedExecutionPayloadBid().getMessage().getBlobKzgCommitments();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloasImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/gloas/BeaconBlockBodySchemaGloasImpl.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.Sy
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBidSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -219,12 +220,15 @@ public class BeaconBlockBodySchemaGloasImpl
 
   @Override
   public SszListSchema<SszKZGCommitment, ?> getBlobKzgCommitmentsSchema() {
-    throw new UnsupportedOperationException("blob_kzg_commitments field was removed in Gloas");
+    return ((SignedExecutionPayloadBidSchema)
+            getChildSchema(getFieldIndex(BlockBodyFields.SIGNED_EXECUTION_PAYLOAD_BID)))
+        .getMessageSchema()
+        .getBlobKzgCommitmentsSchema();
   }
 
   @Override
   public long getBlobKzgCommitmentsGeneralizedIndex() {
-    throw new UnsupportedOperationException("blob_kzg_commitments field was removed in Gloas");
+    throw new UnsupportedOperationException("Not required in Gloas");
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema11;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -127,5 +128,10 @@ public class ExecutionPayloadBidSchema
         ZERO,
         ZERO,
         blobKzgCommitments);
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszListSchema<SszKZGCommitment, ?> getBlobKzgCommitmentsSchema() {
+    return (SszListSchema<SszKZGCommitment, ?>) getChildSchema(getFieldIndex(BLOB_KZG_COMMITMENTS));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBidSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadBidSchema.java
@@ -41,4 +41,8 @@ public class SignedExecutionPayloadBidSchema
   public SignedExecutionPayloadBid createFromBackingNode(final TreeNode node) {
     return new SignedExecutionPayloadBid(this, node);
   }
+
+  public ExecutionPayloadBidSchema getMessageSchema() {
+    return (ExecutionPayloadBidSchema) getChildSchema(0);
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -114,6 +115,14 @@ public interface ReadOnlyStore extends TimeProvider {
    */
   Optional<SignedBeaconBlock> getBlockIfAvailable(Bytes32 blockRoot);
 
+  /**
+   * Returns an execution payload only if it is immediately available (not pruned).
+   *
+   * @param blockRoot The block root of the execution payload to retrieve
+   * @return The execution payload if available.
+   */
+  Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(Bytes32 blockRoot);
+
   Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(SlotAndBlockRoot slotAndBlockRoot);
 
   default SafeFuture<Optional<BeaconBlock>> retrieveBlock(final Bytes32 blockRoot) {
@@ -129,6 +138,9 @@ public interface ReadOnlyStore extends TimeProvider {
   SafeFuture<Optional<BeaconState>> retrieveBlockState(Bytes32 blockRoot);
 
   SafeFuture<Optional<BeaconState>> retrieveBlockState(SlotAndBlockRoot slotAndBlockRoot);
+
+  SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayload(
+      Bytes32 blockRoot);
 
   SafeFuture<Optional<BeaconState>> retrieveExecutionPayloadState(
       SlotAndBlockRoot slotAndBlockRoot);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -179,6 +179,10 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     return Optional.of(new SignedBlockAndState(block, state));
   }
 
+  private SignedExecutionPayloadEnvelope getSignedExecutionPayload(final Bytes32 blockRoot) {
+    return executionPayloads.get(blockRoot);
+  }
+
   @Override
   public boolean containsBlock(final Bytes32 blockRoot) {
     return blocks.containsKey(blockRoot);
@@ -226,6 +230,12 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
+  public Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(
+      final Bytes32 blockRoot) {
+    return Optional.ofNullable(getSignedExecutionPayload(blockRoot));
+  }
+
+  @Override
   public SafeFuture<Optional<SignedBeaconBlock>> retrieveSignedBlock(final Bytes32 blockRoot) {
     return SafeFuture.completedFuture(getBlockIfAvailable(blockRoot));
   }
@@ -256,6 +266,12 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   public SafeFuture<Optional<BeaconState>> retrieveBlockState(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Not implemented"));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayload(
+      final Bytes32 blockRoot) {
+    return SafeFuture.completedFuture(getExecutionPayloadIfAvailable(blockRoot));
   }
 
   @Override

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRangeIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+@TestSpecContext(milestone = {GLOAS})
+public class ExecutionPayloadEnvelopesByRangeIntegrationTest
+    extends AbstractRpcMethodIntegrationTest {
+
+  private Eth2Peer peer;
+
+  @BeforeEach
+  public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    peer = createPeer(specContext.getSpec());
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopesByRange_shouldReturnExecutionPayloadEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+
+    // up to slot 3
+    final UInt64 targetSlot = UInt64.valueOf(3);
+    final SignedBlockAndState block = peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+    peerStorage.chainUpdater().updateBestBlock(block);
+
+    // grab expected execution payload envelopes from storage
+    final List<SignedExecutionPayloadEnvelope> expectedExecutionPayloadEnvelopes =
+        peerStorage
+            .chainBuilder()
+            .streamExecutionPayloadsAndStates(UInt64.ZERO)
+            .map(SignedExecutionPayloadAndState::executionPayload)
+            .toList();
+
+    assertThat(expectedExecutionPayloadEnvelopes).hasSize(3);
+
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes =
+        requestExecutionPayloadEnvelopesByRange(peer, UInt64.ONE, UInt64.valueOf(3));
+
+    assertThat(executionPayloadEnvelopes)
+        .containsExactlyInAnyOrderElementsOf(expectedExecutionPayloadEnvelopes);
+  }
+
+  private List<SignedExecutionPayloadEnvelope> requestExecutionPayloadEnvelopesByRange(
+      final Eth2Peer peer, final UInt64 startSlot, final UInt64 count)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = new ArrayList<>();
+    waitFor(
+        peer.requestExecutionPayloadEnvelopesByRange(
+            startSlot, count, RpcResponseListener.from(executionPayloadEnvelopes::add)));
+    assertThat(peer.getOutstandingRequests()).isEqualTo(0);
+    return executionPayloadEnvelopes;
+  }
+}

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/ExecutionPayloadEnvelopesByRootIntegrationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+@TestSpecContext(milestone = {GLOAS})
+public class ExecutionPayloadEnvelopesByRootIntegrationTest
+    extends AbstractRpcMethodIntegrationTest {
+
+  private Eth2Peer peer;
+
+  @BeforeEach
+  public void setUp(final TestSpecInvocationContextProvider.SpecContext specContext) {
+    peer = createPeer(specContext.getSpec());
+  }
+
+  @TestTemplate
+  public void requestExecutionPayloadEnvelopesByRoot_shouldReturnExecutionPayloadEnvelopes()
+      throws ExecutionException, InterruptedException, TimeoutException {
+
+    // up to slot 3
+    final UInt64 targetSlot = UInt64.valueOf(3);
+    final SignedBlockAndState block = peerStorage.chainUpdater().advanceChainUntil(targetSlot);
+    peerStorage.chainUpdater().updateBestBlock(block);
+
+    // grab expected execution payload envelopes from storage
+    final List<SignedExecutionPayloadEnvelope> expectedExecutionPayloadEnvelopes =
+        peerStorage
+            .chainBuilder()
+            .streamExecutionPayloadsAndStates(UInt64.ZERO)
+            .map(SignedExecutionPayloadAndState::executionPayload)
+            .toList();
+
+    assertThat(expectedExecutionPayloadEnvelopes).hasSize(3);
+
+    final List<Bytes32> beaconBlockRoots =
+        expectedExecutionPayloadEnvelopes.stream()
+            .map(SignedExecutionPayloadEnvelope::getMessage)
+            .map(ExecutionPayloadEnvelope::getBeaconBlockRoot)
+            .toList();
+
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes =
+        requestExecutionPayloadEnvelopesByRoot(peer, beaconBlockRoots);
+
+    assertThat(executionPayloadEnvelopes)
+        .containsExactlyInAnyOrderElementsOf(expectedExecutionPayloadEnvelopes);
+  }
+
+  private List<SignedExecutionPayloadEnvelope> requestExecutionPayloadEnvelopesByRoot(
+      final Eth2Peer peer, final List<Bytes32> beaconBlockRoots)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    final List<SignedExecutionPayloadEnvelope> executionPayloadEnvelopes = new ArrayList<>();
+    waitFor(
+        peer.requestExecutionPayloadEnvelopesByRoot(
+            beaconBlockRoots, RpcResponseListener.from(executionPayloadEnvelopes::add)));
+    assertThat(peer.getOutstandingRequests()).isEqualTo(0);
+    return executionPayloadEnvelopes;
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -223,7 +224,7 @@ public class BeaconChainMethods {
         createExecutionPayloadEnvelopesByRoot(
             spec, asyncRunner, peerLookup, rpcEncoding, recentChainData, metricsSystem),
         createExecutionPayloadEnvelopesByRange(
-            spec, asyncRunner, peerLookup, rpcEncoding, recentChainData, metricsSystem),
+            spec, asyncRunner, peerLookup, rpcEncoding, combinedChainDataClient, metricsSystem),
         createMetadata(spec, asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding),
         createPing(asyncRunner, metadataMessagesFactory, peerLookup, rpcEncoding));
   }
@@ -594,7 +595,7 @@ public class BeaconChainMethods {
           final AsyncRunner asyncRunner,
           final PeerLookup peerLookup,
           final RpcEncoding rpcEncoding,
-          final RecentChainData recentChainData,
+          final CombinedChainDataClient combinedChainDataClient,
           final MetricsSystem metricsSystem) {
 
     if (!spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
@@ -607,12 +608,14 @@ public class BeaconChainMethods {
 
     final RpcContextCodec<Bytes4, SignedExecutionPayloadEnvelope> forkDigestContextCodec =
         RpcContextCodec.forkDigest(
-            spec, recentChainData, ForkDigestPayloadContext.SIGNED_EXECUTION_PAYLOAD_ENVELOPE);
+            spec,
+            combinedChainDataClient.getRecentChainData(),
+            ForkDigestPayloadContext.SIGNED_EXECUTION_PAYLOAD_ENVELOPE);
 
     final ExecutionPayloadEnvelopesByRangeMessageHandler
         executionPayloadEnvelopesByRangeMessageHandler =
             new ExecutionPayloadEnvelopesByRangeMessageHandler(
-                spec, metricsSystem, recentChainData);
+                getSpecConfigGloas(spec), metricsSystem, combinedChainDataClient);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(
@@ -737,6 +740,10 @@ public class BeaconChainMethods {
 
   private static SpecConfigFulu getSpecConfigFulu(final Spec spec) {
     return SpecConfigFulu.required(spec.forMilestone(SpecMilestone.FULU).getConfig());
+  }
+
+  private static SpecConfigGloas getSpecConfigGloas(final Spec spec) {
+    return SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig());
   }
 
   public Collection<RpcMethod<?, ?, ?>> all() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
@@ -136,6 +136,11 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
     final RequestState initialState =
         new RequestState(callback, startSlot, count, headSlot, hotRoots);
 
+    if (initialState.isComplete()) {
+      callback.completeSuccessfully();
+      return;
+    }
+
     sendNextExecutionPayloadEnvelope(initialState)
         .finish(
             requestState -> {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
@@ -13,15 +13,17 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Iterator;
-import java.util.List;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
@@ -33,14 +35,11 @@ import tech.pegasys.teku.networking.eth2.peers.RequestKey;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.ExecutionPayloadEnvelopesByRangeRequestMessage;
-import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-// TODO-GLOAS: https://github.com/Consensys/teku/issues/9974
 /**
  * <a
  * href="https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#executionpayloadenvelopesbyrange-v1">ExecutionPayloadEnvelopesByRange</a>
@@ -52,16 +51,17 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
   private static final Logger LOG = LogManager.getLogger();
 
   private final SpecConfigGloas config;
-  private final Spec spec;
   private final LabelledMetric<Counter> requestCounter;
-  private final RecentChainData recentChainData;
+  private final CombinedChainDataClient combinedChainDataClient;
   private final Counter totalExecutionPayloadEnvelopesRequestedCounter;
 
   public ExecutionPayloadEnvelopesByRangeMessageHandler(
-      final Spec spec, final MetricsSystem metricsSystem, final RecentChainData recentChainData) {
-    this.spec = spec;
-    this.config = SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig());
-    this.recentChainData = recentChainData;
+      final SpecConfigGloas config,
+      final MetricsSystem metricsSystem,
+      final CombinedChainDataClient combinedChainDataClient) {
+    ;
+    this.config = config;
+    this.combinedChainDataClient = combinedChainDataClient;
     requestCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.NETWORK,
@@ -87,14 +87,6 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
                   "Only a maximum of %s execution payload envelopes can be requested per request",
                   config.getMaxRequestBlocksDeneb())));
     }
-    final UInt64 finalizedEpoch = recentChainData.getFinalizedEpoch();
-    if (spec.computeEpochAtSlot(request.getStartSlot()).isLessThan(finalizedEpoch)) {
-      requestCounter.labels("start_slot_invalid").inc();
-      return Optional.of(
-          new RpcException(
-              INVALID_REQUEST_CODE,
-              String.format("Start slot is prior to finalized epoch %s", finalizedEpoch)));
-    }
     return Optional.empty();
   }
 
@@ -104,11 +96,12 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
       final Eth2Peer peer,
       final ExecutionPayloadEnvelopesByRangeRequestMessage message,
       final ResponseCallback<SignedExecutionPayloadEnvelope> callback) {
+    final UInt64 startSlot = message.getStartSlot();
     LOG.trace(
         "Peer {} requested {} execution payload envelopes starting at slot {}",
         peer.getId(),
         message.getCount(),
-        message.getStartSlot());
+        startSlot);
 
     final Optional<RequestKey> maybeRequestKey =
         peer.approveExecutionPayloadEnvelopesRequest(callback, message.getCount().longValue());
@@ -119,70 +112,147 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
     }
     requestCounter.labels("ok").inc();
     totalExecutionPayloadEnvelopesRequestedCounter.inc(message.getCount().longValue());
-    final SafeFuture<List<SignedExecutionPayloadEnvelope>> future =
-        recentChainData.retrieveSignedExecutionPayloadEnvelopeByRange(
-            message.getStartSlot(), message.getCount());
 
-    future
-        .thenCompose(
-            payloads -> {
-              final RequestState requestState = new RequestState(callback, payloads);
-              if (payloads.isEmpty() || requestState.isComplete()) {
-                return SafeFuture.completedFuture(requestState);
-              }
-              return sendExecutionPayloadEnvelopes(requestState);
-            })
+    final NavigableMap<UInt64, Bytes32> hotRoots =
+        combinedChainDataClient.getAncestorRoots(startSlot, UInt64.ONE, message.getCount());
+
+    final UInt64 headSlot = hotRoots.lastKey();
+
+    final RequestState initialState =
+        new RequestState(callback, startSlot, message.getCount(), headSlot, hotRoots);
+
+    sendNextExecutionPayloadEnvelope(initialState)
         .finish(
             requestState -> {
-              if (requestState.getSentCount() != message.getCount().longValue()) {
+              if (requestState.sentExecutionPayloadEnvelopes.get()
+                  != message.getCount().longValue()) {
                 peer.adjustExecutionPayloadEnvelopesRequest(
-                    maybeRequestKey.get(), requestState.getSentCount());
+                    maybeRequestKey.get(), requestState.sentExecutionPayloadEnvelopes.get());
               }
               callback.completeSuccessfully();
             },
             err -> handleError(err, callback, "execution payload envelopes by range"));
   }
 
-  private SafeFuture<RequestState> sendExecutionPayloadEnvelopes(final RequestState requestState) {
+  private SafeFuture<RequestState> sendNextExecutionPayloadEnvelope(
+      final RequestState requestState) {
+    SafeFuture<Boolean> executionPayloadFuture = processNextExecutionPayloadEnvelope(requestState);
+    // similar logic to BeaconBlocksByRange
+    while (executionPayloadFuture.isDone() && !executionPayloadFuture.isCompletedExceptionally()) {
+      if (executionPayloadFuture.join()) {
+        return completedFuture(requestState);
+      }
+      executionPayloadFuture = processNextExecutionPayloadEnvelope(requestState);
+    }
+    return executionPayloadFuture.thenCompose(
+        complete ->
+            complete
+                ? completedFuture(requestState)
+                : sendNextExecutionPayloadEnvelope(requestState));
+  }
+
+  private SafeFuture<Boolean> processNextExecutionPayloadEnvelope(final RequestState requestState) {
+    // Ensure execution payloads are loaded off of the event thread
     return requestState
-        .sendNextPayload()
+        .loadNextExecutionPayloadEnvelope()
         .thenCompose(
+            block -> {
+              requestState.decrementRemainingExecutionPayloadEnvelopes();
+              return handleLoadedExecutionPayloadEnvelope(requestState, block);
+            });
+  }
+
+  /** Sends the execution payload and returns true if the request is now complete. */
+  private SafeFuture<Boolean> handleLoadedExecutionPayloadEnvelope(
+      final RequestState requestState,
+      final Optional<SignedExecutionPayloadEnvelope> executionPayloadEnvelope) {
+    return executionPayloadEnvelope
+        .map(requestState::sendExecutionPayloadEnvelope)
+        .orElse(SafeFuture.COMPLETE)
+        .thenApply(
             __ -> {
               if (requestState.isComplete()) {
-                return SafeFuture.completedFuture(requestState);
+                return true;
               } else {
-                return sendExecutionPayloadEnvelopes(requestState);
+                requestState.incrementCurrentSlot();
+                return false;
               }
             });
   }
 
   @VisibleForTesting
-  static class RequestState {
+  class RequestState {
+
     private final ResponseCallback<SignedExecutionPayloadEnvelope> callback;
-    private final Iterator<SignedExecutionPayloadEnvelope> payloadIterator;
+    private UInt64 currentSlot;
+    private UInt64 remainingExecutionPayloadEnvelopes;
+    private final UInt64 headSlot;
+    private final NavigableMap<UInt64, Bytes32> knownBlockRoots;
+
     private final AtomicInteger sentExecutionPayloadEnvelopes = new AtomicInteger(0);
 
     RequestState(
         final ResponseCallback<SignedExecutionPayloadEnvelope> callback,
-        final List<SignedExecutionPayloadEnvelope> payloads) {
+        final UInt64 startSlot,
+        final UInt64 count,
+        final UInt64 headSlot,
+        final NavigableMap<UInt64, Bytes32> knownBlockRoots) {
       this.callback = callback;
-      this.payloadIterator = payloads.iterator();
+      this.currentSlot = startSlot;
+      this.remainingExecutionPayloadEnvelopes = count;
+      this.headSlot = headSlot;
+      this.knownBlockRoots = knownBlockRoots;
     }
 
-    SafeFuture<Void> sendNextPayload() {
-      if (!payloadIterator.hasNext()) {
-        return SafeFuture.COMPLETE;
-      }
-      final SignedExecutionPayloadEnvelope payload = payloadIterator.next();
-      return callback.respond(payload).thenRun(sentExecutionPayloadEnvelopes::incrementAndGet);
+    private boolean needsMoreExecutionPayloadEnvelopes() {
+      return !remainingExecutionPayloadEnvelopes.equals(ZERO);
+    }
+
+    private boolean hasReachedHeadSlot() {
+      return currentSlot.compareTo(headSlot) >= 0;
     }
 
     boolean isComplete() {
-      return !payloadIterator.hasNext();
+      return !needsMoreExecutionPayloadEnvelopes() || hasReachedHeadSlot();
     }
 
-    int getSentCount() {
-      return sentExecutionPayloadEnvelopes.get();
+    SafeFuture<Void> sendExecutionPayloadEnvelope(
+        final SignedExecutionPayloadEnvelope executionPayloadEnvelope) {
+      return callback
+          .respond(executionPayloadEnvelope)
+          .thenRun(sentExecutionPayloadEnvelopes::incrementAndGet);
+    }
+
+    void decrementRemainingExecutionPayloadEnvelopes() {
+      remainingExecutionPayloadEnvelopes = remainingExecutionPayloadEnvelopes.minusMinZero(1);
+    }
+
+    void incrementCurrentSlot() {
+      currentSlot = currentSlot.increment();
+    }
+
+    @SuppressWarnings("DuplicateBranches")
+    SafeFuture<Optional<SignedExecutionPayloadEnvelope>> loadNextExecutionPayloadEnvelope() {
+      final UInt64 slot = this.currentSlot;
+      final Bytes32 knownBlockRoot = knownBlockRoots.get(slot);
+      if (knownBlockRoot != null) {
+        // Known root so lookup by root
+        return combinedChainDataClient
+            .getExecutionPayloadByBlockRoot(knownBlockRoot)
+            .thenApply(
+                maybeExecutionPayload ->
+                    maybeExecutionPayload.filter(
+                        executionPayload -> executionPayload.getSlot().equals(slot)));
+      } else if ((!knownBlockRoots.isEmpty() && slot.compareTo(knownBlockRoots.firstKey()) >= 0)
+          || slot.compareTo(headSlot) > 0) {
+        // Unknown root but not finalized means this is an empty slot (or payload absent)
+        // Could also be because the first execution payload requested is above our head slot
+        return SafeFuture.completedFuture(Optional.empty());
+      } else {
+        // TODO-GLOAS: https://github.com/Consensys/teku/issues/9974 implement when we support
+        // finalized execution payload lookup
+        return SafeFuture.completedFuture(Optional.empty());
+      }
     }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/ExecutionPayloadEnvelopesByRangeMessageHandler.java
@@ -252,7 +252,6 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
       currentSlot = currentSlot.increment();
     }
 
-    @SuppressWarnings("DuplicateBranches")
     SafeFuture<Optional<SignedExecutionPayloadEnvelope>> loadNextExecutionPayloadEnvelope() {
       final UInt64 slot = this.currentSlot;
       final Bytes32 knownBlockRoot = knownBlockRoots.get(slot);
@@ -272,7 +271,9 @@ public class ExecutionPayloadEnvelopesByRangeMessageHandler
       } else {
         // TODO-GLOAS: https://github.com/Consensys/teku/issues/9974 implement when we support
         // finalized execution payload lookup
-        return SafeFuture.completedFuture(Optional.empty());
+        return SafeFuture.failedFuture(
+            new UnsupportedOperationException(
+                "Lookup of finalized execution payload envelopes is not implemented yet"));
       }
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -653,17 +653,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
     if (store == null) {
       return EmptyStoreResults.EMPTY_SIGNED_EXECUTION_PAYLOAD_ENVELOPE_FUTURE;
     }
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098
-    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
-  }
-
-  public SafeFuture<List<SignedExecutionPayloadEnvelope>>
-      retrieveSignedExecutionPayloadEnvelopeByRange(final UInt64 startSlot, final UInt64 count) {
-    if (store == null) {
-      return SafeFuture.completedFuture(Collections.emptyList());
-    }
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098
-    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+    return store.retrieveSignedExecutionPayload(beaconBlockRoot);
   }
 
   public SafeFuture<Optional<BeaconState>> retrieveBlockState(final Bytes32 blockRoot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -458,6 +458,7 @@ class Store extends CacheableStore {
     checkpointStates.clear();
     blocks.clear();
     executionPayloadStates.clear();
+    executionPayloads.clear();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.SignedExecutionPayloadAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -92,6 +93,7 @@ class Store extends CacheableStore {
 
   private final MetricsSystem metricsSystem;
   private Optional<SettableGauge> blockCountGauge = Optional.empty();
+  private Optional<SettableGauge> executionPayloadCountGauge = Optional.empty();
   private Optional<SettableGauge> epochStatesCountGauge = Optional.empty();
   private Optional<SettableGauge> blobSidecarsBlocksCountGauge = Optional.empty();
 
@@ -119,6 +121,7 @@ class Store extends CacheableStore {
   private UInt64 highestVotedValidatorIndex;
   private Optional<UInt64> custodyGroupCount = Optional.empty();
   private final CachingTaskQueue<Bytes32, BeaconState> executionPayloadStates;
+  private final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads;
 
   private UInt64 reorgThreshold = UInt64.ZERO;
   private UInt64 parentThreshold = UInt64.ZERO;
@@ -145,7 +148,8 @@ class Store extends CacheableStore {
       final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates,
       final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
       final Optional<UInt64> custodyGroupCount,
-      final CachingTaskQueue<Bytes32, BeaconState> executionPayloadStates) {
+      final CachingTaskQueue<Bytes32, BeaconState> executionPayloadStates,
+      final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads) {
     checkArgument(
         time.isGreaterThanOrEqualTo(genesisTime),
         "Time must be greater than or equal to genesisTime");
@@ -198,6 +202,7 @@ class Store extends CacheableStore {
     this.custodyGroupCount = custodyGroupCount;
 
     this.executionPayloadStates = executionPayloadStates;
+    this.executionPayloads = executionPayloads;
   }
 
   private BlockProvider createBlockProviderFromMapWhileLocked(
@@ -256,6 +261,8 @@ class Store extends CacheableStore {
             metricsSystem,
             "memory_execution_payload_states",
             config.getStateCacheSize());
+    final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloads =
+        LimitedMap.createSynchronizedNatural(config.getBlockCacheSize());
 
     return new Store(
         metricsSystem,
@@ -279,7 +286,8 @@ class Store extends CacheableStore {
         maybeEpochStates,
         blobSidecars,
         custodyGroupCount,
-        executionPayloadStateTaskQueue);
+        executionPayloadStateTaskQueue,
+        executionPayloads);
   }
 
   static UpdatableStore create(
@@ -422,6 +430,13 @@ class Store extends CacheableStore {
                     "memory_epoch_states_cache_size",
                     "Number of Epoch aligned states held in the in-memory store"));
       }
+      executionPayloadCountGauge =
+          Optional.of(
+              SettableGauge.create(
+                  metricsSystem,
+                  TekuMetricCategory.STORAGE,
+                  "memory_execution_payload_count",
+                  "Number of execution payload envelopes held in the in-memory store"));
       blockStates.startMetrics();
       checkpointStates.startMetrics();
       executionPayloadStates.startMetrics();
@@ -610,6 +625,17 @@ class Store extends CacheableStore {
   }
 
   @Override
+  public Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(
+      final Bytes32 blockRoot) {
+    readLock.lock();
+    try {
+      return Optional.ofNullable(executionPayloads.get(blockRoot));
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
   public boolean isHeadWeak(final Bytes32 root) {
     final Optional<ProtoNodeData> maybeBlockData = getBlockDataFromForkChoiceStrategy(root);
     return maybeBlockData
@@ -736,6 +762,14 @@ class Store extends CacheableStore {
       final SlotAndBlockRoot slotAndBlockRoot) {
     return checkpointStates.perform(
         new StateAtSlotTask(spec, slotAndBlockRoot, this::retrieveBlockState));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayload(
+      final Bytes32 blockRoot) {
+    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 we need a logic similar to
+    // blockProvider potentially
+    return SafeFuture.completedFuture(getExecutionPayloadIfAvailable(blockRoot));
   }
 
   @Override
@@ -874,7 +908,14 @@ class Store extends CacheableStore {
   @Override
   void cacheExecutionPayloadAndStates(
       final Map<Bytes32, SignedExecutionPayloadAndState> executionPayloadAndStates) {
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 store the execution payload
+    executionPayloadAndStates.values().stream()
+        .sorted(Comparator.comparing(SignedExecutionPayloadAndState::getSlot))
+        .forEach(
+            executionPayloadAndState ->
+                executionPayloads.put(
+                    executionPayloadAndState.getBeaconBlockRoot(),
+                    executionPayloadAndState.executionPayload()));
+    executionPayloadCountGauge.ifPresent(gauge -> gauge.set(executionPayloads.size()));
     executionPayloadStates.cacheAll(
         Maps.transformValues(executionPayloadAndStates, SignedExecutionPayloadAndState::state));
   }
@@ -1132,8 +1173,7 @@ class Store extends CacheableStore {
   }
 
   void removeExecutionPayloadAndState(final Bytes32 blockRoot) {
-    // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 remove execution payload when we
-    // implement storing it
+    executionPayloads.remove(blockRoot);
     executionPayloadStates.remove(blockRoot);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -454,6 +454,17 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> retrieveSignedExecutionPayload(
+      final Bytes32 blockRoot) {
+    if (executionPayloadData.containsKey(blockRoot)) {
+      return SafeFuture.completedFuture(
+          Optional.of(executionPayloadData.get(blockRoot))
+              .map(SignedExecutionPayloadAndState::executionPayload));
+    }
+    return store.retrieveSignedExecutionPayload(blockRoot);
+  }
+
+  @Override
   public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
     SignedBlockAndState inMemoryCheckpointBlockState = blockData.get(checkpoint.getRoot());
     if (inMemoryCheckpointBlockState != null) {
@@ -525,6 +536,14 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
     return Optional.ofNullable(blockData.get(blockRoot))
         .map(SignedBlockAndState::getBlock)
         .or(() -> store.getBlockIfAvailable(blockRoot));
+  }
+
+  @Override
+  public Optional<SignedExecutionPayloadEnvelope> getExecutionPayloadIfAvailable(
+      final Bytes32 blockRoot) {
+    return Optional.ofNullable(executionPayloadData.get(blockRoot))
+        .map(SignedExecutionPayloadAndState::executionPayload)
+        .or(() -> store.getExecutionPayloadIfAvailable(blockRoot));
   }
 
   @Override

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -34,6 +34,7 @@ public class StoreAssertions {
             "timeMillis",
             "stateCountGauge",
             "blockCountGauge",
+            "executionPayloadCountGauge",
             "checkpointCountGauge",
             "votesLock",
             "readVotesLock",
@@ -59,7 +60,8 @@ public class StoreAssertions {
             "epochStatesCountGauge",
             "blobSidecars",
             "blobSidecarsBlocksCountGauge",
-            "executionPayloadStates")
+            "executionPayloadStates",
+            "executionPayloads")
         .isEqualTo(expectedState);
     assertThat(actualState.getOrderedBlockRoots())
         .containsExactlyElementsOf(expectedState.getOrderedBlockRoots());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Make `byRange` implementation similar to blocks by range (and integration tests) plus implement execution payloads in-memory caching and retrieval.

## Fixed Issue(s)
related to #9833 and #9974 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches networking RPC handlers and forkchoice/store caching paths, which can impact sync correctness and memory behavior; however changes are scoped to Gloas features and are covered by new unit/integration tests.
> 
> **Overview**
> Implements the Gloas `ExecutionPayloadEnvelopesByRange` RPC to stream signed execution payload envelopes slot-by-slot (similar to blocks-by-range), using `CombinedChainDataClient` to derive hot-chain roots and fetch envelopes by block root, and adjusting peer rate limits based on actual responses.
> 
> Adds in-memory storage, retrieval APIs, and metrics for `SignedExecutionPayloadEnvelope` in the forkchoice `Store`/`StoreTransaction`/`ReadOnlyStore` path (with `RecentChainData` now delegating block-root lookups to the store), and updates Gloas schemas to expose blob KZG commitments via the embedded `SignedExecutionPayloadBid` rather than treating the field as removed. New integration tests cover by-range/by-root envelope requests, and previously GLOAS-ignored blob selector tests are re-enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 435b480c4cc9a9d8f0a2aa5bccb22a84a9153c14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->