### PR TITLE
fixed getProposerDuties to be pre-fulu compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 ### Bug Fixes
 
 - fixed an issue with dependent root calculation which was causing future epoch block proposal duties to be recalculated.
+- fixed v1 proposer duties returning incompatible roots for the v1 endpoint (should be compatible with pre-fulu dependent roots).

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -1047,7 +1047,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     final BlockProposalUtil blockProposalUtil;
     if (isFuluCompatible) {
       blockProposalUtil = spec.atEpoch(epoch).getBlockProposalUtil();
-
     } else {
       blockProposalUtil = spec.forMilestone(SpecMilestone.PHASE0).getBlockProposalUtil();
     }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -101,6 +101,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
+import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -312,7 +313,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   }
 
   @Override
-  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(
+      final UInt64 epoch, final boolean isFuluCompatible) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
@@ -328,7 +330,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     }
 
     final UInt64 stateSlot =
-        spec.atEpoch(epoch).getBlockProposalUtil().getStateSlotForProposerDuties(spec, epoch);
+        spec.atEpoch(epoch)
+            .getBlockProposalUtil()
+            .getStateSlotForProposerDuties(spec, currentEpoch, epoch);
     LOG.debug(
         "Retrieving proposer duties for epoch {}, current epoch {}, state query slot {}",
         epoch,
@@ -336,7 +340,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
         stateSlot);
     return combinedChainDataClient
         .getStateAtSlotExact(stateSlot)
-        .thenApply(maybeState -> maybeState.map(state -> getProposerDutiesFromState(state, epoch)));
+        .thenApply(
+            maybeState ->
+                maybeState.map(
+                    state -> getProposerDutiesFromState(state, epoch, isFuluCompatible)));
   }
 
   @Override
@@ -1026,7 +1033,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     return !syncStateProvider.getCurrentSyncState().isInSync();
   }
 
-  private ProposerDuties getProposerDutiesFromState(final BeaconState state, final UInt64 epoch) {
+  private ProposerDuties getProposerDutiesFromState(
+      final BeaconState state, final UInt64 epoch, final boolean isFuluCompatible) {
     final List<ProposerDuty> result = getProposalSlotsForEpoch(state, epoch);
     if (spec.atEpoch(epoch).getMilestone().isLessThan(SpecMilestone.FULU)) {
       return new ProposerDuties(
@@ -1036,10 +1044,20 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     }
     final UInt64 currentEpoch = spec.getCurrentEpoch(state);
     final boolean greaterThanCurrentEpoch = epoch.isGreaterThan(currentEpoch);
+    final BlockProposalUtil blockProposalUtil;
+    if (isFuluCompatible) {
+      blockProposalUtil = spec.atEpoch(epoch).getBlockProposalUtil();
+
+    } else {
+      blockProposalUtil = spec.forMilestone(SpecMilestone.PHASE0).getBlockProposalUtil();
+    }
     final Bytes32 dependentRoot =
-        greaterThanCurrentEpoch
-            ? spec.atEpoch(epoch).getBeaconStateUtil().getCurrentDutyDependentRoot(state)
-            : spec.atEpoch(epoch).getBeaconStateUtil().getPreviousDutyDependentRoot(state);
+        blockProposalUtil.getBlockProposalDependentRoot(
+            combinedChainDataClient.getBestBlockRoot().orElseThrow(),
+            spec.atEpoch(epoch).getBeaconStateUtil().getPreviousDutyDependentRoot(state),
+            spec.atEpoch(epoch).getBeaconStateUtil().getCurrentDutyDependentRoot(state),
+            spec.computeEpochAtSlot(state.getSlot()),
+            epoch);
     LOG.trace(
         "state epoch {}, duties epoch {}, greaterThanCurrentEpoch {}, dependentRoot {}",
         currentEpoch,

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
@@ -35,6 +35,11 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
 
   private static final Logger LOG = LogManager.getLogger();
 
+  // epoch | 0                   |<1>
+  // slot  | 1  2  3  4  5  6  7 | 8
+  // query |                     | ^
+  // dep   |                   D |
+  // EXPECT - should be able to query for the current epoch (currentDependentRoot)
   @Test
   void shouldReturnCorrectDependentRootPreFulu() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.ALTAIR);
@@ -51,7 +56,7 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
   // slot  | 1  2  3  4  5  6  7 |
   // query |                   ^ |
   // dep   |                   D |
-  // EXPECT - should be able to query for the next epoch, may not be stable if it's too early.
+  // EXPECT - should be able to query for the next epoch (head)
   @Test
   void shouldReturnNextEpochDutiesFutureEpochPreFulu() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.ALTAIR);
@@ -68,8 +73,8 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
   // epoch  GENESIS | 0                   |<1>
   // slot         0 | 1  2  3  4  5  6  7 |
   // query          |                   ^ |
-  // dep          D |                     |
-  // EXPECT epoch 1 duties with dependent root slot 0 (GENESIS)
+  // dep            |                   D |
+  // EXPECT epoch 1 duties with dependent root slot 7 (head)
   @Test
   void shouldReturnNextEpochDutiesFutureEpochPostFulu() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
@@ -80,14 +85,14 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     final Response response = getProposerDuties("1");
     final String responseBody = response.body().string();
     assertThat(response.code()).isEqualTo(200);
-    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getFirst().getParentRoot());
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getRoot());
   }
 
   // epoch  GENESIS | 0                   |<1>
   // slot         0 | 1  2  3  4  5  6  7 | 8
   // query          |                     | ^
-  // dep          D |                     |
-  // EXPECT epoch 1 duties with dependent root slot 0 (GENESIS)
+  // dep          D |                   D |
+  // EXPECT epoch 1 duties with dependent root slot 7 (currentDutyDependentRoot)
   @Test
   void shouldReturnCorrectDependentRootPostFulu() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
@@ -98,7 +103,7 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     final Response response = getProposerDuties("1");
     final String responseBody = response.body().string();
     assertThat(response.code()).isEqualTo(200);
-    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getFirst().getParentRoot());
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
   }
 
   // epoch | 0                   | 1                      | <2>
@@ -106,6 +111,7 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
   // query |                     |                        |  ^
   // dep   |                     |                      D |
   // EXPECT - expect epoch 2 duties with dependent root slot 15
+  //         (currentDependentRoot of epoch 2 state)
   @Test
   void shouldReturnCorrectDependentRootPreFuluExtraSlots() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.BELLATRIX);
@@ -124,8 +130,9 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
   // epoch  GENESIS | 0                   |<1>                     |  2
   // slot         0 | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
   // query          |                     |                        |  ^
-  // dep          D |                     |                        |
-  // EXPECT - expect epoch 1 duties with dependent root slot 0 (GENESIS)
+  // dep            |                   D |                        |
+  // EXPECT - expect epoch 1 duties with dependent root slot 0
+  //          (previousDependentRoot of epoch 1 state)
   @Test
   void shouldReturnCorrectDependentRootPostFuluExtraSlots() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
@@ -136,15 +143,17 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     logChainData(chain);
     final Response response = getProposerDuties("1");
     final String responseBody = response.body().string();
+    LOG.debug(responseBody);
     assertThat(response.code()).isEqualTo(200);
-    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getFirst().getParentRoot());
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.get(6).getRoot());
   }
 
   // epoch | 0                   | 1                      | <2>
   // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 |
   // query |                     |                      ^ |
-  // dep   |                   D |                        |
+  // dep   |                     |                      D |
   // EXPECT - expect epoch 2 duties with dependent root slot 15
+  //          (head state)
   @Test
   void shouldReturnCorrectDependentRootPostFuluExtraSlotsFutureEpoch() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
@@ -157,14 +166,15 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     final Response response = getProposerDuties("2");
     final String responseBody = response.body().string();
     assertThat(response.code()).isEqualTo(200);
-    assertThat(dependentRoot(responseBody)).isEqualTo(chain.get(6).getRoot());
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getRoot());
   }
 
   // epoch | 0                   | 1                      | <2>
   // slot  | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
   // query |                     |                        |  ^
-  // dep   |                   D |                        |
+  // dep   |                     |                      D |
   // EXPECT - expect epoch 2 duties with dependent root slot 15
+  //          (currentDependentRoot of epoch 2 state)
   @Test
   void shouldReturnCorrectDependentRootSecondEpoch() throws IOException {
     startRestApiAtGenesisWithValidatorApiHandler(SpecMilestone.FULU);
@@ -176,7 +186,7 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
     final Response response = getProposerDuties("2");
     final String responseBody = response.body().string();
     assertThat(response.code()).isEqualTo(200);
-    assertThat(dependentRoot(responseBody)).isEqualTo(chain.get(6).getRoot());
+    assertThat(dependentRoot(responseBody)).isEqualTo(chain.getLast().getParentRoot());
   }
 
   final Bytes32 dependentRoot(final String responseBody) {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetProposerDutiesIntegrationTest.java
@@ -131,7 +131,7 @@ public class GetProposerDutiesIntegrationTest extends AbstractDataBackedRestAPII
   // slot         0 | 1  2  3  4  5  6  7 | 8  9 10 11 12 13 14 15 | 16
   // query          |                     |                        |  ^
   // dep            |                   D |                        |
-  // EXPECT - expect epoch 1 duties with dependent root slot 0
+  // EXPECT - expect epoch 1 duties with dependent root slot 7
   //          (previousDependentRoot of epoch 1 state)
   @Test
   void shouldReturnCorrectDependentRootPostFuluExtraSlots() throws IOException {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
@@ -77,7 +77,8 @@ public class GetProposerDuties extends RestApiEndpoint {
     }
 
     final UInt64 epoch = request.getPathParameter(EPOCH_PARAMETER);
-    SafeFuture<Optional<ProposerDuties>> future = validatorDataProvider.getProposerDuties(epoch);
+    SafeFuture<Optional<ProposerDuties>> future =
+        validatorDataProvider.getProposerDutiesElectraDependentRoot(epoch);
 
     request.respondAsync(
         future.thenApply(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
@@ -66,7 +66,7 @@ public class GetProposerDutiesTest extends AbstractMigratedBeaconHandlerTest {
 
     when(validatorDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
-    when(validatorDataProvider.getProposerDuties(eq(UInt64.valueOf(100))))
+    when(validatorDataProvider.getProposerDutiesElectraDependentRoot(eq(UInt64.valueOf(100))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(duties)));
 
     handler.handleRequest(request);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -199,7 +199,12 @@ public class ValidatorDataProvider {
   }
 
   public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
-    return SafeFuture.of(() -> validatorApiChannel.getProposerDuties(epoch));
+    return SafeFuture.of(() -> validatorApiChannel.getProposerDuties(epoch, true));
+  }
+
+  public SafeFuture<Optional<ProposerDuties>> getProposerDutiesElectraDependentRoot(
+      final UInt64 epoch) {
+    return SafeFuture.of(() -> validatorApiChannel.getProposerDuties(epoch, false));
   }
 
   public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
@@ -30,7 +30,7 @@ public interface BlockProposalUtil {
       Bytes32 headBlockRoot,
       Bytes32 previousTargetRoot,
       Bytes32 currentTargetRoot,
-      UInt64 headEpoch,
+      UInt64 stateEpoch,
       UInt64 dutyEpoch);
 
   SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
@@ -41,5 +41,5 @@ public interface BlockProposalUtil {
       Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder,
       BlockProductionPerformance blockProductionPerformance);
 
-  UInt64 getStateSlotForProposerDuties(Spec spec, UInt64 dutiesEpoch);
+  UInt64 getStateSlotForProposerDuties(Spec spec, UInt64 stateEpoch, UInt64 dutiesEpoch);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFulu.java
@@ -44,7 +44,7 @@ public class BlockProposalUtilFulu extends BlockProposalUtilPhase0 {
 
   @Override
   public UInt64 getStateSlotForProposerDuties(
-          final Spec spec, final UInt64 stateEpoch, final UInt64 dutiesEpoch) {
+      final Spec spec, final UInt64 stateEpoch, final UInt64 dutiesEpoch) {
     return dutiesEpoch.isGreaterThan(stateEpoch)
         ? spec.computeStartSlotAtEpoch(stateEpoch)
         : spec.computeStartSlotAtEpoch(dutiesEpoch);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
@@ -70,7 +70,7 @@ public class BlockProposalUtilPhase0 implements BlockProposalUtil {
 
   @Override
   public UInt64 getStateSlotForProposerDuties(
-          final Spec spec, final UInt64 stateEpoch, final UInt64 dutiesEpoch) {
+      final Spec spec, final UInt64 stateEpoch, final UInt64 dutiesEpoch) {
     return spec.computeStartSlotAtEpoch(dutiesEpoch);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
@@ -58,18 +58,19 @@ public class BlockProposalUtilPhase0 implements BlockProposalUtil {
       final Bytes32 headBlockRoot,
       final Bytes32 previousTargetRoot,
       final Bytes32 currentTargetRoot,
-      final UInt64 headEpoch,
+      final UInt64 stateEpoch,
       final UInt64 dutyEpoch) {
     checkArgument(
-        dutyEpoch.isGreaterThanOrEqualTo(headEpoch),
-        "Attempting to calculate dependent root for duty epoch %s that is before the updated head epoch %s",
+        dutyEpoch.isGreaterThanOrEqualTo(stateEpoch),
+        "Attempting to calculate dependent root for duty epoch %s that is before the updated state epoch %s",
         dutyEpoch,
-        headEpoch);
-    return headEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
+        stateEpoch);
+    return stateEpoch.equals(dutyEpoch) ? currentTargetRoot : headBlockRoot;
   }
 
   @Override
-  public UInt64 getStateSlotForProposerDuties(final Spec spec, final UInt64 dutiesEpoch) {
+  public UInt64 getStateSlotForProposerDuties(
+          final Spec spec, final UInt64 stateEpoch, final UInt64 dutiesEpoch) {
     return spec.computeStartSlotAtEpoch(dutiesEpoch);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFuluTest.java
@@ -44,7 +44,11 @@ class BlockProposalUtilFuluTest {
     // |   2   |      16    |    23    |
     // |   3   |      24    |    31    |
     return Stream.of(
-        Arguments.of(0, 0), Arguments.of(1, 0), Arguments.of(2, 8), Arguments.of(3, 16));
+        Arguments.of(1, 1, 8),
+        Arguments.of(2, 2, 16),
+        Arguments.of(2, 1, 8),
+        Arguments.of(3, 1, 8),
+        Arguments.of(3, 3, 24));
   }
 
   enum ExpectedResult {
@@ -56,11 +60,13 @@ class BlockProposalUtilFuluTest {
 
   @ParameterizedTest
   @MethodSource("getStateSlotForProposerDutiesTestCases")
-  public void getStateSlotForProposerDuties(final int requestedEpoch, final int expectedSlot) {
+  public void getStateSlotForProposerDuties(
+      final int requestedEpoch, final int headEpochIn, final int expectedSlot) {
+    final UInt64 headEpoch = UInt64.valueOf(headEpochIn);
     final UInt64 querySlot =
         spec.getGenesisSpec()
             .getBlockProposalUtil()
-            .getStateSlotForProposerDuties(spec, UInt64.valueOf(requestedEpoch));
+            .getStateSlotForProposerDuties(spec, headEpoch, UInt64.valueOf(requestedEpoch));
 
     assertThat(querySlot.intValue()).isEqualTo(expectedSlot);
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0Test.java
@@ -38,12 +38,13 @@ class BlockProposalUtilPhase0Test {
   @ParameterizedTest
   @MethodSource("getStateSlotForProposerDutiesTestCases")
   public void getStateSlotForProposerDuties(final int requestedEpoch, final int expectedSlot) {
+    final UInt64 epoch = UInt64.valueOf(requestedEpoch);
     final Spec localSpec = TestSpecFactory.createMinimal(SpecMilestone.PHASE0);
     final UInt64 querySlot =
         localSpec
             .getGenesisSpec()
             .getBlockProposalUtil()
-            .getStateSlotForProposerDuties(localSpec, UInt64.valueOf(requestedEpoch));
+            .getStateSlotForProposerDuties(localSpec, epoch, epoch);
 
     assertThat(querySlot.intValue()).isEqualTo(expectedSlot);
   }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -89,7 +89,8 @@ public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface
         }
 
         @Override
-        public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
+        public SafeFuture<Optional<ProposerDuties>> getProposerDuties(
+            final UInt64 epoch, final boolean isFuluCompatible) {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
@@ -266,7 +267,8 @@ public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface
   SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
       UInt64 epoch, IntCollection validatorIndices);
 
-  SafeFuture<Optional<ProposerDuties>> getProposerDuties(UInt64 epoch);
+  SafeFuture<Optional<ProposerDuties>> getProposerDuties(
+      UInt64 epoch, final boolean isFuluCompatible);
 
   SafeFuture<Optional<PtcDuties>> getPtcDuties(UInt64 epoch, IntCollection validatorIndices);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -130,9 +130,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(
+      final UInt64 epoch, final boolean isFuluCompatible) {
     return countOptionalDataRequest(
-        delegate.getProposerDuties(epoch),
+        delegate.getProposerDuties(epoch, isFuluCompatible),
         BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -51,7 +51,7 @@ public class BlockProductionDutyLoader
     if (validatorIndices.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
     }
-    return validatorApiChannel.getProposerDuties(epoch);
+    return validatorApiChannel.getProposerDuties(epoch, true);
   }
 
   @Override

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BlockDutySchedulerTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -67,7 +68,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
   @Test
   public void shouldFetchDutiesForCurrentEpoch() {
     createDutySchedulerWithRealDuties();
-    when(validatorApiChannel.getProposerDuties(any()))
+    when(validatorApiChannel.getProposerDuties(any(), anyBoolean()))
         .thenReturn(
             completedFuture(
                 Optional.of(
@@ -75,8 +76,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
 
     dutyScheduler.onSlot(spec.computeStartSlotAtEpoch(UInt64.ONE));
 
-    verify(validatorApiChannel).getProposerDuties(UInt64.ONE);
-    verify(validatorApiChannel, never()).getProposerDuties(UInt64.valueOf(2));
+    verify(validatorApiChannel).getProposerDuties(eq(UInt64.ONE), eq(true));
+    verify(validatorApiChannel, never()).getProposerDuties(eq(UInt64.valueOf(2)), anyBoolean());
   }
 
   @Test
@@ -84,7 +85,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties();
     final UInt64 blockProposerSlot = UInt64.valueOf(5);
     final ProposerDuty validator1Duties = new ProposerDuty(VALIDATOR1_KEY, 5, blockProposerSlot);
-    when(validatorApiChannel.getProposerDuties(eq(ZERO)))
+    when(validatorApiChannel.getProposerDuties(eq(ZERO), eq(true)))
         .thenReturn(
             completedFuture(
                 Optional.of(
@@ -125,7 +126,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties();
     final UInt64 blockProposerSlot = UInt64.valueOf(5);
     final ProposerDuty validator1Duties = new ProposerDuty(VALIDATOR1_KEY, 5, blockProposerSlot);
-    when(validatorApiChannel.getProposerDuties(ZERO))
+    when(validatorApiChannel.getProposerDuties(eq(ZERO), eq(true)))
         .thenReturn(
             completedFuture(
                 Optional.of(
@@ -158,7 +159,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithMockDuties();
     final SafeFuture<Optional<ProposerDuties>> epoch0Duties = new SafeFuture<>();
 
-    when(validatorApiChannel.getProposerDuties(ZERO)).thenReturn(epoch0Duties);
+    when(validatorApiChannel.getProposerDuties(eq(ZERO), anyBoolean())).thenReturn(epoch0Duties);
     dutyScheduler.onSlot(ZERO);
 
     dutyScheduler.onBlockProductionDue(ZERO);
@@ -169,8 +170,8 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
         Optional.of(new ProposerDuties(dataStructureUtil.randomBytes32(), emptyList(), false)));
 
     verify(scheduledDuties).performProductionDuty(ZERO);
-    verify(validatorApiChannel).getProposerDuties(ZERO);
-    verify(validatorApiChannel, never()).getProposerDuties(ONE);
+    verify(validatorApiChannel).getProposerDuties(eq(ZERO), anyBoolean());
+    verify(validatorApiChannel, never()).getProposerDuties(eq(ONE), anyBoolean());
   }
 
   @Test
@@ -180,13 +181,13 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     final UInt64 currentSlot = spec.computeStartSlotAtEpoch(currentEpoch);
     final Bytes32 previousDependentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 currentDependentRoot = dataStructureUtil.randomBytes32();
-    when(validatorApiChannel.getProposerDuties(any()))
+    when(validatorApiChannel.getProposerDuties(any(), anyBoolean()))
         .thenReturn(
             SafeFuture.completedFuture(
                 Optional.of(new ProposerDuties(currentDependentRoot, emptyList(), false))));
     dutyScheduler.onSlot(currentSlot);
 
-    verify(validatorApiChannel).getProposerDuties(currentEpoch);
+    verify(validatorApiChannel).getProposerDuties(currentEpoch, true);
 
     dutyScheduler.onHeadUpdate(
         currentSlot,
@@ -194,7 +195,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
         dataStructureUtil.randomBytes32(),
         dataStructureUtil.randomBytes32());
 
-    verify(validatorApiChannel, times(2)).getProposerDuties(currentEpoch);
+    verify(validatorApiChannel, times(2)).getProposerDuties(currentEpoch, true);
     verifyNoMoreInteractions(validatorApiChannel);
   }
 
@@ -205,13 +206,13 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     final UInt64 currentSlot = spec.computeStartSlotAtEpoch(currentEpoch);
     final Bytes32 previousDependentRoot = dataStructureUtil.randomBytes32();
     final Bytes32 currentDependentRoot = dataStructureUtil.randomBytes32();
-    when(validatorApiChannel.getProposerDuties(any()))
+    when(validatorApiChannel.getProposerDuties(any(), anyBoolean()))
         .thenReturn(
             SafeFuture.completedFuture(
                 Optional.of(new ProposerDuties(currentDependentRoot, emptyList(), false))));
     dutyScheduler.onSlot(currentSlot);
 
-    verify(validatorApiChannel).getProposerDuties(currentEpoch);
+    verify(validatorApiChannel).getProposerDuties(currentEpoch, true);
 
     dutyScheduler.onHeadUpdate(
         currentSlot,
@@ -227,15 +228,15 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     createDutySchedulerWithRealDuties();
     final UInt64 currentEpoch = UInt64.valueOf(5);
     final UInt64 currentSlot = spec.computeStartSlotAtEpoch(currentEpoch);
-    when(validatorApiChannel.getProposerDuties(any())).thenReturn(new SafeFuture<>());
+    when(validatorApiChannel.getProposerDuties(any(), anyBoolean())).thenReturn(new SafeFuture<>());
     dutyScheduler.onSlot(currentSlot);
 
-    verify(validatorApiChannel).getProposerDuties(currentEpoch);
+    verify(validatorApiChannel).getProposerDuties(currentEpoch, true);
 
     dutyScheduler.onPossibleMissedEvents();
 
     // Remembers the previous latest epoch and uses it to recalculate duties
-    verify(validatorApiChannel, times(2)).getProposerDuties(currentEpoch);
+    verify(validatorApiChannel, times(2)).getProposerDuties(currentEpoch, true);
     verifyNoMoreInteractions(validatorApiChannel);
   }
 
@@ -276,7 +277,7 @@ public class BlockDutySchedulerTest extends AbstractDutySchedulerTest {
     when(scheduledDuties.performProductionDuty(slot))
         .thenReturn(SafeFuture.completedFuture(DutyResult.success(Bytes32.ZERO)));
 
-    when(validatorApiChannel.getProposerDuties(ZERO))
+    when(validatorApiChannel.getProposerDuties(eq(ZERO), anyBoolean()))
         .thenReturn(
             SafeFuture.completedFuture(
                 Optional.of(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -155,9 +155,10 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(
+      final UInt64 epoch, final boolean isFuluCompatible) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getProposerDuties(epoch),
+        apiChannel -> apiChannel.getProposerDuties(epoch, isFuluCompatible),
         BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -214,7 +214,9 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(
+      final UInt64 epoch, final boolean isFuluCompatible) {
+    // fixme #10346
     return sendRequest(() -> typeDefClient.getProposerDuties(epoch));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -105,8 +105,9 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
-    return dutiesProviderChannel.getProposerDuties(epoch);
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(
+      final UInt64 epoch, final boolean isFuluCompatible) {
+    return dutiesProviderChannel.getProposerDuties(epoch, isFuluCompatible);
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -731,7 +731,7 @@ class FailoverValidatorApiHandlerTest {
             Optional.of(mock(SyncCommitteeDuties.class))),
         getArguments(
             "getProposerDuties",
-            apiChannel -> apiChannel.getProposerDuties(epoch),
+            apiChannel -> apiChannel.getProposerDuties(epoch, true),
             BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD,
             Optional.of(mock(ProposerDuties.class))),
         getArguments(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -182,7 +182,7 @@ class RemoteValidatorApiHandlerTest {
     when(typeDefClient.getGenesis())
         .thenReturn(Optional.of(new GenesisData(genesisTime, dataStructureUtil.randomBytes32())));
 
-    SafeFuture<Optional<GenesisData>> future = apiHandler.getGenesisData();
+    final SafeFuture<Optional<GenesisData>> future = apiHandler.getGenesisData();
 
     assertThat(unwrapToValue(future).getGenesisTime()).isEqualTo(genesisTime);
   }
@@ -191,7 +191,7 @@ class RemoteValidatorApiHandlerTest {
   public void getGenesisTime_WhenNotPresent_ReturnsEmpty() {
     when(typeDefClient.getGenesis()).thenReturn(Optional.empty());
 
-    SafeFuture<Optional<GenesisData>> future = apiHandler.getGenesisData();
+    final SafeFuture<Optional<GenesisData>> future = apiHandler.getGenesisData();
 
     assertThat(unwrapToOptional(future)).isNotPresent();
   }
@@ -341,7 +341,7 @@ class RemoteValidatorApiHandlerTest {
 
   @Test
   public void getAttestationDuties_WithEmptyPublicKeys_ReturnsEmpty() {
-    SafeFuture<Optional<AttesterDuties>> future =
+    final SafeFuture<Optional<AttesterDuties>> future =
         apiHandler.getAttestationDuties(ONE, IntList.of());
 
     assertThat(unwrapToOptional(future)).isEmpty();
@@ -355,7 +355,7 @@ class RemoteValidatorApiHandlerTest {
                 new AttesterDuties(
                     false, dataStructureUtil.randomBytes32(), Collections.emptyList())));
 
-    SafeFuture<Optional<AttesterDuties>> future =
+    final SafeFuture<Optional<AttesterDuties>> future =
         apiHandler.getAttestationDuties(ONE, IntList.of(1234));
 
     assertThat(unwrapToValue(future).getDuties()).isEmpty();
@@ -385,17 +385,17 @@ class RemoteValidatorApiHandlerTest {
                 new AttesterDuties(
                     false, dataStructureUtil.randomBytes32(), List.of(expectedValidatorDuties))));
 
-    SafeFuture<Optional<AttesterDuties>> future =
+    final SafeFuture<Optional<AttesterDuties>> future =
         apiHandler.getAttestationDuties(ONE, IntList.of(validatorIndex));
 
-    AttesterDuties validatorDuties = unwrapToValue(future);
+    final AttesterDuties validatorDuties = unwrapToValue(future);
 
     assertThat(validatorDuties.getDuties().get(0)).isEqualTo(expectedValidatorDuties);
   }
 
   @Test
   public void getProposerDuties_WithEmptyPublicKeys_ReturnsEmpty() {
-    SafeFuture<Optional<ProposerDuties>> future = apiHandler.getProposerDuties(ONE);
+    final SafeFuture<Optional<ProposerDuties>> future = apiHandler.getProposerDuties(ONE, false);
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -408,7 +408,7 @@ class RemoteValidatorApiHandlerTest {
                 new ProposerDuties(
                     Bytes32.fromHexString("0x1234"), Collections.emptyList(), false)));
 
-    SafeFuture<Optional<ProposerDuties>> future = apiHandler.getProposerDuties(ONE);
+    final SafeFuture<Optional<ProposerDuties>> future = apiHandler.getProposerDuties(ONE, false);
 
     assertThat(unwrapToValue(future).getDuties()).isEmpty();
   }
@@ -426,9 +426,9 @@ class RemoteValidatorApiHandlerTest {
 
     when(typeDefClient.getProposerDuties(ONE)).thenReturn(Optional.of(response));
 
-    SafeFuture<Optional<ProposerDuties>> future = apiHandler.getProposerDuties(ONE);
+    final SafeFuture<Optional<ProposerDuties>> future = apiHandler.getProposerDuties(ONE, false);
 
-    ProposerDuties validatorDuties = unwrapToValue(future);
+    final ProposerDuties validatorDuties = unwrapToValue(future);
 
     assertThat(validatorDuties.getDuties().get(0)).isEqualTo(expectedValidatorDuties);
     assertThat(validatorDuties.getDependentRoot()).isEqualTo(response.getDependentRoot());
@@ -443,7 +443,7 @@ class RemoteValidatorApiHandlerTest {
             .build();
     when(typeDefClient.getPeerCount()).thenReturn(Optional.of(response));
     final SafeFuture<Optional<PeerCount>> peerCountFuture = apiHandler.getPeerCount();
-    PeerCount peerCount = unwrapToValue(readinessAsyncRunner, peerCountFuture);
+    final PeerCount peerCount = unwrapToValue(readinessAsyncRunner, peerCountFuture);
     assertThat(peerCount).isEqualTo(response);
   }
 
@@ -451,7 +451,7 @@ class RemoteValidatorApiHandlerTest {
   public void createAttestationData_WhenNone_ReturnsEmpty() {
     when(typeDefClient.createAttestationData(any(), anyInt())).thenReturn(Optional.empty());
 
-    SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(ONE, 0);
+    final SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(ONE, 0);
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -463,7 +463,7 @@ class RemoteValidatorApiHandlerTest {
     when(typeDefClient.createAttestationData(ONE, 0))
         .thenReturn(Optional.of(attestation.getData()));
 
-    SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(ONE, 0);
+    final SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(ONE, 0);
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(attestation.getData());
   }
@@ -472,7 +472,7 @@ class RemoteValidatorApiHandlerTest {
   public void createUnsignedBlock_WhenNoneFound_ReturnsEmpty() {
     final BLSSignature blsSignature = dataStructureUtil.randomSignature();
 
-    SafeFuture<Optional<BlockContainerAndMetaData>> future =
+    final SafeFuture<Optional<BlockContainerAndMetaData>> future =
         apiHandler.createUnsignedBlock(
             ONE, blsSignature, Optional.of(Bytes32.random()), Optional.empty());
 
@@ -493,7 +493,7 @@ class RemoteValidatorApiHandlerTest {
             eq(Optional.empty())))
         .thenReturn(Optional.of(blockContainerAndMetaData));
 
-    SafeFuture<Optional<BlockContainerAndMetaData>> future =
+    final SafeFuture<Optional<BlockContainerAndMetaData>> future =
         apiHandler.createUnsignedBlock(ONE, blsSignature, graffiti, Optional.empty());
 
     final BlockContainerAndMetaData resultValue = unwrapToValue(future);
@@ -518,7 +518,7 @@ class RemoteValidatorApiHandlerTest {
             eq(Optional.of(ONE))))
         .thenReturn(Optional.of(blockContainerAndMetaData));
 
-    SafeFuture<Optional<BlockContainerAndMetaData>> future =
+    final SafeFuture<Optional<BlockContainerAndMetaData>> future =
         apiHandler.createUnsignedBlock(ONE, blsSignature, graffiti, Optional.of(ONE));
 
     final BlockContainerAndMetaData resultValue = unwrapToValue(future);
@@ -543,7 +543,7 @@ class RemoteValidatorApiHandlerTest {
             eq(Optional.empty())))
         .thenReturn(Optional.of(blockContentsAndMetaData));
 
-    SafeFuture<Optional<BlockContainerAndMetaData>> future =
+    final SafeFuture<Optional<BlockContainerAndMetaData>> future =
         apiHandler.createUnsignedBlock(ONE, blsSignature, graffiti, Optional.empty());
 
     final BlockContainerAndMetaData resultValue = unwrapToValue(future);
@@ -562,7 +562,7 @@ class RemoteValidatorApiHandlerTest {
 
     when(typeDefClient.sendSignedBlock(any(), any())).thenReturn(expectedResult);
 
-    ArgumentCaptor<SignedBeaconBlock> argumentCaptor =
+    final ArgumentCaptor<SignedBeaconBlock> argumentCaptor =
         ArgumentCaptor.forClass(SignedBeaconBlock.class);
 
     final SafeFuture<SendSignedBlockResult> result =
@@ -584,7 +584,7 @@ class RemoteValidatorApiHandlerTest {
         .when(typeDefClient)
         .createAggregate(slot, attHashTreeRoot, Optional.empty());
 
-    SafeFuture<Optional<Attestation>> future =
+    final SafeFuture<Optional<Attestation>> future =
         apiHandler.createAggregate(slot, attHashTreeRoot, Optional.of(ONE));
 
     assertThat(unwrapToOptional(future)).isEmpty();
@@ -603,7 +603,7 @@ class RemoteValidatorApiHandlerTest {
         .when(typeDefClient)
         .createAggregate(slot, attHashTreeRoot, Optional.of(ONE));
 
-    SafeFuture<Optional<Attestation>> future =
+    final SafeFuture<Optional<Attestation>> future =
         apiHandler.createAggregate(slot, attHashTreeRoot, Optional.of(ONE));
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(attestation);
@@ -706,9 +706,9 @@ class RemoteValidatorApiHandlerTest {
 
     final UInt64 epoch = dataStructureUtil.randomEpoch();
 
-    List<UInt64> validatorIndices = List.of(firstIndex, secondIndex, thirdIndex);
+    final List<UInt64> validatorIndices = List.of(firstIndex, secondIndex, thirdIndex);
 
-    List<ValidatorLivenessAtEpoch> validatorLivenesses =
+    final List<ValidatorLivenessAtEpoch> validatorLivenesses =
         List.of(
             new ValidatorLivenessAtEpoch(firstIndex, false),
             new ValidatorLivenessAtEpoch(secondIndex, true),
@@ -722,7 +722,7 @@ class RemoteValidatorApiHandlerTest {
 
     assertThat(result).isCompleted();
     assertThat(result.get()).isPresent();
-    List<ValidatorLivenessAtEpoch> validatorLivenessAtEpochesResult = result.get().get();
+    final List<ValidatorLivenessAtEpoch> validatorLivenessAtEpochesResult = result.get().get();
     assertThat(validatorIsLive(validatorLivenessAtEpochesResult, firstIndex)).isFalse();
     assertThat(validatorIsLive(validatorLivenessAtEpochesResult, secondIndex)).isTrue();
     assertThat(validatorIsLive(validatorLivenessAtEpochesResult, thirdIndex)).isTrue();

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
@@ -114,9 +114,9 @@ class SentryValidatorApiChannelTest {
 
   @Test
   void getProposerDutiesShouldUseDutiesProviderChannel() {
-    sentryValidatorApiChannel.getProposerDuties(UInt64.ZERO);
+    sentryValidatorApiChannel.getProposerDuties(UInt64.ZERO, false);
 
-    verify(dutiesProviderChannel).getProposerDuties(eq(UInt64.ZERO));
+    verify(dutiesProviderChannel).getProposerDuties(eq(UInt64.ZERO), eq(false));
     verifyNoInteractions(blockHandlerChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }


### PR DESCRIPTION
There's a new endpoint in ValidatorApiHandler that is called for dependent root compatibility.

With this change, the dependent root computation on the `proposers/{epoch}` endpoint will be returning the same roots as pre-fulu.

This is basically currentDependentRoot for current epoch, and HEAD root for next epoch.

Further work will be needed to introduce a v2 proposers endpoint that correctly follows the fulu dependent root calculations.

fixes #10345

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator duty calculation and the public proposer-duties endpoint behavior, so incorrect epoch/root selection could cause validators or external clients to react to wrong duty roots; changes are covered by expanded unit/integration tests.
> 
> **Overview**
> Updates proposer duties handling so the v1 REST endpoint `GET /eth/v1/validator/duties/proposer/{epoch}` returns *pre-Fulu-compatible* `dependent_root` values even on Fulu networks.
> 
> This threads a new `isFuluCompatible` flag through `ValidatorApiChannel.getProposerDuties`, adds `ValidatorDataProvider.getProposerDutiesElectraDependentRoot`, and updates `ValidatorApiHandler` to (a) query the correct state slot based on both current and requested epochs and (b) compute `dependent_root` via `BlockProposalUtil.getBlockProposalDependentRoot` using either the Fulu or Phase0 util depending on compatibility mode.
> 
> Spec utilities are updated to reflect the new state-epoch-aware `BlockProposalUtil` signatures, and unit/integration tests are adjusted to validate the new dependent-root expectations across pre/post-Fulu scenarios. The changelog is updated to note the v1 proposer duties root compatibility fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2a361a8147f3b496cbb60288979c4a18d6c16b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->