### PR TITLE
fixed parentPayloadStatus to be asynchronous

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -144,6 +144,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         TestDataUtils.loadStateFromSsz(testDefinition, "anchor_state" + SSZ_SNAPPY_EXTENSION);
     final SignedBeaconBlock anchorBlock = loadAnchorBlock(testDefinition);
 
+    LOG.debug(
+        "AnchorState: {}, anchorBlock: {}", anchorState.hashTreeRoot(), anchorBlock.getRoot());
+
     final StorageSystem storageSystem =
         InMemoryStorageSystemBuilder.create().specProvider(spec).build();
     final RecentChainData recentChainData = storageSystem.recentChainData();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatus.PAYLOAD_STATUS_EMPTY;
 
 import java.util.Optional;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -134,15 +133,15 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
                 throw new IllegalStateException("Parent block not found: " + block.getParentRoot());
               }
               final BeaconBlock parent = maybeParentBlock.get();
-              final BeaconBlockBodyGloas blockBody = BeaconBlockBodyGloas.required(block.getBody());
-              final BeaconBlockBodyGloas parentBody =
-                  BeaconBlockBodyGloas.required(parent.getBody());
               // TODO-GLOAS: https://github.com/Consensys/teku/issues/10341
               // if the parent is pre-gloas, we'd use the block state,
               // there would be no payload state
               if (parent.getSlot().isLessThan(earliestGloasSlot)) {
                 return PAYLOAD_STATUS_EMPTY;
               }
+              final BeaconBlockBodyGloas blockBody = BeaconBlockBodyGloas.required(block.getBody());
+              final BeaconBlockBodyGloas parentBody =
+                  BeaconBlockBodyGloas.required(parent.getBody());
               final Bytes32 parentBlockHash =
                   blockBody.getSignedExecutionPayloadBid().getMessage().getParentBlockHash();
               final Bytes32 messageBlockHash =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -100,18 +102,15 @@ class ForkChoiceUtilGloasTest {
     when(store.retrieveBlock(currentBlock.getParentRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
-    // Test
     final SafeFuture<Boolean> result =
-        forkChoiceUtil
-            .isParentNodeFull(store, currentBlock.getMessage())
-            .exceptionally(
-                t -> {
-                  assertThat(t.getCause())
-                      .isInstanceOf(IllegalStateException.class)
-                      .hasMessage("Parent block not found");
-                  return null;
-                });
+        forkChoiceUtil.isParentNodeFull(store, currentBlock.getMessage());
+
     assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join)
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .cause()
+        .hasMessageStartingWith("Parent block not found");
   }
 
   @Test
@@ -170,18 +169,15 @@ class ForkChoiceUtilGloasTest {
     when(store.retrieveBlock(currentBlock.getParentRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
-    // Test
     final SafeFuture<Boolean> result =
-        forkChoiceUtil
-            .isParentNodeFull(store, currentBlock.getMessage())
-            .exceptionally(
-                t -> {
-                  assertThat(t.getCause())
-                      .isInstanceOf(IllegalStateException.class)
-                      .hasMessage("Parent block not found");
-                  return null;
-                });
+        forkChoiceUtil.isParentNodeFull(store, currentBlock.getMessage());
+
     assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join)
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .cause()
+        .hasMessageStartingWith("Parent block not found");
   }
 
   // Helper methods to create blocks with specific properties

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -213,8 +213,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final ExecutionLayerChannel executionLayer) {
     recentChainData.setBlockTimelinessIfEmpty(block);
     final ForkChoiceUtil forkChoiceUtil = spec.atSlot(block.getSlot()).getForkChoiceUtil();
-    return forkChoiceUtil
-        .retrievePreStateRequiredOnBlock(recentChainData.getStore(), block)
+    return recentChainData
+        .retrieveBlockState(new SlotAndBlockRoot(block.getSlot(), block.getParentRoot()))
         .thenPeek(__ -> blockImportPerformance.ifPresent(BlockImportPerformance::preStateRetrieved))
         .thenCompose(
             blockSlotState ->


### PR DESCRIPTION
Needed to allow the pre-state for fork choice gloas tests, but they still need more work.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-choice pre-state selection and block import pre-state retrieval, which can affect block processing correctness; changes are small but in consensus-critical paths.
> 
> **Overview**
> Updates Gloas fork-choice pre-state selection to be fully async: `getParentPayloadStatus`/`isParentNodeFull` now return `SafeFuture`s and `retrievePreStateRequiredOnBlock` composes on the async parent check (with added debug logging).
> 
> Adjusts block import to fetch pre-state via `RecentChainData.retrieveBlockState` directly instead of `ForkChoiceUtil.retrievePreStateRequiredOnBlock`, and updates unit tests to mock `ReadOnlyStore.retrieveBlock` and assert async completion/exception behavior. Reference fork-choice tests also add extra debug output for the anchor state/block roots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48c16f7d9bf769cedee8411b64660600b5d7ab92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->