### PR TITLE
Add getSignedExecutionPayloadEnvelope Beacon API

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
-@Disabled("Integration tests failing in CI")
 public class GetExecutionPayloadEnvelopeIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.beaconrestapi.v1.beacon;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +34,7 @@ public class GetExecutionPayloadEnvelopeIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
 
   @Test
-  public void shouldGetExecutionPayloadEnvelope() throws IOException {
+  public void shouldGetExecutionPayloadEnvelopeAtTheHeadOfTheChain() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.GLOAS);
     final List<SignedBlockAndState> created = createBlocksAtSlots(10);
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.List;
 import okhttp3.Response;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetExecutionPayloadEnvelope;

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.List;
 import okhttp3.Response;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetExecutionPayloadEnvelope;
@@ -37,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
+@Disabled("Integration tests failing in CI")
 public class GetExecutionPayloadEnvelopeIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -14,10 +14,13 @@
 package tech.pegasys.teku.beaconrestapi.v1.beacon;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import okhttp3.Response;
@@ -25,11 +28,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetExecutionPayloadEnvelope;
+import tech.pegasys.teku.ethereum.json.types.EthereumTypes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class GetExecutionPayloadEnvelopeIntegrationTest
@@ -93,6 +98,26 @@ public class GetExecutionPayloadEnvelopeIntegrationTest
         .isEqualTo(chainBuilder.getExecutionPayload(block.getRoot()).orElseThrow());
   }
 
+  @Test
+  public void shouldGetExecutionPayloadEnvelopeAsSsz() throws IOException {
+    final List<SignedBlockAndState> created = createBlocksAtSlots(1, 2, 3);
+
+    final Response response =
+        getResponse(GetExecutionPayloadEnvelope.ROUTE.replace("{block_id}", "head"), OCTET_STREAM);
+
+    assertThat(response.code()).isEqualTo(SC_OK);
+    assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo("gloas");
+
+    final byte[] responseBody = response.body().bytes();
+
+    assertThat(responseBody)
+        .isEqualTo(
+            getExpectedSsz(
+                chainBuilder
+                    .getExecutionPayload(created.getLast().getBlock().getRoot())
+                    .orElseThrow()));
+  }
+
   private SignedExecutionPayloadEnvelope getSignedExecutionPayloadEnvelope(final JsonNode body)
       throws JsonProcessingException {
     return JsonUtil.parse(
@@ -105,5 +130,14 @@ public class GetExecutionPayloadEnvelopeIntegrationTest
 
   private Response get(final String blockIdString) throws IOException {
     return getResponse(GetExecutionPayloadEnvelope.ROUTE.replace("{block_id}", blockIdString));
+  }
+
+  private byte[] getExpectedSsz(final SignedExecutionPayloadEnvelope data) throws IOException {
+    final ExecutionPayloadAndMetaData value =
+        new ExecutionPayloadAndMetaData(data, SpecMilestone.GLOAS, false, false);
+    try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+      EthereumTypes.executionPayloadAndMetaDataSszResponseType().serialize(value, outputStream);
+      return outputStream.toByteArray();
+    }
   }
 }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -21,11 +21,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.List;
 import okhttp3.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetExecutionPayloadEnvelope;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -33,10 +35,14 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 public class GetExecutionPayloadEnvelopeIntegrationTest
     extends AbstractDataBackedRestAPIIntegrationTest {
 
+  @BeforeEach
+  public void setUp() {
+    startRestAPIAtGenesis(SpecMilestone.GLOAS);
+  }
+
   @Test
   public void shouldGetExecutionPayloadEnvelopeAtTheHeadOfTheChain() throws IOException {
-    startRestAPIAtGenesis(SpecMilestone.GLOAS);
-    final List<SignedBlockAndState> created = createBlocksAtSlots(10);
+    final List<SignedBlockAndState> created = createBlocksAtSlots(1, 2, 3);
 
     final Response response = get("head");
     final JsonNode body = OBJECT_MAPPER.readTree(response.body().string());
@@ -47,21 +53,52 @@ public class GetExecutionPayloadEnvelopeIntegrationTest
     assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo("gloas");
 
     final SignedExecutionPayloadEnvelope executionPayloadEnvelope =
-        getSignedExecutionPayloadEnvelope(SpecMilestone.GLOAS, body.get("data").toString());
+        getSignedExecutionPayloadEnvelope(body);
 
-    assertThat(executionPayloadEnvelope.getBeaconBlockRoot())
-        .isEqualTo(created.getLast().getBlock().getRoot());
     assertThat(executionPayloadEnvelope)
         .isEqualTo(
             chainBuilder.getExecutionPayload(created.getLast().getBlock().getRoot()).orElseThrow());
   }
 
-  private SignedExecutionPayloadEnvelope getSignedExecutionPayloadEnvelope(
-      final SpecMilestone milestone, final String data) throws JsonProcessingException {
-    System.out.println(data);
+  @Test
+  public void shouldGetExecutionPayloadEnvelopeByBlockRoot() throws IOException {
+    final List<SignedBlockAndState> created = createBlocksAtSlots(1, 2, 3);
+
+    final SignedBeaconBlock block = created.get(1).getBlock();
+
+    final Response response = get(block.getRoot().toHexString());
+    final JsonNode body = OBJECT_MAPPER.readTree(response.body().string());
+
+    final SignedExecutionPayloadEnvelope executionPayloadEnvelope =
+        getSignedExecutionPayloadEnvelope(body);
+
+    assertThat(executionPayloadEnvelope)
+        .isEqualTo(chainBuilder.getExecutionPayload(block.getRoot()).orElseThrow());
+  }
+
+  @Test
+  public void shouldGetExecutionPayloadEnvelopeBySlot() throws IOException {
+    final List<SignedBlockAndState> created = createBlocksAtSlots(1, 2, 3);
+
+    final SignedBeaconBlock block = created.get(1).getBlock();
+
+    final Response response = get("2");
+
+    final JsonNode body = OBJECT_MAPPER.readTree(response.body().string());
+
+    final SignedExecutionPayloadEnvelope executionPayloadEnvelope =
+        getSignedExecutionPayloadEnvelope(body);
+
+    assertThat(executionPayloadEnvelope)
+        .isEqualTo(chainBuilder.getExecutionPayload(block.getRoot()).orElseThrow());
+  }
+
+  private SignedExecutionPayloadEnvelope getSignedExecutionPayloadEnvelope(final JsonNode body)
+      throws JsonProcessingException {
     return JsonUtil.parse(
-        data,
-        SchemaDefinitionsGloas.required(spec.forMilestone(milestone).getSchemaDefinitions())
+        body.get("data").toString(),
+        SchemaDefinitionsGloas.required(
+                spec.forMilestone(SpecMilestone.GLOAS).getSchemaDefinitions())
             .getSignedExecutionPayloadEnvelopeSchema()
             .getJsonTypeDefinition());
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetExecutionPayloadEnvelopeIntegrationTest.java
@@ -1,0 +1,59 @@
+package tech.pegasys.teku.beaconrestapi.v1.beacon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetExecutionPayloadEnvelope;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+public class GetExecutionPayloadEnvelopeIntegrationTest
+    extends AbstractDataBackedRestAPIIntegrationTest {
+
+  @Test
+  public void shouldGetExecutionPayloadEnvelope() throws IOException {
+    startRestAPIAtGenesis(SpecMilestone.GLOAS);
+    final List<SignedBlockAndState> created = createBlocksAtSlots(10);
+
+    final Response response = get("head");
+    final JsonNode body = OBJECT_MAPPER.readTree(response.body().string());
+
+    assertThat(body.get("version").asText()).isEqualTo("gloas");
+    assertThat(body.get("execution_optimistic").asBoolean()).isFalse();
+    assertThat(body.get("finalized").asBoolean()).isFalse();
+    assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo("gloas");
+
+    final SignedExecutionPayloadEnvelope executionPayloadEnvelope =
+        getSignedExecutionPayloadEnvelope(SpecMilestone.GLOAS, body.get("data").toString());
+
+    assertThat(executionPayloadEnvelope.getBeaconBlockRoot())
+        .isEqualTo(created.getLast().getBlock().getRoot());
+    assertThat(executionPayloadEnvelope)
+        .isEqualTo(
+            chainBuilder.getExecutionPayload(created.getLast().getBlock().getRoot()).orElseThrow());
+  }
+
+  private SignedExecutionPayloadEnvelope getSignedExecutionPayloadEnvelope(
+      final SpecMilestone milestone, final String data) throws JsonProcessingException {
+    System.out.println(data);
+    return JsonUtil.parse(
+        data,
+        SchemaDefinitionsGloas.required(spec.forMilestone(milestone).getSchemaDefinitions())
+            .getSignedExecutionPayloadEnvelopeSchema()
+            .getJsonTypeDefinition());
+  }
+
+  private Response get(final String blockIdString) throws IOException {
+    return getResponse(GetExecutionPayloadEnvelope.ROUTE.replace("{block_id}", blockIdString));
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_execution_payload_envelope_{block_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_execution_payload_envelope_{block_id}.json
@@ -1,0 +1,84 @@
+{
+  "get": {
+    "tags": [
+      "Beacon"
+    ],
+    "operationId": "getSignedExecutionPayloadEnvelope",
+    "summary": "Get signed execution payload envelope",
+    "description": "Retrieves signed execution payload envelope for a given block id.",
+    "parameters": [
+      {
+        "name": "block_id",
+        "required": true,
+        "in": "path",
+        "schema": {
+          "type": "string",
+          "description": "Block identifier. Can be one of: \"head\" (canonical head in node's view), \"genesis\", \"finalized\", &lt;slot&gt;, &lt;hex encoded blockRoot with 0x prefix&gt;.",
+          "example": "head"
+        }
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Request successful",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GetExecutionPayloadEnvelopeResponse"
+            }
+          },
+          "application/octet-stream": {
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "Not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "503": {
+        "description": "Service unavailable",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "204": {
+        "description": "Data is unavailable because the chain has not yet reached genesis",
+        "content": {}
+      },
+      "400": {
+        "description": "The request could not be processed, check the response for more information.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "500": {
+        "description": "Internal server error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadEnvelope.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadEnvelope.json
@@ -1,0 +1,37 @@
+{
+  "title" : "ExecutionPayloadEnvelope",
+  "type" : "object",
+  "required" : [ "payload", "execution_requests", "builder_index", "beacon_block_root", "slot", "state_root" ],
+  "properties" : {
+    "payload" : {
+      "$ref" : "#/components/schemas/ExecutionPayloadDeneb"
+    },
+    "execution_requests" : {
+      "$ref" : "#/components/schemas/ExecutionRequestsElectra"
+    },
+    "builder_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "beacon_block_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetExecutionPayloadEnvelopeResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetExecutionPayloadEnvelopeResponse.json
@@ -1,0 +1,24 @@
+{
+  "title" : "GetExecutionPayloadEnvelopeResponse",
+  "type" : "object",
+  "required" : [ "version", "execution_optimistic", "finalized", "data" ],
+  "properties" : {
+    "version" : {
+      "type" : "string",
+      "enum" : [ "phase0", "altair", "bellatrix", "capella", "deneb", "electra", "fulu", "gloas" ]
+    },
+    "execution_optimistic" : {
+      "type" : "boolean"
+    },
+    "finalized" : {
+      "type" : "boolean"
+    },
+    "data" : {
+      "title" : "SignedExecutionPayloadEnvelope",
+      "type" : "object",
+      "oneOf" : [ {
+        "$ref" : "#/components/schemas/SignedExecutionPayloadEnvelope"
+      } ]
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedExecutionPayloadEnvelope.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedExecutionPayloadEnvelope.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedExecutionPayloadEnvelope",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/ExecutionPayloadEnvelope"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
 import tech.pegasys.teku.beaconrestapi.addon.CapellaRestApiBuilderAddon;
 import tech.pegasys.teku.beaconrestapi.addon.DenebRestApiBuilderAddon;
 import tech.pegasys.teku.beaconrestapi.addon.FuluRestApiBuilderAddon;
+import tech.pegasys.teku.beaconrestapi.addon.GloasRestApiBuilderAddon;
 import tech.pegasys.teku.beaconrestapi.addon.LightClientRestApiBuilderAddon;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.AddPeer;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
@@ -350,6 +351,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             new CapellaRestApiBuilderAddon(spec, dataProvider, schemaCache),
             new DenebRestApiBuilderAddon(spec, dataProvider, schemaCache),
             new FuluRestApiBuilderAddon(spec, dataProvider, schemaCache),
+            new GloasRestApiBuilderAddon(spec, dataProvider, schemaCache),
             new LightClientRestApiBuilderAddon(config, dataProvider, schemaCache));
 
     RestApiBuilder builderUpdated = builder;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/addon/GloasRestApiBuilderAddon.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/addon/GloasRestApiBuilderAddon.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.addon;
+
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.beaconrestapi.RestApiBuilderAddon;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetExecutionPayloadEnvelope;
+import tech.pegasys.teku.infrastructure.restapi.RestApiBuilder;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+
+public class GloasRestApiBuilderAddon implements RestApiBuilderAddon {
+
+  final Spec spec;
+  final DataProvider dataProvider;
+  final SchemaDefinitionCache schemaCache;
+
+  public GloasRestApiBuilderAddon(
+      final Spec spec, final DataProvider dataProvider, final SchemaDefinitionCache schemaCache) {
+    this.spec = spec;
+    this.dataProvider = dataProvider;
+    this.schemaCache = schemaCache;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return spec.isMilestoneSupported(SpecMilestone.GLOAS);
+  }
+
+  @Override
+  public RestApiBuilder apply(final RestApiBuilder builder) {
+    return builder.endpoint(new GetExecutionPayloadEnvelope(dataProvider, schemaCache));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BLOCK_ID;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
-import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.sszResponseType;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.executionPayloadAndMetaDataSszResponseType;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.FINALIZED;
@@ -65,7 +65,7 @@ public class GetExecutionPayloadEnvelope extends RestApiEndpoint {
                 SC_OK,
                 "Request successful",
                 getResponseType(schemaDefinitionCache),
-                sszResponseType())
+                executionPayloadAndMetaDataSszResponseType())
             .withNotFoundResponse()
             .withChainDataResponses()
             .build());

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
@@ -13,19 +13,6 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
-/*
- * Copyright Consensys Software Inc., 2022
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
- */
-
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BLOCK_ID;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelope.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BLOCK_ID;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.sszResponseType;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.FINALIZED;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+public class GetExecutionPayloadEnvelope extends RestApiEndpoint {
+
+  public static final String ROUTE = "/eth/v1/beacon/execution_payload_envelope/{block_id}";
+
+  private final ChainDataProvider chainDataProvider;
+
+  public GetExecutionPayloadEnvelope(
+      final DataProvider dataProvider, final SchemaDefinitionCache schemaDefinitionCache) {
+    this(dataProvider.getChainDataProvider(), schemaDefinitionCache);
+  }
+
+  public GetExecutionPayloadEnvelope(
+      final ChainDataProvider chainDataProvider,
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    super(
+        EndpointMetadata.get(ROUTE)
+            .operationId("getSignedExecutionPayloadEnvelope")
+            .summary("Get signed execution payload envelope")
+            .description("Retrieves signed execution payload envelope for a given block id.")
+            .tags(TAG_BEACON)
+            .pathParam(PARAMETER_BLOCK_ID)
+            .response(
+                SC_OK,
+                "Request successful",
+                getResponseType(schemaDefinitionCache),
+                sszResponseType())
+            .withNotFoundResponse()
+            .withChainDataResponses()
+            .build());
+    this.chainDataProvider = chainDataProvider;
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    final SafeFuture<Optional<ExecutionPayloadAndMetaData>> future =
+        chainDataProvider.getExecutionPayloadEnvelope(request.getPathParameter(PARAMETER_BLOCK_ID));
+
+    request.respondAsync(
+        future.thenApply(
+            maybeExecutionPayloadEnvelopeAndMetaData ->
+                maybeExecutionPayloadEnvelopeAndMetaData
+                    .map(
+                        executionPayloadEnvelopeAndMetaData -> {
+                          request.header(
+                              HEADER_CONSENSUS_VERSION,
+                              executionPayloadEnvelopeAndMetaData.milestone().lowerCaseName());
+                          return AsyncApiResponse.respondOk(executionPayloadEnvelopeAndMetaData);
+                        })
+                    .orElseGet(AsyncApiResponse::respondNotFound)));
+  }
+
+  private static SerializableTypeDefinition<ExecutionPayloadAndMetaData> getResponseType(
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    final SerializableTypeDefinition<SignedExecutionPayloadEnvelope>
+        signedExecutionPayloadEnvelopeType =
+            getSchemaDefinitionForAllSupportedMilestones(
+                schemaDefinitionCache,
+                "SignedExecutionPayloadEnvelope",
+                __ ->
+                    SchemaDefinitionsGloas.required(
+                            schemaDefinitionCache.getSchemaDefinition(SpecMilestone.GLOAS))
+                        .getSignedExecutionPayloadEnvelopeSchema(),
+                (signedExecutionPayloadEnvelope, milestone) ->
+                    schemaDefinitionCache
+                        .milestoneAtSlot(signedExecutionPayloadEnvelope.getMessage().getSlot())
+                        .equals(milestone));
+
+    return SerializableTypeDefinition.<ExecutionPayloadAndMetaData>object()
+        .name("GetExecutionPayloadEnvelopeResponse")
+        .withField("version", MILESTONE_TYPE, ExecutionPayloadAndMetaData::milestone)
+        .withField(
+            EXECUTION_OPTIMISTIC, BOOLEAN_TYPE, ExecutionPayloadAndMetaData::executionOptimistic)
+        .withField(FINALIZED, BOOLEAN_TYPE, ExecutionPayloadAndMetaData::finalized)
+        .withField("data", signedExecutionPayloadEnvelopeType, ExecutionPayloadAndMetaData::data)
+        .build();
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelopeTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelopeTest.java
@@ -33,12 +33,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
 import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
-import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
-
-import javax.validation.metadata.ExecutableDescriptor;
 
 class GetExecutionPayloadEnvelopeTest
     extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelopeTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetExecutionPayloadEnvelopeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseStringFromMetadata;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataEmptyResponse;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.io.Resources;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
+import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+
+import javax.validation.metadata.ExecutableDescriptor;
+
+class GetExecutionPayloadEnvelopeTest
+    extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
+
+  @BeforeEach
+  void setup() {
+    initialise(SpecMilestone.GLOAS);
+    genesis();
+
+    setHandler(new GetExecutionPayloadEnvelope(chainDataProvider, schemaDefinitionCache));
+    request.setPathParameter("block_id", "head");
+  }
+
+  @Test
+  void metadata_shouldHandle400() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_BAD_REQUEST);
+  }
+
+  @Test
+  void metadata_shouldHandle404() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_NOT_FOUND);
+  }
+
+  @Test
+  void metadata_shouldHandle500() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void metadata_shouldHandle200() throws Exception {
+    final SignedExecutionPayloadEnvelope executionPayloadEnvelope =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(1);
+    final ExecutionPayloadAndMetaData responseData =
+        new ExecutionPayloadAndMetaData(
+            executionPayloadEnvelope, spec.getGenesisSpec().getMilestone(), false, false);
+    final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
+    final JsonNode responseDataAsJsonNode = JsonTestUtil.parseAsJsonNode(data);
+    final String expected =
+        Resources.toString(
+            Resources.getResource(
+                GetExecutionPayloadEnvelopeTest.class, "getExecutionPayload.json"),
+            UTF_8);
+    final JsonNode expectedAsJsonNode = JsonTestUtil.parseAsJsonNode(expected);
+    assertThat(responseDataAsJsonNode).isEqualTo(expectedAsJsonNode);
+  }
+
+  @Test
+  void metadata_shouldHandle204() {
+    verifyMetadataEmptyResponse(handler, SC_NO_CONTENT);
+  }
+
+  @Test
+  void metadata_shouldHandle503() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_SERVICE_UNAVAILABLE);
+  }
+}

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
@@ -1,0 +1,74 @@
+{
+  "version": "gloas",
+  "execution_optimistic": false,
+  "finalized": false,
+  "data": {
+    "message": {
+      "payload": {
+        "parent_hash": "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef",
+        "fee_recipient": "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d",
+        "state_root": "0x103ac9406cdc59b89027eb1c9e97f607dd5fdccfa8fb2da4eaeea9d25032add9",
+        "receipts_root": "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a938e7f946cf74fbbb9416428f",
+        "logs_bloom": "0x8200a6402ca295554fb9562193cc71d60272d63beeaf2201fdf53e846e77f919f9baec48b037438512f21e75157c9bae6a09b5c486a1490ce72c45ff9ade728dd88b8abf34dfacbd855264120cea4f17f8b11544cfb01b897ccda2c8b1bfcd2da844e16ea30f6dd1f321317193169b19208914dd57e37159006682033def101b66e3cf524f654aae3a6b2375c63f9af207ac8cff51d623788b6de2360edc1bd5032db8ff6a6a69b14a5bc2d6471ebcbd08facc61128fbdff880a52b8b7135e46e317ad398eefbee7a9efb0e5bb311c8b33a7321295dbee96362910de0ed74ac75f06142a36f444acf2f417c44b1d4b84c99e9369f842560a2ae28684b0befa4f",
+        "prev_randao": "0x499db7404cbff78670f0209f1932346fef68d985cb55a8d27472742bdf54d379",
+        "block_number": "4661716390776343276",
+        "gas_limit": "4600574485989226763",
+        "gas_used": "4598922002772542634",
+        "timestamp": "4603879456717562315",
+        "extra_data": "0x0c65de3f6bad3d7be19d0de5aff82b13d6d8b49f26588dba111e361d6f545486",
+        "base_fee_per_gas": "48416477019128246725380374409950726173176617399493993885769417069594850945339",
+        "block_hash": "0x7e2bbb3f2a737918a12f79e9a52da7e1fceaae0b6c0c82172425cbce8d99a0c6",
+        "transactions": [
+          "0xb88ea93f0a5617"
+        ],
+        "withdrawals": [
+          {
+            "index": "4589007099177470570",
+            "validator_index": "2268866",
+            "address": "0x17348c3f2ad0733f4b47b34442744b4a2e03a79b",
+            "amount": "4584049649527418186"
+          }
+        ],
+        "blob_gas_used": "4582397162015766762",
+        "excess_blob_gas": "4627014230341074699"
+      },
+      "execution_requests": {
+        "deposits": [
+          {
+            "pubkey": "0x957b584f85a85a770a334e18e8af755406089824d3558487983161a8cb61b6503b02e939f75407c3b8bbbbd9d4e9ad15",
+            "withdrawal_credentials": "0x0100000000000000000000003af91e408b6da58558bd9d0797174a4392b7bf59",
+            "amount": "4618751809962686763",
+            "signature": "0xadd071eb32731713b9040770807acb7033344aafc6df54ebf8a790187ddc947e2bb06a9547eb7c3876533720f36e54761018488a3857bb1d87175f7905620088fd81593465b7139e794f75bba0daaef713a9b7bec99656073c1396866d35f9b0",
+            "index": "4622056780691022315"
+          },
+          {
+            "pubkey": "0xb8b37b9a8444d8405693cf5decca1fac4ce06a5646b785702a27592b853689c5545b8c2d9054ee0e4e67ed45092981e4",
+            "withdrawal_credentials": "0x010000000000000000000000603b1340cb04640f42436c5e3e2973dd9ebdbd7d",
+            "amount": "4615446843529318507",
+            "signature": "0xb2213ef588828a7c18cdc781d0ed2516fd3e11de625f191aae7ae4be8b1ad2cc217728c65a500aedea276d345f09fd3212b009568a6549f5f40ead6d7ec4d0f3f329c00a1b4bca59068ee0555c94aec91bebc18365ca0b2d6692557b4b0c4267",
+            "index": "4605531939934246443"
+          }
+        ],
+        "withdrawals": [
+          {
+            "source_address": "0x82a81c3f096d065c7e3f5d7df79bd182a53c9471",
+            "validator_pubkey": "0x922b5a6e6f8f6e9d69b523e4516a54a5bd20f0b44ef34d102fca67bcf98e0785cccc29e4b275900ec8aebaa50f3e024c",
+            "amount": "4550999968013866441"
+          }
+        ],
+        "consolidations": [
+          {
+            "source_address": "0xe24dff3e29e762b4488e615619483884c44b8f4b",
+            "source_pubkey": "0x953a8de3dcd4d3de3c66b228c393694124651a7a3068fa0fd70ec051e42b8f53eb753d04e6101ab4374b65a79d71400f",
+            "target_pubkey": "0xa3a76501f1755df6cddb593cf2b7d6180426e55dfdb83e167be72f9d4596645edd7f861a34b482606e238f8530d4ddc1"
+          }
+        ]
+      },
+      "builder_index": "2882381",
+      "beacon_block_root": "0x2ed2e73ea915e0c71d9afe03676b8ab8dd578b9311463e45934f49f843386a48",
+      "slot": "1",
+      "state_root": "0xf56ef93ec93242f93dd1c881ecd04c51ca4e8eddeeebc3160acc7e9fb41544a8"
+    },
+    "signature": "0xab3a58bfd1c22804ef873a2649c06a702348f3321f34ccc8077566e4400874269dd30dd5d65ff7178d6bf7ada6d09567110517564bfbb7f9947797dfd8fa1c15a1c7593ef92369c9b3050ee2ddf8308628d176eb537696f7914a5d2a94622496"
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.datacolumnselector.DataColumnSidecarSelectorFactory;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
+import tech.pegasys.teku.api.executionpayloadselector.ExecutionPayloadSelectorFactory;
 import tech.pegasys.teku.api.fulu.ColumnCustodyAtSlot;
 import tech.pegasys.teku.api.migrated.AttestationRewardsData;
 import tech.pegasys.teku.api.migrated.BlockHeadersResponse;
@@ -75,6 +76,7 @@ import tech.pegasys.teku.spec.datastructures.metadata.BlobSidecarsAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlobsAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.DataColumnSidecarsAndMetaData;
+import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -100,6 +102,7 @@ public class ChainDataProvider {
   private final BlobSidecarSelectorFactory blobSidecarSelectorFactory;
   private final BlobSelectorFactory blobSelectorFactory;
   private final DataColumnSidecarSelectorFactory dataColumnSidecarSelectorFactory;
+  private final ExecutionPayloadSelectorFactory executionPayloadSelectorFactory;
   private final Spec spec;
   private final CombinedChainDataClient combinedChainDataClient;
   private final RecentChainData recentChainData;
@@ -122,6 +125,7 @@ public class ChainDataProvider {
             spec, combinedChainDataClient, blobSidecarReconstructionProvider),
         new BlobSelectorFactory(spec, combinedChainDataClient, blobReconstructionProvider),
         new DataColumnSidecarSelectorFactory(spec, combinedChainDataClient),
+        new ExecutionPayloadSelectorFactory(spec, combinedChainDataClient),
         rewardCalculator);
   }
 
@@ -135,6 +139,7 @@ public class ChainDataProvider {
       final BlobSidecarSelectorFactory blobSidecarSelectorFactory,
       final BlobSelectorFactory blobSelectorFactory,
       final DataColumnSidecarSelectorFactory dataColumnSidecarSelectorFactory,
+      final ExecutionPayloadSelectorFactory executionPayloadSelectorFactory,
       final RewardCalculator rewardCalculator) {
     this.spec = spec;
     this.combinedChainDataClient = combinedChainDataClient;
@@ -144,6 +149,7 @@ public class ChainDataProvider {
     this.blobSidecarSelectorFactory = blobSidecarSelectorFactory;
     this.blobSelectorFactory = blobSelectorFactory;
     this.dataColumnSidecarSelectorFactory = dataColumnSidecarSelectorFactory;
+    this.executionPayloadSelectorFactory = executionPayloadSelectorFactory;
     this.rewardCalculator = rewardCalculator;
   }
 
@@ -232,6 +238,13 @@ public class ChainDataProvider {
     return dataColumnSidecarSelectorFactory
         .createSelectorForBlockId(blockIdParam)
         .getDataColumnSidecars(indices);
+  }
+
+  public SafeFuture<Optional<ExecutionPayloadAndMetaData>> getExecutionPayloadEnvelope(
+      final String blockIdParam) {
+    return executionPayloadSelectorFactory
+        .createSelectorForBlockId(blockIdParam)
+        .getExecutionPayload();
   }
 
   public SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> getBlockRoot(final String blockIdParam) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelector.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.executionpayloadselector;
+
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
+
+public interface ExecutionPayloadSelector {
+
+  SafeFuture<Optional<ExecutionPayloadAndMetaData>> getExecutionPayload();
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelectorFactory.java
@@ -55,6 +55,11 @@ public class ExecutionPayloadSelectorFactory
 
   // TODO-GLOAS: http://github.com/Consensys/teku/issues/9997
   @Override
+  public ExecutionPayloadSelector genesisSelector() {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
   public ExecutionPayloadSelector finalizedSelector() {
     throw new UnsupportedOperationException("Not yet implemented");
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/executionpayloadselector/ExecutionPayloadSelectorFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.executionpayloadselector;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.AbstractSelectorFactory;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
+import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class ExecutionPayloadSelectorFactory
+    extends AbstractSelectorFactory<ExecutionPayloadSelector> {
+
+  private final Spec spec;
+
+  public ExecutionPayloadSelectorFactory(final Spec spec, final CombinedChainDataClient client) {
+    super(client);
+    this.spec = spec;
+  }
+
+  @Override
+  public ExecutionPayloadSelector blockRootSelector(final Bytes32 blockRoot) {
+    return () -> client.getExecutionPayloadByBlockRoot(blockRoot).thenApply(this::addMetaData);
+  }
+
+  @Override
+  public ExecutionPayloadSelector headSelector() {
+    return () ->
+        client
+            .getChainHead()
+            .map(
+                chainHead ->
+                    client
+                        .getExecutionPayloadByBlockRoot(chainHead.getRoot())
+                        .thenApply(
+                            maybeExecutionPayload -> addMetaData(maybeExecutionPayload, chainHead)))
+            .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  // TODO-GLOAS: http://github.com/Consensys/teku/issues/9997
+  @Override
+  public ExecutionPayloadSelector finalizedSelector() {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public ExecutionPayloadSelector justifiedSelector() {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public ExecutionPayloadSelector slotSelector(final UInt64 slot) {
+    return () ->
+        client
+            .getChainHead()
+            .map(
+                chainHead ->
+                    client
+                        .getExecutionPayloadAtSlotExact(slot, chainHead.getRoot())
+                        .thenApply(
+                            maybeExecutionPayload -> addMetaData(maybeExecutionPayload, chainHead)))
+            .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  private Optional<ExecutionPayloadAndMetaData> addMetaData(
+      final Optional<SignedExecutionPayloadEnvelope> maybeExecutionPayload) {
+    // Ensure we use the same chain head when calculating metadata to ensure a consistent view.
+    return client
+        .getChainHead()
+        .flatMap(chainHead -> addMetaData(maybeExecutionPayload, chainHead));
+  }
+
+  private Optional<ExecutionPayloadAndMetaData> addMetaData(
+      final Optional<SignedExecutionPayloadEnvelope> maybeExecutionPayload,
+      final ChainHead chainHead) {
+    return maybeExecutionPayload.map(
+        executionPayload ->
+            new ExecutionPayloadAndMetaData(
+                executionPayload,
+                spec.atSlot(executionPayload.getSlot()).getMilestone(),
+                chainHead.isOptimistic()
+                    || client.isOptimisticBlock(executionPayload.getBeaconBlockRoot()),
+                client.isFinalized(executionPayload.getSlot())));
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.api.blobselector.BlobSelectorFactory;
 import tech.pegasys.teku.api.blobselector.BlobSidecarSelectorFactory;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.datacolumnselector.DataColumnSidecarSelectorFactory;
+import tech.pegasys.teku.api.executionpayloadselector.ExecutionPayloadSelectorFactory;
 import tech.pegasys.teku.api.stateselector.StateSelectorFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -63,6 +64,7 @@ public abstract class AbstractChainDataProviderTest {
   protected BlobSidecarSelectorFactory blobSidecarSelectorFactory;
   protected BlobSelectorFactory blobSelectorFactory;
   protected DataColumnSidecarSelectorFactory dataColumnSidecarSelectorFactory;
+  protected ExecutionPayloadSelectorFactory executionPayloadSelectorFactory;
   protected StateSelectorFactory stateSelectorFactory;
   protected BeaconState beaconStateInternal;
   protected SignedBlockAndState bestBlock;
@@ -123,6 +125,8 @@ public abstract class AbstractChainDataProviderTest {
                 spec, mockCombinedChainDataClient, mockBlobReconstructionProvider));
     this.dataColumnSidecarSelectorFactory =
         spy(new DataColumnSidecarSelectorFactory(spec, mockCombinedChainDataClient));
+    this.executionPayloadSelectorFactory =
+        spy(new ExecutionPayloadSelectorFactory(spec, mockCombinedChainDataClient));
     final ChainDataProvider provider =
         new ChainDataProvider(
             spec,
@@ -133,6 +137,7 @@ public abstract class AbstractChainDataProviderTest {
             blobSidecarSelectorFactory,
             blobSelectorFactory,
             dataColumnSidecarSelectorFactory,
+            executionPayloadSelectorFactory,
             rewardCalculatorMock);
 
     if (spec.getGenesisSpec().getMilestone().isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
+import tech.pegasys.teku.spec.datastructures.metadata.ExecutionPayloadAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
@@ -147,6 +148,13 @@ public class EthereumTypes {
     return new OctetStreamResponseContentTypeDefinition<>(
         (data, out) -> data.blockContainer().sszSerialize(out),
         value -> getSszHeaders(__ -> value.specMilestone(), value.blockContainer()));
+  }
+
+  public static ResponseContentTypeDefinition<ExecutionPayloadAndMetaData>
+      executionPayloadAndMetaDataSszResponseType() {
+    return new OctetStreamResponseContentTypeDefinition<>(
+        (value, out) -> value.data().sszSerialize(out),
+        value -> getSszHeaders(__ -> value.milestone(), value.data()));
   }
 
   public static <T extends SszData> ResponseContentTypeDefinition<T> sszResponseType(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/ExecutionPayloadAndMetaData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/metadata/ExecutionPayloadAndMetaData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.metadata;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public record ExecutionPayloadAndMetaData(
+    SignedExecutionPayloadEnvelope data,
+    SpecMilestone milestone,
+    boolean executionOptimistic,
+    boolean finalized) {}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -192,6 +192,8 @@ public class BeaconBlocksByRangeMessageHandler
               final UInt64 headSlot = hotRoots.isEmpty() ? headBlockSlot : hotRoots.lastKey();
               final RequestState initialState =
                   new RequestState(startSlot, step, count, headSlot, hotRoots, callback);
+              // there is an edge case when startSlot == headSlot in which case we don't return
+              // anything
               if (initialState.isComplete()) {
                 return SafeFuture.completedFuture(initialState);
               }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -64,6 +64,8 @@ public class CombinedChainDataClient {
       completedFuture(Optional.empty());
   private static final SafeFuture<Optional<SignedBeaconBlock>> BLOCK_NOT_AVAILABLE =
       completedFuture(Optional.empty());
+  private static final SafeFuture<Optional<SignedExecutionPayloadEnvelope>>
+      EXECUTION_PAYLOAD_NOT_AVAILABLE = completedFuture(Optional.empty());
 
   private final RecentChainData recentChainData;
   private final StorageQueryChannel historicalChainData;
@@ -129,6 +131,39 @@ public class CombinedChainDataClient {
                     .thenApply(
                         maybeBlock -> maybeBlock.filter(block -> block.getSlot().equals(slot))))
         .orElseGet(() -> historicalChainData.getFinalizedBlockAtSlot(slot));
+  }
+
+  /**
+   * Returns the execution payload envelope proposed for the requested slot on the chain identified
+   * by <code>headBlockRoot</code>. If the slot was empty or the payload was absent, no execution
+   * payload is returned.
+   *
+   * @param slot the slot to get the execution payload for
+   * @param headBlockRoot the block root of the head of the chain
+   * @return the execution payload at the requested slot or empty if the slot was empty or the
+   *     payload was absent
+   */
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> getExecutionPayloadAtSlotExact(
+      final UInt64 slot, final Bytes32 headBlockRoot) {
+    if (!isStoreAvailable()) {
+      return EXECUTION_PAYLOAD_NOT_AVAILABLE;
+    }
+
+    // Try to pull root from recent data
+    return recentChainData
+        .getBlockRootInEffectBySlot(slot, headBlockRoot)
+        .map(
+            blockRoot ->
+                getExecutionPayloadByBlockRoot(blockRoot)
+                    .thenApply(
+                        maybeBlock -> maybeBlock.filter(block -> block.getSlot().equals(slot))))
+        .orElseGet(
+            () -> {
+              // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 query for an execution
+              // payload for a finalized slot from the  historical chain data
+              return SafeFuture.failedFuture(
+                  new UnsupportedOperationException("Not yet implemented"));
+            });
   }
 
   public SafeFuture<Optional<SignedBeaconBlock>> getBlockInEffectAtSlot(final UInt64 slot) {
@@ -555,7 +590,7 @@ public class CombinedChainDataClient {
                 return SafeFuture.completedFuture(maybeExecutionPayload);
               }
               // TODO-GLOAS: https://github.com/Consensys/teku/issues/10098 query for an execution
-              // payload from the historical chain data
+              // payload by block root from the historical chain data
               return SafeFuture.failedFuture(
                   new UnsupportedOperationException("Not yet implemented"));
             });


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Equivalent to https://github.com/Consensys/teku/pull/10376 . I want to see if CI passes.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive API/plumbing, but it introduces new data-access paths and has unimplemented selector/historical branches that can throw `UnsupportedOperationException` for some block IDs or finalized slots.
> 
> **Overview**
> Adds a new Beacon REST endpoint, `GET /eth/v1/beacon/execution_payload_envelope/{block_id}`, returning a `SignedExecutionPayloadEnvelope` plus `version`, `execution_optimistic`, and `finalized` metadata, and supporting both JSON and SSZ (`application/octet-stream`) with the `Eth-Consensus-Version` header set from the payload’s milestone.
> 
> Wires the endpoint behind a new `GloasRestApiBuilderAddon` (enabled only when `SpecMilestone.GLOAS` is supported) and introduces a new execution-payload selection path (`ExecutionPayloadSelectorFactory` + `ChainDataProvider.getExecutionPayloadEnvelope`) backed by `CombinedChainDataClient` methods to fetch envelopes by block root or exact slot (historical/finalized/genesis selectors are explicitly *not yet implemented* and may throw). Integration/unit tests and OpenAPI path/schema fixtures are added to validate behavior and response shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0c441bb8e861345028f9ee8996c292acf6ebf8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->