### PR TITLE
[Gloas] Add RecentExecutionPayloadsFetcher

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncService.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSyncService;
 import tech.pegasys.teku.beacon.sync.gossip.blobs.RecentBlobSidecarsFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetcher;
+import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.RecentExecutionPayloadsFetcher;
 import tech.pegasys.teku.beacon.sync.historical.HistoricalBlockSyncService;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.service.serviceutils.Service;
@@ -29,6 +30,7 @@ public class DefaultSyncService extends Service implements SyncService {
   private final ForwardSyncService forwardSyncService;
   private final RecentBlocksFetcher recentBlocksFetcher;
   private final RecentBlobSidecarsFetcher recentBlobSidecarsFetcher;
+  private final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher;
   private final SyncStateTracker syncStateTracker;
   private final HistoricalBlockSyncService historicalBlockSyncService;
 
@@ -36,11 +38,13 @@ public class DefaultSyncService extends Service implements SyncService {
       final ForwardSyncService forwardSyncService,
       final RecentBlocksFetcher recentBlocksFetcher,
       final RecentBlobSidecarsFetcher recentBlobSidecarsFetcher,
+      final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher,
       final SyncStateTracker syncStateTracker,
       final HistoricalBlockSyncService historicalBlockSyncService) {
     this.forwardSyncService = forwardSyncService;
     this.recentBlocksFetcher = recentBlocksFetcher;
     this.recentBlobSidecarsFetcher = recentBlobSidecarsFetcher;
+    this.recentExecutionPayloadsFetcher = recentExecutionPayloadsFetcher;
     this.syncStateTracker = syncStateTracker;
     this.historicalBlockSyncService = historicalBlockSyncService;
   }
@@ -51,6 +55,7 @@ public class DefaultSyncService extends Service implements SyncService {
         forwardSyncService.start(),
         recentBlocksFetcher.start(),
         recentBlobSidecarsFetcher.start(),
+        recentExecutionPayloadsFetcher.start(),
         syncStateTracker.start(),
         historicalBlockSyncService.start());
   }
@@ -61,6 +66,7 @@ public class DefaultSyncService extends Service implements SyncService {
         forwardSyncService.stop(),
         recentBlocksFetcher.stop(),
         recentBlobSidecarsFetcher.stop(),
+        recentExecutionPayloadsFetcher.stop(),
         syncStateTracker.stop(),
         historicalBlockSyncService.stop());
   }
@@ -78,6 +84,11 @@ public class DefaultSyncService extends Service implements SyncService {
   @Override
   public RecentBlobSidecarsFetcher getRecentBlobSidecarsFetcher() {
     return recentBlobSidecarsFetcher;
+  }
+
+  @Override
+  public RecentExecutionPayloadsFetcher getRecentExecutionPayloadsFetcher() {
+    return recentExecutionPayloadsFetcher;
   }
 
   @Override

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.MultipeerSyncService;
 import tech.pegasys.teku.beacon.sync.forward.singlepeer.SinglePeerSyncServiceFactory;
 import tech.pegasys.teku.beacon.sync.gossip.blobs.RecentBlobSidecarsFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetchService;
+import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.RecentExecutionPayloadsFetcher;
 import tech.pegasys.teku.beacon.sync.historical.HistoricalBlockSyncService;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
@@ -42,6 +43,7 @@ import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
@@ -69,6 +71,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
   private final Eth2P2PNetwork p2pNetwork;
   private final BlockImporter blockImporter;
   private final BlobSidecarManager blobSidecarManager;
+  private final ExecutionPayloadManager executionPayloadManager;
   private final PendingPool<SignedBeaconBlock> pendingBlocks;
   private final PendingPool<ValidatableAttestation> pendingAttestations;
   private final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
@@ -91,6 +94,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
       final Eth2P2PNetwork p2pNetwork,
       final BlockImporter blockImporter,
       final BlobSidecarManager blobSidecarManager,
+      final ExecutionPayloadManager executionPayloadManager,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final PendingPool<ValidatableAttestation> pendingAttestations,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
@@ -111,6 +115,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
     this.p2pNetwork = p2pNetwork;
     this.blockImporter = blockImporter;
     this.blobSidecarManager = blobSidecarManager;
+    this.executionPayloadManager = executionPayloadManager;
     this.pendingBlocks = pendingBlocks;
     this.pendingAttestations = pendingAttestations;
     this.blockBlobSidecarsTrackersPool = blockBlobSidecarsTrackersPool;
@@ -141,6 +146,9 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
     final RecentBlobSidecarsFetcher recentBlobSidecarsFetcher =
         RecentBlobSidecarsFetcher.create(
             spec, asyncRunner, blockBlobSidecarsTrackersPool, forwardSyncService, fetchTaskFactory);
+    final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher =
+        RecentExecutionPayloadsFetcher.create(
+            spec, asyncRunner, forwardSyncService, fetchTaskFactory, executionPayloadManager);
 
     final SyncStateTracker syncStateTracker = createSyncStateTracker(forwardSyncService);
 
@@ -151,6 +159,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
         forwardSyncService,
         recentBlocksFetchService,
         recentBlobSidecarsFetcher,
+        recentExecutionPayloadsFetcher,
         syncStateTracker,
         historicalBlockSyncService);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/NoopSyncService.java
@@ -25,8 +25,11 @@ import tech.pegasys.teku.beacon.sync.gossip.blobs.BlobSidecarSubscriber;
 import tech.pegasys.teku.beacon.sync.gossip.blobs.RecentBlobSidecarsFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.BlockSubscriber;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetcher;
+import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.ExecutionPayloadSubscriber;
+import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.RecentExecutionPayloadsFetcher;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice.OptimisticHeadSubscriber;
 
@@ -34,6 +37,7 @@ public class NoopSyncService
     implements ForwardSync,
         RecentBlocksFetcher,
         RecentBlobSidecarsFetcher,
+        RecentExecutionPayloadsFetcher,
         SyncService,
         OptimisticHeadSubscriber {
 
@@ -59,6 +63,11 @@ public class NoopSyncService
 
   @Override
   public RecentBlobSidecarsFetcher getRecentBlobSidecarsFetcher() {
+    return this;
+  }
+
+  @Override
+  public RecentExecutionPayloadsFetcher getRecentExecutionPayloadsFetcher() {
     return this;
   }
 
@@ -93,9 +102,7 @@ public class NoopSyncService
   public void unsubscribeFromSyncChanges(final long subscriberId) {}
 
   @Override
-  public void subscribeBlockFetched(final BlockSubscriber subscriber) {
-    // No-op
-  }
+  public void subscribeBlockFetched(final BlockSubscriber subscriber) {}
 
   @Override
   public void requestRecentBlock(final Bytes32 blockRoot) {
@@ -119,6 +126,21 @@ public class NoopSyncService
 
   @Override
   public void cancelRecentBlobSidecarRequest(final BlobIdentifier blobIdentifier) {
+    // No-op
+  }
+
+  @Override
+  public void subscribeExecutionPayloadFetched(final ExecutionPayloadSubscriber subscriber) {
+    // No-op
+  }
+
+  @Override
+  public void requestRecentExecutionPayload(final Bytes32 beaconBlockRoot) {
+    // No-op
+  }
+
+  @Override
+  public void cancelRecentExecutionPayloadRequest(final Bytes32 beaconBlockRoot) {
     // No-op
   }
 
@@ -159,6 +181,11 @@ public class NoopSyncService
 
   @Override
   public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
+    // No-op
+  }
+
+  @Override
+  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
     // No-op
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncService.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.beacon.sync.events.SyncingStatus;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
 import tech.pegasys.teku.beacon.sync.gossip.blobs.RecentBlobSidecarsFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetcher;
+import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.RecentExecutionPayloadsFetcher;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice.OptimisticHeadSubscriber;
 
@@ -33,6 +34,8 @@ public interface SyncService extends SyncStateProvider {
   RecentBlocksFetcher getRecentBlocksFetcher();
 
   RecentBlobSidecarsFetcher getRecentBlobSidecarsFetcher();
+
+  RecentExecutionPayloadsFetcher getRecentExecutionPayloadsFetcher();
 
   default boolean isSyncActive() {
     return getForwardSync().isSyncActive();

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/DefaultFetchTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/DefaultFetchTaskFactory.java
@@ -38,4 +38,10 @@ public class DefaultFetchTaskFactory implements FetchTaskFactory {
       final BlobIdentifier blobIdentifier, final Optional<Eth2Peer> preferredPeer) {
     return new FetchBlobSidecarTask(eth2Network, preferredPeer, blobIdentifier);
   }
+
+  @Override
+  public FetchExecutionPayloadTask createFetchExecutionPayloadTask(
+      final Bytes32 beaconBlockRoot, final Optional<Eth2Peer> preferredPeer) {
+    return new FetchExecutionPayloadTask(eth2Network, preferredPeer, beaconBlockRoot);
+  }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTask.java
@@ -59,9 +59,9 @@ public class FetchBlobSidecarTask extends AbstractFetchTask<BlobIdentifier, Blob
         .exceptionally(
             err -> {
               LOG.debug(
-                  String.format(
-                      "Failed to fetch blob sidecar by identifier %s from peer %s",
-                      blobIdentifier, peer.getId()),
+                  "Failed to fetch blob sidecar by identifier {} from peer {}",
+                  blobIdentifier,
+                  peer.getId(),
                   err);
               return FetchResult.createFailed(peer, Status.FETCH_FAILED);
             });

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchTaskFactory.java
@@ -32,4 +32,11 @@ public interface FetchTaskFactory {
 
   FetchBlobSidecarTask createFetchBlobSidecarTask(
       BlobIdentifier blobIdentifier, Optional<Eth2Peer> preferredPeer);
+
+  default FetchExecutionPayloadTask createFetchExecutionPayloadTask(final Bytes32 beaconBlockRoot) {
+    return createFetchExecutionPayloadTask(beaconBlockRoot, Optional.empty());
+  }
+
+  FetchExecutionPayloadTask createFetchExecutionPayloadTask(
+      Bytes32 beaconBlockRoot, Optional<Eth2Peer> preferredPeer);
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/RecentBlobSidecarsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/RecentBlobSidecarsFetchService.java
@@ -53,7 +53,7 @@ public class RecentBlobSidecarsFetchService
     this.fetchTaskFactory = fetchTaskFactory;
   }
 
-  public static RecentBlobSidecarsFetchService create(
+  static RecentBlobSidecarsFetchService create(
       final AsyncRunner asyncRunner,
       final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final ForwardSync forwardSync,

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/ExecutionPayloadSubscriber.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/ExecutionPayloadSubscriber.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beacon.sync.gossip.executionpayloads;
+
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public interface ExecutionPayloadSubscriber {
+
+  void onExecutionPayload(SignedExecutionPayloadEnvelope executionPayload);
+}

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchService.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beacon.sync.gossip.executionpayloads;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.beacon.sync.fetch.FetchExecutionPayloadTask;
+import tech.pegasys.teku.beacon.sync.fetch.FetchTaskFactory;
+import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
+import tech.pegasys.teku.beacon.sync.gossip.AbstractFetchService;
+import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetchService;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+
+public class RecentExecutionPayloadsFetchService
+    extends AbstractFetchService<Bytes32, FetchExecutionPayloadTask, SignedExecutionPayloadEnvelope>
+    implements RecentExecutionPayloadsFetcher {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Subscribers<ExecutionPayloadSubscriber> executionPayloadSubscribers =
+      Subscribers.create(true);
+
+  private final ForwardSync forwardSync;
+  private final FetchTaskFactory fetchTaskFactory;
+  private final ExecutionPayloadManager executionPayloadManager;
+
+  RecentExecutionPayloadsFetchService(
+      final AsyncRunner asyncRunner,
+      final int maxConcurrentRequests,
+      final ForwardSync forwardSync,
+      final FetchTaskFactory fetchTaskFactory,
+      final ExecutionPayloadManager executionPayloadManager) {
+    super(asyncRunner, maxConcurrentRequests);
+    this.forwardSync = forwardSync;
+    this.fetchTaskFactory = fetchTaskFactory;
+    this.executionPayloadManager = executionPayloadManager;
+  }
+
+  public static RecentExecutionPayloadsFetchService create(
+      final AsyncRunner asyncRunner,
+      final ForwardSync forwardSync,
+      final FetchTaskFactory fetchTaskFactory,
+      final ExecutionPayloadManager executionPayloadManager) {
+    return new RecentExecutionPayloadsFetchService(
+        asyncRunner,
+        // same limit as blocks
+        RecentBlocksFetchService.MAX_CONCURRENT_REQUESTS,
+        forwardSync,
+        fetchTaskFactory,
+        executionPayloadManager);
+  }
+
+  @Override
+  protected SafeFuture<?> doStart() {
+    setupSubscribers();
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  protected SafeFuture<?> doStop() {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public FetchExecutionPayloadTask createTask(final Bytes32 key) {
+    return fetchTaskFactory.createFetchExecutionPayloadTask(key);
+  }
+
+  @Override
+  public void processFetchedResult(
+      final FetchExecutionPayloadTask task, final SignedExecutionPayloadEnvelope executionPayload) {
+    LOG.trace("Successfully fetched execution payload: {}", executionPayload);
+    executionPayloadSubscribers.forEach(s -> s.onExecutionPayload(executionPayload));
+    // After retrieved execution payload has been processed, stop tracking it
+    removeTask(task);
+  }
+
+  @Override
+  public void subscribeExecutionPayloadFetched(final ExecutionPayloadSubscriber subscriber) {
+    executionPayloadSubscribers.subscribe(subscriber);
+  }
+
+  @Override
+  public void requestRecentExecutionPayload(final Bytes32 beaconBlockRoot) {
+    if (forwardSync.isSyncActive()) {
+      // Forward sync already in progress, assume it will fetch any missing execution payloads
+      return;
+    }
+    if (executionPayloadManager.isExecutionPayloadRecentlySeen(beaconBlockRoot)) {
+      // We've already got this execution payload
+      return;
+    }
+    final FetchExecutionPayloadTask task = createTask(beaconBlockRoot);
+    if (allTasks.putIfAbsent(beaconBlockRoot, task) != null) {
+      // We're already tracking this task
+      task.cancel();
+      return;
+    }
+    LOG.trace("Queue execution payload to be fetched: {}", beaconBlockRoot);
+    queueTask(task);
+  }
+
+  @Override
+  public void cancelRecentExecutionPayloadRequest(final Bytes32 beaconBlockRoot) {
+    cancelRequest(beaconBlockRoot);
+  }
+
+  @Override
+  public void onExecutionPayloadImported(final SignedExecutionPayloadEnvelope executionPayload) {
+    cancelRecentExecutionPayloadRequest(executionPayload.getBeaconBlockRoot());
+  }
+
+  // TODO-GLOAS: configure subscribers who require fetching of execution payloads (not required for
+  // devnet-0)
+  private void setupSubscribers() {}
+}

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetcher.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beacon.sync.gossip.executionpayloads;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.beacon.sync.fetch.FetchTaskFactory;
+import tech.pegasys.teku.beacon.sync.forward.ForwardSyncService;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.service.serviceutils.ServiceFacade;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
+
+public interface RecentExecutionPayloadsFetcher
+    extends ServiceFacade, ReceivedExecutionPayloadEventsChannel {
+
+  RecentExecutionPayloadsFetcher NOOP =
+      new RecentExecutionPayloadsFetcher() {
+        @Override
+        public void subscribeExecutionPayloadFetched(final ExecutionPayloadSubscriber subscriber) {}
+
+        @Override
+        public void requestRecentExecutionPayload(final Bytes32 beaconBlockRoot) {}
+
+        @Override
+        public void cancelRecentExecutionPayloadRequest(final Bytes32 beaconBlockRoot) {}
+
+        @Override
+        public SafeFuture<?> start() {
+          return SafeFuture.COMPLETE;
+        }
+
+        @Override
+        public SafeFuture<?> stop() {
+          return SafeFuture.COMPLETE;
+        }
+
+        @Override
+        public boolean isRunning() {
+          return false;
+        }
+
+        @Override
+        public void onExecutionPayloadImported(
+            final SignedExecutionPayloadEnvelope executionPayload) {}
+      };
+
+  static RecentExecutionPayloadsFetcher create(
+      final Spec spec,
+      final AsyncRunner asyncRunner,
+      final ForwardSyncService forwardSyncService,
+      final FetchTaskFactory fetchTaskFactory,
+      final ExecutionPayloadManager executionPayloadManager) {
+    final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher;
+    if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      recentExecutionPayloadsFetcher =
+          RecentExecutionPayloadsFetchService.create(
+              asyncRunner, forwardSyncService, fetchTaskFactory, executionPayloadManager);
+    } else {
+      recentExecutionPayloadsFetcher = RecentExecutionPayloadsFetcher.NOOP;
+    }
+
+    return recentExecutionPayloadsFetcher;
+  }
+
+  void subscribeExecutionPayloadFetched(ExecutionPayloadSubscriber subscriber);
+
+  void requestRecentExecutionPayload(Bytes32 beaconBlockRoot);
+
+  void cancelRecentExecutionPayloadRequest(Bytes32 beaconBlockRoot);
+}

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchTaskTest.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 public class AbstractFetchTaskTest {
 
   protected final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(TestSpecFactory.createMinimalDeneb());
+      new DataStructureUtil(TestSpecFactory.createMinimalGloas());
   protected final Eth2P2PNetwork eth2P2PNetwork = mock(Eth2P2PNetwork.class);
   protected final List<Eth2Peer> peers = new ArrayList<>();
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/DefaultFetchTaskFactoryTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/DefaultFetchTaskFactoryTest.java
@@ -42,4 +42,11 @@ public class DefaultFetchTaskFactoryTest {
         fetchTaskFactory.createFetchBlobSidecarTask(new BlobIdentifier(Bytes32.ZERO, UInt64.ZERO));
     assertThat(task).isNotNull();
   }
+
+  @Test
+  public void createsFetchExecutionPayloadTask() {
+    final FetchExecutionPayloadTask task =
+        fetchTaskFactory.createFetchExecutionPayloadTask(Bytes32.ZERO);
+    assertThat(task).isNotNull();
+  }
 }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchExecutionPayloadTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchExecutionPayloadTaskTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beacon.sync.fetch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beacon.sync.fetch.FetchResult.Status;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+
+public class FetchExecutionPayloadTaskTest extends AbstractFetchTaskTest {
+
+  @Test
+  public void run_successful() {
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, beaconBlockRoot);
+    assertThat(task.getKey()).isEqualTo(beaconBlockRoot);
+
+    final Eth2Peer peer = registerNewPeer(1);
+    when(peer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayload)));
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).hasValue(peer);
+    assertThat(fetchResult.isSuccessful()).isTrue();
+    assertThat(fetchResult.getResult()).hasValue(executionPayload);
+  }
+
+  @Test
+  public void run_noPeers() {
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, beaconBlockRoot);
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).isEmpty();
+    assertThat(fetchResult.isSuccessful()).isFalse();
+    assertThat(fetchResult.getStatus()).isEqualTo(Status.NO_AVAILABLE_PEERS);
+  }
+
+  @Test
+  public void run_failAndRetryWithNoNewPeers() {
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, beaconBlockRoot);
+
+    final Eth2Peer peer = registerNewPeer(1);
+    when(peer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("whoops")));
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).hasValue(peer);
+    assertThat(fetchResult.isSuccessful()).isFalse();
+    assertThat(fetchResult.getStatus()).isEqualTo(Status.FETCH_FAILED);
+    assertThat(task.getNumberOfRetries()).isEqualTo(0);
+
+    // Retry
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result2 = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult2 = result2.getNow(null);
+    assertThat(fetchResult2.getPeer()).isEmpty();
+    assertThat(fetchResult2.isSuccessful()).isFalse();
+    assertThat(fetchResult2.getStatus()).isEqualTo(Status.NO_AVAILABLE_PEERS);
+    assertThat(task.getNumberOfRetries()).isEqualTo(0);
+  }
+
+  @Test
+  public void run_failAndRetryWithNewPeer() {
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, beaconBlockRoot);
+
+    final Eth2Peer peer = registerNewPeer(1);
+    when(peer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("whoops")));
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).hasValue(peer);
+    assertThat(fetchResult.isSuccessful()).isFalse();
+    assertThat(fetchResult.getStatus()).isEqualTo(Status.FETCH_FAILED);
+    assertThat(task.getNumberOfRetries()).isEqualTo(0);
+
+    // Add another peer
+    final Eth2Peer peer2 = registerNewPeer(2);
+    when(peer2.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayload)));
+
+    // Retry
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result2 = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult2 = result2.getNow(null);
+    assertThat(fetchResult2.getPeer()).hasValue(peer2);
+    assertThat(fetchResult2.isSuccessful()).isTrue();
+    assertThat(fetchResult2.getResult()).hasValue(executionPayload);
+    assertThat(task.getNumberOfRetries()).isEqualTo(1);
+  }
+
+  @Test
+  public void run_withMultiplesPeersAvailable() {
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, beaconBlockRoot);
+
+    final Eth2Peer peer = registerNewPeer(1);
+    when(peer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("whoops")));
+    when(peer.getOutstandingRequests()).thenReturn(1);
+    // Add another peer
+    final Eth2Peer peer2 = registerNewPeer(2);
+    when(peer2.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayload)));
+    when(peer2.getOutstandingRequests()).thenReturn(0);
+
+    // We should choose the peer that is less busy, which successfully returns the block
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).hasValue(peer2);
+    assertThat(fetchResult.isSuccessful()).isTrue();
+    assertThat(fetchResult.getResult()).hasValue(executionPayload);
+  }
+
+  @Test
+  public void run_withPreferredPeer() {
+    final Eth2Peer preferredPeer = createNewPeer(1);
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    when(preferredPeer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayload)));
+
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, Optional.of(preferredPeer), beaconBlockRoot);
+
+    // Add a peer
+    registerNewPeer(2);
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).hasValue(preferredPeer);
+    assertThat(fetchResult.isSuccessful()).isTrue();
+    assertThat(fetchResult.getResult()).hasValue(executionPayload);
+  }
+
+  @Test
+  public void run_withRandomPeerWhenFetchingWithPreferredPeerFails() {
+    final Eth2Peer preferredPeer = createNewPeer(1);
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    when(preferredPeer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("whoops")));
+
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, Optional.of(preferredPeer), beaconBlockRoot);
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).hasValue(preferredPeer);
+    assertThat(fetchResult.isSuccessful()).isFalse();
+    assertThat(fetchResult.getStatus()).isEqualTo(Status.FETCH_FAILED);
+    assertThat(task.getNumberOfRetries()).isEqualTo(0);
+
+    // Add a peer
+    final Eth2Peer peer = registerNewPeer(2);
+    when(peer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayload)));
+
+    // Retry
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result2 = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult2 = result2.getNow(null);
+    assertThat(fetchResult2.getPeer()).hasValue(peer);
+    assertThat(fetchResult2.isSuccessful()).isTrue();
+    assertThat(fetchResult2.getResult()).hasValue(executionPayload);
+    assertThat(task.getNumberOfRetries()).isEqualTo(1);
+  }
+
+  @Test
+  public void cancel() {
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(10);
+    final Bytes32 beaconBlockRoot = executionPayload.getBeaconBlockRoot();
+    final FetchExecutionPayloadTask task =
+        new FetchExecutionPayloadTask(eth2P2PNetwork, beaconBlockRoot);
+
+    final Eth2Peer peer = registerNewPeer(1);
+    when(peer.requestExecutionPayloadEnvelopeByRoot(beaconBlockRoot))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayload)));
+
+    task.cancel();
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> result = task.run();
+    assertThat(result).isDone();
+    final FetchResult<SignedExecutionPayloadEnvelope> fetchResult = result.getNow(null);
+    assertThat(fetchResult.getPeer()).isEmpty();
+    assertThat(fetchResult.isSuccessful()).isFalse();
+    assertThat(fetchResult.getStatus()).isEqualTo(Status.CANCELLED);
+  }
+}

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/executionpayloads/RecentExecutionPayloadsFetchServiceTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beacon.sync.gossip.executionpayloads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import tech.pegasys.teku.beacon.sync.fetch.FetchExecutionPayloadTask;
+import tech.pegasys.teku.beacon.sync.fetch.FetchResult;
+import tech.pegasys.teku.beacon.sync.fetch.FetchResult.Status;
+import tech.pegasys.teku.beacon.sync.fetch.FetchTaskFactory;
+import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
+
+class RecentExecutionPayloadsFetchServiceTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private final ExecutionPayloadManager executionPayloadManager =
+      mock(ExecutionPayloadManager.class);
+
+  private final FetchTaskFactory fetchTaskFactory = mock(FetchTaskFactory.class);
+
+  private final ForwardSync forwardSync = mock(ForwardSync.class);
+
+  private final int maxConcurrentRequests = 2;
+
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+
+  private final List<FetchExecutionPayloadTask> tasks = new ArrayList<>();
+  private final List<SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>>> taskFutures =
+      new ArrayList<>();
+  private final List<SignedExecutionPayloadEnvelope> importedExecutionPayloads = new ArrayList<>();
+
+  private RecentExecutionPayloadsFetchService recentExecutionPayloadsFetchService;
+
+  @BeforeEach
+  public void setup() {
+    recentExecutionPayloadsFetchService =
+        new RecentExecutionPayloadsFetchService(
+            asyncRunner,
+            maxConcurrentRequests,
+            forwardSync,
+            fetchTaskFactory,
+            executionPayloadManager);
+
+    lenient()
+        .when(fetchTaskFactory.createFetchExecutionPayloadTask(any()))
+        .thenAnswer(this::createMockTask);
+    recentExecutionPayloadsFetchService.subscribeExecutionPayloadFetched(
+        importedExecutionPayloads::add);
+  }
+
+  @Test
+  public void fetchSingleBlockSuccessfully() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+
+    assertTaskCounts(1, 1, 0);
+    assertThat(importedExecutionPayloads).isEmpty();
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> future = taskFutures.get(0);
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(1);
+    future.complete(FetchResult.createSuccessful(executionPayload));
+
+    assertThat(importedExecutionPayloads).containsExactly(executionPayload);
+    assertTaskCounts(0, 0, 0);
+  }
+
+  @Test
+  public void handleDuplicateRequiredExecutionPayloads() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+
+    assertTaskCounts(1, 1, 0);
+    assertThat(importedExecutionPayloads).isEmpty();
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> future = taskFutures.get(0);
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(1);
+    future.complete(FetchResult.createSuccessful(executionPayload));
+
+    assertThat(importedExecutionPayloads).containsExactly(executionPayload);
+    assertTaskCounts(0, 0, 0);
+  }
+
+  @Test
+  public void ignoreKnownExecutionPayload() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    when(executionPayloadManager.isExecutionPayloadRecentlySeen(beaconBlockRoot)).thenReturn(true);
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+
+    assertTaskCounts(0, 0, 0);
+    assertThat(importedExecutionPayloads).isEmpty();
+  }
+
+  @Test
+  public void cancelExecutionPayloadRequest() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+    recentExecutionPayloadsFetchService.cancelRecentExecutionPayloadRequest(beaconBlockRoot);
+
+    verify(tasks.getFirst()).cancel();
+    // Manually cancel future
+    taskFutures.getFirst().complete(FetchResult.createFailed(Status.CANCELLED));
+
+    // Task should be removed
+    assertTaskCounts(0, 0, 0);
+    assertThat(importedExecutionPayloads).isEmpty();
+  }
+
+  @Test
+  public void fetchSingleExecutionPayloadWithRetry() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+
+    assertTaskCounts(1, 1, 0);
+    assertThat(importedExecutionPayloads).isEmpty();
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> future = taskFutures.get(0);
+    future.complete(FetchResult.createFailed(Status.FETCH_FAILED));
+
+    // Task should be queued for a retry via the scheduled executor
+    verify(tasks.getFirst()).getNumberOfRetries();
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+    assertTaskCounts(1, 0, 0);
+
+    // Executor should requeue task
+    when(tasks.getFirst().run()).thenReturn(new SafeFuture<>());
+    asyncRunner.executeQueuedActions();
+    assertTaskCounts(1, 1, 0);
+  }
+
+  @Test
+  public void cancelTaskWhileWaitingToRetry() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+
+    assertTaskCounts(1, 1, 0);
+    assertThat(importedExecutionPayloads).isEmpty();
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> future = taskFutures.getFirst();
+    future.complete(FetchResult.createFailed(Status.FETCH_FAILED));
+
+    // Task should be queued for a retry via the scheduled executor
+    verify(tasks.getFirst()).getNumberOfRetries();
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+    assertTaskCounts(1, 0, 0);
+
+    // Cancel task
+    recentExecutionPayloadsFetchService.cancelRecentExecutionPayloadRequest(beaconBlockRoot);
+    verify(tasks.getFirst()).cancel();
+    when(tasks.getFirst().run())
+        .thenReturn(SafeFuture.completedFuture(FetchResult.createFailed(Status.CANCELLED)));
+
+    // Executor should requeue task, it should complete immediately and be removed
+    asyncRunner.executeQueuedActions();
+    assertTaskCounts(0, 0, 0);
+  }
+
+  @Test
+  public void handlesPeersUnavailable() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+
+    assertTaskCounts(1, 1, 0);
+    assertThat(importedExecutionPayloads).isEmpty();
+
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> future = taskFutures.getFirst();
+    future.complete(FetchResult.createFailed(Status.NO_AVAILABLE_PEERS));
+
+    // Task should be queued for a retry via the scheduled executor
+    verify(tasks.getFirst(), never()).getNumberOfRetries();
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+    assertTaskCounts(1, 0, 0);
+
+    // Executor should requeue task
+    when(tasks.getFirst().run()).thenReturn(new SafeFuture<>());
+    asyncRunner.executeQueuedActions();
+    assertTaskCounts(1, 1, 0);
+  }
+
+  @Test
+  public void queueFetchTaskWhenConcurrencyLimitReached() {
+    final int taskCount = maxConcurrentRequests + 1;
+    for (int i = 0; i < taskCount; i++) {
+      final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+      recentExecutionPayloadsFetchService.requestRecentExecutionPayload(beaconBlockRoot);
+    }
+
+    assertTaskCounts(taskCount, taskCount - 1, 1);
+
+    // Complete first task
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> future = taskFutures.getFirst();
+    final SignedExecutionPayloadEnvelope executionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelope(1);
+    future.complete(FetchResult.createSuccessful(executionPayload));
+
+    // After first task completes, remaining pending count should become active
+    assertTaskCounts(taskCount - 1, taskCount - 1, 0);
+  }
+
+  @Test
+  void shouldNotFetchBlocksWhileForwardSyncIsInProgress() {
+    when(forwardSync.isSyncActive()).thenReturn(true);
+
+    recentExecutionPayloadsFetchService.requestRecentExecutionPayload(
+        dataStructureUtil.randomBytes32());
+    assertTaskCounts(0, 0, 0);
+  }
+
+  private FetchExecutionPayloadTask createMockTask(final InvocationOnMock invocationOnMock) {
+    final Bytes32 beaconBlockRoot = invocationOnMock.getArgument(0);
+    final FetchExecutionPayloadTask task = mock(FetchExecutionPayloadTask.class);
+
+    lenient().when(task.getKey()).thenReturn(beaconBlockRoot);
+    lenient().when(task.getNumberOfRetries()).thenReturn(0);
+    final SafeFuture<FetchResult<SignedExecutionPayloadEnvelope>> future = new SafeFuture<>();
+    lenient().when(task.run()).thenReturn(future);
+    taskFutures.add(future);
+    tasks.add(task);
+
+    return task;
+  }
+
+  private void assertTaskCounts(
+      final int totalTasks, final int activeTasks, final int queuedTasks) {
+    assertThat(recentExecutionPayloadsFetchService.countTrackedTasks())
+        .describedAs("Tracked tasks")
+        .isEqualTo(totalTasks);
+    assertThat(recentExecutionPayloadsFetchService.countActiveTasks())
+        .describedAs("Active tasks")
+        .isEqualTo(activeTasks);
+    assertThat(recentExecutionPayloadsFetchService.countPendingTasks())
+        .describedAs("Pending tasks")
+        .isEqualTo(queuedTasks);
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -428,6 +428,21 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> requestExecutionPayloadEnvelopeByRoot(
+      final Bytes32 beaconBlockRoot) {
+    return rpcMethods
+        .executionPayloadEnvelopesByRoot()
+        .map(
+            method ->
+                requestOptionalItem(
+                    method,
+                    new ExecutionPayloadEnvelopesByRootRequestMessage(
+                        executionPayloadEnvelopesByRootRequestMessageSchema.get(),
+                        List.of(beaconBlockRoot))))
+        .orElse(failWithUnsupportedMethodException("ExecutionPayloadEnvelopesByRoot"));
+  }
+
+  @Override
   public SafeFuture<Void> requestBlocksByRange(
       final UInt64 startSlot,
       final UInt64 count,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -125,6 +125,9 @@ public interface Eth2Peer extends Peer, SyncSource {
 
   SafeFuture<Optional<BlobSidecar>> requestBlobSidecarByRoot(BlobIdentifier blobIdentifier);
 
+  SafeFuture<Optional<SignedExecutionPayloadEnvelope>> requestExecutionPayloadEnvelopeByRoot(
+      Bytes32 beaconBlockRoot);
+
   SafeFuture<MetadataMessage> requestMetadata();
 
   default <I extends RpcRequest, O extends SszData> SafeFuture<O> requestSingleItem(

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -370,6 +370,18 @@ public class RespondingEth2Peer implements Eth2Peer {
     return createPendingBlobSidecarRequest(handler);
   }
 
+  @Override
+  public SafeFuture<Optional<SignedExecutionPayloadEnvelope>> requestExecutionPayloadEnvelopeByRoot(
+      final Bytes32 beaconBlockRoot) {
+    final PendingRequestHandler<
+            Optional<SignedExecutionPayloadEnvelope>, SignedExecutionPayloadEnvelope>
+        handler =
+            PendingRequestHandler.createForSingleExecutionPayloadRequest(
+                () -> findExecutionPayloadByRoot(beaconBlockRoot));
+
+    return createPendingExecutionPayloadEnvelopeRequest(handler);
+  }
+
   private <T> SafeFuture<T> createPendingBlockRequest(
       final PendingRequestHandler<T, SignedBeaconBlock> handler) {
     final PendingRequestHandler<T, SignedBeaconBlock> filteredHandler =
@@ -642,6 +654,13 @@ public class RespondingEth2Peer implements Eth2Peer {
         createForSingleBlobSidecarRequest(
             final Supplier<Optional<BlobSidecar>> blobSidecarSupplier) {
       return createForSingleRequest(blobSidecarSupplier);
+    }
+
+    static PendingRequestHandler<
+            Optional<SignedExecutionPayloadEnvelope>, SignedExecutionPayloadEnvelope>
+        createForSingleExecutionPayloadRequest(
+            final Supplier<Optional<SignedExecutionPayloadEnvelope>> executionPayloadSupplier) {
+      return createForSingleRequest(executionPayloadSupplier);
     }
 
     static <T> PendingRequestHandler<Void, T> createForBatchRequest(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.beacon.sync.events.CoalescingChainHeadChannel;
 import tech.pegasys.teku.beacon.sync.events.SyncPreImportBlockChannel;
 import tech.pegasys.teku.beacon.sync.gossip.blobs.RecentBlobSidecarsFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetcher;
+import tech.pegasys.teku.beacon.sync.gossip.executionpayloads.RecentExecutionPayloadsFetcher;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApi;
 import tech.pegasys.teku.beaconrestapi.JsonTypeDefinitionBeaconRestApi;
 import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
@@ -503,6 +504,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
         (executionProof, remoteOrigin) ->
             // TODO add actual logic to handle valid execution proofs
             LOG.debug("Received valid execution proof: {}", executionProof));
+    final RecentExecutionPayloadsFetcher recentExecutionPayloadsFetcher =
+        syncService.getRecentExecutionPayloadsFetcher();
+    eventChannels.subscribe(
+        ReceivedExecutionPayloadEventsChannel.class, recentExecutionPayloadsFetcher);
+    // TODO-GLOAS: configure usage of RecentExecutionPayloadsFetcher (importing payload/cancelling
+    // request) (not required for devnet-0)
 
     final Optional<Eth2Network> network = beaconConfig.eth2NetworkConfig().getEth2Network();
     if (network.isPresent() && network.get() == Eth2Network.EPHEMERY) {
@@ -2176,6 +2183,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         p2pNetwork,
         blockImporter,
         blobSidecarManager,
+        executionPayloadManager,
         pendingBlocks,
         pendingAttestations,
         blockBlobSidecarsTrackersPool,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Introduce `RecentExecutionPayloadsFetcher` similar to how we do for blocks and blobs. Left TODOs to configure subscribers and consumers.

## Fixed Issue(s)
related to #10069 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync startup wiring and P2P peer request APIs to add a new fetch path; while gated to `SpecMilestone.GLOAS`, incorrect request/cancellation logic could impact network load or sync behavior when enabled.
> 
> **Overview**
> Adds a new `RecentExecutionPayloadsFetcher` pipeline (Gloas-gated) to fetch missing `SignedExecutionPayloadEnvelope`s by beacon block root, mirroring the existing recent blocks/blob-sidecars fetchers with concurrency limits, de-duping, cancellation, and basic retry behavior.
> 
> Wires the new fetcher through `SyncService`/`DefaultSyncService` lifecycle and factory construction (injecting `ExecutionPayloadManager`), subscribes it to `ReceivedExecutionPayloadEventsChannel` in `BeaconChainController`, and extends `Eth2Peer` with a single-item `ExecutionPayloadEnvelopesByRoot` request used by the new `FetchExecutionPayloadTask`.
> 
> Also includes minor logging cleanups (parameterized `LOG.debug`) and adds unit tests covering the new task/fetch service and updates fetch task test fixtures to use a Gloas spec.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a92a84acfccdb912d7ccd39f95c8105f3ebc3ed7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->