### PR TITLE
[Gloas] Introduce new event streams

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -169,7 +169,8 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected final PerformanceTracker performanceTracker = mock(PerformanceTracker.class);
   protected final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager =
       mock(SyncCommitteeSubscriptionManager.class);
-  protected final PayloadAttestationPool payloadAttestationPool = PayloadAttestationPool.NOOP;
+  protected final PayloadAttestationPool payloadAttestationPool =
+      mock(PayloadAttestationPool.class);
   protected final ExecutionPayloadManager executionPayloadManager =
       mock(ExecutionPayloadManager.class);
   protected final ExecutionPayloadFactory executionPayloadFactory =
@@ -284,6 +285,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             .forkChoiceNotifier(forkChoiceNotifier)
             .rewardCalculator(rewardCalculator)
             .dataColumnSidecarManager(dataColumnSidecarManager)
+            .payloadAttestationPool(payloadAttestationPool)
             .build();
 
     beaconRestApi =

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
@@ -9,7 +9,7 @@
       "in" : "query",
       "schema" : {
         "type" : "string",
-        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `finalized_checkpoint`, `head`, `payload_attributes`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
+        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `execution_payload_available`, `execution_payload_bid`, `finalized_checkpoint`, `head`, `payload_attestation_message`, `payload_attributes`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
         "example" : "head"
       }
     } ],

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/DataColumnSidecarEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/DataColumnSidecarEvent.java
@@ -46,7 +46,6 @@ public class DataColumnSidecarEvent extends Event<DataColumnSidecarEvent.DataCol
       final UInt64 index,
       final UInt64 slot,
       final List<KZGCommitment> kzgCommitments) {
-
     super(
         DATA_COLUMN_SIDECAR_EVENT_TYPE,
         new DataColumnSidecarData(blockRoot, index, slot, kzgCommitments));
@@ -57,9 +56,14 @@ public class DataColumnSidecarEvent extends Event<DataColumnSidecarEvent.DataCol
         dataColumnSidecar.getBeaconBlockRoot(),
         dataColumnSidecar.getIndex(),
         dataColumnSidecar.getSlot(),
-        dataColumnSidecar.getKzgCommitments().asList().stream()
-            .map(SszKZGCommitment::getKZGCommitment)
-            .toList());
+        dataColumnSidecar
+            .getMaybeKzgCommitments()
+            .map(
+                kzgCommitments ->
+                    kzgCommitments.asList().stream()
+                        .map(SszKZGCommitment::getKZGCommitment)
+                        .toList())
+            .orElse(List.of()));
   }
 
   public static class DataColumnSidecarData {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -44,6 +44,9 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -52,6 +55,8 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
+import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadBidEventsChannel;
+import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
@@ -59,7 +64,11 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.ReorgContext;
 
 public class EventSubscriptionManager
-    implements ChainHeadChannel, FinalizedCheckpointChannel, ReceivedBlockEventsChannel {
+    implements ChainHeadChannel,
+        FinalizedCheckpointChannel,
+        ReceivedBlockEventsChannel,
+        ReceivedExecutionPayloadEventsChannel,
+        ReceivedExecutionPayloadBidEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
@@ -91,6 +100,7 @@ public class EventSubscriptionManager
     eventChannels.subscribe(ChainHeadChannel.class, this);
     eventChannels.subscribe(FinalizedCheckpointChannel.class, this);
     eventChannels.subscribe(ReceivedBlockEventsChannel.class, this);
+    eventChannels.subscribe(ReceivedExecutionPayloadEventsChannel.class, this);
     syncDataProvider.subscribeToSyncStateChanges(this::onSyncStateChange);
     nodeDataProvider.subscribeToReceivedBlobSidecar(this::onNewBlobSidecar);
     nodeDataProvider.subscribeToAttesterSlashing(this::onNewAttesterSlashing);
@@ -102,6 +112,7 @@ public class EventSubscriptionManager
     nodeDataProvider.subscribeToForkChoiceUpdatedResult(this::onForkChoiceUpdatedResult);
     nodeDataProvider.subscribeToValidDataColumnSidecars(
         (dataColumnSidecar, remoteOrigin) -> onNewDataColumnSidecar(dataColumnSidecar));
+    nodeDataProvider.subscribeToPayloadAttestationMessages(this::onNewPayloadAttestationMessage);
   }
 
   public void registerClient(final SseClient sseClient) {
@@ -182,6 +193,16 @@ public class EventSubscriptionManager
   @Override
   public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
     onNewBlock(block, executionOptimistic);
+  }
+
+  @Override
+  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+    onExecutionPayloadAvailable(executionPayload);
+  }
+
+  @Override
+  public void onExecutionPayloadBidValidated(final SignedExecutionPayloadBid executionPayloadBid) {
+    onExecutionPayloadBid(executionPayloadBid);
   }
 
   protected void onNewVoluntaryExit(
@@ -286,6 +307,30 @@ public class EventSubscriptionManager
 
   protected void onSyncStateChange(final SyncState syncState) {
     notifySubscribersOfEvent(EventType.sync_state, new SyncStateChangeEvent(syncState.name()));
+  }
+
+  protected void onExecutionPayloadAvailable(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    final ExecutionPayloadAvailableEvent executionPayloadAvailableEvent =
+        new ExecutionPayloadAvailableEvent(
+            executionPayload.getSlot(), executionPayload.getBeaconBlockRoot());
+    notifySubscribersOfEvent(EventType.execution_payload_available, executionPayloadAvailableEvent);
+  }
+
+  protected void onExecutionPayloadBid(final SignedExecutionPayloadBid executionPayloadBid) {
+    notifySubscribersOfEvent(
+        EventType.execution_payload_bid, new ExecutionPayloadBidEvent(executionPayloadBid));
+  }
+
+  protected void onNewPayloadAttestationMessage(
+      final PayloadAttestationMessage payloadAttestationMessage,
+      final InternalValidationResult result,
+      final boolean fromNetwork) {
+    if (result.isAccept()) {
+      notifySubscribersOfEvent(
+          EventType.payload_attestation_message,
+          new PayloadAttestationMessageEvent(payloadAttestationMessage));
+    }
   }
 
   private void notifySubscribersOfEvent(final EventType eventType, final Event<?> event) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -101,6 +101,7 @@ public class EventSubscriptionManager
     eventChannels.subscribe(FinalizedCheckpointChannel.class, this);
     eventChannels.subscribe(ReceivedBlockEventsChannel.class, this);
     eventChannels.subscribe(ReceivedExecutionPayloadEventsChannel.class, this);
+    eventChannels.subscribe(ReceivedExecutionPayloadBidEventsChannel.class, this);
     syncDataProvider.subscribeToSyncStateChanges(this::onSyncStateChange);
     nodeDataProvider.subscribeToReceivedBlobSidecar(this::onNewBlobSidecar);
     nodeDataProvider.subscribeToAttesterSlashing(this::onNewAttesterSlashing);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadAvailableEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadAvailableEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.BLOCK_ROOT;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ExecutionPayloadAvailableEvent extends Event<ExecutionPayloadAvailableEvent.Data> {
+
+  public static final SerializableTypeDefinition<ExecutionPayloadAvailableEvent.Data>
+      EXECUTION_PAYLOAD_AVAILABLE_EVENT_TYPE =
+          SerializableTypeDefinition.object(ExecutionPayloadAvailableEvent.Data.class)
+              .name("ExecutionPayloadAvailableEvent")
+              .withField(SLOT, UINT64_TYPE, ExecutionPayloadAvailableEvent.Data::slot)
+              .withField(BLOCK_ROOT, BYTES32_TYPE, ExecutionPayloadAvailableEvent.Data::blockRoot)
+              .build();
+
+  public ExecutionPayloadAvailableEvent(final UInt64 slot, final Bytes32 blockRoot) {
+    super(EXECUTION_PAYLOAD_AVAILABLE_EVENT_TYPE, new Data(slot, blockRoot));
+  }
+
+  public record Data(UInt64 slot, Bytes32 blockRoot) {}
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadBidEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ExecutionPayloadBidEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+
+public class ExecutionPayloadBidEvent extends Event<SignedExecutionPayloadBid> {
+
+  public ExecutionPayloadBidEvent(final SignedExecutionPayloadBid executionPayloadBid) {
+    super(executionPayloadBid.getSchema().getJsonTypeDefinition(), executionPayloadBid);
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/PayloadAttestationMessageEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/PayloadAttestationMessageEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+
+public class PayloadAttestationMessageEvent extends Event<PayloadAttestationMessage> {
+
+  public PayloadAttestationMessageEvent(final PayloadAttestationMessage payloadAttestationMessage) {
+    super(payloadAttestationMessage.getSchema().getJsonTypeDefinition(), payloadAttestationMessage);
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
+import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
 import tech.pegasys.teku.storage.client.BlobReconstructionProvider;
@@ -124,6 +125,7 @@ public class DataProvider {
     private BlobReconstructionProvider blobReconstructionProvider;
     private DataColumnSidecarManager dataColumnSidecarManager;
     private CustodyGroupCountManager custodyGroupCountManager;
+    private PayloadAttestationPool payloadAttestationPool;
 
     public Builder recentChainData(final RecentChainData recentChainData) {
       this.recentChainData = recentChainData;
@@ -263,6 +265,7 @@ public class DataProvider {
               recentChainData,
               dataColumnSidecarManager,
               custodyGroupCountManager,
+              payloadAttestationPool,
               spec);
       final ChainDataProvider chainDataProvider =
           new ChainDataProvider(
@@ -303,6 +306,11 @@ public class DataProvider {
     public Builder custodyGroupCountManager(
         final CustodyGroupCountManager custodyGroupCountManager) {
       this.custodyGroupCountManager = custodyGroupCountManager;
+      return this;
+    }
+
+    public Builder payloadAttestationPool(final PayloadAttestationPool payloadAttestationPool) {
+      this.payloadAttestationPool = payloadAttestationPool;
       return this;
     }
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -56,6 +57,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubsc
 import tech.pegasys.teku.statetransition.forkchoice.PreparedProposerInfo;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.forkchoice.RegisteredValidatorInfo;
+import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
@@ -79,6 +81,7 @@ public class NodeDataProvider {
   private final RecentChainData recentChainData;
   private final DataColumnSidecarManager dataColumnSidecarManager;
   private final CustodyGroupCountManager custodyGroupCountManager;
+  private final PayloadAttestationPool payloadAttestationPool;
   private final Spec spec;
 
   public NodeDataProvider(
@@ -97,6 +100,7 @@ public class NodeDataProvider {
       final RecentChainData recentChainData,
       final DataColumnSidecarManager dataColumnSidecarManager,
       final CustodyGroupCountManager custodyGroupCountManager,
+      final PayloadAttestationPool payloadAttestationPool,
       final Spec spec) {
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingsPool;
@@ -113,6 +117,7 @@ public class NodeDataProvider {
     this.recentChainData = recentChainData;
     this.dataColumnSidecarManager = dataColumnSidecarManager;
     this.custodyGroupCountManager = custodyGroupCountManager;
+    this.payloadAttestationPool = payloadAttestationPool;
     this.spec = spec;
   }
 
@@ -308,6 +313,11 @@ public class NodeDataProvider {
 
   public void subscribeToForkChoiceUpdatedResult(final ForkChoiceUpdatedResultSubscriber listener) {
     forkChoiceNotifier.subscribeToForkChoiceUpdatedResult(listener);
+  }
+
+  public void subscribeToPayloadAttestationMessages(
+      final OperationAddedSubscriber<PayloadAttestationMessage> listener) {
+    payloadAttestationPool.subscribeOperationAdded(listener);
   }
 
   public SafeFuture<Optional<List<ValidatorLivenessAtEpoch>>> getValidatorLiveness(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/NodeDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/NodeDataProviderTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
+import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
@@ -67,6 +68,7 @@ public class NodeDataProviderTest {
   private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   private final CustodyGroupCountManager custodyGroupCountManager =
       mock(CustodyGroupCountManager.class);
+  private final PayloadAttestationPool payloadAttestationPool = mock(PayloadAttestationPool.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
 
   private final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
@@ -101,6 +103,7 @@ public class NodeDataProviderTest {
             recentChainData,
             dataColumnSidecarManager,
             custodyGroupCountManager,
+            payloadAttestationPool,
             spec);
   }
 
@@ -226,6 +229,7 @@ public class NodeDataProviderTest {
             recentChainData,
             dataColumnSidecarManager,
             custodyGroupCountManager,
+            payloadAttestationPool,
             specMock);
     return specMock;
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
@@ -32,7 +32,10 @@ public enum EventType {
   payload_attributes,
   block_gossip,
   single_attestation,
-  data_column_sidecar;
+  data_column_sidecar,
+  execution_payload_available,
+  execution_payload_bid,
+  payload_attestation_message;
 
   public static List<EventType> getTopics(final List<String> topics) {
     return topics.stream().map(EventType::valueOf).toList();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/DataColumnSidecar.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/DataColumnSidecar.java
@@ -31,8 +31,12 @@ public interface DataColumnSidecar extends SszContainer {
 
   DataColumn getColumn();
 
+  default Optional<SszList<SszKZGCommitment>> getMaybeKzgCommitments() {
+    return Optional.of(getKzgCommitments());
+  }
+
   // TODO-GLOAS: https://github.com/Consensys/teku/issues/10311 need to verify this is not called
-  // for Gloas or make it an Optional
+  // for Gloas or use everywhere getMaybeKzgCommitments() alternatively
   SszList<SszKZGCommitment> getKzgCommitments();
 
   SszList<SszKZGProof> getKzgProofs();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/gloas/DataColumnSidecarGloas.java
@@ -63,6 +63,11 @@ public class DataColumnSidecarGloas
   }
 
   @Override
+  public Optional<SszList<SszKZGCommitment>> getMaybeKzgCommitments() {
+    return Optional.empty();
+  }
+
+  @Override
   public SszList<SszKZGCommitment> getKzgCommitments() {
     throw new UnsupportedOperationException("kzg_commitments field was removed in Gloas");
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -72,7 +72,7 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
             case REJECT, SAVE_FOR_FUTURE, IGNORE -> {}
           }
         });
-    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+    return validationResult;
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -42,12 +42,18 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
 
   private final Spec spec;
   private final ExecutionPayloadBidGossipValidator executionPayloadBidGossipValidator;
+  private final ReceivedExecutionPayloadBidEventsChannel
+      receivedExecutionPayloadBidEventsChannelPublisher;
 
   public DefaultExecutionPayloadBidManager(
       final Spec spec,
-      final ExecutionPayloadBidGossipValidator executionPayloadBidGossipValidator) {
+      final ExecutionPayloadBidGossipValidator executionPayloadBidGossipValidator,
+      final ReceivedExecutionPayloadBidEventsChannel
+          receivedExecutionPayloadBidEventsChannelPublisher) {
     this.spec = spec;
     this.executionPayloadBidGossipValidator = executionPayloadBidGossipValidator;
+    this.receivedExecutionPayloadBidEventsChannelPublisher =
+        receivedExecutionPayloadBidEventsChannelPublisher;
   }
 
   @Override
@@ -60,7 +66,10 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
         result -> {
           switch (result.code()) {
             // TODO-GLOAS handle bids
-            case ACCEPT, REJECT, SAVE_FOR_FUTURE, IGNORE -> {}
+            case ACCEPT ->
+                receivedExecutionPayloadBidEventsChannelPublisher.onExecutionPayloadBidValidated(
+                    signedBid);
+            case REJECT, SAVE_FOR_FUTURE, IGNORE -> {}
           }
         });
     return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
@@ -89,6 +98,9 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
               weiToEth(getPayloadResponse.getExecutionPayloadValue()),
               formatAbbreviatedHashRoot(localSelfBuiltSignedBid.getMessage().getBlockHash()),
               slot);
+          // no need for gossip validation for local self-built bids
+          receivedExecutionPayloadBidEventsChannelPublisher.onExecutionPayloadBidValidated(
+              localSelfBuiltSignedBid);
           return localSelfBuiltSignedBid;
         });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -42,16 +42,21 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
   private final ExecutionPayloadGossipValidator executionPayloadGossipValidator;
   private final ForkChoice forkChoice;
   private final ExecutionLayerChannel executionLayer;
+  private final ReceivedExecutionPayloadEventsChannel
+      receivedExecutionPayloadEventsChannelPublisher;
 
   public DefaultExecutionPayloadManager(
       final AsyncRunner asyncRunner,
       final ExecutionPayloadGossipValidator executionPayloadGossipValidator,
       final ForkChoice forkChoice,
-      final ExecutionLayerChannel executionLayer) {
+      final ExecutionLayerChannel executionLayer,
+      final ReceivedExecutionPayloadEventsChannel receivedExecutionPayloadEventsChannelPublisher) {
     this.asyncRunner = asyncRunner;
     this.executionPayloadGossipValidator = executionPayloadGossipValidator;
     this.forkChoice = forkChoice;
     this.executionLayer = executionLayer;
+    this.receivedExecutionPayloadEventsChannelPublisher =
+        receivedExecutionPayloadEventsChannelPublisher;
   }
 
   @Override
@@ -92,6 +97,8 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
                 LOG.debug(
                     "Successfully imported execution payload {}",
                     signedExecutionPayload::toLogString);
+                receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
+                    signedExecutionPayload);
               } else {
                 LOG.debug(
                     "Failed to import execution payload for reason {}: {}",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadBidEventsChannel.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadBidEventsChannel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+
+public interface ReceivedExecutionPayloadBidEventsChannel extends VoidReturningChannelInterface {
+
+  /** Execution payload bid passes validation rules of the `execution_payload_bid` topic */
+  void onExecutionPayloadBidValidated(SignedExecutionPayloadBid executionPayloadBid);
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadEventsChannel.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ReceivedExecutionPayloadEventsChannel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.execution;
+
+import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public interface ReceivedExecutionPayloadEventsChannel extends VoidReturningChannelInterface {
+
+  /** Successfully imported on the fork-choice `on_execution_payload` handler */
+  void onExecutionPayloadImported(SignedExecutionPayloadEnvelope executionPayload);
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManagerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 
 import java.util.Optional;
@@ -49,8 +50,15 @@ public class DefaultExecutionPayloadBidManagerTest {
   private final ExecutionPayloadBidGossipValidator executionPayloadBidGossipValidator =
       mock(ExecutionPayloadBidGossipValidator.class);
 
+  private final ReceivedExecutionPayloadBidEventsChannel
+      receivedExecutionPayloadBidEventsChannelPublisher =
+          mock(ReceivedExecutionPayloadBidEventsChannel.class);
+
   private final DefaultExecutionPayloadBidManager executionPayloadBidManager =
-      new DefaultExecutionPayloadBidManager(spec, executionPayloadBidGossipValidator);
+      new DefaultExecutionPayloadBidManager(
+          spec,
+          executionPayloadBidGossipValidator,
+          receivedExecutionPayloadBidEventsChannelPublisher);
 
   @Test
   public void createsLocalBidForBlock() {
@@ -97,5 +105,9 @@ public class DefaultExecutionPayloadBidManagerTest {
                 expectedBlobKzgCommitments);
 
     assertThat(bid).isEqualTo(expectedBid);
+
+    // verify event is triggered to subscribers
+    verify(receivedExecutionPayloadBidEventsChannelPublisher)
+        .onExecutionPayloadBidValidated(signedBid);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -43,10 +44,17 @@ class DefaultExecutionPayloadManagerTest {
       mock(ExecutionPayloadGossipValidator.class);
   private final ForkChoice forkChoice = mock(ForkChoice.class);
   private final ExecutionLayerChannel executionLayer = mock(ExecutionLayerChannel.class);
+  private final ReceivedExecutionPayloadEventsChannel
+      receivedExecutionPayloadEventsChannelPublisher =
+          mock(ReceivedExecutionPayloadEventsChannel.class);
 
   private final DefaultExecutionPayloadManager executionPayloadManager =
       new DefaultExecutionPayloadManager(
-          asyncRunner, executionPayloadGossipValidator, forkChoice, executionLayer);
+          asyncRunner,
+          executionPayloadGossipValidator,
+          forkChoice,
+          executionLayer,
+          receivedExecutionPayloadEventsChannelPublisher);
 
   private final SignedExecutionPayloadEnvelope signedExecutionPayload =
       dataStructureUtil.randomSignedExecutionPayloadEnvelope(42);
@@ -70,6 +78,9 @@ class DefaultExecutionPayloadManagerTest {
     }
 
     assertThat(resultFuture).isCompletedWithValue(InternalValidationResult.ACCEPT);
+
+    verify(receivedExecutionPayloadEventsChannelPublisher)
+        .onExecutionPayloadImported(signedExecutionPayload);
 
     // verify the `beacon_block_root` is cached
     assertThat(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Introduce three new event streams:
 - execution_payload_available
 - execution_payload_bid
- payload_attestation_message

Ref: https://github.com/ethereum/beacon-APIs/blob/master/apis/eventstream/index.yaml

## Fixed Issue(s)
related to #9997 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution-payload import/validation flow and global event channel wiring; mistakes could drop events or increase event volume, but changes are additive and covered by updated tests.
> 
> **Overview**
> Adds three new `/eth/v1/events` SSE topics: `execution_payload_available`, `execution_payload_bid`, and `payload_attestation_message`, including new event wrappers and updates to the documented supported topic list.
> 
> Wires new execution-side event channels so `DefaultExecutionPayloadManager` and `DefaultExecutionPayloadBidManager` publish notifications on successful import/validation (including local self-built bids), and updates `EventSubscriptionManager`/`NodeDataProvider`/`DataProvider` to subscribe and emit these events (plus updates tests/integration wiring).
> 
> Fixes `data_column_sidecar` event serialization for Gloas by making `kzg_commitments` optional via `getMaybeKzgCommitments()` and emitting an empty list when absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 906375a5bb449347a919520ff70385d45bae6f98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->