### PR TITLE
hashing optimization for epoch transition

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
@@ -41,6 +41,7 @@ public class BeaconStateBenchmark {
           .withPubKeyGenerator(() -> pubkey);
   private static final BeaconState beaconState = dataStructureUtil.randomBeaconState(400_000);
 
+  private static final int VALIDATOR_COUNT = 400_000;
   private static final int NUM_EB_CHANGES = 2000;
   private int[] ebChangeIndices;
 
@@ -49,7 +50,7 @@ public class BeaconStateBenchmark {
     var random = new Random(42);
     var indSet = new IntOpenHashSet();
     while (indSet.size() < NUM_EB_CHANGES) {
-      indSet.add(random.nextInt(0, 400_000));
+      indSet.add(random.nextInt(0, VALIDATOR_COUNT));
     }
     ebChangeIndices = indSet.toIntArray();
     System.out.println("ebChangeIndices created: " + ebChangeIndices.length);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
@@ -104,7 +104,7 @@ public class BeaconStateBenchmark {
             state -> {
               for (int idx : EB_CHANGE_INDICES) {
                 final UInt64 newBalance =
-                    state.getValidators().get(idx).getEffectiveBalance().plus(1_000_000_00L);
+                    state.getValidators().get(idx).getEffectiveBalance().plus(1_000_000_000L);
                 state
                     .getValidators()
                     .set(idx, state.getValidators().get(idx).withEffectiveBalance(newBalance));

--- a/infrastructure/crypto/src/main/java/tech/pegasys/teku/infrastructure/crypto/Sha256.java
+++ b/infrastructure/crypto/src/main/java/tech/pegasys/teku/infrastructure/crypto/Sha256.java
@@ -28,6 +28,12 @@ public class Sha256 {
     this.messageDigest = messageDigest;
   }
 
+  public byte[] digest(final byte[] a, final byte[] b) {
+    messageDigest.update(a);
+    messageDigest.update(b);
+    return messageDigest.digest();
+  }
+
   public byte[] digest(final Bytes a, final Bytes b) {
     a.update(messageDigest);
     b.update(messageDigest);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -51,19 +51,21 @@ class SimpleLeafNode implements LeafNode, TreeNode {
   @Override
   public Bytes32 hashTreeRoot() {
     Bytes32 cachedHash = this.cachedHash;
-    if (cachedHash != null) {
-      return cachedHash;
+    if (cachedHash == null) {
+      cachedHash = Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
+      this.cachedHash = cachedHash;
     }
-    return Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
+    return cachedHash;
   }
 
   @Override
   public Bytes32 hashTreeRoot(final Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
-    if (cachedHash != null) {
-      return cachedHash;
+    if (cachedHash == null) {
+      cachedHash = Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
+      this.cachedHash = cachedHash;
     }
-    return Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
+    return cachedHash;
   }
 
   @Override


### PR DESCRIPTION
## Reduce `ArrayWrappingBytes32` Allocations in SSZ Tree Hashing

  ### JMH Benchmark: `updateEffectiveBalancesAndHash`

  **Scenario:** Update effective balance on 2,000 randomly selected validators (out of 400K), then compute `hashTreeRoot()`.

  **JMH args:** `-f 3 -wi 5 -i 10 -w 2s -r 2s -prof gc`
  **JVM:** JDK 21.0.6, OpenJDK 64-Bit Server VM (Zulu), Compiler Blackhole mode

  | Metric | Before (master) | After (optimized) | Delta |
  |---|---|---|---|
  | **Throughput** | 5.518 ± 0.073 ops/s | 5.725 ± 0.030 ops/s | **+3.7%** |
  | **gc.alloc.rate** | 2707.620 ± 36.025 MB/sec | 1697.425 ± 9.000 MB/sec | **-37.3%** |
  | **gc.alloc.rate.norm** | 514,516,233 B/op | 310,923,036 B/op | **-39.6%** |

  ### Mainnet Profiling: async-profiler `alloc` event

  **Conditions:** Mainnet, checkpoint sync, `--ee-endpoint unsafe-test-stub`, all subnets + all custody subnets, `-Xmx10G`, 1 epoch capture after sync completion.

  | Path | Before (samples) | After (samples) | Delta |
  |---|---|---|---|
  | `SszNodeTemplate` → `ArrayWrappingBytes32` | 2,393 | 0 | **-100%** |
  | `SszSuperNode` → `ArrayWrappingBytes32` | 3,945 | 460 | **-88.3%** |
  | `calcHashTreeRoot` / `calculateHashTreeRoot` → `ArrayWrappingBytes32` | 2,530 | 1 | **-99.96%** |
  | `MutableBytes32.create` (right-pad allocs) | 1,046 | 29 | **-97.2%** |

  **Note:** Total alloc samples differ between runs (660K vs 795K) due to network variability. The targeted SSZ hashing paths are deterministic for a given state size, making the
  per-path comparisons reliable.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SSZ Merkle hashing internals to use raw byte arrays and new digest overloads; while aimed at allocation reduction, any subtle hashing/caching bug would affect state roots and consensus behavior.
> 
> **Overview**
> Optimizes SSZ tree hashing for packed nodes by avoiding repeated `Bytes32`/right-padding allocations: `SszNodeTemplate` and `SszSuperNode` now compute intermediate Merkle hashes as raw `byte[32]` and only wrap to `Bytes32` at the end, reusing a precomputed default leaf hash.
> 
> Extends `Sha256` with a `digest(byte[], byte[])` overload to support the new raw-hash path, and fixes `SimpleLeafNode.hashTreeRoot()` to actually return the cached value instead of re-allocating on every call.
> 
> Adds a new JMH benchmark (`updateEffectiveBalancesAndHash`) and trial `@Setup` to model epoch-transition-like validator effective balance updates and pre-warm hashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbd73184b63080c3888e62747f6d8b417fa8973b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->