### PR TITLE
Progressive ssz

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -63,7 +63,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    *
    * <p>May be overridden by the ENV_DISPLAY_NAME environment variable.
    */
-  private static final String DISPLAY_NAME = "";
+  private static final String DISPLAY_NAME = "progressive";
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("loadReferenceTests")

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -63,7 +63,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    *
    * <p>May be overridden by the ENV_DISPLAY_NAME environment variable.
    */
-  private static final String DISPLAY_NAME = "progressive";
+  private static final String DISPLAY_NAME = "";
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("loadReferenceTests")

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveBitlistTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveBitlistTestExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+
+public class SszGenericProgressiveBitlistTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected void assertStringValueMatches(
+      final TestDefinition testDefinition, final String stringValue, final SszData result) {
+    assertThat(result.sszSerialize().toString()).isEqualTo(stringValue);
+  }
+
+  @Override
+  protected SszSchema<?> getSchema(final TestDefinition testDefinition) {
+    return new SszProgressiveBitlistSchema();
+  }
+
+  @Override
+  protected Object parseString(final TestDefinition testDefinition, final String value) {
+    return value;
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveContainerTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveContainerTestExecutor.java
@@ -31,17 +31,13 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveContainerSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
 import tech.pegasys.teku.reference.TestDataUtils;
-import tech.pegasys.teku.reference.phase0.ssz_generic.containers.BitsStructSchema;
-import tech.pegasys.teku.reference.phase0.ssz_generic.containers.ComplexTestStructSchema;
-import tech.pegasys.teku.reference.phase0.ssz_generic.containers.FixedTestStructSchema;
-import tech.pegasys.teku.reference.phase0.ssz_generic.containers.ProgressiveTestStructSchema;
-import tech.pegasys.teku.reference.phase0.ssz_generic.containers.SingleFieldTestStructSchema;
-import tech.pegasys.teku.reference.phase0.ssz_generic.containers.SmallTestStructSchema;
-import tech.pegasys.teku.reference.phase0.ssz_generic.containers.VarTestStructSchema;
 
-public class SszGenericContainerTestExecutor extends AbstractSszGenericTestExecutor {
+public class SszGenericProgressiveContainerTestExecutor extends AbstractSszGenericTestExecutor {
 
   @Override
   protected void assertValueCorrect(final TestDefinition testDefinition, final SszData result)
@@ -66,18 +62,32 @@ public class SszGenericContainerTestExecutor extends AbstractSszGenericTestExecu
     final String testName = testDefinition.getTestName();
     final String type = testName.substring(testName.indexOf('/') + 1, testName.indexOf('_'));
     return switch (type) {
-      case "SingleFieldTestStruct" -> new SingleFieldTestStructSchema();
-      case "BitsStruct" -> new BitsStructSchema();
-      case "SmallTestStruct" -> new SmallTestStructSchema();
-      case "VarTestStruct" -> new VarTestStructSchema();
-      case "FixedTestStruct" -> new FixedTestStructSchema();
-      case "ComplexTestStruct" -> // Not implemented yet
-          new ComplexTestStructSchema();
-      case "ProgressiveTestStruct" -> new ProgressiveTestStructSchema();
-      case "ProgressiveBitsStruct" ->
+      case "ProgressiveSingleFieldContainerTestStruct" ->
+          // active_fields=[1], A: byte
+          new SszProgressiveContainerSchema<>(
+              "ProgressiveSingleFieldContainerTestStruct",
+              new boolean[] {true},
+              NamedSchema.of("A", SszPrimitiveSchemas.BYTE_SCHEMA));
+      case "ProgressiveSingleListContainerTestStruct" ->
+          // active_fields=[0, 0, 0, 0, 1], C: ProgressiveBitlist
+          // ProgressiveBitlist not implemented yet
           throw new TestAbortedException(
-              "ProgressiveBitsStruct type not supported: " + testDefinition.getTestName());
-      default -> throw new UnsupportedOperationException("Unsupported container type: " + type);
+              "ProgressiveSingleListContainerTestStruct requires ProgressiveBitlist: "
+                  + testDefinition.getTestName());
+      case "ProgressiveVarTestStruct" ->
+          // active_fields=[1, 0, 1, 0, 1], A: byte, B: List[uint16, 123], C: ProgressiveBitlist
+          // ProgressiveBitlist not implemented yet
+          throw new TestAbortedException(
+              "ProgressiveVarTestStruct requires ProgressiveBitlist: "
+                  + testDefinition.getTestName());
+      case "ProgressiveComplexTestStruct" ->
+          // Uses ProgressiveBitlist not implemented yet
+          throw new TestAbortedException(
+              "ProgressiveComplexTestStruct requires ProgressiveBitlist: "
+                  + testDefinition.getTestName());
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported progressive container type: " + type);
     };
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveContainerTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveContainerTestExecutor.java
@@ -112,7 +112,7 @@ public class SszGenericProgressiveContainerTestExecutor extends AbstractSszGener
    * ProgressiveList[ProgressiveVarTestStruct]
    */
   private static SszProgressiveContainerSchema<?> createProgressiveComplexTestStructSchema() {
-    SszProgressiveContainerSchema<?> singleFieldSchema =
+    final SszProgressiveContainerSchema<?> singleFieldSchema =
         new SszProgressiveContainerSchema<>(
             "ProgressiveSingleFieldContainerTestStruct",
             new boolean[] {true},

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveListTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericProgressiveListTestExecutor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.reference.phase0.ssz_generic.containers.UInt16PrimitiveSchema.UINT16_SCHEMA;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.opentest4j.TestAbortedException;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.reference.TestDataUtils;
+
+public class SszGenericProgressiveListTestExecutor extends AbstractSszGenericTestExecutor {
+
+  @Override
+  protected void assertValueCorrect(final TestDefinition testDefinition, final SszData result)
+      throws IOException {
+    final List<String> expectedValue =
+        ((List<?>) TestDataUtils.loadYaml(testDefinition, "value.yaml", List.class))
+            .stream().map(value -> parseString(testDefinition, value.toString())).collect(toList());
+    final SszList<?> list = (SszList<?>) result;
+    final List<?> actualList = list.stream().map(Object::toString).collect(toList());
+    assertThat(actualList).isEqualTo(expectedValue);
+  }
+
+  @Override
+  protected SszSchema<?> getSchema(final TestDefinition testDefinition) {
+    final SszSchema<?> elementSchema = getElementSchema(testDefinition);
+    return SszProgressiveListSchema.create(elementSchema);
+  }
+
+  @Override
+  protected String parseString(final TestDefinition testDefinition, final String value) {
+    switch (getElementType(testDefinition)) {
+      case "uint8" -> {
+        return Byte.toString((byte) Integer.parseUnsignedInt(value));
+      }
+      case "uint256" -> {
+        return UInt256.valueOf(new BigInteger(value)).toString();
+      }
+      default -> {
+        return value;
+      }
+    }
+  }
+
+  // proglist_{element_type}_{mode}_{index}
+  private SszSchema<?> getElementSchema(final TestDefinition testDefinition) {
+    final String elementType = getElementType(testDefinition);
+    return switch (elementType) {
+      case "uint8" -> SszPrimitiveSchemas.BYTE_SCHEMA;
+      case "bool" -> SszPrimitiveSchemas.BOOLEAN_SCHEMA;
+      case "uint16" -> UINT16_SCHEMA;
+      case "uint64" -> SszPrimitiveSchemas.UINT64_SCHEMA;
+      case "uint256" -> SszPrimitiveSchemas.UINT256_SCHEMA;
+      case "uint32", "uint128" ->
+          throw new TestAbortedException(
+              "Element type not supported: "
+                  + elementType
+                  + " From: "
+                  + testDefinition.getTestName());
+      default ->
+          throw new UnsupportedOperationException(
+              "No schema for type: " + testDefinition.getTestName());
+    };
+  }
+
+  private String getElementType(final TestDefinition testDefinition) {
+    final String testName = testDefinition.getTestName();
+    // Format: proglist_{element_type}_{mode}_{index}
+    final String typePart = testName.substring(testName.indexOf('/') + 1 + "proglist_".length());
+    return typePart.substring(0, typePart.indexOf("_"));
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
@@ -27,7 +27,7 @@ public class SszGenericTests {
           .put("ssz_generic/bitvector", new SszGenericBitvectorTestExecutor())
           .put("ssz_generic/boolean", new SszGenericBooleanTestExecutor())
           .put("ssz_generic/containers", new SszGenericContainerTestExecutor())
-          .put("ssz_generic/progressive_bitlist", TestExecutor.IGNORE_TESTS)
+          .put("ssz_generic/progressive_bitlist", new SszGenericProgressiveBitlistTestExecutor())
           .put(
               "ssz_generic/progressive_containers",
               new SszGenericProgressiveContainerTestExecutor())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/SszGenericTests.java
@@ -21,14 +21,16 @@ public class SszGenericTests {
   public static final ImmutableMap<String, TestExecutor> SSZ_GENERIC_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           // SSZ Generic
-          .put("ssz_generic/basic_progressive_list", TestExecutor.IGNORE_TESTS)
+          .put("ssz_generic/basic_progressive_list", new SszGenericProgressiveListTestExecutor())
           .put("ssz_generic/basic_vector", new SszGenericBasicVectorTestExecutor())
           .put("ssz_generic/bitlist", new SszGenericBitlistTestExecutor())
           .put("ssz_generic/bitvector", new SszGenericBitvectorTestExecutor())
           .put("ssz_generic/boolean", new SszGenericBooleanTestExecutor())
           .put("ssz_generic/containers", new SszGenericContainerTestExecutor())
           .put("ssz_generic/progressive_bitlist", TestExecutor.IGNORE_TESTS)
-          .put("ssz_generic/progressive_containers", TestExecutor.IGNORE_TESTS)
+          .put(
+              "ssz_generic/progressive_containers",
+              new SszGenericProgressiveContainerTestExecutor())
           .put("ssz_generic/compatible_unions", TestExecutor.IGNORE_TESTS)
           .put("ssz_generic/uints", new SszGenericUIntTestExecutor())
           .build();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ProgressiveTestStruct.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ProgressiveTestStruct.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class ProgressiveTestStruct
+    extends Container4<
+        ProgressiveTestStruct,
+        SszList<SszByte>,
+        SszList<SszUInt64>,
+        SszList<SmallTestStruct>,
+        SszList<SszList<VarTestStruct>>> {
+
+  protected ProgressiveTestStruct(
+      final ContainerSchema4<
+              ProgressiveTestStruct,
+              SszList<SszByte>,
+              SszList<SszUInt64>,
+              SszList<SmallTestStruct>,
+              SszList<SszList<VarTestStruct>>>
+          schema,
+      final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ProgressiveTestStructSchema.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_generic/containers/ProgressiveTestStructSchema.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.ssz_generic.containers;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+/**
+ * Schema for ProgressiveTestStruct - a regular Container with ProgressiveList fields.
+ *
+ * <pre>
+ * class ProgressiveTestStruct(Container):
+ *     A: ProgressiveList[byte]
+ *     B: ProgressiveList[uint64]
+ *     C: ProgressiveList[SmallTestStruct]
+ *     D: ProgressiveList[ProgressiveList[VarTestStruct]]
+ * </pre>
+ */
+public class ProgressiveTestStructSchema
+    extends ContainerSchema4<
+        ProgressiveTestStruct,
+        SszList<SszByte>,
+        SszList<SszUInt64>,
+        SszList<SmallTestStruct>,
+        SszList<SszList<VarTestStruct>>> {
+
+  public ProgressiveTestStructSchema() {
+    super(
+        ProgressiveTestStruct.class.getSimpleName(),
+        NamedSchema.of("A", SszProgressiveListSchema.create(SszPrimitiveSchemas.BYTE_SCHEMA)),
+        NamedSchema.of("B", SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA)),
+        NamedSchema.of("C", SszProgressiveListSchema.create(new SmallTestStructSchema())),
+        NamedSchema.of(
+            "D",
+            SszProgressiveListSchema.create(
+                SszProgressiveListSchema.create(new VarTestStructSchema()))));
+  }
+
+  @Override
+  public ProgressiveTestStruct createFromBackingNode(final TreeNode node) {
+    return new ProgressiveTestStruct(this, node);
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableProgressiveBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableProgressiveBitlistImpl.java
@@ -60,21 +60,21 @@ public class SszMutableProgressiveBitlistImpl
   @Override
   protected TreeUpdates changesToNewNodes(
       final Stream<Map.Entry<Integer, SszBit>> newChildValues, final TreeNode original) {
-    SszPrimitiveSchema primitiveSchema = getPrimitiveElementSchema();
-    int elementsPerChunk = BITS_PER_CHUNK;
-    TreeNode dataTree = original.get(GIndexUtil.LEFT_CHILD_G_INDEX);
-    int previousSize = backingImmutableData.size();
-    int previousTotalChunks = (previousSize + BITS_PER_CHUNK - 1) / BITS_PER_CHUNK;
-    int previousMaxLevel =
+    final SszPrimitiveSchema primitiveSchema = getPrimitiveElementSchema();
+    final int elementsPerChunk = BITS_PER_CHUNK;
+    final TreeNode dataTree = original.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    final int previousSize = backingImmutableData.size();
+    final int previousTotalChunks = (previousSize + BITS_PER_CHUNK - 1) / BITS_PER_CHUNK;
+    final int previousMaxLevel =
         previousTotalChunks > 0 ? ProgressiveTreeUtil.levelForIndex(previousTotalChunks - 1) : -1;
 
     // Group bit changes by chunk index
-    Int2ObjectMap<List<SszPrimitiveSchema.PackedNodeUpdate>> grouped =
+    final Int2ObjectMap<List<SszPrimitiveSchema.PackedNodeUpdate>> grouped =
         new Int2ObjectOpenHashMap<>();
     newChildValues.forEach(
         entry -> {
-          int chunkIndex = entry.getKey() / elementsPerChunk;
-          int internalIndex = entry.getKey() % elementsPerChunk;
+          final int chunkIndex = entry.getKey() / elementsPerChunk;
+          final int internalIndex = entry.getKey() % elementsPerChunk;
           grouped
               .computeIfAbsent(chunkIndex, k -> new ArrayList<>())
               .add(new SszPrimitiveSchema.PackedNodeUpdate(internalIndex, entry.getValue()));
@@ -84,13 +84,13 @@ public class SszMutableProgressiveBitlistImpl
     pendingChunkUpdates = new Int2ObjectOpenHashMap<>();
     for (Int2ObjectMap.Entry<List<SszPrimitiveSchema.PackedNodeUpdate>> chunkEntry :
         grouped.int2ObjectEntrySet()) {
-      int chunkIndex = chunkEntry.getIntKey();
-      List<SszPrimitiveSchema.PackedNodeUpdate> packedUpdates = chunkEntry.getValue();
+      final int chunkIndex = chunkEntry.getIntKey();
+      final List<SszPrimitiveSchema.PackedNodeUpdate> packedUpdates = chunkEntry.getValue();
 
       TreeNode originalChunk;
-      int chunkLevel = ProgressiveTreeUtil.levelForIndex(chunkIndex);
+      final int chunkLevel = ProgressiveTreeUtil.levelForIndex(chunkIndex);
       if (chunkLevel <= previousMaxLevel && packedUpdates.size() < elementsPerChunk) {
-        long chunkGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(chunkIndex);
+        final long chunkGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(chunkIndex);
         originalChunk = dataTree.get(chunkGIdx);
       } else {
         originalChunk = LeafNode.EMPTY_LEAF;
@@ -109,10 +109,10 @@ public class SszMutableProgressiveBitlistImpl
       return updateSize(tree);
     }
 
-    TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
-    int totalChunks = (size() + BITS_PER_CHUNK - 1) / BITS_PER_CHUNK;
+    final TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    final int totalChunks = (size() + BITS_PER_CHUNK - 1) / BITS_PER_CHUNK;
 
-    TreeNode updatedDataTree =
+    final TreeNode updatedDataTree =
         ProgressiveTreeUtil.updateProgressiveTree(dataTree, pendingChunkUpdates, totalChunks);
 
     pendingChunkUpdates = null;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableProgressiveBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableProgressiveBitlistImpl.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections.impl;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszMutablePrimitiveList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszPrimitiveList;
+import tech.pegasys.teku.infrastructure.ssz.impl.AbstractSszComposite;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeUpdates;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Mutable implementation of SszBitlist backed by a progressive merkle tree.
+ *
+ * <p>Groups bit changes by 256-bit chunk, applies packed bit updates per chunk, and uses {@link
+ * ProgressiveTreeUtil#updateProgressiveTree} to apply chunk-level changes to the progressive data
+ * tree.
+ */
+public class SszMutableProgressiveBitlistImpl
+    extends AbstractSszMutablePrimitiveCollection<Boolean, SszBit>
+    implements SszMutablePrimitiveList<Boolean, SszBit> {
+
+  private static final int BITS_PER_CHUNK = 256;
+
+  private int cachedSize;
+  private Int2ObjectMap<TreeNode> pendingChunkUpdates;
+
+  public SszMutableProgressiveBitlistImpl(final SszProgressiveBitlistImpl backingImmutableBitlist) {
+    super(backingImmutableBitlist);
+    cachedSize = backingImmutableBitlist.size();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Override
+  protected TreeUpdates changesToNewNodes(
+      final Stream<Map.Entry<Integer, SszBit>> newChildValues, final TreeNode original) {
+    SszPrimitiveSchema primitiveSchema = getPrimitiveElementSchema();
+    int elementsPerChunk = BITS_PER_CHUNK;
+    TreeNode dataTree = original.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    int previousSize = backingImmutableData.size();
+    int previousTotalChunks = (previousSize + BITS_PER_CHUNK - 1) / BITS_PER_CHUNK;
+    int previousMaxLevel =
+        previousTotalChunks > 0 ? ProgressiveTreeUtil.levelForIndex(previousTotalChunks - 1) : -1;
+
+    // Group bit changes by chunk index
+    Int2ObjectMap<List<SszPrimitiveSchema.PackedNodeUpdate>> grouped =
+        new Int2ObjectOpenHashMap<>();
+    newChildValues.forEach(
+        entry -> {
+          int chunkIndex = entry.getKey() / elementsPerChunk;
+          int internalIndex = entry.getKey() % elementsPerChunk;
+          grouped
+              .computeIfAbsent(chunkIndex, k -> new ArrayList<>())
+              .add(new SszPrimitiveSchema.PackedNodeUpdate(internalIndex, entry.getValue()));
+        });
+
+    // Apply packed updates per chunk
+    pendingChunkUpdates = new Int2ObjectOpenHashMap<>();
+    for (Int2ObjectMap.Entry<List<SszPrimitiveSchema.PackedNodeUpdate>> chunkEntry :
+        grouped.int2ObjectEntrySet()) {
+      int chunkIndex = chunkEntry.getIntKey();
+      List<SszPrimitiveSchema.PackedNodeUpdate> packedUpdates = chunkEntry.getValue();
+
+      TreeNode originalChunk;
+      int chunkLevel = ProgressiveTreeUtil.levelForIndex(chunkIndex);
+      if (chunkLevel <= previousMaxLevel && packedUpdates.size() < elementsPerChunk) {
+        long chunkGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(chunkIndex);
+        originalChunk = dataTree.get(chunkGIdx);
+      } else {
+        originalChunk = LeafNode.EMPTY_LEAF;
+      }
+
+      pendingChunkUpdates.put(
+          chunkIndex, primitiveSchema.updatePackedNode(originalChunk, packedUpdates));
+    }
+
+    return new TreeUpdates(List.of(), List.of());
+  }
+
+  @Override
+  protected TreeNode doFinalTreeUpdates(final TreeNode tree) {
+    if (pendingChunkUpdates == null || pendingChunkUpdates.isEmpty()) {
+      return updateSize(tree);
+    }
+
+    TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    int totalChunks = (size() + BITS_PER_CHUNK - 1) / BITS_PER_CHUNK;
+
+    TreeNode updatedDataTree =
+        ProgressiveTreeUtil.updateProgressiveTree(dataTree, pendingChunkUpdates, totalChunks);
+
+    pendingChunkUpdates = null;
+    return BranchNode.create(updatedDataTree, createSizeNode());
+  }
+
+  private TreeNode updateSize(final TreeNode root) {
+    return BranchNode.create(root.get(GIndexUtil.LEFT_CHILD_G_INDEX), createSizeNode());
+  }
+
+  private TreeNode createSizeNode() {
+    return SszUInt64.of(UInt64.fromLongBits(size())).getBackingNode();
+  }
+
+  @Override
+  public int size() {
+    return cachedSize;
+  }
+
+  @Override
+  public void set(final int index, final SszBit value) {
+    super.set(index, value);
+    if (index == cachedSize) {
+      cachedSize++;
+    }
+  }
+
+  @Override
+  public void clear() {
+    super.clear();
+    cachedSize = 0;
+  }
+
+  @Override
+  protected void checkIndex(final int index, final boolean set) {
+    if (index < 0 || (!set && index >= size()) || (set && index > size())) {
+      throw new IndexOutOfBoundsException(
+          "Invalid index " + index + " for progressive bitlist with size " + size());
+    }
+  }
+
+  @Override
+  protected AbstractSszComposite<SszBit> createImmutableSszComposite(
+      final TreeNode backingNode, final IntCache<SszBit> childrenCache) {
+    return new SszProgressiveBitlistImpl(getSchema(), backingNode);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszProgressiveBitlistSchema getSchema() {
+    return (SszProgressiveBitlistSchema) super.getSchema();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public SszPrimitiveList<Boolean, SszBit> commitChanges() {
+    return (SszPrimitiveList<Boolean, SszBit>) super.commitChanges();
+  }
+
+  @Override
+  public SszMutablePrimitiveList<Boolean, SszBit> createWritableCopy() {
+    throw new UnsupportedOperationException(
+        "Creating a writable copy from writable instance is not supported");
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszProgressiveBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszProgressiveBitlistImpl.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections.impl;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.BitSet;
+import java.util.stream.IntStream;
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszMutablePrimitiveList;
+import tech.pegasys.teku.infrastructure.ssz.impl.AbstractSszCollection;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SszProgressiveBitlistImpl extends AbstractSszCollection<SszBit> implements SszBitlist {
+
+  private final BitlistImpl value;
+
+  public SszProgressiveBitlistImpl(
+      final SszProgressiveBitlistSchema schema, final TreeNode backingNode) {
+    super(schema, backingNode);
+    this.value = BitlistImpl.fromSszBytes(this.sszSerialize(), Long.MAX_VALUE);
+  }
+
+  private SszProgressiveBitlistImpl(
+      final SszProgressiveBitlistSchema schema, final BitlistImpl value) {
+    super(schema, () -> schema.createTreeFromBitData(value.getCurrentSize(), value.toByteArray()));
+    this.value = value;
+  }
+
+  public static SszProgressiveBitlistImpl ofBits(
+      final SszProgressiveBitlistSchema schema, final int size, final int... bits) {
+    return new SszProgressiveBitlistImpl(schema, new BitlistImpl(size, Long.MAX_VALUE, bits));
+  }
+
+  public static SszProgressiveBitlistImpl wrapBitSet(
+      final SszProgressiveBitlistSchema schema, final int size, final BitSet bitSet) {
+    return new SszProgressiveBitlistImpl(
+        schema, BitlistImpl.wrapBitSet(size, Long.MAX_VALUE, bitSet));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszBitlistSchema<SszBitlist> getSchema() {
+    return (SszBitlistSchema<SszBitlist>) super.getSchema();
+  }
+
+  @Override
+  protected int sizeImpl() {
+    return value.getCurrentSize();
+  }
+
+  @Override
+  protected IntCache<SszBit> createCache() {
+    return IntCache.noop();
+  }
+
+  @Override
+  public BitSet getAsBitSet() {
+    return value.getAsBitSet();
+  }
+
+  @Override
+  public BitSet getAsBitSet(final int start, final int end) {
+    return value.getAsBitSet(start, end);
+  }
+
+  @Override
+  public int getLastSetBitIndex() {
+    return value.getLastSetBitIndex();
+  }
+
+  @Override
+  public SszBitlist or(final SszBitlist other) {
+    return new SszProgressiveBitlistImpl(
+        (SszProgressiveBitlistSchema) getSchema(),
+        value.or(((SszProgressiveBitlistImpl) other).value));
+  }
+
+  @Override
+  public boolean getBit(final int i) {
+    return value.getBit(i);
+  }
+
+  @Override
+  public int getBitCount() {
+    return value.getBitCount();
+  }
+
+  @Override
+  public boolean intersects(final SszBitlist other) {
+    return value.intersects(((SszProgressiveBitlistImpl) other).value);
+  }
+
+  @Override
+  public boolean isSuperSetOf(final SszBitlist other) {
+    return value.isSuperSetOf(((SszProgressiveBitlistImpl) other).value);
+  }
+
+  @Override
+  public IntList getAllSetBits() {
+    return value.getAllSetBits();
+  }
+
+  @Override
+  public IntStream streamAllSetBits() {
+    return value.streamAllSetBits();
+  }
+
+  @Override
+  protected void checkIndex(final int index) {
+    if (index < 0 || index >= size()) {
+      throw new IndexOutOfBoundsException(
+          "Invalid index " + index + " for progressive bitlist with size " + size());
+    }
+  }
+
+  @Override
+  public SszMutablePrimitiveList<Boolean, SszBit> createWritableCopy() {
+    throw new UnsupportedOperationException("SszProgressiveBitlist is immutable structure");
+  }
+
+  @Override
+  public boolean isWritableSupported() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "SszProgressiveBitlist{size=" + this.size() + ", " + value.toString() + "}";
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszProgressiveBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszProgressiveBitlistImpl.java
@@ -130,12 +130,12 @@ public class SszProgressiveBitlistImpl extends AbstractSszCollection<SszBit> imp
 
   @Override
   public SszMutablePrimitiveList<Boolean, SszBit> createWritableCopy() {
-    throw new UnsupportedOperationException("SszProgressiveBitlist is immutable structure");
+    return new SszMutableProgressiveBitlistImpl(this);
   }
 
   @Override
   public boolean isWritableSupported() {
-    return false;
+    return true;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/PackedChunkUpdateUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/PackedChunkUpdateUtil.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.impl;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import tech.pegasys.teku.infrastructure.ssz.SszPrimitive;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Shared helpers for building packed-primitive chunk updates in progressive tree-backed mutable
+ * collections. Used by {@code SszMutableProgressiveListImpl} (packed branch) and {@code
+ * SszMutableProgressiveBitlistImpl}.
+ */
+public class PackedChunkUpdateUtil {
+
+  private PackedChunkUpdateUtil() {}
+
+  /**
+   * Groups element-level changes by chunk index and applies {@link
+   * SszPrimitiveSchema#updatePackedNode} per chunk.
+   *
+   * @param changes element-level changes (elementIndex -> value)
+   * @param dataTree the current progressive data tree (left child of root)
+   * @param elementsPerChunk how many primitive elements fit in one 32-byte chunk
+   * @param previousSize the previous collection size (used to decide whether to read existing
+   *     chunks)
+   * @param primitiveSchema the primitive element schema
+   * @return map from chunk index to updated chunk node
+   */
+  public static <DataT, SszDataT extends SszPrimitive<DataT>>
+      Int2ObjectMap<TreeNode> buildPackedChunkUpdates(
+          final List<? extends Map.Entry<Integer, SszDataT>> changes,
+          final TreeNode dataTree,
+          final int elementsPerChunk,
+          final int previousSize,
+          final SszPrimitiveSchema<DataT, SszDataT> primitiveSchema) {
+
+    final int previousTotalChunks = (previousSize + elementsPerChunk - 1) / elementsPerChunk;
+    final int previousMaxLevel =
+        previousTotalChunks > 0 ? ProgressiveTreeUtil.levelForIndex(previousTotalChunks - 1) : -1;
+
+    // Group by chunk index
+    final Int2ObjectMap<List<SszPrimitiveSchema.PackedNodeUpdate<DataT, SszDataT>>> grouped =
+        new Int2ObjectOpenHashMap<>();
+    for (Map.Entry<Integer, SszDataT> entry : changes) {
+      final int chunkIndex = entry.getKey() / elementsPerChunk;
+      final int internalIndex = entry.getKey() % elementsPerChunk;
+      grouped
+          .computeIfAbsent(chunkIndex, k -> new ArrayList<>())
+          .add(new SszPrimitiveSchema.PackedNodeUpdate<>(internalIndex, entry.getValue()));
+    }
+
+    // Apply packed updates per chunk
+    final Int2ObjectMap<TreeNode> chunkUpdates = new Int2ObjectOpenHashMap<>();
+    for (Int2ObjectMap.Entry<List<SszPrimitiveSchema.PackedNodeUpdate<DataT, SszDataT>>>
+        chunkEntry : grouped.int2ObjectEntrySet()) {
+      final int chunkIndex = chunkEntry.getIntKey();
+      final List<SszPrimitiveSchema.PackedNodeUpdate<DataT, SszDataT>> packedUpdates =
+          chunkEntry.getValue();
+
+      TreeNode originalChunk;
+      final int chunkLevel = ProgressiveTreeUtil.levelForIndex(chunkIndex);
+      if (chunkLevel <= previousMaxLevel && packedUpdates.size() < elementsPerChunk) {
+        final long chunkGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(chunkIndex);
+        originalChunk = dataTree.get(chunkGIdx);
+      } else {
+        originalChunk = LeafNode.EMPTY_LEAF;
+      }
+
+      chunkUpdates.put(chunkIndex, primitiveSchema.updatePackedNode(originalChunk, packedUpdates));
+    }
+
+    return chunkUpdates;
+  }
+
+  /**
+   * Replaces the length node (right child) while preserving the data tree (left child).
+   *
+   * @param root the current list/bitlist root node
+   * @param newSize the new size to encode
+   * @return updated root node with new length
+   */
+  public static TreeNode updateSize(final TreeNode root, final int newSize) {
+    return BranchNode.create(root.get(GIndexUtil.LEFT_CHILD_G_INDEX), createSizeNode(newSize));
+  }
+
+  public static TreeNode createSizeNode(final int size) {
+    return SszUInt64.of(UInt64.fromLongBits(size)).getBackingNode();
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveContainerImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveContainerImpl.java
@@ -61,21 +61,21 @@ public class SszMutableProgressiveContainerImpl
       return tree;
     }
 
-    SszProgressiveContainerSchema<?> schema = getSchema();
-    TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
-    TreeNode activeFieldsNode = tree.get(GIndexUtil.RIGHT_CHILD_G_INDEX);
+    final SszProgressiveContainerSchema<?> schema = getSchema();
+    final TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    final TreeNode activeFieldsNode = tree.get(GIndexUtil.RIGHT_CHILD_G_INDEX);
 
     // Map field indices to tree-position slots
-    Int2ObjectMap<TreeNode> slotUpdates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> slotUpdates = new Int2ObjectOpenHashMap<>();
     for (Map.Entry<Integer, SszData> entry : pendingChanges) {
-      int fieldIndex = entry.getKey();
-      int treePosition = schema.getTreePosition(fieldIndex);
+      final int fieldIndex = entry.getKey();
+      final int treePosition = schema.getTreePosition(fieldIndex);
       slotUpdates.put(treePosition, entry.getValue().getBackingNode());
     }
 
-    int totalSlots = schema.getActiveFields().length;
+    final int totalSlots = schema.getActiveFields().length;
 
-    TreeNode updatedDataTree =
+    final TreeNode updatedDataTree =
         ProgressiveTreeUtil.updateProgressiveTree(dataTree, slotUpdates, totalSlots);
 
     pendingChanges = null;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveContainerImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveContainerImpl.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.impl;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableData;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableRefContainer;
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeUpdates;
+
+/**
+ * Mutable implementation of SszContainer backed by a progressive merkle tree.
+ *
+ * <p>Overrides the standard change-to-tree-update flow because progressive trees have mixed-depth
+ * generalized indices. Field changes are mapped to tree-position slot changes and applied via
+ * {@link ProgressiveTreeUtil#updateProgressiveTree}.
+ */
+public class SszMutableProgressiveContainerImpl
+    extends AbstractSszMutableComposite<SszData, SszMutableData> implements SszMutableRefContainer {
+
+  private List<Map.Entry<Integer, SszData>> pendingChanges;
+
+  public SszMutableProgressiveContainerImpl(
+      final SszProgressiveContainerImpl backingImmutableView) {
+    super(backingImmutableView);
+  }
+
+  @Override
+  protected TreeUpdates changesToNewNodes(
+      final Stream<Map.Entry<Integer, SszData>> newChildValues, final TreeNode original) {
+    pendingChanges = newChildValues.toList();
+    return new TreeUpdates(List.of(), List.of());
+  }
+
+  @Override
+  protected TreeNode doFinalTreeUpdates(final TreeNode tree) {
+    if (pendingChanges == null || pendingChanges.isEmpty()) {
+      return tree;
+    }
+
+    SszProgressiveContainerSchema<?> schema = getSchema();
+    TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    TreeNode activeFieldsNode = tree.get(GIndexUtil.RIGHT_CHILD_G_INDEX);
+
+    // Map field indices to tree-position slots
+    Int2ObjectMap<TreeNode> slotUpdates = new Int2ObjectOpenHashMap<>();
+    for (Map.Entry<Integer, SszData> entry : pendingChanges) {
+      int fieldIndex = entry.getKey();
+      int treePosition = schema.getTreePosition(fieldIndex);
+      slotUpdates.put(treePosition, entry.getValue().getBackingNode());
+    }
+
+    int totalSlots = schema.getActiveFields().length;
+
+    TreeNode updatedDataTree =
+        ProgressiveTreeUtil.updateProgressiveTree(dataTree, slotUpdates, totalSlots);
+
+    pendingChanges = null;
+    return BranchNode.create(updatedDataTree, activeFieldsNode);
+  }
+
+  @Override
+  protected SszProgressiveContainerImpl createImmutableSszComposite(
+      final TreeNode backingNode, final IntCache<SszData> viewCache) {
+    return new SszProgressiveContainerImpl(getSchema(), backingNode, viewCache);
+  }
+
+  @Override
+  public SszProgressiveContainerSchema<?> getSchema() {
+    return (SszProgressiveContainerSchema<?>) super.getSchema();
+  }
+
+  @Override
+  public SszContainer commitChanges() {
+    return (SszContainer) super.commitChanges();
+  }
+
+  @Override
+  public SszMutableContainer createWritableCopy() {
+    throw new UnsupportedOperationException(
+        "createWritableCopy() is now implemented for immutable SszData only");
+  }
+
+  @Override
+  protected void checkIndex(final int index, final boolean set) {
+    if (index >= size()) {
+      throw new IndexOutOfBoundsException(
+          "Invalid index " + index + " for progressive container with size " + size());
+    }
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveListImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveListImpl.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.impl;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableRefList;
+import tech.pegasys.teku.infrastructure.ssz.SszPrimitive;
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeUpdates;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Mutable implementation of SszList backed by a progressive merkle tree. Handles both composite and
+ * packed primitive element types.
+ *
+ * <p>Overrides the standard change-to-tree-update flow because progressive trees have mixed-depth
+ * generalized indices. Changes are stored during {@link #changesToNewNodes} and applied level-by-
+ * level in {@link #doFinalTreeUpdates} via {@link ProgressiveTreeUtil#updateProgressiveTree}.
+ */
+public class SszMutableProgressiveListImpl<
+        SszElementT extends SszData, SszMutableElementT extends SszElementT>
+    extends AbstractSszMutableCollection<SszElementT, SszMutableElementT>
+    implements SszMutableRefList<SszElementT, SszMutableElementT> {
+
+  private int cachedSize;
+  private List<Map.Entry<Integer, SszElementT>> pendingChanges;
+
+  public SszMutableProgressiveListImpl(
+      final SszProgressiveListImpl<SszElementT> backingImmutableList) {
+    super(backingImmutableList);
+    cachedSize = backingImmutableList.size();
+  }
+
+  @Override
+  protected TreeUpdates changesToNewNodes(
+      final Stream<Map.Entry<Integer, SszElementT>> newChildValues, final TreeNode original) {
+    // Consume and store changes; return empty TreeUpdates to bypass mixed-depth issue
+    pendingChanges = newChildValues.toList();
+    return new TreeUpdates(List.of(), List.of());
+  }
+
+  @Override
+  protected TreeNode doFinalTreeUpdates(final TreeNode tree) {
+    if (pendingChanges == null || pendingChanges.isEmpty()) {
+      return updateSize(tree);
+    }
+
+    TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    int elementsPerChunk = getSchema().getElementsPerChunk();
+    int previousSize = backingImmutableData.size();
+
+    Int2ObjectMap<TreeNode> chunkUpdates =
+        buildChunkUpdates(dataTree, elementsPerChunk, previousSize);
+
+    int totalChunks =
+        elementsPerChunk > 1 ? (size() + elementsPerChunk - 1) / elementsPerChunk : size();
+
+    TreeNode updatedDataTree =
+        ProgressiveTreeUtil.updateProgressiveTree(dataTree, chunkUpdates, totalChunks);
+
+    pendingChanges = null;
+    return BranchNode.create(updatedDataTree, createSizeNode());
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private Int2ObjectMap<TreeNode> buildChunkUpdates(
+      final TreeNode dataTree, final int elementsPerChunk, final int previousSize) {
+    Int2ObjectMap<TreeNode> chunkUpdates = new Int2ObjectOpenHashMap<>();
+
+    if (elementsPerChunk > 1) {
+      // Packed primitives: group element changes by chunk, apply updatePackedNode
+      SszPrimitiveSchema primitiveSchema = (SszPrimitiveSchema) getSchema().getElementSchema();
+      int previousTotalChunks = (previousSize + elementsPerChunk - 1) / elementsPerChunk;
+      int previousMaxLevel =
+          previousTotalChunks > 0 ? ProgressiveTreeUtil.levelForIndex(previousTotalChunks - 1) : -1;
+
+      // Group by chunk index
+      Int2ObjectMap<List<SszPrimitiveSchema.PackedNodeUpdate>> grouped =
+          new Int2ObjectOpenHashMap<>();
+      for (Map.Entry<Integer, SszElementT> entry : pendingChanges) {
+        int chunkIndex = entry.getKey() / elementsPerChunk;
+        int internalIndex = entry.getKey() % elementsPerChunk;
+        grouped
+            .computeIfAbsent(chunkIndex, k -> new ArrayList<>())
+            .add(
+                new SszPrimitiveSchema.PackedNodeUpdate(
+                    internalIndex, (SszPrimitive) entry.getValue()));
+      }
+
+      for (Int2ObjectMap.Entry<List<SszPrimitiveSchema.PackedNodeUpdate>> chunkEntry :
+          grouped.int2ObjectEntrySet()) {
+        int chunkIndex = chunkEntry.getIntKey();
+        List<SszPrimitiveSchema.PackedNodeUpdate> packedUpdates = chunkEntry.getValue();
+
+        TreeNode originalChunk;
+        int chunkLevel = ProgressiveTreeUtil.levelForIndex(chunkIndex);
+        if (chunkLevel <= previousMaxLevel && packedUpdates.size() < elementsPerChunk) {
+          long chunkGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(chunkIndex);
+          originalChunk = dataTree.get(chunkGIdx);
+        } else {
+          originalChunk = LeafNode.EMPTY_LEAF;
+        }
+
+        chunkUpdates.put(
+            chunkIndex, primitiveSchema.updatePackedNode(originalChunk, packedUpdates));
+      }
+    } else {
+      // Composite elements: 1:1 chunk mapping
+      for (Map.Entry<Integer, SszElementT> entry : pendingChanges) {
+        chunkUpdates.put((int) entry.getKey(), entry.getValue().getBackingNode());
+      }
+    }
+
+    return chunkUpdates;
+  }
+
+  private TreeNode updateSize(final TreeNode root) {
+    return BranchNode.create(root.get(GIndexUtil.LEFT_CHILD_G_INDEX), createSizeNode());
+  }
+
+  private TreeNode createSizeNode() {
+    return SszUInt64.of(UInt64.fromLongBits(size())).getBackingNode();
+  }
+
+  @Override
+  public int size() {
+    return cachedSize;
+  }
+
+  @Override
+  public void set(final int index, final SszElementT value) {
+    super.set(index, value);
+    if (index == cachedSize) {
+      cachedSize++;
+    }
+  }
+
+  @Override
+  public void clear() {
+    super.clear();
+    cachedSize = 0;
+  }
+
+  @Override
+  protected void checkIndex(final int index, final boolean set) {
+    if (index < 0 || (!set && index >= size()) || (set && index > size())) {
+      throw new IndexOutOfBoundsException(
+          "Invalid index " + index + " for progressive list with size " + size());
+    }
+  }
+
+  @Override
+  protected SszProgressiveListImpl<SszElementT> createImmutableSszComposite(
+      final TreeNode backingNode, final IntCache<SszElementT> childrenCache) {
+    return new SszProgressiveListImpl<>(getSchema(), backingNode, childrenCache);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszProgressiveListSchema<SszElementT> getSchema() {
+    return (SszProgressiveListSchema<SszElementT>) super.getSchema();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public SszList<SszElementT> commitChanges() {
+    return (SszList<SszElementT>) super.commitChanges();
+  }
+
+  @Override
+  public SszMutableList<SszElementT> createWritableCopy() {
+    throw new UnsupportedOperationException("Creating a copy from writable list is not supported");
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveListImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszMutableProgressiveListImpl.java
@@ -72,17 +72,17 @@ public class SszMutableProgressiveListImpl<
       return updateSize(tree);
     }
 
-    TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
-    int elementsPerChunk = getSchema().getElementsPerChunk();
-    int previousSize = backingImmutableData.size();
+    final TreeNode dataTree = tree.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    final int elementsPerChunk = getSchema().getElementsPerChunk();
+    final int previousSize = backingImmutableData.size();
 
-    Int2ObjectMap<TreeNode> chunkUpdates =
+    final Int2ObjectMap<TreeNode> chunkUpdates =
         buildChunkUpdates(dataTree, elementsPerChunk, previousSize);
 
-    int totalChunks =
+    final int totalChunks =
         elementsPerChunk > 1 ? (size() + elementsPerChunk - 1) / elementsPerChunk : size();
 
-    TreeNode updatedDataTree =
+    final TreeNode updatedDataTree =
         ProgressiveTreeUtil.updateProgressiveTree(dataTree, chunkUpdates, totalChunks);
 
     pendingChanges = null;
@@ -92,21 +92,22 @@ public class SszMutableProgressiveListImpl<
   @SuppressWarnings({"unchecked", "rawtypes"})
   private Int2ObjectMap<TreeNode> buildChunkUpdates(
       final TreeNode dataTree, final int elementsPerChunk, final int previousSize) {
-    Int2ObjectMap<TreeNode> chunkUpdates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> chunkUpdates = new Int2ObjectOpenHashMap<>();
 
     if (elementsPerChunk > 1) {
       // Packed primitives: group element changes by chunk, apply updatePackedNode
-      SszPrimitiveSchema primitiveSchema = (SszPrimitiveSchema) getSchema().getElementSchema();
-      int previousTotalChunks = (previousSize + elementsPerChunk - 1) / elementsPerChunk;
-      int previousMaxLevel =
+      final SszPrimitiveSchema primitiveSchema =
+          (SszPrimitiveSchema) getSchema().getElementSchema();
+      final int previousTotalChunks = (previousSize + elementsPerChunk - 1) / elementsPerChunk;
+      final int previousMaxLevel =
           previousTotalChunks > 0 ? ProgressiveTreeUtil.levelForIndex(previousTotalChunks - 1) : -1;
 
       // Group by chunk index
-      Int2ObjectMap<List<SszPrimitiveSchema.PackedNodeUpdate>> grouped =
+      final Int2ObjectMap<List<SszPrimitiveSchema.PackedNodeUpdate>> grouped =
           new Int2ObjectOpenHashMap<>();
       for (Map.Entry<Integer, SszElementT> entry : pendingChanges) {
-        int chunkIndex = entry.getKey() / elementsPerChunk;
-        int internalIndex = entry.getKey() % elementsPerChunk;
+        final int chunkIndex = entry.getKey() / elementsPerChunk;
+        final int internalIndex = entry.getKey() % elementsPerChunk;
         grouped
             .computeIfAbsent(chunkIndex, k -> new ArrayList<>())
             .add(
@@ -116,13 +117,13 @@ public class SszMutableProgressiveListImpl<
 
       for (Int2ObjectMap.Entry<List<SszPrimitiveSchema.PackedNodeUpdate>> chunkEntry :
           grouped.int2ObjectEntrySet()) {
-        int chunkIndex = chunkEntry.getIntKey();
-        List<SszPrimitiveSchema.PackedNodeUpdate> packedUpdates = chunkEntry.getValue();
+        final int chunkIndex = chunkEntry.getIntKey();
+        final List<SszPrimitiveSchema.PackedNodeUpdate> packedUpdates = chunkEntry.getValue();
 
         TreeNode originalChunk;
-        int chunkLevel = ProgressiveTreeUtil.levelForIndex(chunkIndex);
+        final int chunkLevel = ProgressiveTreeUtil.levelForIndex(chunkIndex);
         if (chunkLevel <= previousMaxLevel && packedUpdates.size() < elementsPerChunk) {
-          long chunkGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(chunkIndex);
+          final long chunkGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(chunkIndex);
           originalChunk = dataTree.get(chunkGIdx);
         } else {
           originalChunk = LeafNode.EMPTY_LEAF;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveContainerImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveContainerImpl.java
@@ -44,8 +44,8 @@ public class SszProgressiveContainerImpl extends AbstractSszComposite<SszData>
 
   @Override
   protected SszData getImpl(final int index) {
-    SszProgressiveContainerSchema<?> schema = getSchema();
-    TreeNode node = getBackingNode().get(schema.getChildGeneralizedIndex(index));
+    final SszProgressiveContainerSchema<?> schema = getSchema();
+    final TreeNode node = getBackingNode().get(schema.getChildGeneralizedIndex(index));
     return schema.getChildSchema(index).createFromBackingNode(node);
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveContainerImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveContainerImpl.java
@@ -35,6 +35,13 @@ public class SszProgressiveContainerImpl extends AbstractSszComposite<SszData>
     super(type, backingNode);
   }
 
+  public SszProgressiveContainerImpl(
+      final SszProgressiveContainerSchema<?> type,
+      final TreeNode backingNode,
+      final IntCache<SszData> cache) {
+    super(type, backingNode, cache);
+  }
+
   @Override
   protected SszData getImpl(final int index) {
     SszProgressiveContainerSchema<?> schema = getSchema();
@@ -49,13 +56,12 @@ public class SszProgressiveContainerImpl extends AbstractSszComposite<SszData>
 
   @Override
   public SszMutableContainer createWritableCopy() {
-    throw new UnsupportedOperationException(
-        "Mutable copies not supported for progressive containers");
+    return new SszMutableProgressiveContainerImpl(this);
   }
 
   @Override
   public boolean isWritableSupported() {
-    return false;
+    return true;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveContainerImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveContainerImpl.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.impl;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableContainer;
+import tech.pegasys.teku.infrastructure.ssz.cache.ArrayIntCache;
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+/**
+ * Immutable implementation of SszContainer backed by a progressive merkle tree. The backing tree
+ * has the structure: BranchNode(progressiveDataTree, activeFieldsLeafNode)
+ */
+public class SszProgressiveContainerImpl extends AbstractSszComposite<SszData>
+    implements SszContainer {
+
+  public SszProgressiveContainerImpl(
+      final SszProgressiveContainerSchema<?> type, final TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  @Override
+  protected SszData getImpl(final int index) {
+    SszProgressiveContainerSchema<?> schema = getSchema();
+    TreeNode node = getBackingNode().get(schema.getChildGeneralizedIndex(index));
+    return schema.getChildSchema(index).createFromBackingNode(node);
+  }
+
+  @Override
+  public SszProgressiveContainerSchema<?> getSchema() {
+    return (SszProgressiveContainerSchema<?>) super.getSchema();
+  }
+
+  @Override
+  public SszMutableContainer createWritableCopy() {
+    throw new UnsupportedOperationException(
+        "Mutable copies not supported for progressive containers");
+  }
+
+  @Override
+  public boolean isWritableSupported() {
+    return false;
+  }
+
+  @Override
+  protected int sizeImpl() {
+    return getSchema().getFieldsCount();
+  }
+
+  @Override
+  protected IntCache<SszData> createCache() {
+    return new ArrayIntCache<>(size());
+  }
+
+  @Override
+  protected void checkIndex(final int index) {
+    if (index >= size()) {
+      throw new IndexOutOfBoundsException(
+          "Invalid index " + index + " for progressive container with size " + size());
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getSchema().getContainerName()
+        + "{"
+        + IntStream.range(0, getSchema().getFieldsCount())
+            .mapToObj(idx -> getSchema().getFieldNames().get(idx) + "=" + get(idx))
+            .collect(Collectors.joining(", "))
+        + "}";
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveListImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveListImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.impl;
+
+import java.util.stream.Collectors;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+/**
+ * Immutable implementation of SszList backed by a progressive merkle tree. The backing tree has the
+ * structure: BranchNode(progressiveDataTree, lengthNode)
+ */
+public class SszProgressiveListImpl<SszElementT extends SszData>
+    extends AbstractSszCollection<SszElementT> implements SszList<SszElementT> {
+
+  public SszProgressiveListImpl(
+      final SszProgressiveListSchema<SszElementT> schema, final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  public SszProgressiveListImpl(
+      final SszProgressiveListSchema<SszElementT> schema,
+      final TreeNode backingNode,
+      final IntCache<SszElementT> cache) {
+    super(schema, backingNode, cache);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public SszListSchema<SszElementT, ?> getSchema() {
+    return (SszListSchema<SszElementT, ?>) super.getSchema();
+  }
+
+  @Override
+  protected int sizeImpl() {
+    return SszPrimitiveSchemas.UINT64_SCHEMA.createFromBackingNode(getSizeNode()).get().intValue();
+  }
+
+  private TreeNode getSizeNode() {
+    return getBackingNode().get(GIndexUtil.RIGHT_CHILD_G_INDEX);
+  }
+
+  @Override
+  public SszMutableList<SszElementT> createWritableCopy() {
+    throw new UnsupportedOperationException("Mutable copies not supported for progressive lists");
+  }
+
+  @Override
+  public boolean isWritableSupported() {
+    return false;
+  }
+
+  @Override
+  protected void checkIndex(final int index) {
+    if (index < 0 || index >= size()) {
+      throw new IndexOutOfBoundsException(
+          "Invalid index " + index + " for progressive list with size " + size());
+    }
+  }
+
+  @Override
+  public String toString() {
+    int maxToDisplay = 1024;
+    String elements =
+        stream().limit(maxToDisplay).map(Object::toString).collect(Collectors.joining(", "));
+    if (size() > maxToDisplay) {
+      elements += " ... more " + (size() - maxToDisplay) + " elements";
+    }
+    return "SszProgressiveList{size=" + size() + ": " + elements + "}";
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveListImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveListImpl.java
@@ -78,7 +78,7 @@ public class SszProgressiveListImpl<SszElementT extends SszData>
 
   @Override
   public String toString() {
-    int maxToDisplay = 1024;
+    final int maxToDisplay = 1024;
     String elements =
         stream().limit(maxToDisplay).map(Object::toString).collect(Collectors.joining(", "));
     if (size() > maxToDisplay) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveListImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/impl/SszProgressiveListImpl.java
@@ -60,12 +60,12 @@ public class SszProgressiveListImpl<SszElementT extends SszData>
 
   @Override
   public SszMutableList<SszElementT> createWritableCopy() {
-    throw new UnsupportedOperationException("Mutable copies not supported for progressive lists");
+    return new SszMutableProgressiveListImpl<>(this);
   }
 
   @Override
   public boolean isWritableSupported() {
-    return false;
+    return true;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/ContainerSchemaUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/ContainerSchemaUtil.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszLengthBounds;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+/**
+ * Shared helpers for SSZ container schemas. Extracts the identical serialization, deserialization,
+ * and computed-property logic used by both {@code AbstractSszContainerSchema} and {@code
+ * SszProgressiveContainerSchema}.
+ */
+public class ContainerSchemaUtil {
+
+  private ContainerSchemaUtil() {}
+
+  public static boolean isFixedSize(final SszContainerSchema<?> schema) {
+    for (int i = 0; i < schema.getFieldsCount(); i++) {
+      if (!schema.getChildSchema(i).isFixedSize()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static int calcSszFixedPartSize(final SszContainerSchema<?> schema) {
+    int size = 0;
+    for (int i = 0; i < schema.getFieldsCount(); i++) {
+      SszSchema<?> childType = schema.getChildSchema(i);
+      size += childType.isFixedSize() ? childType.getSszFixedPartSize() : SszType.SSZ_LENGTH_SIZE;
+    }
+    return size;
+  }
+
+  public static int getSszVariablePartSize(
+      final SszContainerSchema<?> schema, final TreeNode node) {
+    if (schema.isFixedSize()) {
+      return 0;
+    }
+    int size = 0;
+    for (int i = 0; i < schema.getFieldsCount(); i++) {
+      SszSchema<?> childType = schema.getChildSchema(i);
+      if (!childType.isFixedSize()) {
+        size += childType.getSszSize(node.get(schema.getChildGeneralizedIndex(i)));
+      }
+    }
+    return size;
+  }
+
+  public static int sszSerializeTree(
+      final SszContainerSchema<?> schema,
+      final TreeNode node,
+      final SszWriter writer,
+      final int fixedPartSize) {
+    int variableChildOffset = fixedPartSize;
+    int[] variableSizes = new int[schema.getFieldsCount()];
+    for (int i = 0; i < schema.getFieldsCount(); i++) {
+      TreeNode childSubtree = node.get(schema.getChildGeneralizedIndex(i));
+      SszSchema<?> childType = schema.getChildSchema(i);
+      if (childType.isFixedSize()) {
+        int size = childType.sszSerializeTree(childSubtree, writer);
+        assert size == childType.getSszFixedPartSize();
+      } else {
+        writer.write(SszType.sszLengthToBytes(variableChildOffset));
+        int childSize = childType.getSszSize(childSubtree);
+        variableSizes[i] = childSize;
+        variableChildOffset += childSize;
+      }
+    }
+    for (int i = 0; i < schema.getFieldsCount(); i++) {
+      SszSchema<?> childType = schema.getChildSchema(i);
+      if (!childType.isFixedSize()) {
+        TreeNode childSubtree = node.get(schema.getChildGeneralizedIndex(i));
+        int size = childType.sszSerializeTree(childSubtree, writer);
+        assert size == variableSizes[i];
+      }
+    }
+    return variableChildOffset;
+  }
+
+  public static TreeNode sszDeserializeTree(
+      final SszContainerSchema<?> schema,
+      final SszReader reader,
+      final Function<List<TreeNode>, TreeNode> treeAssembler) {
+    int endOffset = reader.getAvailableBytes();
+    int childCount = schema.getFieldsCount();
+    Queue<TreeNode> fixedChildrenSubtrees = new ArrayDeque<>(childCount);
+    IntList variableChildrenOffsets = new IntArrayList(childCount);
+    for (int i = 0; i < childCount; i++) {
+      SszSchema<?> childType = schema.getChildSchema(i);
+      if (childType.isFixedSize()) {
+        try (SszReader sszReader = reader.slice(childType.getSszFixedPartSize())) {
+          fixedChildrenSubtrees.add(childType.sszDeserializeTree(sszReader));
+        }
+      } else {
+        int childOffset = SszType.sszBytesToLength(reader.read(SszType.SSZ_LENGTH_SIZE));
+        variableChildrenOffsets.add(childOffset);
+      }
+    }
+
+    if (variableChildrenOffsets.isEmpty()) {
+      if (reader.getAvailableBytes() > 0) {
+        throw new SszDeserializeException("Invalid SSZ: unread bytes for fixed size container");
+      }
+    } else {
+      if (variableChildrenOffsets.getInt(0) != endOffset - reader.getAvailableBytes()) {
+        throw new SszDeserializeException(
+            "First variable element offset doesn't match the end of fixed part");
+      }
+    }
+
+    variableChildrenOffsets.add(endOffset);
+
+    ArrayDeque<Integer> variableChildrenSizes =
+        new ArrayDeque<>(variableChildrenOffsets.size() - 1);
+    for (int i = 0; i < variableChildrenOffsets.size() - 1; i++) {
+      variableChildrenSizes.add(
+          variableChildrenOffsets.getInt(i + 1) - variableChildrenOffsets.getInt(i));
+    }
+
+    if (variableChildrenSizes.stream().anyMatch(s -> s < 0)) {
+      throw new SszDeserializeException("Invalid SSZ: wrong child offsets");
+    }
+
+    List<TreeNode> fieldNodes = new ArrayList<>(childCount);
+    for (int i = 0; i < childCount; i++) {
+      SszSchema<?> childType = schema.getChildSchema(i);
+      if (childType.isFixedSize()) {
+        fieldNodes.add(fixedChildrenSubtrees.remove());
+      } else {
+        try (SszReader sszReader = reader.slice(variableChildrenSizes.remove())) {
+          fieldNodes.add(childType.sszDeserializeTree(sszReader));
+        }
+      }
+    }
+
+    return treeAssembler.apply(fieldNodes);
+  }
+
+  public static SszLengthBounds computeSszLengthBounds(final SszContainerSchema<?> schema) {
+    return IntStream.range(0, schema.getFieldsCount())
+        .mapToObj(schema::getChildSchema)
+        .map(t -> t.getSszLengthBounds().addBytes(t.isFixedSize() ? 0 : SszType.SSZ_LENGTH_SIZE))
+        .map(SszLengthBounds::ceilToBytes)
+        .reduce(SszLengthBounds.ZERO, SszLengthBounds::add);
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/ListSchemaUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/ListSchemaUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import java.nio.ByteOrder;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+/**
+ * Shared helpers for SSZ list-like schemas that store their backing tree as BranchNode(dataTree,
+ * lengthNode). Used by {@code AbstractSszListSchema}, {@code SszProgressiveListSchema}, and {@code
+ * SszProgressiveBitlistSchema}.
+ */
+public class ListSchemaUtil {
+
+  private ListSchemaUtil() {}
+
+  public static TreeNode toLengthNode(final int length) {
+    return length == 0
+        ? LeafNode.ZERO_LEAVES[8]
+        : LeafNode.create(Bytes.ofUnsignedLong(length, ByteOrder.LITTLE_ENDIAN));
+  }
+
+  public static long fromLengthNode(final TreeNode lengthNode) {
+    assert lengthNode instanceof LeafNode;
+    return ((LeafNode) lengthNode).getData().toLong(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  public static int getLength(final TreeNode listNode) {
+    long longLength = fromLengthNode(listNode.get(GIndexUtil.RIGHT_CHILD_G_INDEX));
+    return Math.toIntExact(longLength);
+  }
+
+  public static TreeNode getVectorNode(final TreeNode listNode) {
+    return listNode.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCompositeSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCompositeSchema.java
@@ -27,7 +27,11 @@ public interface SszCompositeSchema<SszCompositeT extends SszComposite<?>>
   /**
    * Returns the maximum number of elements in ssz structures of this scheme. For structures with
    * fixed number of children (like Containers and Vectors) their size should always be equal to
-   * maxLength
+   * maxLength.
+   *
+   * <p><b>Warning:</b> Progressive types (EIP-7916) return {@code Long.MAX_VALUE} since they have
+   * no max capacity. Callers must not use this value to size data structures or cast to int without
+   * checking first.
    */
   long getMaxLength();
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getLength;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getVectorNode;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.toLengthNode;
 import static tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil.bitsCeilToBytes;
 
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -292,27 +294,6 @@ public class SszProgressiveBitlistSchema implements SszBitlistSchema<SszBitlist>
 
     final TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(chunks);
     return BranchNode.create(progressiveTree, toLengthNode(size));
-  }
-
-  static int getLength(final TreeNode listNode) {
-    long longLength = fromLengthNode(listNode.get(GIndexUtil.RIGHT_CHILD_G_INDEX));
-    checkArgument(longLength < Integer.MAX_VALUE, "Bitlist length exceeds integer range");
-    return (int) longLength;
-  }
-
-  private static TreeNode getVectorNode(final TreeNode listNode) {
-    return listNode.get(GIndexUtil.LEFT_CHILD_G_INDEX);
-  }
-
-  private static TreeNode toLengthNode(final int length) {
-    return length == 0
-        ? LeafNode.ZERO_LEAVES[8]
-        : LeafNode.create(Bytes.ofUnsignedLong(length, ByteOrder.LITTLE_ENDIAN));
-  }
-
-  private static long fromLengthNode(final TreeNode lengthNode) {
-    assert lengthNode instanceof LeafNode;
-    return ((LeafNode) lengthNode).getData().toLong(ByteOrder.LITTLE_ENDIAN);
   }
 
   private int chunksForBitCount(final int bitCount) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
@@ -252,7 +252,10 @@ public class SszProgressiveBitlistSchema implements SszBitlistSchema<SszBitlist>
 
   @Override
   public SszLengthBounds getSszLengthBounds() {
-    return SszLengthBounds.ofBytes(1, Long.MAX_VALUE / 2);
+    // Progressive bitlists have no max capacity — use Long.MAX_VALUE bits directly
+    // to avoid overflow when converting from bytes to bits. Min is 8 bits (1 byte for boundary
+    // bit).
+    return SszLengthBounds.ofBits(8, Long.MAX_VALUE);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
@@ -130,7 +130,7 @@ public class SszProgressiveBitlistSchema implements SszBitlistSchema<SszBitlist>
 
   @Override
   public long maxChunks() {
-    return Long.MAX_VALUE;
+    throw new UnsupportedOperationException("Progressive bitlists don't have a fixed maxChunks");
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil.bitsCeilToBytes;
+
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszProgressiveBitlistImpl;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszLengthBounds;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeStore;
+
+/**
+ * Schema for ProgressiveBitlist (EIP-7916) — a variable-length bit collection with no max capacity
+ * that uses a progressive merkle tree for stable generalized indices.
+ *
+ * <p>Tree structure: BranchNode(progressiveDataTree, lengthNode)
+ *
+ * <p>Serialization is identical to regular Bitlist (bits packed + trailing boundary bit).
+ * Merkleization uses the progressive tree structure with 256 bits per chunk.
+ */
+public class SszProgressiveBitlistSchema implements SszBitlistSchema<SszBitlist> {
+
+  private static final int ELEMENTS_PER_CHUNK = 256;
+
+  private final TreeNode defaultTree;
+  private final DeserializableTypeDefinition<SszBitlist> jsonTypeDefinition;
+
+  public SszProgressiveBitlistSchema() {
+    this.defaultTree =
+        BranchNode.create(ProgressiveTreeUtil.createProgressiveTree(List.of()), toLengthNode(0));
+    this.jsonTypeDefinition =
+        SszPrimitiveTypeDefinitions.sszSerializedType(this, "SSZ hexadecimal");
+  }
+
+  // ===== SszBitlistSchema =====
+
+  @Override
+  public SszBitlist ofBits(final int size, final int... setBitIndices) {
+    return SszProgressiveBitlistImpl.ofBits(this, size, setBitIndices);
+  }
+
+  @Override
+  public SszBitlist wrapBitSet(final int size, final BitSet bitSet) {
+    return SszProgressiveBitlistImpl.wrapBitSet(this, size, bitSet);
+  }
+
+  @Override
+  public SszBitlist fromBytes(final Bytes bytes) {
+    checkArgument(bytes != null, "Input bytes cannot be null");
+    try (final SszReader reader = SszReader.fromBytes(bytes)) {
+      final TreeNode node = sszDeserializeTree(reader);
+      return createFromBackingNode(node);
+    }
+  }
+
+  @Override
+  public SszBitlist createFromElements(final List<? extends SszBit> elements) {
+    return ofBits(
+        elements.size(),
+        IntStream.range(0, elements.size()).filter(i -> elements.get(i).get()).toArray());
+  }
+
+  // ===== SszCollectionSchema =====
+
+  @Override
+  public SszSchema<SszBit> getElementSchema() {
+    return SszPrimitiveSchemas.BIT_SCHEMA;
+  }
+
+  @Override
+  public int getElementsPerChunk() {
+    return ELEMENTS_PER_CHUNK;
+  }
+
+  // ===== SszCompositeSchema =====
+
+  @Override
+  public long getMaxLength() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public SszSchema<?> getChildSchema(final int index) {
+    return SszPrimitiveSchemas.BIT_SCHEMA;
+  }
+
+  @Override
+  public int treeDepth() {
+    throw new UnsupportedOperationException("Progressive bitlists don't have a fixed tree depth");
+  }
+
+  @Override
+  public long treeWidth() {
+    throw new UnsupportedOperationException("Progressive bitlists don't have a fixed tree width");
+  }
+
+  @Override
+  public long maxChunks() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public long getChildGeneralizedIndex(final long elementIndex) {
+    return GIndexUtil.gIdxCompose(
+        GIndexUtil.LEFT_CHILD_G_INDEX,
+        ProgressiveTreeUtil.getElementGeneralizedIndex(elementIndex));
+  }
+
+  @Override
+  public void storeChildNode(
+      final TreeNodeStore nodeStore,
+      final int maxBranchLevelsSkipped,
+      final long gIndex,
+      final TreeNode node) {
+    getElementSchema().storeBackingNodes(nodeStore, maxBranchLevelsSkipped, gIndex, node);
+  }
+
+  // ===== SszSchema =====
+
+  @Override
+  public TreeNode getDefaultTree() {
+    return defaultTree;
+  }
+
+  @Override
+  public SszBitlist createFromBackingNode(final TreeNode node) {
+    return new SszProgressiveBitlistImpl(this, node);
+  }
+
+  @Override
+  public boolean isPrimitive() {
+    return false;
+  }
+
+  @Override
+  public boolean isFixedSize() {
+    return false;
+  }
+
+  @Override
+  public int getSszFixedPartSize() {
+    return 0;
+  }
+
+  @Override
+  public int getSszVariablePartSize(final TreeNode node) {
+    int bitCount = getLength(node);
+    // bits packed + boundary bit byte
+    return bitsCeilToBytes(bitCount) + (bitCount % 8 == 0 ? 1 : 0);
+  }
+
+  @Override
+  public int sszSerializeTree(final TreeNode node, final SszWriter writer) {
+    int bitCount = getLength(node);
+    if (bitCount == 0) {
+      // Empty bitlist: just the boundary bit (0x01)
+      writer.write(new byte[] {1});
+      return 1;
+    }
+
+    TreeNode dataNode = getVectorNode(node);
+    int chunksCount = chunksForBitCount(bitCount);
+    int totalDataBytes = bitsCeilToBytes(bitCount);
+
+    // Collect all chunk data
+    byte[] allData = new byte[totalDataBytes];
+    int offset = 0;
+    for (int c = 0; c < chunksCount; c++) {
+      long gIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(c);
+      TreeNode chunkNode = dataNode.get(gIdx);
+      if (chunkNode instanceof LeafNode leafNode) {
+        Bytes data = leafNode.getData();
+        int toCopy = Math.min(data.size(), totalDataBytes - offset);
+        System.arraycopy(data.toArrayUnsafe(), 0, allData, offset, toCopy);
+        offset += LeafNode.MAX_BYTE_SIZE;
+      }
+    }
+
+    // Add boundary bit
+    int bitIdx = bitCount % 8;
+    if (bitIdx == 0) {
+      writer.write(allData, 0, totalDataBytes);
+      writer.write(new byte[] {1});
+      return totalDataBytes + 1;
+    } else {
+      allData[totalDataBytes - 1] |= (byte) (1 << bitIdx);
+      writer.write(allData, 0, totalDataBytes);
+      return totalDataBytes;
+    }
+  }
+
+  @Override
+  public TreeNode sszDeserializeTree(final SszReader reader) {
+    int availableBytes = reader.getAvailableBytes();
+    if (availableBytes == 0) {
+      throw new SszDeserializeException("Empty progressive bitlist SSZ data");
+    }
+    Bytes bytes = reader.read(availableBytes);
+
+    int length = sszGetLengthAndValidate(bytes);
+    Bytes treeBytes = sszTruncateLeadingBit(bytes, length);
+
+    // Split into 32-byte leaf chunks
+    List<LeafNode> chunks = new ArrayList<>();
+    int off = 0;
+    int size = treeBytes.size();
+    while (off < size) {
+      int chunkSize = Math.min(LeafNode.MAX_BYTE_SIZE, size - off);
+      chunks.add(LeafNode.create(treeBytes.slice(off, chunkSize)));
+      off += LeafNode.MAX_BYTE_SIZE;
+    }
+
+    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    return BranchNode.create(progressiveTree, toLengthNode(length));
+  }
+
+  @Override
+  public SszLengthBounds getSszLengthBounds() {
+    return SszLengthBounds.ofBytes(1, Long.MAX_VALUE / 2);
+  }
+
+  @Override
+  public DeserializableTypeDefinition<SszBitlist> getJsonTypeDefinition() {
+    return jsonTypeDefinition;
+  }
+
+  @Override
+  public void storeBackingNodes(
+      final TreeNodeStore nodeStore,
+      final int maxBranchLevelsSkipped,
+      final long rootGIndex,
+      final TreeNode node) {
+    throw new UnsupportedOperationException(
+        "Store/load backing nodes not yet supported for progressive bitlists");
+  }
+
+  @Override
+  public TreeNode loadBackingNodes(
+      final TreeNodeSource nodeSource, final Bytes32 rootHash, final long rootGIndex) {
+    throw new UnsupportedOperationException(
+        "Store/load backing nodes not yet supported for progressive bitlists");
+  }
+
+  // ===== Internal helpers =====
+
+  public TreeNode createTreeFromBitData(final int size, final byte[] bitSetBytes) {
+    final int dataByteLen = bitsCeilToBytes(size);
+    final byte[] paddedBytes =
+        dataByteLen == 0 ? new byte[0] : Arrays.copyOf(bitSetBytes, dataByteLen);
+
+    List<LeafNode> chunks = new ArrayList<>();
+    int off = 0;
+    while (off < paddedBytes.length) {
+      int chunkSize = Math.min(LeafNode.MAX_BYTE_SIZE, paddedBytes.length - off);
+      chunks.add(LeafNode.create(Bytes.wrap(paddedBytes, off, chunkSize)));
+      off += LeafNode.MAX_BYTE_SIZE;
+    }
+
+    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    return BranchNode.create(progressiveTree, toLengthNode(size));
+  }
+
+  static int getLength(final TreeNode listNode) {
+    long longLength = fromLengthNode(listNode.get(GIndexUtil.RIGHT_CHILD_G_INDEX));
+    checkArgument(longLength < Integer.MAX_VALUE, "Bitlist length exceeds integer range");
+    return (int) longLength;
+  }
+
+  private static TreeNode getVectorNode(final TreeNode listNode) {
+    return listNode.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+  }
+
+  private static TreeNode toLengthNode(final int length) {
+    return length == 0
+        ? LeafNode.ZERO_LEAVES[8]
+        : LeafNode.create(Bytes.ofUnsignedLong(length, ByteOrder.LITTLE_ENDIAN));
+  }
+
+  private static long fromLengthNode(final TreeNode lengthNode) {
+    assert lengthNode instanceof LeafNode;
+    return ((LeafNode) lengthNode).getData().toLong(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private int chunksForBitCount(final int bitCount) {
+    return (bitCount + ELEMENTS_PER_CHUNK - 1) / ELEMENTS_PER_CHUNK;
+  }
+
+  /**
+   * Extracts the bitlist length from SSZ bytes by finding the boundary bit. Reuses the same logic
+   * as SszBitlistImpl.sszGetLengthAndValidate().
+   */
+  private static int sszGetLengthAndValidate(final Bytes bytes) {
+    int numBytes = bytes.size();
+    checkArgument(numBytes > 0, "BitlistImpl must contain at least one byte");
+    checkArgument(bytes.get(numBytes - 1) != 0, "BitlistImpl data must contain end marker bit");
+    int lastByte = 0xFF & bytes.get(bytes.size() - 1);
+    int leadingBitIndex = Integer.bitCount(Integer.highestOneBit(lastByte) - 1);
+    return leadingBitIndex + 8 * (numBytes - 1);
+  }
+
+  /** Removes the boundary bit from SSZ bytes. */
+  private static Bytes sszTruncateLeadingBit(final Bytes bytes, final int length) {
+    Bytes bytesWithoutLast = bytes.slice(0, bytes.size() - 1);
+    if (length % 8 == 0) {
+      return bytesWithoutLast;
+    } else {
+      int lastByte = 0xFF & bytes.get(bytes.size() - 1);
+      int leadingBit = 1 << (length % 8);
+      int lastByteWithoutLeadingBit = lastByte ^ leadingBit;
+      return Bytes.concatenate(bytesWithoutLast, Bytes.of(lastByteWithoutLeadingBit));
+    }
+  }
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of("ProgressiveBitlist");
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof SszProgressiveBitlistSchema;
+  }
+
+  @Override
+  public int hashCode() {
+    return SszProgressiveBitlistSchema.class.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "ProgressiveBitlist";
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.impl.SszProgressiveContainerImpl;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszLengthBounds;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
@@ -425,8 +426,7 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
 
   @Override
   public DeserializableTypeDefinition<C> getJsonTypeDefinition() {
-    throw new UnsupportedOperationException(
-        "JSON type definition not supported for ProgressiveContainer");
+    return SszPrimitiveTypeDefinitions.sszSerializedType(this, "SSZ hexadecimal");
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
@@ -244,7 +244,8 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
 
   @Override
   public long maxChunks() {
-    return activeFields.length;
+    throw new UnsupportedOperationException(
+        "Progressive containers don't have a fixed maxChunks");
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.Suppliers;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.impl.SszProgressiveContainerImpl;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszLengthBounds;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeStore;
+
+/**
+ * Schema for ProgressiveContainer (EIP-7495) — a heterogeneous container with stable merkleization
+ * via an active_fields bitvector and progressive merkle tree.
+ *
+ * <p>Tree structure: BranchNode(progressiveDataTree, activeFieldsLeafNode)
+ *
+ * <p>The progressive data tree has slots for all positions in active_fields. Active positions
+ * contain field backing nodes; inactive positions contain zero hash.
+ *
+ * <p>hash_tree_root = hash(merkleize_progressive(slot_chunks), pack_bits(active_fields))
+ */
+public class SszProgressiveContainerSchema<C extends SszContainer>
+    implements SszContainerSchema<C> {
+
+  private final String containerName;
+  private final boolean[] activeFields;
+  private final List<String> fieldNames;
+  private final Object2IntMap<String> fieldNamesToIndex;
+  private final List<SszSchema<?>> fieldSchemas;
+  private final int[] fieldToTreePosition;
+  private final LeafNode activeFieldsLeafNode;
+  private final TreeNode defaultTree;
+  private final Supplier<SszLengthBounds> sszLengthBounds =
+      Suppliers.memoize(this::computeSszLengthBounds);
+
+  /**
+   * Creates a ProgressiveContainerSchema.
+   *
+   * @param containerName name of the container
+   * @param activeFields bitvector indicating which slots are active (must not be empty, last
+   *     element must be true)
+   * @param fieldSchemas named schemas for ONLY the active fields, in order of their active_fields
+   *     positions
+   */
+  @SafeVarargs
+  public SszProgressiveContainerSchema(
+      final String containerName,
+      final boolean[] activeFields,
+      final NamedSchema<? extends SszData>... fieldSchemas) {
+    this(containerName, activeFields, List.of(fieldSchemas));
+  }
+
+  public SszProgressiveContainerSchema(
+      final String containerName,
+      final boolean[] activeFields,
+      final List<? extends NamedSchema<? extends SszData>> fieldSchemas) {
+    checkArgument(activeFields.length > 0, "activeFields must not be empty");
+    checkArgument(
+        activeFields[activeFields.length - 1], "Last element of activeFields must be true");
+    checkArgument(activeFields.length <= 256, "activeFields length must be <= 256");
+
+    int activeCount = 0;
+    for (boolean b : activeFields) {
+      if (b) {
+        activeCount++;
+      }
+    }
+    checkArgument(
+        activeCount == fieldSchemas.size(),
+        "Number of active fields (%s) must match number of field schemas (%s)",
+        activeCount,
+        fieldSchemas.size());
+
+    this.containerName = containerName;
+    this.activeFields = activeFields.clone();
+    this.fieldNames = new ArrayList<>();
+    this.fieldNamesToIndex = new Object2IntOpenHashMap<>();
+    this.fieldSchemas = new ArrayList<>();
+    this.fieldToTreePosition = new int[fieldSchemas.size()];
+
+    int fieldIdx = 0;
+    for (int slot = 0; slot < activeFields.length; slot++) {
+      if (activeFields[slot]) {
+        NamedSchema<? extends SszData> ns = fieldSchemas.get(fieldIdx);
+        fieldNames.add(ns.getName());
+        fieldNamesToIndex.put(ns.getName(), fieldIdx);
+        this.fieldSchemas.add(ns.getSchema());
+        fieldToTreePosition[fieldIdx] = slot;
+        fieldIdx++;
+      }
+    }
+
+    this.activeFieldsLeafNode = createActiveFieldsLeafNode(activeFields);
+    this.defaultTree = createDefaultTree();
+  }
+
+  private static LeafNode createActiveFieldsLeafNode(final boolean[] activeFields) {
+    int byteLen = (activeFields.length + 7) / 8;
+    byte[] bytes = new byte[byteLen];
+    for (int i = 0; i < activeFields.length; i++) {
+      if (activeFields[i]) {
+        bytes[i / 8] |= (byte) (1 << (i % 8));
+      }
+    }
+    return LeafNode.create(Bytes.wrap(bytes));
+  }
+
+  private TreeNode createDefaultTree() {
+    List<TreeNode> slotChunks = createSlotChunks(getDefaultFieldNodes());
+    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(slotChunks);
+    return BranchNode.create(progressiveTree, activeFieldsLeafNode);
+  }
+
+  private List<TreeNode> getDefaultFieldNodes() {
+    List<TreeNode> nodes = new ArrayList<>();
+    for (int i = 0; i < fieldSchemas.size(); i++) {
+      nodes.add(fieldSchemas.get(i).getDefault().getBackingNode());
+    }
+    return nodes;
+  }
+
+  private List<TreeNode> createSlotChunks(final List<TreeNode> activeFieldNodes) {
+    List<TreeNode> slotChunks = new ArrayList<>(activeFields.length);
+    int fieldIdx = 0;
+    for (boolean activeField : activeFields) {
+      if (activeField) {
+        slotChunks.add(activeFieldNodes.get(fieldIdx));
+        fieldIdx++;
+      } else {
+        slotChunks.add(LeafNode.EMPTY_LEAF);
+      }
+    }
+    return slotChunks;
+  }
+
+  public boolean[] getActiveFields() {
+    return activeFields.clone();
+  }
+
+  public int getTreePosition(final int fieldIndex) {
+    return fieldToTreePosition[fieldIndex];
+  }
+
+  // ===== SszContainerSchema =====
+
+  @Override
+  public int getFieldIndex(final String fieldName) {
+    return fieldNamesToIndex.getOrDefault(fieldName, -1);
+  }
+
+  @Override
+  public TreeNode createTreeFromFieldValues(final List<? extends SszData> fieldValues) {
+    checkArgument(
+        fieldValues.size() == getFieldsCount(),
+        "Wrong number of field values: expected %s, got %s",
+        getFieldsCount(),
+        fieldValues.size());
+    List<TreeNode> fieldNodes =
+        fieldValues.stream()
+            .map(SszData::getBackingNode)
+            .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+    List<TreeNode> slotChunks = createSlotChunks(fieldNodes);
+    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(slotChunks);
+    return BranchNode.create(progressiveTree, activeFieldsLeafNode);
+  }
+
+  @Override
+  public String getContainerName() {
+    return !containerName.isEmpty() ? containerName : getClass().getName();
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return fieldNames;
+  }
+
+  @Override
+  public List<? extends SszSchema<?>> getFieldSchemas() {
+    return fieldSchemas;
+  }
+
+  // ===== SszCompositeSchema =====
+
+  @Override
+  public long getMaxLength() {
+    return fieldSchemas.size();
+  }
+
+  @Override
+  public SszSchema<?> getChildSchema(final int index) {
+    return fieldSchemas.get(index);
+  }
+
+  @Override
+  public int treeDepth() {
+    throw new UnsupportedOperationException("Progressive containers don't have a fixed tree depth");
+  }
+
+  @Override
+  public long treeWidth() {
+    throw new UnsupportedOperationException("Progressive containers don't have a fixed tree width");
+  }
+
+  @Override
+  public long maxChunks() {
+    return activeFields.length;
+  }
+
+  @Override
+  public long getChildGeneralizedIndex(final long fieldIndex) {
+    int treePosition = fieldToTreePosition[(int) fieldIndex];
+    long progressiveGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(treePosition);
+    return GIndexUtil.gIdxCompose(GIndexUtil.LEFT_CHILD_G_INDEX, progressiveGIdx);
+  }
+
+  @Override
+  public void storeChildNode(
+      final TreeNodeStore nodeStore,
+      final int maxBranchLevelsSkipped,
+      final long gIndex,
+      final TreeNode node) {
+    throw new UnsupportedOperationException(
+        "Store/load backing nodes not yet supported for progressive containers");
+  }
+
+  // ===== SszSchema =====
+
+  @Override
+  public TreeNode getDefaultTree() {
+    return defaultTree;
+  }
+
+  @Override
+  public C createFromBackingNode(final TreeNode node) {
+    return createContainerFromBackingNode(node);
+  }
+
+  @SuppressWarnings("unchecked")
+  private C createContainerFromBackingNode(final TreeNode node) {
+    return (C) new SszProgressiveContainerImpl(this, node);
+  }
+
+  @Override
+  public boolean isPrimitive() {
+    return false;
+  }
+
+  @Override
+  public boolean isFixedSize() {
+    for (SszSchema<?> childSchema : fieldSchemas) {
+      if (!childSchema.isFixedSize()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int getSszFixedPartSize() {
+    int size = 0;
+    for (SszSchema<?> childType : fieldSchemas) {
+      size += childType.isFixedSize() ? childType.getSszFixedPartSize() : SszType.SSZ_LENGTH_SIZE;
+    }
+    return size;
+  }
+
+  @Override
+  public int getSszVariablePartSize(final TreeNode node) {
+    if (isFixedSize()) {
+      return 0;
+    }
+    int size = 0;
+    for (int i = 0; i < getFieldsCount(); i++) {
+      SszSchema<?> childType = getChildSchema(i);
+      if (!childType.isFixedSize()) {
+        size += childType.getSszSize(node.get(getChildGeneralizedIndex(i)));
+      }
+    }
+    return size;
+  }
+
+  @Override
+  public int sszSerializeTree(final TreeNode node, final SszWriter writer) {
+    // Same serialization as a regular container — only active fields
+    int variableChildOffset = getSszFixedPartSize();
+    int[] variableSizes = new int[getFieldsCount()];
+    for (int i = 0; i < getFieldsCount(); i++) {
+      TreeNode childSubtree = node.get(getChildGeneralizedIndex(i));
+      SszSchema<?> childType = getChildSchema(i);
+      if (childType.isFixedSize()) {
+        int size = childType.sszSerializeTree(childSubtree, writer);
+        assert size == childType.getSszFixedPartSize();
+      } else {
+        writer.write(SszType.sszLengthToBytes(variableChildOffset));
+        int childSize = childType.getSszSize(childSubtree);
+        variableSizes[i] = childSize;
+        variableChildOffset += childSize;
+      }
+    }
+    for (int i = 0; i < getFieldsCount(); i++) {
+      SszSchema<?> childType = getChildSchema(i);
+      if (!childType.isFixedSize()) {
+        TreeNode childSubtree = node.get(getChildGeneralizedIndex(i));
+        int size = childType.sszSerializeTree(childSubtree, writer);
+        assert size == variableSizes[i];
+      }
+    }
+    return variableChildOffset;
+  }
+
+  @Override
+  public TreeNode sszDeserializeTree(final SszReader reader) {
+    // Same deserialization as regular container — read active fields
+    int endOffset = reader.getAvailableBytes();
+    int childCount = getFieldsCount();
+    Queue<TreeNode> fixedChildrenSubtrees = new ArrayDeque<>(childCount);
+    IntList variableChildrenOffsets = new IntArrayList(childCount);
+    for (int i = 0; i < childCount; i++) {
+      SszSchema<?> childType = getChildSchema(i);
+      if (childType.isFixedSize()) {
+        try (SszReader sszReader = reader.slice(childType.getSszFixedPartSize())) {
+          fixedChildrenSubtrees.add(childType.sszDeserializeTree(sszReader));
+        }
+      } else {
+        int childOffset = SszType.sszBytesToLength(reader.read(SszType.SSZ_LENGTH_SIZE));
+        variableChildrenOffsets.add(childOffset);
+      }
+    }
+
+    if (variableChildrenOffsets.isEmpty()) {
+      if (reader.getAvailableBytes() > 0) {
+        throw new SszDeserializeException("Invalid SSZ: unread bytes for fixed size container");
+      }
+    } else {
+      if (variableChildrenOffsets.getInt(0) != endOffset - reader.getAvailableBytes()) {
+        throw new SszDeserializeException(
+            "First variable element offset doesn't match the end of fixed part");
+      }
+    }
+
+    variableChildrenOffsets.add(endOffset);
+
+    ArrayDeque<Integer> variableChildrenSizes =
+        new ArrayDeque<>(variableChildrenOffsets.size() - 1);
+    for (int i = 0; i < variableChildrenOffsets.size() - 1; i++) {
+      variableChildrenSizes.add(
+          variableChildrenOffsets.getInt(i + 1) - variableChildrenOffsets.getInt(i));
+    }
+
+    if (variableChildrenSizes.stream().anyMatch(s -> s < 0)) {
+      throw new SszDeserializeException("Invalid SSZ: wrong child offsets");
+    }
+
+    // Build field nodes from deserialized data
+    List<TreeNode> fieldNodes = new ArrayList<>(childCount);
+    for (int i = 0; i < childCount; i++) {
+      SszSchema<?> childType = getChildSchema(i);
+      if (childType.isFixedSize()) {
+        fieldNodes.add(fixedChildrenSubtrees.remove());
+      } else {
+        try (SszReader sszReader = reader.slice(variableChildrenSizes.remove())) {
+          fieldNodes.add(childType.sszDeserializeTree(sszReader));
+        }
+      }
+    }
+
+    // Build slot chunks: active positions get field nodes, inactive get zero
+    List<TreeNode> slotChunks = createSlotChunks(fieldNodes);
+    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(slotChunks);
+    return BranchNode.create(progressiveTree, activeFieldsLeafNode);
+  }
+
+  @Override
+  public SszLengthBounds getSszLengthBounds() {
+    return sszLengthBounds.get();
+  }
+
+  private SszLengthBounds computeSszLengthBounds() {
+    return IntStream.range(0, getFieldsCount())
+        .mapToObj(this::getChildSchema)
+        .map(t -> t.getSszLengthBounds().addBytes(t.isFixedSize() ? 0 : SszType.SSZ_LENGTH_SIZE))
+        .map(SszLengthBounds::ceilToBytes)
+        .reduce(SszLengthBounds.ZERO, SszLengthBounds::add);
+  }
+
+  @Override
+  public DeserializableTypeDefinition<C> getJsonTypeDefinition() {
+    throw new UnsupportedOperationException(
+        "JSON type definition not supported for ProgressiveContainer");
+  }
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of(containerName);
+  }
+
+  @Override
+  public void storeBackingNodes(
+      final TreeNodeStore nodeStore,
+      final int maxBranchLevelsSkipped,
+      final long rootGIndex,
+      final TreeNode node) {
+    throw new UnsupportedOperationException(
+        "Store/load backing nodes not yet supported for progressive containers");
+  }
+
+  @Override
+  public TreeNode loadBackingNodes(
+      final TreeNodeSource nodeSource, final Bytes32 rootHash, final long rootGIndex) {
+    throw new UnsupportedOperationException(
+        "Store/load backing nodes not yet supported for progressive containers");
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SszProgressiveContainerSchema<?> that)) {
+      return false;
+    }
+    return Arrays.equals(activeFields, that.activeFields) && fieldSchemas.equals(that.fieldSchemas);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(Arrays.hashCode(activeFields), fieldSchemas);
+  }
+
+  @Override
+  public String toString() {
+    return getContainerName();
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
@@ -244,8 +244,7 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
 
   @Override
   public long maxChunks() {
-    throw new UnsupportedOperationException(
-        "Progressive containers don't have a fixed maxChunks");
+    throw new UnsupportedOperationException("Progressive containers don't have a fixed maxChunks");
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchema.java
@@ -122,7 +122,7 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
     int fieldIdx = 0;
     for (int slot = 0; slot < activeFields.length; slot++) {
       if (activeFields[slot]) {
-        NamedSchema<? extends SszData> ns = fieldSchemas.get(fieldIdx);
+        final NamedSchema<? extends SszData> ns = fieldSchemas.get(fieldIdx);
         fieldNames.add(ns.getName());
         fieldNamesToIndex.put(ns.getName(), fieldIdx);
         this.fieldSchemas.add(ns.getSchema());
@@ -136,8 +136,8 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
   }
 
   private static LeafNode createActiveFieldsLeafNode(final boolean[] activeFields) {
-    int byteLen = (activeFields.length + 7) / 8;
-    byte[] bytes = new byte[byteLen];
+    final int byteLen = (activeFields.length + 7) / 8;
+    final byte[] bytes = new byte[byteLen];
     for (int i = 0; i < activeFields.length; i++) {
       if (activeFields[i]) {
         bytes[i / 8] |= (byte) (1 << (i % 8));
@@ -147,13 +147,13 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
   }
 
   private TreeNode createDefaultTree() {
-    List<TreeNode> slotChunks = createSlotChunks(getDefaultFieldNodes());
-    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(slotChunks);
+    final List<TreeNode> slotChunks = createSlotChunks(getDefaultFieldNodes());
+    final TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(slotChunks);
     return BranchNode.create(progressiveTree, activeFieldsLeafNode);
   }
 
   private List<TreeNode> getDefaultFieldNodes() {
-    List<TreeNode> nodes = new ArrayList<>();
+    final List<TreeNode> nodes = new ArrayList<>();
     for (int i = 0; i < fieldSchemas.size(); i++) {
       nodes.add(fieldSchemas.get(i).getDefault().getBackingNode());
     }
@@ -161,7 +161,7 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
   }
 
   private List<TreeNode> createSlotChunks(final List<TreeNode> activeFieldNodes) {
-    List<TreeNode> slotChunks = new ArrayList<>(activeFields.length);
+    final List<TreeNode> slotChunks = new ArrayList<>(activeFields.length);
     int fieldIdx = 0;
     for (boolean activeField : activeFields) {
       if (activeField) {
@@ -249,8 +249,8 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
 
   @Override
   public long getChildGeneralizedIndex(final long fieldIndex) {
-    int treePosition = fieldToTreePosition[(int) fieldIndex];
-    long progressiveGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(treePosition);
+    final int treePosition = fieldToTreePosition[(int) fieldIndex];
+    final long progressiveGIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(treePosition);
     return GIndexUtil.gIdxCompose(GIndexUtil.LEFT_CHILD_G_INDEX, progressiveGIdx);
   }
 
@@ -324,25 +324,25 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
   public int sszSerializeTree(final TreeNode node, final SszWriter writer) {
     // Same serialization as a regular container — only active fields
     int variableChildOffset = getSszFixedPartSize();
-    int[] variableSizes = new int[getFieldsCount()];
+    final int[] variableSizes = new int[getFieldsCount()];
     for (int i = 0; i < getFieldsCount(); i++) {
-      TreeNode childSubtree = node.get(getChildGeneralizedIndex(i));
-      SszSchema<?> childType = getChildSchema(i);
+      final TreeNode childSubtree = node.get(getChildGeneralizedIndex(i));
+      final SszSchema<?> childType = getChildSchema(i);
       if (childType.isFixedSize()) {
-        int size = childType.sszSerializeTree(childSubtree, writer);
+        final int size = childType.sszSerializeTree(childSubtree, writer);
         assert size == childType.getSszFixedPartSize();
       } else {
         writer.write(SszType.sszLengthToBytes(variableChildOffset));
-        int childSize = childType.getSszSize(childSubtree);
+        final int childSize = childType.getSszSize(childSubtree);
         variableSizes[i] = childSize;
         variableChildOffset += childSize;
       }
     }
     for (int i = 0; i < getFieldsCount(); i++) {
-      SszSchema<?> childType = getChildSchema(i);
+      final SszSchema<?> childType = getChildSchema(i);
       if (!childType.isFixedSize()) {
-        TreeNode childSubtree = node.get(getChildGeneralizedIndex(i));
-        int size = childType.sszSerializeTree(childSubtree, writer);
+        final TreeNode childSubtree = node.get(getChildGeneralizedIndex(i));
+        final int size = childType.sszSerializeTree(childSubtree, writer);
         assert size == variableSizes[i];
       }
     }
@@ -352,18 +352,18 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
   @Override
   public TreeNode sszDeserializeTree(final SszReader reader) {
     // Same deserialization as regular container — read active fields
-    int endOffset = reader.getAvailableBytes();
-    int childCount = getFieldsCount();
-    Queue<TreeNode> fixedChildrenSubtrees = new ArrayDeque<>(childCount);
-    IntList variableChildrenOffsets = new IntArrayList(childCount);
+    final int endOffset = reader.getAvailableBytes();
+    final int childCount = getFieldsCount();
+    final Queue<TreeNode> fixedChildrenSubtrees = new ArrayDeque<>(childCount);
+    final IntList variableChildrenOffsets = new IntArrayList(childCount);
     for (int i = 0; i < childCount; i++) {
-      SszSchema<?> childType = getChildSchema(i);
+      final SszSchema<?> childType = getChildSchema(i);
       if (childType.isFixedSize()) {
         try (SszReader sszReader = reader.slice(childType.getSszFixedPartSize())) {
           fixedChildrenSubtrees.add(childType.sszDeserializeTree(sszReader));
         }
       } else {
-        int childOffset = SszType.sszBytesToLength(reader.read(SszType.SSZ_LENGTH_SIZE));
+        final int childOffset = SszType.sszBytesToLength(reader.read(SszType.SSZ_LENGTH_SIZE));
         variableChildrenOffsets.add(childOffset);
       }
     }
@@ -381,7 +381,7 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
 
     variableChildrenOffsets.add(endOffset);
 
-    ArrayDeque<Integer> variableChildrenSizes =
+    final ArrayDeque<Integer> variableChildrenSizes =
         new ArrayDeque<>(variableChildrenOffsets.size() - 1);
     for (int i = 0; i < variableChildrenOffsets.size() - 1; i++) {
       variableChildrenSizes.add(
@@ -393,9 +393,9 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
     }
 
     // Build field nodes from deserialized data
-    List<TreeNode> fieldNodes = new ArrayList<>(childCount);
+    final List<TreeNode> fieldNodes = new ArrayList<>(childCount);
     for (int i = 0; i < childCount; i++) {
-      SszSchema<?> childType = getChildSchema(i);
+      final SszSchema<?> childType = getChildSchema(i);
       if (childType.isFixedSize()) {
         fieldNodes.add(fixedChildrenSubtrees.remove());
       } else {
@@ -406,8 +406,8 @@ public class SszProgressiveContainerSchema<C extends SszContainer>
     }
 
     // Build slot chunks: active positions get field nodes, inactive get zero
-    List<TreeNode> slotChunks = createSlotChunks(fieldNodes);
-    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(slotChunks);
+    final List<TreeNode> slotChunks = createSlotChunks(fieldNodes);
+    final TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(slotChunks);
     return BranchNode.create(progressiveTree, activeFieldsLeafNode);
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
@@ -296,6 +296,13 @@ public class SszProgressiveListSchema<ElementDataT extends SszData>
       if (firstElementOffset % SszType.SSZ_LENGTH_SIZE != 0) {
         throw new SszDeserializeException("Invalid first element offset");
       }
+      if (firstElementOffset > endOffset) {
+        throw new SszDeserializeException(
+            "First element offset exceeds available data: "
+                + firstElementOffset
+                + " > "
+                + endOffset);
+      }
       int elementsCount = firstElementOffset / SszType.SSZ_LENGTH_SIZE;
       List<Integer> elementOffsets = new ArrayList<>(elementsCount + 1);
       elementOffsets.add(firstElementOffset);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
@@ -115,7 +115,7 @@ public class SszProgressiveListSchema<ElementDataT extends SszData>
 
   @Override
   public long maxChunks() {
-    return Long.MAX_VALUE;
+    throw new UnsupportedOperationException("Progressive lists don't have a fixed maxChunks");
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.infrastructure.ssz.schema;
 
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getLength;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getVectorNode;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.toLengthNode;
 import static tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil.bitsCeilToBytes;
 
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -360,26 +362,6 @@ public class SszProgressiveListSchema<ElementDataT extends SszData>
       return ((SszPrimitiveSchema<?, ?>) elementSchema).getBitsSize();
     }
     return elementSchema.getSszFixedPartSize() * 8;
-  }
-
-  static int getLength(final TreeNode listNode) {
-    long longLength = fromLengthNode(listNode.get(GIndexUtil.RIGHT_CHILD_G_INDEX));
-    return Math.toIntExact(longLength);
-  }
-
-  static TreeNode getVectorNode(final TreeNode listNode) {
-    return listNode.get(GIndexUtil.LEFT_CHILD_G_INDEX);
-  }
-
-  private static TreeNode toLengthNode(final int length) {
-    return length == 0
-        ? LeafNode.ZERO_LEAVES[8]
-        : LeafNode.create(Bytes.ofUnsignedLong(length, ByteOrder.LITTLE_ENDIAN));
-  }
-
-  private static long fromLengthNode(final TreeNode lengthNode) {
-    assert lengthNode instanceof LeafNode;
-    return ((LeafNode) lengthNode).getData().toLong(ByteOrder.LITTLE_ENDIAN);
   }
 
   private List<TreeNode> packElementsToChunks(final List<? extends ElementDataT> elements) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
@@ -329,8 +329,9 @@ public class SszProgressiveListSchema<ElementDataT extends SszData>
 
   @Override
   public SszLengthBounds getSszLengthBounds() {
-    // Progressive lists have no max - use a very large upper bound
-    return SszLengthBounds.ofBytes(0, Long.MAX_VALUE / 2);
+    // Progressive lists have no max capacity — use Long.MAX_VALUE bits directly
+    // to avoid overflow when converting from bytes to bits
+    return SszLengthBounds.ofBits(0, Long.MAX_VALUE);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
@@ -69,7 +69,6 @@ public class SszProgressiveListSchema<ElementDataT extends SszData>
             elementSchema.getJsonTypeDefinition(), this::createFromElements);
   }
 
-  @SuppressWarnings("unchecked")
   public static <T extends SszData> SszProgressiveListSchema<T> create(
       final SszSchema<T> elementSchema) {
     return new SszProgressiveListSchema<>(elementSchema);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchema.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil.bitsCeilToBytes;
+
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableArrayTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.impl.SszProgressiveListImpl;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszPrimitiveSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszLengthBounds;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeStore;
+
+/**
+ * Schema for ProgressiveList (EIP-7916) — a variable-length homogeneous collection with no max
+ * capacity that uses a progressive merkle tree for stable generalized indices.
+ *
+ * <p>Tree structure: BranchNode(progressiveDataTree, lengthNode)
+ *
+ * <p>The progressive data tree is a right-leaning asymmetric tree where subtree capacities grow by
+ * 4x per level.
+ */
+public class SszProgressiveListSchema<ElementDataT extends SszData>
+    implements SszListSchema<ElementDataT, SszList<ElementDataT>> {
+
+  private final SszSchema<ElementDataT> elementSchema;
+  private final TreeNode defaultTree;
+  private final int elementsPerChunk;
+  private final DeserializableTypeDefinition<SszList<ElementDataT>> jsonTypeDefinition;
+
+  public SszProgressiveListSchema(final SszSchema<ElementDataT> elementSchema) {
+    this.elementSchema = elementSchema;
+    this.elementsPerChunk = computeElementsPerChunk(elementSchema);
+    this.defaultTree =
+        BranchNode.create(ProgressiveTreeUtil.createProgressiveTree(List.of()), toLengthNode(0));
+    this.jsonTypeDefinition =
+        new DeserializableArrayTypeDefinition<>(
+            elementSchema.getJsonTypeDefinition(), this::createFromElements);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends SszData> SszProgressiveListSchema<T> create(
+      final SszSchema<T> elementSchema) {
+    return new SszProgressiveListSchema<>(elementSchema);
+  }
+
+  private static int computeElementsPerChunk(final SszSchema<?> schema) {
+    if (schema.isPrimitive()) {
+      return 256 / ((SszPrimitiveSchema<?, ?>) schema).getBitsSize();
+    }
+    return 1;
+  }
+
+  // ===== SszCollectionSchema =====
+
+  @Override
+  public SszSchema<ElementDataT> getElementSchema() {
+    return elementSchema;
+  }
+
+  @Override
+  public TreeNode createTreeFromElements(final List<? extends ElementDataT> elements) {
+    List<TreeNode> chunks = packElementsToChunks(elements);
+    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    return BranchNode.create(progressiveTree, toLengthNode(elements.size()));
+  }
+
+  // ===== SszCompositeSchema =====
+
+  @Override
+  public long getMaxLength() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public SszSchema<?> getChildSchema(final int index) {
+    return elementSchema;
+  }
+
+  @Override
+  public int getElementsPerChunk() {
+    return elementsPerChunk;
+  }
+
+  @Override
+  public long maxChunks() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public int treeDepth() {
+    throw new UnsupportedOperationException("Progressive lists don't have a fixed tree depth");
+  }
+
+  @Override
+  public long treeWidth() {
+    throw new UnsupportedOperationException("Progressive lists don't have a fixed tree width");
+  }
+
+  @Override
+  public long getChildGeneralizedIndex(final long elementIndex) {
+    return GIndexUtil.gIdxCompose(
+        GIndexUtil.LEFT_CHILD_G_INDEX,
+        ProgressiveTreeUtil.getElementGeneralizedIndex(elementIndex));
+  }
+
+  @Override
+  public void storeChildNode(
+      final TreeNodeStore nodeStore,
+      final int maxBranchLevelsSkipped,
+      final long gIndex,
+      final TreeNode node) {
+    elementSchema.storeBackingNodes(nodeStore, maxBranchLevelsSkipped, gIndex, node);
+  }
+
+  // ===== SszSchema =====
+
+  @Override
+  public TreeNode getDefaultTree() {
+    return defaultTree;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SszList<ElementDataT> createFromBackingNode(final TreeNode node) {
+    return new SszProgressiveListImpl<>(this, node);
+  }
+
+  @Override
+  public boolean isPrimitive() {
+    return false;
+  }
+
+  @Override
+  public boolean isFixedSize() {
+    return false;
+  }
+
+  @Override
+  public int getSszFixedPartSize() {
+    return 0;
+  }
+
+  @Override
+  public int getSszVariablePartSize(final TreeNode node) {
+    int length = getLength(node);
+    if (elementSchema.isFixedSize()) {
+      return (int) bitsCeilToBytes((long) length * getSszElementBitSize());
+    } else {
+      int size = 0;
+      for (int i = 0; i < length; i++) {
+        size += elementSchema.getSszSize(node.get(getChildGeneralizedIndex(i)));
+        size += SszType.SSZ_LENGTH_SIZE;
+      }
+      return size;
+    }
+  }
+
+  @Override
+  public int sszSerializeTree(final TreeNode node, final SszWriter writer) {
+    int elementsCount = getLength(node);
+    if (elementsCount == 0) {
+      return 0;
+    }
+    TreeNode dataNode = getVectorNode(node);
+    if (elementSchema.isFixedSize()) {
+      return sszSerializeFixed(dataNode, writer, elementsCount);
+    } else {
+      return sszSerializeVariable(dataNode, writer, elementsCount);
+    }
+  }
+
+  private int sszSerializeFixed(
+      final TreeNode dataNode, final SszWriter writer, final int elementsCount) {
+    // For primitives packed in chunks, iterate leaf data
+    int chunksCount = getChunks(elementsCount);
+    int[] bytesCnt = new int[1];
+    for (int c = 0; c < chunksCount; c++) {
+      long gIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(c);
+      TreeNode chunkNode = dataNode.get(gIdx);
+      if (chunkNode instanceof LeafNode leafNode) {
+        Bytes data = leafNode.getData();
+        writer.write(data);
+        bytesCnt[0] += data.size();
+      }
+    }
+    return bytesCnt[0];
+  }
+
+  private int sszSerializeVariable(
+      final TreeNode dataNode, final SszWriter writer, final int elementsCount) {
+    int variableOffset = SszType.SSZ_LENGTH_SIZE * elementsCount;
+    int[] childSizes = new int[elementsCount];
+    for (int i = 0; i < elementsCount; i++) {
+      long gIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(i);
+      TreeNode childSubtree = dataNode.get(gIdx);
+      childSizes[i] = elementSchema.getSszSize(childSubtree);
+      writer.write(SszType.sszLengthToBytes(variableOffset));
+      variableOffset += childSizes[i];
+    }
+    for (int i = 0; i < elementsCount; i++) {
+      long gIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(i);
+      TreeNode childSubtree = dataNode.get(gIdx);
+      elementSchema.sszSerializeTree(childSubtree, writer);
+    }
+    return variableOffset;
+  }
+
+  @Override
+  public TreeNode sszDeserializeTree(final SszReader reader) {
+    if (elementSchema.isFixedSize()) {
+      return sszDeserializeFixed(reader);
+    } else {
+      return sszDeserializeVariable(reader);
+    }
+  }
+
+  private TreeNode sszDeserializeFixed(final SszReader reader) {
+    int bytesSize = reader.getAvailableBytes();
+    int elementBitSize = getSszElementBitSize();
+    if (elementBitSize >= 8) {
+      if (bytesSize * 8L % elementBitSize != 0) {
+        throw new SszDeserializeException(
+            "SSZ sequence length is not multiple of fixed element size");
+      }
+    }
+
+    if (elementSchema instanceof AbstractSszPrimitiveSchema) {
+      // Primitive packing: multiple values per 32-byte leaf
+      int bytesPerElement = elementBitSize / 8;
+      int bytesRemain = bytesSize;
+      List<LeafNode> childNodes = new ArrayList<>(bytesRemain / LeafNode.MAX_BYTE_SIZE + 1);
+      while (bytesRemain > 0) {
+        int toRead = Math.min(bytesRemain, LeafNode.MAX_BYTE_SIZE);
+        bytesRemain -= toRead;
+        Bytes bytes = reader.read(toRead);
+        // Validate each element within the chunk (e.g., booleans must be 0 or 1)
+        for (int offset = 0; offset < bytes.size(); offset += bytesPerElement) {
+          elementSchema.sszDeserialize(bytes.slice(offset, bytesPerElement));
+        }
+        childNodes.add(LeafNode.create(bytes));
+      }
+      int elementsCount = (int) (bytesSize * 8L / elementBitSize);
+      TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(childNodes);
+      return BranchNode.create(progressiveTree, toLengthNode(elementsCount));
+    } else {
+      // Fixed-size composite elements: one per chunk
+      int elementsCount = bytesSize / elementSchema.getSszFixedPartSize();
+      List<TreeNode> childNodes = new ArrayList<>();
+      for (int i = 0; i < elementsCount; i++) {
+        try (SszReader sszReader = reader.slice(elementSchema.getSszFixedPartSize())) {
+          childNodes.add(elementSchema.sszDeserializeTree(sszReader));
+        }
+      }
+      TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(childNodes);
+      return BranchNode.create(progressiveTree, toLengthNode(elementsCount));
+    }
+  }
+
+  private TreeNode sszDeserializeVariable(final SszReader reader) {
+    int endOffset = reader.getAvailableBytes();
+    List<TreeNode> childNodes = new ArrayList<>();
+    if (endOffset > 0) {
+      int firstElementOffset = SszType.sszBytesToLength(reader.read(SszType.SSZ_LENGTH_SIZE));
+      if (firstElementOffset % SszType.SSZ_LENGTH_SIZE != 0) {
+        throw new SszDeserializeException("Invalid first element offset");
+      }
+      int elementsCount = firstElementOffset / SszType.SSZ_LENGTH_SIZE;
+      List<Integer> elementOffsets = new ArrayList<>(elementsCount + 1);
+      elementOffsets.add(firstElementOffset);
+      for (int i = 1; i < elementsCount; i++) {
+        elementOffsets.add(SszType.sszBytesToLength(reader.read(SszType.SSZ_LENGTH_SIZE)));
+      }
+      elementOffsets.add(endOffset);
+
+      for (int i = 0; i < elementsCount; i++) {
+        int elementSize = elementOffsets.get(i + 1) - elementOffsets.get(i);
+        if (elementSize < 0) {
+          throw new SszDeserializeException("Invalid SSZ: wrong child offsets");
+        }
+        try (SszReader sszReader = reader.slice(elementSize)) {
+          childNodes.add(elementSchema.sszDeserializeTree(sszReader));
+        }
+      }
+    }
+    TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(childNodes);
+    return BranchNode.create(progressiveTree, toLengthNode(childNodes.size()));
+  }
+
+  @Override
+  public SszLengthBounds getSszLengthBounds() {
+    // Progressive lists have no max - use a very large upper bound
+    return SszLengthBounds.ofBytes(0, Long.MAX_VALUE / 2);
+  }
+
+  @Override
+  public DeserializableTypeDefinition<SszList<ElementDataT>> getJsonTypeDefinition() {
+    return jsonTypeDefinition;
+  }
+
+  @Override
+  public void storeBackingNodes(
+      final TreeNodeStore nodeStore,
+      final int maxBranchLevelsSkipped,
+      final long rootGIndex,
+      final TreeNode node) {
+    throw new UnsupportedOperationException(
+        "Store/load backing nodes not yet supported for progressive lists");
+  }
+
+  @Override
+  public TreeNode loadBackingNodes(
+      final TreeNodeSource nodeSource, final Bytes32 rootHash, final long rootGIndex) {
+    throw new UnsupportedOperationException(
+        "Store/load backing nodes not yet supported for progressive lists");
+  }
+
+  // ===== Internal helpers =====
+
+  private int getSszElementBitSize() {
+    if (elementSchema.isPrimitive()) {
+      return ((SszPrimitiveSchema<?, ?>) elementSchema).getBitsSize();
+    }
+    return elementSchema.getSszFixedPartSize() * 8;
+  }
+
+  static int getLength(final TreeNode listNode) {
+    long longLength = fromLengthNode(listNode.get(GIndexUtil.RIGHT_CHILD_G_INDEX));
+    checkArgument(longLength < Integer.MAX_VALUE, "List length exceeds integer range");
+    return (int) longLength;
+  }
+
+  static TreeNode getVectorNode(final TreeNode listNode) {
+    return listNode.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+  }
+
+  private static TreeNode toLengthNode(final int length) {
+    return length == 0
+        ? LeafNode.ZERO_LEAVES[8]
+        : LeafNode.create(Bytes.ofUnsignedLong(length, ByteOrder.LITTLE_ENDIAN));
+  }
+
+  private static long fromLengthNode(final TreeNode lengthNode) {
+    assert lengthNode instanceof LeafNode;
+    return ((LeafNode) lengthNode).getData().toLong(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private List<TreeNode> packElementsToChunks(final List<? extends ElementDataT> elements) {
+    if (elementSchema.isPrimitive()) {
+      // Pack primitive values into 32-byte chunks
+      int bitsPerElement = ((SszPrimitiveSchema<?, ?>) elementSchema).getBitsSize();
+      int elemPerChunk = 256 / bitsPerElement;
+      int bytesPerElement = bitsPerElement / 8;
+      List<TreeNode> chunks = new ArrayList<>();
+      for (int i = 0; i < elements.size(); i += elemPerChunk) {
+        int count = Math.min(elemPerChunk, elements.size() - i);
+        byte[] chunkData = new byte[count * bytesPerElement];
+        for (int j = 0; j < count; j++) {
+          Bytes elemBytes = elements.get(i + j).getBackingNode().hashTreeRoot();
+          System.arraycopy(
+              elemBytes.toArrayUnsafe(), 0, chunkData, j * bytesPerElement, bytesPerElement);
+        }
+        chunks.add(LeafNode.create(Bytes.wrap(chunkData)));
+      }
+      return chunks;
+    } else {
+      return elements.stream().map(SszData::getBackingNode).collect(Collectors.toList());
+    }
+  }
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of("ProgressiveList[" + elementSchema + "]");
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SszProgressiveListSchema<?> that)) {
+      return false;
+    }
+    return elementSchema.equals(that.elementSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(elementSchema);
+  }
+
+  @Override
+  public String toString() {
+    return "ProgressiveList[" + elementSchema + "]";
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.infrastructure.ssz.schema.collections.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getLength;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getVectorNode;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -14,6 +14,9 @@
 package tech.pegasys.teku.infrastructure.ssz.schema.impl;
 
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getLength;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getVectorNode;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.toLengthNode;
 import static tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil.bitsCeilToBytes;
 
 import java.nio.ByteOrder;
@@ -35,7 +38,6 @@ import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
 import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
-import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.SszSuperNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource;
@@ -278,27 +280,6 @@ public abstract class AbstractSszListSchema<
             lastUsefulGIndex,
             childLoader);
     return BranchNode.create(vectorNode, toLengthNode(length));
-  }
-
-  private static TreeNode toLengthNode(final int length) {
-    return length == 0
-        ? LeafNode.ZERO_LEAVES[8]
-        : LeafNode.create(Bytes.ofUnsignedLong(length, ByteOrder.LITTLE_ENDIAN));
-  }
-
-  private static long fromLengthNode(final TreeNode lengthNode) {
-    assert lengthNode instanceof LeafNode;
-    return ((LeafNode) lengthNode).getData().toLong(ByteOrder.LITTLE_ENDIAN);
-  }
-
-  protected static int getLength(final TreeNode listNode) {
-    long longLength = fromLengthNode(listNode.get(GIndexUtil.RIGHT_CHILD_G_INDEX));
-    assert longLength < Integer.MAX_VALUE;
-    return (int) longLength;
-  }
-
-  protected static TreeNode getVectorNode(final TreeNode listNode) {
-    return listNode.get(GIndexUtil.LEFT_CHILD_G_INDEX);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
@@ -67,7 +67,7 @@ public class ProgressiveTreeUtil {
   public static int levelForIndex(final long elementIndex) {
     // formula: level = floor(log4(3 * elementIndex + 1))
     checkArgument(elementIndex >= 0, "Element index must be non-negative");
-    final long val = 3L * elementIndex + 1;
+    final long val = (3L * elementIndex) + 1;
     final int log2 = 63 - Long.numberOfLeadingZeros(val);
     return log2 / 2; // floor(log2(val)) / 2 == floor(log4(val))
   }
@@ -93,11 +93,12 @@ public class ProgressiveTreeUtil {
     if (chunks.isEmpty()) {
       return LeafNode.EMPTY_LEAF;
     }
-    long cap = levelCapacity(currentLevel);
-    int split = (int) Math.min(chunks.size(), cap);
-    int depth = levelDepth(currentLevel);
-    TreeNode left = TreeUtil.createTree(chunks.subList(0, split), depth);
-    TreeNode right = createProgressiveTree(chunks.subList(split, chunks.size()), currentLevel + 1);
+    final long cap = levelCapacity(currentLevel);
+    final int split = (int) Math.min(chunks.size(), cap);
+    final int depth = levelDepth(currentLevel);
+    final TreeNode left = TreeUtil.createTree(chunks.subList(0, split), depth);
+    final TreeNode right =
+        createProgressiveTree(chunks.subList(split, chunks.size()), currentLevel + 1);
     return BranchNode.create(left, right);
   }
 
@@ -124,19 +125,19 @@ public class ProgressiveTreeUtil {
     if (chunkUpdates.isEmpty()) {
       return dataTree;
     }
-    int maxLevel = levelForIndex(newTotalChunks - 1);
+    final int maxLevel = levelForIndex(newTotalChunks - 1);
 
     // Group by level and compute gIndices within each level's balanced subtree
     @SuppressWarnings({"unchecked", "rawtypes"})
-    List<TreeUpdates.Update>[] updatesByLevel = new List[maxLevel + 1];
+    final List<TreeUpdates.Update>[] updatesByLevel = new List[maxLevel + 1];
 
     for (Int2ObjectMap.Entry<TreeNode> entry : chunkUpdates.int2ObjectEntrySet()) {
-      int chunkIndex = entry.getIntKey();
-      int level = levelForIndex(chunkIndex);
-      long cumulativeBefore = level > 0 ? cumulativeCapacity(level - 1) : 0;
-      long posInLevel = chunkIndex - cumulativeBefore;
-      int depth = levelDepth(level);
-      long gIdx =
+      final int chunkIndex = entry.getIntKey();
+      final int level = levelForIndex(chunkIndex);
+      final long cumulativeBefore = level > 0 ? cumulativeCapacity(level - 1) : 0;
+      final long posInLevel = chunkIndex - cumulativeBefore;
+      final int depth = levelDepth(level);
+      final long gIdx =
           depth > 0
               ? GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, posInLevel, depth)
               : GIndexUtil.SELF_G_INDEX;
@@ -177,16 +178,16 @@ public class ProgressiveTreeUtil {
       right = LeafNode.EMPTY_LEAF;
     }
 
-    TreeNode originalLeft = left;
+    final TreeNode originalLeft = left;
 
     // Apply changes for this level
-    List<TreeUpdates.Update> levelUpdates = updatesByLevel[level];
+    final List<TreeUpdates.Update> levelUpdates = updatesByLevel[level];
     if (levelUpdates != null && !levelUpdates.isEmpty()) {
-      TreeUpdates treeUpdates = new TreeUpdates(levelUpdates);
+      final TreeUpdates treeUpdates = new TreeUpdates(levelUpdates);
       left = left.updated(treeUpdates);
     }
 
-    TreeNode newRight = updateLevel(right, level + 1, maxLevel, updatesByLevel);
+    final TreeNode newRight = updateLevel(right, level + 1, maxLevel, updatesByLevel);
 
     @SuppressWarnings("ReferenceComparison")
     boolean unchanged = left == originalLeft && newRight == right;
@@ -210,8 +211,8 @@ public class ProgressiveTreeUtil {
    */
   public static long getElementGeneralizedIndex(final long elementIndex) {
     checkArgument(elementIndex >= 0, "Element index must be non-negative");
-    int level = levelForIndex(elementIndex);
-    long posInLevel = elementIndex - (level > 0 ? cumulativeCapacity(level - 1) : 0);
+    final int level = levelForIndex(elementIndex);
+    final long posInLevel = elementIndex - (level > 0 ? cumulativeCapacity(level - 1) : 0);
 
     // Navigate from root: take 'level' right turns, then one left turn into the balanced subtree
     // Each right turn is gIdxRightGIndex, one left turn is gIdxLeftGIndex
@@ -222,9 +223,10 @@ public class ProgressiveTreeUtil {
     gIdx = GIndexUtil.gIdxLeftGIndex(gIdx);
 
     // Within the balanced subtree at this level
-    int depth = levelDepth(level);
+    final int depth = levelDepth(level);
     if (depth > 0) {
-      long subtreeGIdx = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, posInLevel, depth);
+      final long subtreeGIdx =
+          GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, posInLevel, depth);
       gIdx = GIndexUtil.gIdxCompose(gIdx, subtreeGIdx);
     }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
@@ -65,21 +65,11 @@ public class ProgressiveTreeUtil {
 
   /** Determines which level contains the element at the given zero-based index. */
   public static int levelForIndex(final long elementIndex) {
+    // formula: level = floor(log4(3 * elementIndex + 1))
     checkArgument(elementIndex >= 0, "Element index must be non-negative");
-    // Level 0 holds indices [0, 0] (capacity 1, cumulative 1)
-    // Level 1 holds indices [1, 4] (capacity 4, cumulative 5)
-    // Level 2 holds indices [5, 20] (capacity 16, cumulative 21)
-    // ...
-    int level = 0;
-    long cumulative = 0;
-    while (true) {
-      long cap = levelCapacity(level);
-      if (elementIndex < cumulative + cap) {
-        return level;
-      }
-      cumulative += cap;
-      level++;
-    }
+    final long val = 3L * elementIndex + 1;
+    final int log2 = 63 - Long.numberOfLeadingZeros(val);
+    return log2 / 2; // floor(log2(val)) / 2 == floor(log4(val))
   }
 
   /**

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.tree;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+
+/**
+ * Utility for constructing and navigating progressive merkle trees as defined in EIP-7916.
+ *
+ * <p>A progressive merkle tree is a right-leaning asymmetric tree where subtree capacities grow by
+ * 4x per level:
+ *
+ * <pre>
+ *            root
+ *             /\
+ *            /  \
+ *  Level 0 (1)  /\
+ *              /  \
+ *  Level 1 (4)   /\
+ *               /  \
+ *  Level 2 (16)  ...
+ * </pre>
+ *
+ * Level L has capacity 4^L and depth 2*L in the balanced subtree.
+ */
+public class ProgressiveTreeUtil {
+
+  /** Returns the capacity of a single level: 4^level */
+  public static long levelCapacity(final int level) {
+    checkArgument(level >= 0 && level <= 31, "Level must be in range [0, 31]");
+    return 1L << (2 * level);
+  }
+
+  /**
+   * Returns the cumulative capacity through level L (inclusive): (4^(L+1) - 1) / 3
+   *
+   * <p>Sequence: 1, 5, 21, 85, 341, 1365, ...
+   */
+  public static long cumulativeCapacity(final int level) {
+    checkArgument(level >= 0 && level <= 31, "Level must be in range [0, 31]");
+    // (4^(level+1) - 1) / 3
+    return ((1L << (2 * (level + 1))) - 1) / 3;
+  }
+
+  /** Returns the depth of the balanced subtree at a given level: 2 * level */
+  public static int levelDepth(final int level) {
+    return 2 * level;
+  }
+
+  /** Determines which level contains the element at the given zero-based index. */
+  public static int levelForIndex(final long elementIndex) {
+    checkArgument(elementIndex >= 0, "Element index must be non-negative");
+    // Level 0 holds indices [0, 0] (capacity 1, cumulative 1)
+    // Level 1 holds indices [1, 4] (capacity 4, cumulative 5)
+    // Level 2 holds indices [5, 20] (capacity 16, cumulative 21)
+    // ...
+    int level = 0;
+    long cumulative = 0;
+    while (true) {
+      long cap = levelCapacity(level);
+      if (elementIndex < cumulative + cap) {
+        return level;
+      }
+      cumulative += cap;
+      level++;
+    }
+  }
+
+  /**
+   * Builds a progressive merkle tree from a list of chunk nodes.
+   *
+   * <p>Implements: merkleize_progressive(chunks):
+   *
+   * <pre>
+   *   if chunks is empty: return Bytes32(0)
+   *   a = merkleize(chunks[:cap], cap)
+   *   b = merkleize_progressive(chunks[cap:], cap*4)
+   *   return hash(a, b)
+   * </pre>
+   */
+  public static TreeNode createProgressiveTree(final List<? extends TreeNode> chunks) {
+    return createProgressiveTree(chunks, 0);
+  }
+
+  private static TreeNode createProgressiveTree(
+      final List<? extends TreeNode> chunks, final int currentLevel) {
+    if (chunks.isEmpty()) {
+      return LeafNode.EMPTY_LEAF;
+    }
+    long cap = levelCapacity(currentLevel);
+    int split = (int) Math.min(chunks.size(), cap);
+    int depth = levelDepth(currentLevel);
+    TreeNode left = TreeUtil.createTree(chunks.subList(0, split), depth);
+    TreeNode right = createProgressiveTree(chunks.subList(split, chunks.size()), currentLevel + 1);
+    return BranchNode.create(left, right);
+  }
+
+  /**
+   * Computes the generalized index for an element at the given logical index within a progressive
+   * data tree.
+   *
+   * <p>For element i at level L, position p = i - cumulativeCapacity(L-1):
+   *
+   * <ol>
+   *   <li>From root: take L right turns to reach level L's subtree parent, then 1 left turn
+   *   <li>Within the balanced subtree: standard gIdxChildGIndex(SELF, p, levelDepth(L))
+   *   <li>Compose all segments
+   * </ol>
+   */
+  public static long getElementGeneralizedIndex(final long elementIndex) {
+    checkArgument(elementIndex >= 0, "Element index must be non-negative");
+    int level = levelForIndex(elementIndex);
+    long posInLevel = elementIndex - (level > 0 ? cumulativeCapacity(level - 1) : 0);
+
+    // Navigate from root: take 'level' right turns, then one left turn into the balanced subtree
+    // Each right turn is gIdxRightGIndex, one left turn is gIdxLeftGIndex
+    long gIdx = GIndexUtil.SELF_G_INDEX;
+    for (int i = 0; i < level; i++) {
+      gIdx = GIndexUtil.gIdxRightGIndex(gIdx);
+    }
+    gIdx = GIndexUtil.gIdxLeftGIndex(gIdx);
+
+    // Within the balanced subtree at this level
+    int depth = levelDepth(level);
+    if (depth > 0) {
+      long subtreeGIdx = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, posInLevel, depth);
+      gIdx = GIndexUtil.gIdxCompose(gIdx, subtreeGIdx);
+    }
+
+    return gIdx;
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveContainerTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveContainerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class SszMutableProgressiveContainerTest {
+
+  private static final SszProgressiveContainerSchema<SszContainer> ALL_FIXED_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "AllFixed",
+          new boolean[] {true, true, true},
+          NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
+          NamedSchema.of("b", SszPrimitiveSchemas.BYTE_SCHEMA),
+          NamedSchema.of("c", SszPrimitiveSchemas.UINT64_SCHEMA));
+
+  private static final SszProgressiveContainerSchema<SszContainer> GAPPED_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "Gapped",
+          new boolean[] {true, false, true},
+          NamedSchema.of("first", SszPrimitiveSchemas.UINT64_SCHEMA),
+          NamedSchema.of("third", SszPrimitiveSchemas.BYTE_SCHEMA));
+
+  private static SszContainer createAllFixed(final UInt64 a, final byte b, final UInt64 c) {
+    TreeNode tree =
+        ALL_FIXED_SCHEMA.createTreeFromFieldValues(
+            List.of(SszUInt64.of(a), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(b), SszUInt64.of(c)));
+    return ALL_FIXED_SCHEMA.createFromBackingNode(tree);
+  }
+
+  private static SszContainer createGapped(final UInt64 first, final byte third) {
+    TreeNode tree =
+        GAPPED_SCHEMA.createTreeFromFieldValues(
+            List.of(SszUInt64.of(first), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(third)));
+    return GAPPED_SCHEMA.createFromBackingNode(tree);
+  }
+
+  @Test
+  void isWritableSupported_shouldReturnTrue() {
+    SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
+    assertThat(container.isWritableSupported()).isTrue();
+  }
+
+  @Test
+  void createWritableCopy_shouldSucceed() {
+    SszContainer container = createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    assertThat(mutable.size()).isEqualTo(3);
+    assertThat(((SszUInt64) mutable.get(0)).get()).isEqualTo(UInt64.valueOf(10));
+  }
+
+  @Test
+  void setAndGet_roundtrip() {
+    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+
+    mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
+
+    assertThat(((SszUInt64) mutable.get(0)).get()).isEqualTo(UInt64.valueOf(100));
+    assertThat(((SszByte) mutable.get(1)).get()).isEqualTo((byte) 2);
+    assertThat(((SszUInt64) mutable.get(2)).get()).isEqualTo(UInt64.valueOf(3));
+  }
+
+  @Test
+  void commitChanges_producesCorrectImmutable() {
+    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+
+    mutable.set(1, SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 99));
+    SszContainer committed = mutable.commitChanges();
+
+    assertThat(((SszUInt64) committed.get(0)).get()).isEqualTo(UInt64.ONE);
+    assertThat(((SszByte) committed.get(1)).get()).isEqualTo((byte) 99);
+    assertThat(((SszUInt64) committed.get(2)).get()).isEqualTo(UInt64.valueOf(3));
+  }
+
+  @Test
+  void commitChanges_hashTreeRootMatchesFreshCreation() {
+    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+
+    mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
+    mutable.set(2, SszUInt64.of(UInt64.valueOf(300)));
+    SszContainer committed = mutable.commitChanges();
+
+    SszContainer expected = createAllFixed(UInt64.valueOf(100), (byte) 2, UInt64.valueOf(300));
+    assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
+  }
+
+  @Test
+  void unchangedFields_remainUntouched() {
+    SszContainer container = createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+
+    // Only modify field 1
+    mutable.set(1, SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 99));
+    SszContainer committed = mutable.commitChanges();
+
+    assertThat(((SszUInt64) committed.get(0)).get()).isEqualTo(UInt64.valueOf(10));
+    assertThat(((SszByte) committed.get(1)).get()).isEqualTo((byte) 99);
+    assertThat(((SszUInt64) committed.get(2)).get()).isEqualTo(UInt64.valueOf(30));
+  }
+
+  @Test
+  void gappedContainer_setAndCommit() {
+    SszContainer container = createGapped(UInt64.valueOf(42), (byte) 7);
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+
+    mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
+    SszContainer committed = mutable.commitChanges();
+
+    assertThat(((SszUInt64) committed.get(0)).get()).isEqualTo(UInt64.valueOf(100));
+    assertThat(((SszByte) committed.get(1)).get()).isEqualTo((byte) 7);
+
+    // Verify hash matches fresh creation
+    SszContainer expected = createGapped(UInt64.valueOf(100), (byte) 7);
+    assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
+  }
+
+  @Test
+  void multipleCommits() {
+    SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
+
+    // First mutation
+    SszMutableContainer mutable1 = (SszMutableContainer) container.createWritableCopy();
+    mutable1.set(0, SszUInt64.of(UInt64.valueOf(10)));
+    SszContainer committed1 = mutable1.commitChanges();
+
+    // Second mutation
+    SszMutableContainer mutable2 = (SszMutableContainer) committed1.createWritableCopy();
+    mutable2.set(2, SszUInt64.of(UInt64.valueOf(30)));
+    SszContainer committed2 = mutable2.commitChanges();
+
+    assertThat(((SszUInt64) committed2.get(0)).get()).isEqualTo(UInt64.valueOf(10));
+    assertThat(((SszByte) committed2.get(1)).get()).isEqualTo((byte) 2);
+    assertThat(((SszUInt64) committed2.get(2)).get()).isEqualTo(UInt64.valueOf(30));
+
+    SszContainer expected = createAllFixed(UInt64.valueOf(10), (byte) 2, UInt64.valueOf(30));
+    assertThat(committed2.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
+  }
+
+  @Test
+  void commitWithNoChanges_returnsSameData() {
+    SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+
+    SszContainer committed = mutable.commitChanges();
+    assertThat(committed.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
+  }
+
+  @Test
+  void sszSerializationRoundtrip_afterMutation() {
+    SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
+    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    mutable.set(0, SszUInt64.of(UInt64.valueOf(42)));
+    SszContainer committed = mutable.commitChanges();
+
+    Bytes serialized = committed.sszSerialize();
+    SszContainer deserialized = ALL_FIXED_SCHEMA.sszDeserialize(serialized);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(committed.hashTreeRoot());
+    assertThat(((SszUInt64) deserialized.get(0)).get()).isEqualTo(UInt64.valueOf(42));
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveContainerTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveContainerTest.java
@@ -44,14 +44,14 @@ class SszMutableProgressiveContainerTest {
           NamedSchema.of("third", SszPrimitiveSchemas.BYTE_SCHEMA));
 
   private static SszContainer createAllFixed(final UInt64 a, final byte b, final UInt64 c) {
-    TreeNode tree =
+    final TreeNode tree =
         ALL_FIXED_SCHEMA.createTreeFromFieldValues(
             List.of(SszUInt64.of(a), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(b), SszUInt64.of(c)));
     return ALL_FIXED_SCHEMA.createFromBackingNode(tree);
   }
 
   private static SszContainer createGapped(final UInt64 first, final byte third) {
-    TreeNode tree =
+    final TreeNode tree =
         GAPPED_SCHEMA.createTreeFromFieldValues(
             List.of(SszUInt64.of(first), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(third)));
     return GAPPED_SCHEMA.createFromBackingNode(tree);
@@ -59,22 +59,23 @@ class SszMutableProgressiveContainerTest {
 
   @Test
   void isWritableSupported_shouldReturnTrue() {
-    SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
+    final SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
     assertThat(container.isWritableSupported()).isTrue();
   }
 
   @Test
   void createWritableCopy_shouldSucceed() {
-    SszContainer container = createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container =
+        createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
     assertThat(mutable.size()).isEqualTo(3);
     assertThat(((SszUInt64) mutable.get(0)).get()).isEqualTo(UInt64.valueOf(10));
   }
 
   @Test
   void setAndGet_roundtrip() {
-    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
 
     mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
 
@@ -85,11 +86,11 @@ class SszMutableProgressiveContainerTest {
 
   @Test
   void commitChanges_producesCorrectImmutable() {
-    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
 
     mutable.set(1, SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 99));
-    SszContainer committed = mutable.commitChanges();
+    final SszContainer committed = mutable.commitChanges();
 
     assertThat(((SszUInt64) committed.get(0)).get()).isEqualTo(UInt64.ONE);
     assertThat(((SszByte) committed.get(1)).get()).isEqualTo((byte) 99);
@@ -98,25 +99,27 @@ class SszMutableProgressiveContainerTest {
 
   @Test
   void commitChanges_hashTreeRootMatchesFreshCreation() {
-    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
 
     mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
     mutable.set(2, SszUInt64.of(UInt64.valueOf(300)));
-    SszContainer committed = mutable.commitChanges();
+    final SszContainer committed = mutable.commitChanges();
 
-    SszContainer expected = createAllFixed(UInt64.valueOf(100), (byte) 2, UInt64.valueOf(300));
+    final SszContainer expected =
+        createAllFixed(UInt64.valueOf(100), (byte) 2, UInt64.valueOf(300));
     assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
   }
 
   @Test
   void unchangedFields_remainUntouched() {
-    SszContainer container = createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container =
+        createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
 
     // Only modify field 1
     mutable.set(1, SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 99));
-    SszContainer committed = mutable.commitChanges();
+    final SszContainer committed = mutable.commitChanges();
 
     assertThat(((SszUInt64) committed.get(0)).get()).isEqualTo(UInt64.valueOf(10));
     assertThat(((SszByte) committed.get(1)).get()).isEqualTo((byte) 99);
@@ -125,60 +128,60 @@ class SszMutableProgressiveContainerTest {
 
   @Test
   void gappedContainer_setAndCommit() {
-    SszContainer container = createGapped(UInt64.valueOf(42), (byte) 7);
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container = createGapped(UInt64.valueOf(42), (byte) 7);
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
 
     mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
-    SszContainer committed = mutable.commitChanges();
+    final SszContainer committed = mutable.commitChanges();
 
     assertThat(((SszUInt64) committed.get(0)).get()).isEqualTo(UInt64.valueOf(100));
     assertThat(((SszByte) committed.get(1)).get()).isEqualTo((byte) 7);
 
     // Verify hash matches fresh creation
-    SszContainer expected = createGapped(UInt64.valueOf(100), (byte) 7);
+    final SszContainer expected = createGapped(UInt64.valueOf(100), (byte) 7);
     assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
   }
 
   @Test
   void multipleCommits() {
-    SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
+    final SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
 
     // First mutation
-    SszMutableContainer mutable1 = (SszMutableContainer) container.createWritableCopy();
+    final SszMutableContainer mutable1 = (SszMutableContainer) container.createWritableCopy();
     mutable1.set(0, SszUInt64.of(UInt64.valueOf(10)));
-    SszContainer committed1 = mutable1.commitChanges();
+    final SszContainer committed1 = mutable1.commitChanges();
 
     // Second mutation
-    SszMutableContainer mutable2 = (SszMutableContainer) committed1.createWritableCopy();
+    final SszMutableContainer mutable2 = (SszMutableContainer) committed1.createWritableCopy();
     mutable2.set(2, SszUInt64.of(UInt64.valueOf(30)));
-    SszContainer committed2 = mutable2.commitChanges();
+    final SszContainer committed2 = mutable2.commitChanges();
 
     assertThat(((SszUInt64) committed2.get(0)).get()).isEqualTo(UInt64.valueOf(10));
     assertThat(((SszByte) committed2.get(1)).get()).isEqualTo((byte) 2);
     assertThat(((SszUInt64) committed2.get(2)).get()).isEqualTo(UInt64.valueOf(30));
 
-    SszContainer expected = createAllFixed(UInt64.valueOf(10), (byte) 2, UInt64.valueOf(30));
+    final SszContainer expected = createAllFixed(UInt64.valueOf(10), (byte) 2, UInt64.valueOf(30));
     assertThat(committed2.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
   }
 
   @Test
   void commitWithNoChanges_returnsSameData() {
-    SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
 
-    SszContainer committed = mutable.commitChanges();
+    final SszContainer committed = mutable.commitChanges();
     assertThat(committed.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
   }
 
   @Test
   void sszSerializationRoundtrip_afterMutation() {
-    SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
-    SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
+    final SszContainer container = createAllFixed(UInt64.ONE, (byte) 2, UInt64.valueOf(3));
+    final SszMutableContainer mutable = (SszMutableContainer) container.createWritableCopy();
     mutable.set(0, SszUInt64.of(UInt64.valueOf(42)));
-    SszContainer committed = mutable.commitChanges();
+    final SszContainer committed = mutable.commitChanges();
 
-    Bytes serialized = committed.sszSerialize();
-    SszContainer deserialized = ALL_FIXED_SCHEMA.sszDeserialize(serialized);
+    final Bytes serialized = committed.sszSerialize();
+    final SszContainer deserialized = ALL_FIXED_SCHEMA.sszDeserialize(serialized);
 
     assertThat(deserialized.hashTreeRoot()).isEqualTo(committed.hashTreeRoot());
     assertThat(((SszUInt64) deserialized.get(0)).get()).isEqualTo(UInt64.valueOf(42));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveListTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveListTest.java
@@ -32,24 +32,24 @@ class SszMutableProgressiveListTest {
       SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA);
 
   private static SszList<SszUInt64> createUInt64List(final int count) {
-    List<SszUInt64> elements =
+    final List<SszUInt64> elements =
         IntStream.range(0, count)
             .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
             .collect(Collectors.toList());
-    TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
+    final TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
     return UINT64_LIST_SCHEMA.createFromBackingNode(tree);
   }
 
   @Test
   void isWritableSupported_shouldReturnTrue() {
-    SszList<SszUInt64> list = createUInt64List(1);
+    final SszList<SszUInt64> list = createUInt64List(1);
     assertThat(list.isWritableSupported()).isTrue();
   }
 
   @Test
   void createWritableCopy_shouldSucceed() {
-    SszList<SszUInt64> list = createUInt64List(3);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(3);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
     assertThat(mutable.size()).isEqualTo(3);
     for (int i = 0; i < 3; i++) {
       assertThat(mutable.get(i).get()).isEqualTo(UInt64.valueOf(i));
@@ -58,8 +58,8 @@ class SszMutableProgressiveListTest {
 
   @Test
   void setAndGet_roundtrip() {
-    SszList<SszUInt64> list = createUInt64List(5);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(5);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     mutable.set(2, SszUInt64.of(UInt64.valueOf(999)));
 
@@ -69,11 +69,11 @@ class SszMutableProgressiveListTest {
 
   @Test
   void commitChanges_producesCorrectImmutable() {
-    SszList<SszUInt64> list = createUInt64List(5);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(5);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     mutable.set(2, SszUInt64.of(UInt64.valueOf(999)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     assertThat(committed.size()).isEqualTo(5);
     assertThat(committed.get(0).get()).isEqualTo(UInt64.ZERO);
@@ -85,30 +85,30 @@ class SszMutableProgressiveListTest {
 
   @Test
   void commitChanges_hashTreeRootMatchesFreshCreation() {
-    SszList<SszUInt64> list = createUInt64List(5);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(5);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     mutable.set(2, SszUInt64.of(UInt64.valueOf(999)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     // Build expected from scratch
-    List<SszUInt64> expectedElements =
+    final List<SszUInt64> expectedElements =
         List.of(
             SszUInt64.of(UInt64.ZERO),
             SszUInt64.of(UInt64.ONE),
             SszUInt64.of(UInt64.valueOf(999)),
             SszUInt64.of(UInt64.valueOf(3)),
             SszUInt64.of(UInt64.valueOf(4)));
-    TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(expectedElements);
-    SszList<SszUInt64> expected = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
+    final TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(expectedElements);
+    final SszList<SszUInt64> expected = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
 
     assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
   }
 
   @Test
   void append_incrementsSize() {
-    SszList<SszUInt64> list = createUInt64List(3);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(3);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     mutable.append(SszUInt64.of(UInt64.valueOf(100)));
 
@@ -119,12 +119,12 @@ class SszMutableProgressiveListTest {
   @Test
   void append_crossesLevelBoundary() {
     // Create list with 5 elements (fills levels 0 and 1)
-    SszList<SszUInt64> list = createUInt64List(5);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(5);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     // Append element at index 5 (starts level 2)
     mutable.append(SszUInt64.of(UInt64.valueOf(500)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     assertThat(committed.size()).isEqualTo(6);
     for (int i = 0; i < 5; i++) {
@@ -133,30 +133,30 @@ class SszMutableProgressiveListTest {
     assertThat(committed.get(5).get()).isEqualTo(UInt64.valueOf(500));
 
     // Verify hash matches fresh creation
-    List<SszUInt64> expectedElements =
+    final List<SszUInt64> expectedElements =
         IntStream.range(0, 5)
             .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
             .collect(Collectors.toList());
     expectedElements.add(SszUInt64.of(UInt64.valueOf(500)));
-    TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(expectedElements);
-    SszList<SszUInt64> expected = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
+    final TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(expectedElements);
+    final SszList<SszUInt64> expected = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
 
     assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
   }
 
   @Test
   void multipleCommits_worksCorrectly() {
-    SszList<SszUInt64> list = createUInt64List(3);
+    final SszList<SszUInt64> list = createUInt64List(3);
 
     // First mutation
-    SszMutableList<SszUInt64> mutable1 = list.createWritableCopy();
+    final SszMutableList<SszUInt64> mutable1 = list.createWritableCopy();
     mutable1.set(0, SszUInt64.of(UInt64.valueOf(10)));
-    SszList<SszUInt64> committed1 = mutable1.commitChanges();
+    final SszList<SszUInt64> committed1 = mutable1.commitChanges();
 
     // Second mutation on the committed result
-    SszMutableList<SszUInt64> mutable2 = committed1.createWritableCopy();
+    final SszMutableList<SszUInt64> mutable2 = committed1.createWritableCopy();
     mutable2.set(1, SszUInt64.of(UInt64.valueOf(20)));
-    SszList<SszUInt64> committed2 = mutable2.commitChanges();
+    final SszList<SszUInt64> committed2 = mutable2.commitChanges();
 
     assertThat(committed2.get(0).get()).isEqualTo(UInt64.valueOf(10));
     assertThat(committed2.get(1).get()).isEqualTo(UInt64.valueOf(20));
@@ -165,14 +165,14 @@ class SszMutableProgressiveListTest {
 
   @Test
   void clear_thenAppend() {
-    SszList<SszUInt64> list = createUInt64List(5);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(5);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     mutable.clear();
     assertThat(mutable.size()).isEqualTo(0);
 
     mutable.append(SszUInt64.of(UInt64.valueOf(42)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     assertThat(committed.size()).isEqualTo(1);
     assertThat(committed.get(0).get()).isEqualTo(UInt64.valueOf(42));
@@ -180,46 +180,47 @@ class SszMutableProgressiveListTest {
 
   @Test
   void commitWithNoChanges_returnsSameData() {
-    SszList<SszUInt64> list = createUInt64List(3);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(3);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     assertThat(committed.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
   }
 
   @Test
   void appendFromEmpty() {
-    SszList<SszUInt64> list = createUInt64List(0);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(0);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     mutable.append(SszUInt64.of(UInt64.valueOf(1)));
     mutable.append(SszUInt64.of(UInt64.valueOf(2)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     assertThat(committed.size()).isEqualTo(2);
     assertThat(committed.get(0).get()).isEqualTo(UInt64.ONE);
     assertThat(committed.get(1).get()).isEqualTo(UInt64.valueOf(2));
 
     // Verify hash matches fresh creation
-    List<SszUInt64> elems = List.of(SszUInt64.of(UInt64.ONE), SszUInt64.of(UInt64.valueOf(2)));
-    TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(elems);
-    SszList<SszUInt64> expectedList = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
+    final List<SszUInt64> elems =
+        List.of(SszUInt64.of(UInt64.ONE), SszUInt64.of(UInt64.valueOf(2)));
+    final TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(elems);
+    final SszList<SszUInt64> expectedList = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
     assertThat(committed.hashTreeRoot()).isEqualTo(expectedList.hashTreeRoot());
   }
 
   @Test
   void modifyMultipleElementsInSameChunk() {
     // UInt64 is 8 bytes, so 4 UInt64 values per 32-byte chunk
-    SszList<SszUInt64> list = createUInt64List(8);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(8);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     // Modify two values in the same chunk (indices 1 and 2 are in chunk 0 at level 0)
     // Actually for progressive list: chunk 0 = elements 0-3, chunk 1 = elements 4-7
     // chunk 0 is at level 0, chunk 1 is at level 1
     mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
     mutable.set(1, SszUInt64.of(UInt64.valueOf(200)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     assertThat(committed.get(0).get()).isEqualTo(UInt64.valueOf(100));
     assertThat(committed.get(1).get()).isEqualTo(UInt64.valueOf(200));
@@ -228,14 +229,14 @@ class SszMutableProgressiveListTest {
 
   @Test
   void largeList_modifyAndVerify() {
-    SszList<SszUInt64> list = createUInt64List(100);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(100);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
 
     // Modify several elements
     mutable.set(0, SszUInt64.of(UInt64.valueOf(1000)));
     mutable.set(50, SszUInt64.of(UInt64.valueOf(2000)));
     mutable.set(99, SszUInt64.of(UInt64.valueOf(3000)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     assertThat(committed.size()).isEqualTo(100);
     assertThat(committed.get(0).get()).isEqualTo(UInt64.valueOf(1000));
@@ -246,14 +247,14 @@ class SszMutableProgressiveListTest {
 
   @Test
   void sszSerializationRoundtrip_afterMutation() {
-    SszList<SszUInt64> list = createUInt64List(5);
-    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    final SszList<SszUInt64> list = createUInt64List(5);
+    final SszMutableList<SszUInt64> mutable = list.createWritableCopy();
     mutable.set(2, SszUInt64.of(UInt64.valueOf(42)));
-    SszList<SszUInt64> committed = mutable.commitChanges();
+    final SszList<SszUInt64> committed = mutable.commitChanges();
 
     // Serialize and deserialize
-    Bytes serialized = committed.sszSerialize();
-    SszList<SszUInt64> deserialized = UINT64_LIST_SCHEMA.sszDeserialize(serialized);
+    final Bytes serialized = committed.sszSerialize();
+    final SszList<SszUInt64> deserialized = UINT64_LIST_SCHEMA.sszDeserialize(serialized);
 
     assertThat(deserialized.size()).isEqualTo(5);
     assertThat(deserialized.get(2).get()).isEqualTo(UInt64.valueOf(42));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveListTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszMutableProgressiveListTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class SszMutableProgressiveListTest {
+
+  private static final SszProgressiveListSchema<SszUInt64> UINT64_LIST_SCHEMA =
+      SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA);
+
+  private static SszList<SszUInt64> createUInt64List(final int count) {
+    List<SszUInt64> elements =
+        IntStream.range(0, count)
+            .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
+            .collect(Collectors.toList());
+    TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
+    return UINT64_LIST_SCHEMA.createFromBackingNode(tree);
+  }
+
+  @Test
+  void isWritableSupported_shouldReturnTrue() {
+    SszList<SszUInt64> list = createUInt64List(1);
+    assertThat(list.isWritableSupported()).isTrue();
+  }
+
+  @Test
+  void createWritableCopy_shouldSucceed() {
+    SszList<SszUInt64> list = createUInt64List(3);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    assertThat(mutable.size()).isEqualTo(3);
+    for (int i = 0; i < 3; i++) {
+      assertThat(mutable.get(i).get()).isEqualTo(UInt64.valueOf(i));
+    }
+  }
+
+  @Test
+  void setAndGet_roundtrip() {
+    SszList<SszUInt64> list = createUInt64List(5);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    mutable.set(2, SszUInt64.of(UInt64.valueOf(999)));
+
+    assertThat(mutable.get(2).get()).isEqualTo(UInt64.valueOf(999));
+    assertThat(mutable.size()).isEqualTo(5);
+  }
+
+  @Test
+  void commitChanges_producesCorrectImmutable() {
+    SszList<SszUInt64> list = createUInt64List(5);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    mutable.set(2, SszUInt64.of(UInt64.valueOf(999)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    assertThat(committed.size()).isEqualTo(5);
+    assertThat(committed.get(0).get()).isEqualTo(UInt64.ZERO);
+    assertThat(committed.get(1).get()).isEqualTo(UInt64.ONE);
+    assertThat(committed.get(2).get()).isEqualTo(UInt64.valueOf(999));
+    assertThat(committed.get(3).get()).isEqualTo(UInt64.valueOf(3));
+    assertThat(committed.get(4).get()).isEqualTo(UInt64.valueOf(4));
+  }
+
+  @Test
+  void commitChanges_hashTreeRootMatchesFreshCreation() {
+    SszList<SszUInt64> list = createUInt64List(5);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    mutable.set(2, SszUInt64.of(UInt64.valueOf(999)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    // Build expected from scratch
+    List<SszUInt64> expectedElements =
+        List.of(
+            SszUInt64.of(UInt64.ZERO),
+            SszUInt64.of(UInt64.ONE),
+            SszUInt64.of(UInt64.valueOf(999)),
+            SszUInt64.of(UInt64.valueOf(3)),
+            SszUInt64.of(UInt64.valueOf(4)));
+    TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(expectedElements);
+    SszList<SszUInt64> expected = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
+
+    assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
+  }
+
+  @Test
+  void append_incrementsSize() {
+    SszList<SszUInt64> list = createUInt64List(3);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    mutable.append(SszUInt64.of(UInt64.valueOf(100)));
+
+    assertThat(mutable.size()).isEqualTo(4);
+    assertThat(mutable.get(3).get()).isEqualTo(UInt64.valueOf(100));
+  }
+
+  @Test
+  void append_crossesLevelBoundary() {
+    // Create list with 5 elements (fills levels 0 and 1)
+    SszList<SszUInt64> list = createUInt64List(5);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    // Append element at index 5 (starts level 2)
+    mutable.append(SszUInt64.of(UInt64.valueOf(500)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    assertThat(committed.size()).isEqualTo(6);
+    for (int i = 0; i < 5; i++) {
+      assertThat(committed.get(i).get()).isEqualTo(UInt64.valueOf(i));
+    }
+    assertThat(committed.get(5).get()).isEqualTo(UInt64.valueOf(500));
+
+    // Verify hash matches fresh creation
+    List<SszUInt64> expectedElements =
+        IntStream.range(0, 5)
+            .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
+            .collect(Collectors.toList());
+    expectedElements.add(SszUInt64.of(UInt64.valueOf(500)));
+    TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(expectedElements);
+    SszList<SszUInt64> expected = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
+
+    assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
+  }
+
+  @Test
+  void multipleCommits_worksCorrectly() {
+    SszList<SszUInt64> list = createUInt64List(3);
+
+    // First mutation
+    SszMutableList<SszUInt64> mutable1 = list.createWritableCopy();
+    mutable1.set(0, SszUInt64.of(UInt64.valueOf(10)));
+    SszList<SszUInt64> committed1 = mutable1.commitChanges();
+
+    // Second mutation on the committed result
+    SszMutableList<SszUInt64> mutable2 = committed1.createWritableCopy();
+    mutable2.set(1, SszUInt64.of(UInt64.valueOf(20)));
+    SszList<SszUInt64> committed2 = mutable2.commitChanges();
+
+    assertThat(committed2.get(0).get()).isEqualTo(UInt64.valueOf(10));
+    assertThat(committed2.get(1).get()).isEqualTo(UInt64.valueOf(20));
+    assertThat(committed2.get(2).get()).isEqualTo(UInt64.valueOf(2));
+  }
+
+  @Test
+  void clear_thenAppend() {
+    SszList<SszUInt64> list = createUInt64List(5);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    mutable.clear();
+    assertThat(mutable.size()).isEqualTo(0);
+
+    mutable.append(SszUInt64.of(UInt64.valueOf(42)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    assertThat(committed.size()).isEqualTo(1);
+    assertThat(committed.get(0).get()).isEqualTo(UInt64.valueOf(42));
+  }
+
+  @Test
+  void commitWithNoChanges_returnsSameData() {
+    SszList<SszUInt64> list = createUInt64List(3);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    assertThat(committed.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
+  }
+
+  @Test
+  void appendFromEmpty() {
+    SszList<SszUInt64> list = createUInt64List(0);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    mutable.append(SszUInt64.of(UInt64.valueOf(1)));
+    mutable.append(SszUInt64.of(UInt64.valueOf(2)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    assertThat(committed.size()).isEqualTo(2);
+    assertThat(committed.get(0).get()).isEqualTo(UInt64.ONE);
+    assertThat(committed.get(1).get()).isEqualTo(UInt64.valueOf(2));
+
+    // Verify hash matches fresh creation
+    List<SszUInt64> elems = List.of(SszUInt64.of(UInt64.ONE), SszUInt64.of(UInt64.valueOf(2)));
+    TreeNode expectedTree = UINT64_LIST_SCHEMA.createTreeFromElements(elems);
+    SszList<SszUInt64> expectedList = UINT64_LIST_SCHEMA.createFromBackingNode(expectedTree);
+    assertThat(committed.hashTreeRoot()).isEqualTo(expectedList.hashTreeRoot());
+  }
+
+  @Test
+  void modifyMultipleElementsInSameChunk() {
+    // UInt64 is 8 bytes, so 4 UInt64 values per 32-byte chunk
+    SszList<SszUInt64> list = createUInt64List(8);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    // Modify two values in the same chunk (indices 1 and 2 are in chunk 0 at level 0)
+    // Actually for progressive list: chunk 0 = elements 0-3, chunk 1 = elements 4-7
+    // chunk 0 is at level 0, chunk 1 is at level 1
+    mutable.set(0, SszUInt64.of(UInt64.valueOf(100)));
+    mutable.set(1, SszUInt64.of(UInt64.valueOf(200)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    assertThat(committed.get(0).get()).isEqualTo(UInt64.valueOf(100));
+    assertThat(committed.get(1).get()).isEqualTo(UInt64.valueOf(200));
+    assertThat(committed.get(2).get()).isEqualTo(UInt64.valueOf(2));
+  }
+
+  @Test
+  void largeList_modifyAndVerify() {
+    SszList<SszUInt64> list = createUInt64List(100);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+
+    // Modify several elements
+    mutable.set(0, SszUInt64.of(UInt64.valueOf(1000)));
+    mutable.set(50, SszUInt64.of(UInt64.valueOf(2000)));
+    mutable.set(99, SszUInt64.of(UInt64.valueOf(3000)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    assertThat(committed.size()).isEqualTo(100);
+    assertThat(committed.get(0).get()).isEqualTo(UInt64.valueOf(1000));
+    assertThat(committed.get(50).get()).isEqualTo(UInt64.valueOf(2000));
+    assertThat(committed.get(99).get()).isEqualTo(UInt64.valueOf(3000));
+    assertThat(committed.get(1).get()).isEqualTo(UInt64.ONE);
+  }
+
+  @Test
+  void sszSerializationRoundtrip_afterMutation() {
+    SszList<SszUInt64> list = createUInt64List(5);
+    SszMutableList<SszUInt64> mutable = list.createWritableCopy();
+    mutable.set(2, SszUInt64.of(UInt64.valueOf(42)));
+    SszList<SszUInt64> committed = mutable.commitChanges();
+
+    // Serialize and deserialize
+    Bytes serialized = committed.sszSerialize();
+    SszList<SszUInt64> deserialized = UINT64_LIST_SCHEMA.sszDeserialize(serialized);
+
+    assertThat(deserialized.size()).isEqualTo(5);
+    assertThat(deserialized.get(2).get()).isEqualTo(UInt64.valueOf(42));
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(committed.hashTreeRoot());
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.infrastructure.ssz;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -109,16 +108,15 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
   }
 
   @Test
-  void createWritableCopy_shouldThrow() {
+  void createWritableCopy_shouldSucceed() {
     SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
-    assertThatThrownBy(container::createWritableCopy)
-        .isInstanceOf(UnsupportedOperationException.class);
+    assertThat(container.createWritableCopy()).isNotNull();
   }
 
   @Test
-  void isWritableSupported_shouldReturnFalse() {
+  void isWritableSupported_shouldReturnTrue() {
     SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
-    assertThat(container.isWritableSupported()).isFalse();
+    assertThat(container.isWritableSupported()).isTrue();
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
@@ -70,7 +70,7 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
   }
 
   private static SszContainer createAllFixed(final UInt64 a, final byte b, final UInt64 c) {
-    TreeNode tree =
+    final TreeNode tree =
         ALL_FIXED_SCHEMA.createTreeFromFieldValues(
             List.of(SszUInt64.of(a), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(b), SszUInt64.of(c)));
     return ALL_FIXED_SCHEMA.createFromBackingNode(tree);
@@ -78,7 +78,7 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
 
   private static SszContainer createMixed(
       final UInt64 fixedVal, final int bitlistSize, final int... setBits) {
-    TreeNode tree =
+    final TreeNode tree =
         MIXED_SCHEMA.createTreeFromFieldValues(
             List.of(
                 SszUInt64.of(fixedVal), SszBitlistSchema.create(100).ofBits(bitlistSize, setBits)));
@@ -86,7 +86,7 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
   }
 
   private static SszContainer createGapped(final UInt64 first, final byte third) {
-    TreeNode tree =
+    final TreeNode tree =
         GAPPED_SCHEMA.createTreeFromFieldValues(
             List.of(SszUInt64.of(first), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(third)));
     return GAPPED_SCHEMA.createFromBackingNode(tree);
@@ -94,7 +94,8 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
 
   @Test
   void fieldAccess_allFixed() {
-    SszContainer container = createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
+    final SszContainer container =
+        createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
     assertThat(((SszUInt64) container.get(0)).get()).isEqualTo(UInt64.valueOf(10));
     assertThat(((SszByte) container.get(1)).get()).isEqualTo((byte) 20);
     assertThat(((SszUInt64) container.get(2)).get()).isEqualTo(UInt64.valueOf(30));
@@ -102,27 +103,27 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
 
   @Test
   void fieldAccess_gapped() {
-    SszContainer container = createGapped(UInt64.valueOf(99), (byte) 3);
+    final SszContainer container = createGapped(UInt64.valueOf(99), (byte) 3);
     assertThat(((SszUInt64) container.get(0)).get()).isEqualTo(UInt64.valueOf(99));
     assertThat(((SszByte) container.get(1)).get()).isEqualTo((byte) 3);
   }
 
   @Test
   void createWritableCopy_shouldSucceed() {
-    SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
+    final SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
     assertThat(container.createWritableCopy()).isNotNull();
   }
 
   @Test
   void isWritableSupported_shouldReturnTrue() {
-    SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
+    final SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
     assertThat(container.isWritableSupported()).isTrue();
   }
 
   @Test
   void toString_shouldIncludeContainerNameAndFieldValues() {
-    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
-    String str = container.toString();
+    final SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    final String str = container.toString();
     assertThat(str).contains("AllFixed");
     assertThat(str).contains("a=");
     assertThat(str).contains("b=");

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SszProgressiveContainerTest implements SszCompositeTestBase {
+
+  private static final SszProgressiveContainerSchema<SszContainer> ALL_FIXED_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "AllFixed",
+          new boolean[] {true, true, true},
+          NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
+          NamedSchema.of("b", SszPrimitiveSchemas.BYTE_SCHEMA),
+          NamedSchema.of("c", SszPrimitiveSchemas.UINT64_SCHEMA));
+
+  private static final SszProgressiveContainerSchema<SszContainer> MIXED_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "Mixed",
+          new boolean[] {true, true},
+          NamedSchema.of("fixed", SszPrimitiveSchemas.UINT64_SCHEMA),
+          NamedSchema.of("var", SszBitlistSchema.create(100)));
+
+  private static final SszProgressiveContainerSchema<SszContainer> GAPPED_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "Gapped",
+          new boolean[] {true, false, true},
+          NamedSchema.of("first", SszPrimitiveSchemas.UINT64_SCHEMA),
+          NamedSchema.of("third", SszPrimitiveSchemas.BYTE_SCHEMA));
+
+  @Override
+  public Stream<SszContainer> sszData() {
+    return Stream.of(
+        // All-fixed default
+        ALL_FIXED_SCHEMA.createFromBackingNode(ALL_FIXED_SCHEMA.getDefaultTree()),
+        // All-fixed with values
+        createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3)),
+        createAllFixed(UInt64.valueOf(100), (byte) 0, UInt64.valueOf(200)),
+        // Mixed default
+        MIXED_SCHEMA.createFromBackingNode(MIXED_SCHEMA.getDefaultTree()),
+        // Mixed with values
+        createMixed(UInt64.valueOf(5), 10, 0, 3, 9),
+        // Gapped default
+        GAPPED_SCHEMA.createFromBackingNode(GAPPED_SCHEMA.getDefaultTree()),
+        // Gapped with values
+        createGapped(UInt64.valueOf(42), (byte) 7));
+  }
+
+  private static SszContainer createAllFixed(final UInt64 a, final byte b, final UInt64 c) {
+    TreeNode tree =
+        ALL_FIXED_SCHEMA.createTreeFromFieldValues(
+            List.of(SszUInt64.of(a), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(b), SszUInt64.of(c)));
+    return ALL_FIXED_SCHEMA.createFromBackingNode(tree);
+  }
+
+  private static SszContainer createMixed(
+      final UInt64 fixedVal, final int bitlistSize, final int... setBits) {
+    TreeNode tree =
+        MIXED_SCHEMA.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(fixedVal), SszBitlistSchema.create(100).ofBits(bitlistSize, setBits)));
+    return MIXED_SCHEMA.createFromBackingNode(tree);
+  }
+
+  private static SszContainer createGapped(final UInt64 first, final byte third) {
+    TreeNode tree =
+        GAPPED_SCHEMA.createTreeFromFieldValues(
+            List.of(SszUInt64.of(first), SszPrimitiveSchemas.BYTE_SCHEMA.boxed(third)));
+    return GAPPED_SCHEMA.createFromBackingNode(tree);
+  }
+
+  @Test
+  void fieldAccess_allFixed() {
+    SszContainer container = createAllFixed(UInt64.valueOf(10), (byte) 20, UInt64.valueOf(30));
+    assertThat(((SszUInt64) container.get(0)).get()).isEqualTo(UInt64.valueOf(10));
+    assertThat(((SszByte) container.get(1)).get()).isEqualTo((byte) 20);
+    assertThat(((SszUInt64) container.get(2)).get()).isEqualTo(UInt64.valueOf(30));
+  }
+
+  @Test
+  void fieldAccess_gapped() {
+    SszContainer container = createGapped(UInt64.valueOf(99), (byte) 3);
+    assertThat(((SszUInt64) container.get(0)).get()).isEqualTo(UInt64.valueOf(99));
+    assertThat(((SszByte) container.get(1)).get()).isEqualTo((byte) 3);
+  }
+
+  @Test
+  void createWritableCopy_shouldThrow() {
+    SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
+    assertThatThrownBy(container::createWritableCopy)
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void isWritableSupported_shouldReturnFalse() {
+    SszContainer container = createAllFixed(UInt64.ONE, (byte) 0, UInt64.ZERO);
+    assertThat(container.isWritableSupported()).isFalse();
+  }
+
+  @Test
+  void toString_shouldIncludeContainerNameAndFieldValues() {
+    SszContainer container = createAllFixed(UInt64.valueOf(1), (byte) 2, UInt64.valueOf(3));
+    String str = container.toString();
+    assertThat(str).contains("AllFixed");
+    assertThat(str).contains("a=");
+    assertThat(str).contains("b=");
+    assertThat(str).contains("c=");
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
@@ -69,6 +69,23 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
         createGapped(UInt64.valueOf(42), (byte) 7));
   }
 
+  @Test
+  void s() {
+    var squareSchema =
+        new SszProgressiveContainerSchema<>(
+            "Square",
+            new boolean[] {true, false, true},
+            NamedSchema.of("side", SszPrimitiveSchemas.UINT64_SCHEMA),
+            NamedSchema.of("color", SszPrimitiveSchemas.UINT8_SCHEMA));
+
+    final TreeNode tree =
+        squareSchema.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(UInt64.valueOf(3)), SszPrimitiveSchemas.UINT8_SCHEMA.boxed((byte) 2)));
+    var a = squareSchema.createFromBackingNode(tree);
+    var b = a.getSchema().getChildGeneralizedIndex(0);
+  }
+
   private static SszContainer createAllFixed(final UInt64 a, final byte b, final UInt64 c) {
     final TreeNode tree =
         ALL_FIXED_SCHEMA.createTreeFromFieldValues(

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveContainerTest.java
@@ -83,7 +83,7 @@ public class SszProgressiveContainerTest implements SszCompositeTestBase {
             List.of(
                 SszUInt64.of(UInt64.valueOf(3)), SszPrimitiveSchemas.UINT8_SCHEMA.boxed((byte) 2)));
     var a = squareSchema.createFromBackingNode(tree);
-    var b = a.getSchema().getChildGeneralizedIndex(0);
+    a.getSchema().getChildGeneralizedIndex(0);
   }
 
   private static SszContainer createAllFixed(final UInt64 a, final byte b, final UInt64 c) {

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveListTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveListTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.infrastructure.ssz;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -64,14 +63,14 @@ public class SszProgressiveListTest implements SszCollectionTestBase {
   }
 
   @Test
-  void createWritableCopy_shouldThrow() {
+  void createWritableCopy_shouldSucceed() {
     SszList<SszUInt64> list = createUInt64List(3);
-    assertThatThrownBy(list::createWritableCopy).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(list.createWritableCopy()).isNotNull();
   }
 
   @Test
-  void isWritableSupported_shouldReturnFalse() {
+  void isWritableSupported_shouldReturnTrue() {
     SszList<SszUInt64> list = createUInt64List(1);
-    assertThat(list.isWritableSupported()).isFalse();
+    assertThat(list.isWritableSupported()).isTrue();
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveListTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveListTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SszProgressiveListTest implements SszCollectionTestBase {
+
+  private static final SszProgressiveListSchema<SszUInt64> UINT64_LIST_SCHEMA =
+      SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA);
+
+  private static SszList<SszUInt64> createUInt64List(final int count) {
+    List<SszUInt64> elements =
+        IntStream.range(0, count)
+            .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
+            .collect(Collectors.toList());
+    TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
+    return UINT64_LIST_SCHEMA.createFromBackingNode(tree);
+  }
+
+  @Override
+  public Stream<SszList<SszUInt64>> sszData() {
+    return Stream.of(
+        createUInt64List(0),
+        createUInt64List(1),
+        createUInt64List(2),
+        createUInt64List(3),
+        createUInt64List(10),
+        createUInt64List(255),
+        createUInt64List(256),
+        createUInt64List(257),
+        createUInt64List(1000));
+  }
+
+  @Test
+  void elementAccess_shouldReturnCorrectValues() {
+    SszList<SszUInt64> list = createUInt64List(5);
+    for (int i = 0; i < 5; i++) {
+      assertThat(list.get(i).get()).isEqualTo(UInt64.valueOf(i));
+    }
+  }
+
+  @Test
+  void createWritableCopy_shouldThrow() {
+    SszList<SszUInt64> list = createUInt64List(3);
+    assertThatThrownBy(list::createWritableCopy).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void isWritableSupported_shouldReturnFalse() {
+    SszList<SszUInt64> list = createUInt64List(1);
+    assertThat(list.isWritableSupported()).isFalse();
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveListTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszProgressiveListTest.java
@@ -32,11 +32,11 @@ public class SszProgressiveListTest implements SszCollectionTestBase {
       SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA);
 
   private static SszList<SszUInt64> createUInt64List(final int count) {
-    List<SszUInt64> elements =
+    final List<SszUInt64> elements =
         IntStream.range(0, count)
             .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
             .collect(Collectors.toList());
-    TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
+    final TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
     return UINT64_LIST_SCHEMA.createFromBackingNode(tree);
   }
 
@@ -56,7 +56,7 @@ public class SszProgressiveListTest implements SszCollectionTestBase {
 
   @Test
   void elementAccess_shouldReturnCorrectValues() {
-    SszList<SszUInt64> list = createUInt64List(5);
+    final SszList<SszUInt64> list = createUInt64List(5);
     for (int i = 0; i < 5; i++) {
       assertThat(list.get(i).get()).isEqualTo(UInt64.valueOf(i));
     }
@@ -64,13 +64,13 @@ public class SszProgressiveListTest implements SszCollectionTestBase {
 
   @Test
   void createWritableCopy_shouldSucceed() {
-    SszList<SszUInt64> list = createUInt64List(3);
+    final SszList<SszUInt64> list = createUInt64List(3);
     assertThat(list.createWritableCopy()).isNotNull();
   }
 
   @Test
   void isWritableSupported_shouldReturnTrue() {
-    SszList<SszUInt64> list = createUInt64List(1);
+    final SszList<SszUInt64> list = createUInt64List(1);
     assertThat(list.isWritableSupported()).isTrue();
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszMutableProgressiveBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszMutableProgressiveBitlistTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveBitlistSchema;
+
+class SszMutableProgressiveBitlistTest {
+
+  private static final SszProgressiveBitlistSchema SCHEMA = new SszProgressiveBitlistSchema();
+
+  @Test
+  void isWritableSupported_shouldReturnTrue() {
+    SszBitlist bitlist = SCHEMA.ofBits(10, 0, 3, 9);
+    assertThat(bitlist.isWritableSupported()).isTrue();
+  }
+
+  @Test
+  void createWritableCopy_shouldSucceed() {
+    SszBitlist bitlist = SCHEMA.ofBits(10, 0, 3, 9);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    assertThat(mutable.size()).isEqualTo(10);
+  }
+
+  @Test
+  void setIndividualBits() {
+    SszBitlist bitlist = SCHEMA.ofBits(10);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    // Set bits 2 and 7
+    mutable.set(2, SszBit.of(true));
+    mutable.set(7, SszBit.of(true));
+
+    assertThat(mutable.get(2).get()).isTrue();
+    assertThat(mutable.get(7).get()).isTrue();
+    assertThat(mutable.get(0).get()).isFalse();
+    assertThat(mutable.get(5).get()).isFalse();
+  }
+
+  @Test
+  void commitChanges_producesCorrectImmutable() {
+    SszBitlist bitlist = SCHEMA.ofBits(10);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    mutable.set(2, SszBit.of(true));
+    mutable.set(7, SszBit.of(true));
+    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+
+    assertThat(committed.size()).isEqualTo(10);
+    assertThat(committed.get(2).get()).isTrue();
+    assertThat(committed.get(7).get()).isTrue();
+    assertThat(committed.get(0).get()).isFalse();
+  }
+
+  @Test
+  void commitChanges_hashTreeRootMatchesFreshCreation() {
+    SszBitlist bitlist = SCHEMA.ofBits(10);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    mutable.set(2, SszBit.of(true));
+    mutable.set(7, SszBit.of(true));
+    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+
+    SszBitlist expected = SCHEMA.ofBits(10, 2, 7);
+    assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
+  }
+
+  @Test
+  void appendBits() {
+    SszBitlist bitlist = SCHEMA.ofBits(5, 0, 2);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    // Append a true bit
+    mutable.set(5, SszBit.of(true));
+    assertThat(mutable.size()).isEqualTo(6);
+
+    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+    assertThat(committed.size()).isEqualTo(6);
+    assertThat(committed.get(0).get()).isTrue();
+    assertThat(committed.get(2).get()).isTrue();
+    assertThat(committed.get(5).get()).isTrue();
+    assertThat(committed.get(1).get()).isFalse();
+  }
+
+  @Test
+  void sizeTracking() {
+    SszBitlist bitlist = SCHEMA.ofBits(3, 1);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    assertThat(mutable.size()).isEqualTo(3);
+
+    // Append
+    mutable.set(3, SszBit.of(false));
+    assertThat(mutable.size()).isEqualTo(4);
+
+    mutable.set(4, SszBit.of(true));
+    assertThat(mutable.size()).isEqualTo(5);
+  }
+
+  @Test
+  void serializationRoundtripAfterCommit() {
+    SszBitlist bitlist = SCHEMA.ofBits(20, 0, 5, 10, 15, 19);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    // Flip bit 5 off, set bit 3
+    mutable.set(5, SszBit.of(false));
+    mutable.set(3, SszBit.of(true));
+    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+
+    Bytes serialized = committed.sszSerialize();
+    SszBitlist deserialized = SCHEMA.sszDeserialize(serialized);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(committed.hashTreeRoot());
+    assertThat(deserialized.size()).isEqualTo(20);
+  }
+
+  @Test
+  void multipleCommits() {
+    SszBitlist bitlist = SCHEMA.ofBits(5);
+
+    // First mutation
+    SszMutablePrimitiveList<Boolean, SszBit> mutable1 = bitlist.createWritableCopy();
+    mutable1.set(0, SszBit.of(true));
+    SszPrimitiveList<Boolean, SszBit> committed1 = mutable1.commitChanges();
+
+    // Second mutation
+    SszMutablePrimitiveList<Boolean, SszBit> mutable2 = committed1.createWritableCopy();
+    mutable2.set(4, SszBit.of(true));
+    SszPrimitiveList<Boolean, SszBit> committed2 = mutable2.commitChanges();
+
+    assertThat(committed2.get(0).get()).isTrue();
+    assertThat(committed2.get(4).get()).isTrue();
+    assertThat(committed2.get(1).get()).isFalse();
+
+    SszBitlist expected = SCHEMA.ofBits(5, 0, 4);
+    assertThat(committed2.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
+  }
+
+  @Test
+  void clear_thenModify() {
+    SszBitlist bitlist = SCHEMA.ofBits(10, 0, 5, 9);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    mutable.clear();
+    assertThat(mutable.size()).isEqualTo(0);
+
+    mutable.set(0, SszBit.of(true));
+    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+
+    assertThat(committed.size()).isEqualTo(1);
+    assertThat(committed.get(0).get()).isTrue();
+  }
+
+  @Test
+  void commitWithNoChanges_returnsSameData() {
+    SszBitlist bitlist = SCHEMA.ofBits(10, 3, 7);
+    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+
+    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+
+    assertThat(committed.hashTreeRoot()).isEqualTo(bitlist.hashTreeRoot());
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszMutableProgressiveBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszMutableProgressiveBitlistTest.java
@@ -26,21 +26,21 @@ class SszMutableProgressiveBitlistTest {
 
   @Test
   void isWritableSupported_shouldReturnTrue() {
-    SszBitlist bitlist = SCHEMA.ofBits(10, 0, 3, 9);
+    final SszBitlist bitlist = SCHEMA.ofBits(10, 0, 3, 9);
     assertThat(bitlist.isWritableSupported()).isTrue();
   }
 
   @Test
   void createWritableCopy_shouldSucceed() {
-    SszBitlist bitlist = SCHEMA.ofBits(10, 0, 3, 9);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(10, 0, 3, 9);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
     assertThat(mutable.size()).isEqualTo(10);
   }
 
   @Test
   void setIndividualBits() {
-    SszBitlist bitlist = SCHEMA.ofBits(10);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(10);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
     // Set bits 2 and 7
     mutable.set(2, SszBit.of(true));
@@ -54,12 +54,12 @@ class SszMutableProgressiveBitlistTest {
 
   @Test
   void commitChanges_producesCorrectImmutable() {
-    SszBitlist bitlist = SCHEMA.ofBits(10);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(10);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
     mutable.set(2, SszBit.of(true));
     mutable.set(7, SszBit.of(true));
-    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
 
     assertThat(committed.size()).isEqualTo(10);
     assertThat(committed.get(2).get()).isTrue();
@@ -69,27 +69,27 @@ class SszMutableProgressiveBitlistTest {
 
   @Test
   void commitChanges_hashTreeRootMatchesFreshCreation() {
-    SszBitlist bitlist = SCHEMA.ofBits(10);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(10);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
     mutable.set(2, SszBit.of(true));
     mutable.set(7, SszBit.of(true));
-    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
 
-    SszBitlist expected = SCHEMA.ofBits(10, 2, 7);
+    final SszBitlist expected = SCHEMA.ofBits(10, 2, 7);
     assertThat(committed.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
   }
 
   @Test
   void appendBits() {
-    SszBitlist bitlist = SCHEMA.ofBits(5, 0, 2);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(5, 0, 2);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
     // Append a true bit
     mutable.set(5, SszBit.of(true));
     assertThat(mutable.size()).isEqualTo(6);
 
-    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
     assertThat(committed.size()).isEqualTo(6);
     assertThat(committed.get(0).get()).isTrue();
     assertThat(committed.get(2).get()).isTrue();
@@ -99,8 +99,8 @@ class SszMutableProgressiveBitlistTest {
 
   @Test
   void sizeTracking() {
-    SszBitlist bitlist = SCHEMA.ofBits(3, 1);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(3, 1);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
     assertThat(mutable.size()).isEqualTo(3);
 
@@ -114,16 +114,16 @@ class SszMutableProgressiveBitlistTest {
 
   @Test
   void serializationRoundtripAfterCommit() {
-    SszBitlist bitlist = SCHEMA.ofBits(20, 0, 5, 10, 15, 19);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(20, 0, 5, 10, 15, 19);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
     // Flip bit 5 off, set bit 3
     mutable.set(5, SszBit.of(false));
     mutable.set(3, SszBit.of(true));
-    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
 
-    Bytes serialized = committed.sszSerialize();
-    SszBitlist deserialized = SCHEMA.sszDeserialize(serialized);
+    final Bytes serialized = committed.sszSerialize();
+    final SszBitlist deserialized = SCHEMA.sszDeserialize(serialized);
 
     assertThat(deserialized.hashTreeRoot()).isEqualTo(committed.hashTreeRoot());
     assertThat(deserialized.size()).isEqualTo(20);
@@ -131,36 +131,36 @@ class SszMutableProgressiveBitlistTest {
 
   @Test
   void multipleCommits() {
-    SszBitlist bitlist = SCHEMA.ofBits(5);
+    final SszBitlist bitlist = SCHEMA.ofBits(5);
 
     // First mutation
-    SszMutablePrimitiveList<Boolean, SszBit> mutable1 = bitlist.createWritableCopy();
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable1 = bitlist.createWritableCopy();
     mutable1.set(0, SszBit.of(true));
-    SszPrimitiveList<Boolean, SszBit> committed1 = mutable1.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed1 = mutable1.commitChanges();
 
     // Second mutation
-    SszMutablePrimitiveList<Boolean, SszBit> mutable2 = committed1.createWritableCopy();
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable2 = committed1.createWritableCopy();
     mutable2.set(4, SszBit.of(true));
-    SszPrimitiveList<Boolean, SszBit> committed2 = mutable2.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed2 = mutable2.commitChanges();
 
     assertThat(committed2.get(0).get()).isTrue();
     assertThat(committed2.get(4).get()).isTrue();
     assertThat(committed2.get(1).get()).isFalse();
 
-    SszBitlist expected = SCHEMA.ofBits(5, 0, 4);
+    final SszBitlist expected = SCHEMA.ofBits(5, 0, 4);
     assertThat(committed2.hashTreeRoot()).isEqualTo(expected.hashTreeRoot());
   }
 
   @Test
   void clear_thenModify() {
-    SszBitlist bitlist = SCHEMA.ofBits(10, 0, 5, 9);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(10, 0, 5, 9);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
     mutable.clear();
     assertThat(mutable.size()).isEqualTo(0);
 
     mutable.set(0, SszBit.of(true));
-    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
 
     assertThat(committed.size()).isEqualTo(1);
     assertThat(committed.get(0).get()).isTrue();
@@ -168,10 +168,10 @@ class SszMutableProgressiveBitlistTest {
 
   @Test
   void commitWithNoChanges_returnsSameData() {
-    SszBitlist bitlist = SCHEMA.ofBits(10, 3, 7);
-    SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
+    final SszBitlist bitlist = SCHEMA.ofBits(10, 3, 7);
+    final SszMutablePrimitiveList<Boolean, SszBit> mutable = bitlist.createWritableCopy();
 
-    SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
+    final SszPrimitiveList<Boolean, SszBit> committed = mutable.commitChanges();
 
     assertThat(committed.hashTreeRoot()).isEqualTo(bitlist.hashTreeRoot());
   }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszProgressiveBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszProgressiveBitlistTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.infrastructure.ssz.collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
 
 import java.util.BitSet;
@@ -194,9 +193,8 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
 
   @ParameterizedTest
   @MethodSource("bitlistArgs")
-  void createWritableCopy_shouldThrow(final SszBitlist bitlist) {
-    assertThatThrownBy(bitlist::createWritableCopy)
-        .isInstanceOf(UnsupportedOperationException.class);
+  void createWritableCopy_shouldSucceed(final SszBitlist bitlist) {
+    assertThat(bitlist.createWritableCopy()).isNotNull();
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszProgressiveBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszProgressiveBitlistTest.java
@@ -87,8 +87,8 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
   @ParameterizedTest
   @MethodSource("bitlistArgs")
   void testSszRoundtrip(final SszBitlist bitlist1) {
-    Bytes ssz1 = bitlist1.sszSerialize();
-    SszBitlist bitlist2 = bitlist1.getSchema().sszDeserialize(ssz1);
+    final Bytes ssz1 = bitlist1.sszSerialize();
+    final SszBitlist bitlist2 = bitlist1.getSchema().sszDeserialize(ssz1);
 
     assertThatIntCollection(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
     assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
@@ -98,7 +98,7 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
     }
     assertThat(bitlist2.hashTreeRoot()).isEqualTo(bitlist1.hashTreeRoot());
 
-    Bytes ssz2 = bitlist2.sszSerialize();
+    final Bytes ssz2 = bitlist2.sszSerialize();
     assertThat(ssz2).isEqualTo(ssz1);
   }
 
@@ -120,8 +120,8 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
   @ParameterizedTest
   @MethodSource("bitlistArgs")
   void testTreeRoundtrip(final SszBitlist bitlist1) {
-    TreeNode tree = bitlist1.getBackingNode();
-    SszBitlist bitlist2 = bitlist1.getSchema().createFromBackingNode(tree);
+    final TreeNode tree = bitlist1.getBackingNode();
+    final SszBitlist bitlist2 = bitlist1.getSchema().createFromBackingNode(tree);
 
     assertThatIntCollection(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
     assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
@@ -136,15 +136,15 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
   @ParameterizedTest
   @MethodSource("bitlistArgs")
   void or_testEqualList(final SszBitlist bitlist) {
-    SszBitlist res = bitlist.or(bitlist);
+    final SszBitlist res = bitlist.or(bitlist);
     assertThat(res.sszSerialize()).isEqualTo(bitlist.sszSerialize());
   }
 
   @ParameterizedTest
   @MethodSource("bitlistArgs")
   void testOrWithEmptyBitlist(final SszBitlist bitlist) {
-    SszBitlist empty = SCHEMA.ofBits(0);
-    SszBitlist res = bitlist.or(empty);
+    final SszBitlist empty = SCHEMA.ofBits(0);
+    final SszBitlist res = bitlist.or(empty);
     assertThat(res.size()).isEqualTo(bitlist.size());
     for (int i = 0; i < bitlist.size(); i++) {
       assertThat(res.getBit(i)).isEqualTo(bitlist.getBit(i));
@@ -187,7 +187,7 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
   @ParameterizedTest
   @MethodSource("bitlistArgs")
   void getBitCount_shouldReturnCorrectCount(final SszBitlist bitlist) {
-    long bitCount = bitlist.stream().filter(AbstractSszPrimitive::get).count();
+    final long bitCount = bitlist.stream().filter(AbstractSszPrimitive::get).count();
     assertThat(bitlist.getBitCount()).isEqualTo(bitCount);
   }
 
@@ -199,7 +199,7 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
 
   @Test
   void testEmptyBitlistSsz() {
-    SszBitlist empty = SCHEMA.ofBits(0);
+    final SszBitlist empty = SCHEMA.ofBits(0);
     assertThat(empty.sszSerialize()).isEqualTo(Bytes.of(1));
   }
 
@@ -212,7 +212,7 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
   @ParameterizedTest
   @MethodSource("fromBytesTestCases")
   void testFromBytes(final SszBitlist bitlist, final Bytes serialized) {
-    SszBitlist deserialized = SCHEMA.fromBytes(serialized);
+    final SszBitlist deserialized = SCHEMA.fromBytes(serialized);
 
     assertThat(deserialized.size()).isEqualTo(bitlist.size());
     assertThatIntCollection(deserialized.getAllSetBits()).isEqualTo(bitlist.getAllSetBits());
@@ -222,7 +222,7 @@ public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase
   @ParameterizedTest
   @MethodSource("fromHexStringTestCases")
   void testFromHexString(final SszBitlist bitlist, final String hexString) {
-    SszBitlist deserialized = SCHEMA.fromHexString(hexString);
+    final SszBitlist deserialized = SCHEMA.fromHexString(hexString);
 
     assertThat(deserialized.size()).isEqualTo(bitlist.size());
     assertThatIntCollection(deserialized.getAllSetBits()).isEqualTo(bitlist.getAllSetBits());

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszProgressiveBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszProgressiveBitlistTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
+
+import java.util.BitSet;
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.ssz.SszDataAssert;
+import tech.pegasys.teku.infrastructure.ssz.SszTestUtils;
+import tech.pegasys.teku.infrastructure.ssz.impl.AbstractSszPrimitive;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SszProgressiveBitlistTest implements SszPrimitiveCollectionTestBase {
+
+  static final Random RANDOM = new Random(1);
+  static final SszProgressiveBitlistSchema SCHEMA = new SszProgressiveBitlistSchema();
+
+  static SszBitlist random(final SszProgressiveBitlistSchema schema, final int size) {
+    return schema.ofBits(
+        size, IntStream.range(0, size).filter(__ -> RANDOM.nextBoolean()).toArray());
+  }
+
+  @Override
+  public Stream<SszBitlist> sszData() {
+    return Stream.of(
+        SCHEMA.ofBits(0),
+        SCHEMA.ofBits(1),
+        SCHEMA.ofBits(1, 0),
+        random(SCHEMA, 7),
+        random(SCHEMA, 8),
+        random(SCHEMA, 9),
+        random(SCHEMA, 254),
+        SCHEMA.ofBits(255),
+        SCHEMA.ofBits(255, IntStream.range(0, 255).toArray()),
+        random(SCHEMA, 256),
+        SCHEMA.ofBits(256),
+        SCHEMA.ofBits(256, IntStream.range(0, 256).toArray()),
+        random(SCHEMA, 257),
+        random(SCHEMA, 512),
+        random(SCHEMA, 513),
+        random(SCHEMA, 10000));
+  }
+
+  public Stream<Arguments> bitlistArgs() {
+    return sszData().map(Arguments::of);
+  }
+
+  public Stream<Arguments> nonEmptyBitlistArgs() {
+    return sszData().filter(b -> !b.isEmpty()).map(Arguments::of);
+  }
+
+  public Stream<Arguments> emptyBitlistArgs() {
+    return sszData().filter(b -> b.size() == 0).map(Arguments::of);
+  }
+
+  public Stream<Arguments> fromBytesTestCases() {
+    return sszData().map(bitlist -> Arguments.of(bitlist, bitlist.sszSerialize()));
+  }
+
+  public Stream<Arguments> fromHexStringTestCases() {
+    return sszData().map(bitlist -> Arguments.of(bitlist, bitlist.sszSerialize().toHexString()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void testSszRoundtrip(final SszBitlist bitlist1) {
+    Bytes ssz1 = bitlist1.sszSerialize();
+    SszBitlist bitlist2 = bitlist1.getSchema().sszDeserialize(ssz1);
+
+    assertThatIntCollection(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
+    assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
+    for (int i = 0; i < bitlist1.size(); i++) {
+      assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));
+      assertThat(bitlist2.get(i)).isEqualTo(bitlist1.get(i));
+    }
+    assertThat(bitlist2.hashTreeRoot()).isEqualTo(bitlist1.hashTreeRoot());
+
+    Bytes ssz2 = bitlist2.sszSerialize();
+    assertThat(ssz2).isEqualTo(ssz1);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void testBitSetRoundtrip(final SszBitlist bitlist1) {
+    final SszBitlist bitlist2 =
+        bitlist1.getSchema().wrapBitSet(bitlist1.size(), bitlist1.getAsBitSet());
+
+    for (int i = 0; i < bitlist1.size(); i++) {
+      assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));
+      assertThat(bitlist2.get(i)).isEqualTo(bitlist1.get(i));
+    }
+
+    assertThat(bitlist2.hashTreeRoot()).isEqualTo(bitlist1.hashTreeRoot());
+    assertThat(bitlist2.sszSerialize()).isEqualTo(bitlist1.sszSerialize());
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void testTreeRoundtrip(final SszBitlist bitlist1) {
+    TreeNode tree = bitlist1.getBackingNode();
+    SszBitlist bitlist2 = bitlist1.getSchema().createFromBackingNode(tree);
+
+    assertThatIntCollection(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
+    assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
+    for (int i = 0; i < bitlist1.size(); i++) {
+      assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));
+      assertThat(bitlist2.get(i)).isEqualTo(bitlist1.get(i));
+    }
+    assertThat(bitlist2.hashTreeRoot()).isEqualTo(bitlist1.hashTreeRoot());
+    assertThat(bitlist2.sszSerialize()).isEqualTo(bitlist1.sszSerialize());
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void or_testEqualList(final SszBitlist bitlist) {
+    SszBitlist res = bitlist.or(bitlist);
+    assertThat(res.sszSerialize()).isEqualTo(bitlist.sszSerialize());
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void testOrWithEmptyBitlist(final SszBitlist bitlist) {
+    SszBitlist empty = SCHEMA.ofBits(0);
+    SszBitlist res = bitlist.or(empty);
+    assertThat(res.size()).isEqualTo(bitlist.size());
+    for (int i = 0; i < bitlist.size(); i++) {
+      assertThat(res.getBit(i)).isEqualTo(bitlist.getBit(i));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonEmptyBitlistArgs")
+  void intersects_shouldIntersectWithSelf(final SszBitlist bitlist) {
+    if (bitlist.getBitCount() == 0) {
+      return;
+    }
+    assertThat(bitlist.intersects(bitlist)).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void intersects_shouldNotIntersectWithEmpty(final SszBitlist bitlist) {
+    assertThat(bitlist.intersects(SCHEMA.ofBits(0))).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonEmptyBitlistArgs")
+  void intersects_shouldNotIntersectWithNotSelf(final SszBitlist bitlist) {
+    assertThat(bitlist.intersects(SszTestUtils.not(bitlist))).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void isSupersetOf_shouldReturnTrueForSelf(final SszBitlist bitlist) {
+    assertThat(bitlist.isSuperSetOf(bitlist)).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void isSupersetOf_shouldReturnTrueForEmpty(final SszBitlist bitlist) {
+    assertThat(bitlist.isSuperSetOf(SCHEMA.ofBits(0))).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void getBitCount_shouldReturnCorrectCount(final SszBitlist bitlist) {
+    long bitCount = bitlist.stream().filter(AbstractSszPrimitive::get).count();
+    assertThat(bitlist.getBitCount()).isEqualTo(bitCount);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bitlistArgs")
+  void createWritableCopy_shouldThrow(final SszBitlist bitlist) {
+    assertThatThrownBy(bitlist::createWritableCopy)
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void testEmptyBitlistSsz() {
+    SszBitlist empty = SCHEMA.ofBits(0);
+    assertThat(empty.sszSerialize()).isEqualTo(Bytes.of(1));
+  }
+
+  @Test
+  void testEmptyHashTreeRoot() {
+    assertThat(SCHEMA.ofBits(0).hashTreeRoot())
+        .isEqualTo(Hash.sha256(Bytes.concatenate(Bytes32.ZERO, Bytes32.ZERO)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("fromBytesTestCases")
+  void testFromBytes(final SszBitlist bitlist, final Bytes serialized) {
+    SszBitlist deserialized = SCHEMA.fromBytes(serialized);
+
+    assertThat(deserialized.size()).isEqualTo(bitlist.size());
+    assertThatIntCollection(deserialized.getAllSetBits()).isEqualTo(bitlist.getAllSetBits());
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(bitlist.hashTreeRoot());
+  }
+
+  @ParameterizedTest
+  @MethodSource("fromHexStringTestCases")
+  void testFromHexString(final SszBitlist bitlist, final String hexString) {
+    SszBitlist deserialized = SCHEMA.fromHexString(hexString);
+
+    assertThat(deserialized.size()).isEqualTo(bitlist.size());
+    assertThatIntCollection(deserialized.getAllSetBits()).isEqualTo(bitlist.getAllSetBits());
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(bitlist.hashTreeRoot());
+  }
+
+  @Test
+  void getAsBitSet_withFullStartEnd() {
+    final SszBitlist list = random(SCHEMA, 100);
+
+    final BitSet fullSlice = list.getAsBitSet(0, 100);
+
+    final SszBitlist newList = SCHEMA.wrapBitSet(100, fullSlice);
+
+    assertThat(newList.getAsBitSet()).isEqualTo(fullSlice);
+    SszDataAssert.assertThatSszData(newList).isEqualByAllMeansTo(list);
+  }
+
+  @Test
+  void getAsBitSet_withSubsetStartEnd() {
+    final SszBitlist list = random(SCHEMA, 100);
+
+    final BitSet slice = list.getAsBitSet(5, 55);
+
+    final SszBitlist newList = SCHEMA.wrapBitSet(50, slice);
+
+    assertThat(newList.getAsBitSet()).isEqualTo(slice);
+    IntStream.range(0, 50)
+        .forEach(
+            i ->
+                assertThat(newList.getBit(i))
+                    .describedAs("Bit %s should be equal", i)
+                    .isEqualTo(list.getBit(i + 5)));
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchemaTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SszProgressiveBitlistSchemaTest {
+
+  private static final SszProgressiveBitlistSchema SCHEMA = new SszProgressiveBitlistSchema();
+
+  @Test
+  void ofBits_test() {
+    assertThat(SCHEMA.ofBits(1).sszSerialize()).isEqualTo(Bytes.of(0b10));
+    assertThat(SCHEMA.ofBits(1, 0).sszSerialize()).isEqualTo(Bytes.of(0b11));
+    assertThat(SCHEMA.ofBits(2).sszSerialize()).isEqualTo(Bytes.of(0b100));
+    assertThat(SCHEMA.ofBits(2, 0).sszSerialize()).isEqualTo(Bytes.of(0b101));
+    assertThat(SCHEMA.ofBits(2, 1).sszSerialize()).isEqualTo(Bytes.of(0b110));
+    assertThat(SCHEMA.ofBits(2, 0, 1).sszSerialize()).isEqualTo(Bytes.of(0b111));
+  }
+
+  @Test
+  void ofBits_withSetBits() {
+    SszBitlist bitlist = SCHEMA.ofBits(300, 0, 100, 299);
+    assertThat(bitlist.size()).isEqualTo(300);
+    assertThat(bitlist.getBit(0)).isTrue();
+    assertThat(bitlist.getBit(100)).isTrue();
+    assertThat(bitlist.getBit(299)).isTrue();
+    assertThat(bitlist.getBit(1)).isFalse();
+    assertThat(bitlist.getBitCount()).isEqualTo(3);
+    assertThatIntCollection(bitlist.getAllSetBits()).containsExactly(0, 100, 299);
+  }
+
+  @Test
+  void createFromElements_shouldReturnSszBitlist() {
+    SszBitlist bitlist = SCHEMA.createFromElements(List.of(SszBit.of(false), SszBit.of(true)));
+    assertThat(bitlist).isInstanceOf(SszBitlist.class);
+    assertThat(bitlist.size()).isEqualTo(2);
+    assertThat(bitlist.getBit(0)).isFalse();
+    assertThat(bitlist.getBit(1)).isTrue();
+  }
+
+  static Stream<Arguments> createTreeFromBitDataCases() {
+    return Stream.of(
+        Arguments.of(0, new int[] {}),
+        Arguments.of(1, new int[] {}),
+        Arguments.of(1, new int[] {0}),
+        Arguments.of(7, new int[] {0, 3, 6}),
+        Arguments.of(8, new int[] {0, 7}),
+        Arguments.of(9, new int[] {0, 8}),
+        Arguments.of(16, new int[] {}),
+        Arguments.of(255, new int[] {0, 127, 254}),
+        Arguments.of(256, new int[] {0, 128, 255}),
+        Arguments.of(257, new int[] {0, 256}),
+        Arguments.of(500, IntStream.range(0, 500).filter(i -> i % 3 == 0).toArray()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("createTreeFromBitDataCases")
+  void createTreeFromBitData_shouldMatchSszDeserializedTree(final int size, final int[] setBits) {
+    final BitSet bitSet = new BitSet(size);
+    for (int bit : setBits) {
+      bitSet.set(bit);
+    }
+    final TreeNode directTree = SCHEMA.createTreeFromBitData(size, bitSet.toByteArray());
+
+    final SszBitlist bitlist = SCHEMA.ofBits(size, setBits);
+    final Bytes ssz = bitlist.sszSerialize();
+    final TreeNode deserializedTree;
+    try (SszReader reader = SszReader.fromBytes(ssz)) {
+      deserializedTree = SCHEMA.sszDeserializeTree(reader);
+    }
+
+    assertThat(directTree.hashTreeRoot()).isEqualTo(deserializedTree.hashTreeRoot());
+  }
+
+  @Test
+  void getMaxLength_shouldReturnMaxValue() {
+    assertThat(SCHEMA.getMaxLength()).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  void getElementSchema_shouldReturnBitSchema() {
+    assertThat(SCHEMA.getElementSchema()).isEqualTo(SszPrimitiveSchemas.BIT_SCHEMA);
+  }
+
+  @Test
+  void getElementsPerChunk_shouldReturn256() {
+    assertThat(SCHEMA.getElementsPerChunk()).isEqualTo(256);
+  }
+
+  @Test
+  void treeDepth_shouldThrow() {
+    assertThatThrownBy(SCHEMA::treeDepth).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void treeWidth_shouldThrow() {
+    assertThatThrownBy(SCHEMA::treeWidth).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void isFixedSize_shouldReturnFalse() {
+    assertThat(SCHEMA.isFixedSize()).isFalse();
+  }
+
+  @Test
+  void getDefaultTree_shouldBeEmptySize0() {
+    SszBitlist defaultBitlist = SCHEMA.createFromBackingNode(SCHEMA.getDefaultTree());
+    assertThat(defaultBitlist.size()).isZero();
+  }
+
+  @Test
+  void sszDeserialize_emptyBytes_shouldThrow() {
+    assertThatThrownBy(() -> SCHEMA.sszDeserialize(Bytes.EMPTY)).isInstanceOf(Exception.class);
+  }
+
+  @Test
+  void sszDeserialize_zeroOnlyByte_shouldThrow() {
+    assertThatThrownBy(() -> SCHEMA.sszDeserialize(Bytes.of(0))).isInstanceOf(Exception.class);
+  }
+
+  @Test
+  void getName_shouldReturnProgressiveBitlist() {
+    assertThat(SCHEMA.getName()).hasValue("ProgressiveBitlist");
+  }
+
+  @Test
+  void equals_allInstancesShouldBeEqual() {
+    SszProgressiveBitlistSchema other = new SszProgressiveBitlistSchema();
+    assertThat(SCHEMA).isEqualTo(other);
+    assertThat(SCHEMA.hashCode()).isEqualTo(other.hashCode());
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchemaTest.java
@@ -47,7 +47,7 @@ public class SszProgressiveBitlistSchemaTest {
 
   @Test
   void ofBits_withSetBits() {
-    SszBitlist bitlist = SCHEMA.ofBits(300, 0, 100, 299);
+    final SszBitlist bitlist = SCHEMA.ofBits(300, 0, 100, 299);
     assertThat(bitlist.size()).isEqualTo(300);
     assertThat(bitlist.getBit(0)).isTrue();
     assertThat(bitlist.getBit(100)).isTrue();
@@ -59,7 +59,8 @@ public class SszProgressiveBitlistSchemaTest {
 
   @Test
   void createFromElements_shouldReturnSszBitlist() {
-    SszBitlist bitlist = SCHEMA.createFromElements(List.of(SszBit.of(false), SszBit.of(true)));
+    final SszBitlist bitlist =
+        SCHEMA.createFromElements(List.of(SszBit.of(false), SszBit.of(true)));
     assertThat(bitlist).isInstanceOf(SszBitlist.class);
     assertThat(bitlist.size()).isEqualTo(2);
     assertThat(bitlist.getBit(0)).isFalse();
@@ -132,7 +133,7 @@ public class SszProgressiveBitlistSchemaTest {
 
   @Test
   void getDefaultTree_shouldBeEmptySize0() {
-    SszBitlist defaultBitlist = SCHEMA.createFromBackingNode(SCHEMA.getDefaultTree());
+    final SszBitlist defaultBitlist = SCHEMA.createFromBackingNode(SCHEMA.getDefaultTree());
     assertThat(defaultBitlist.size()).isZero();
   }
 
@@ -153,7 +154,7 @@ public class SszProgressiveBitlistSchemaTest {
 
   @Test
   void equals_allInstancesShouldBeEqual() {
-    SszProgressiveBitlistSchema other = new SszProgressiveBitlistSchema();
+    final SszProgressiveBitlistSchema other = new SszProgressiveBitlistSchema();
     assertThat(SCHEMA).isEqualTo(other);
     assertThat(SCHEMA.hashCode()).isEqualTo(other.hashCode());
   }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SszProgressiveContainerSchemaTest {
+
+  private static final SszProgressiveContainerSchema<SszContainer> SINGLE_FIELD_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "SingleField",
+          new boolean[] {true},
+          NamedSchema.of("field0", SszPrimitiveSchemas.UINT64_SCHEMA));
+
+  private static final SszProgressiveContainerSchema<SszContainer> MULTI_FIELD_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "MultiField",
+          new boolean[] {true, true, true},
+          NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
+          NamedSchema.of("b", SszPrimitiveSchemas.BYTE_SCHEMA),
+          NamedSchema.of("c", SszPrimitiveSchemas.UINT64_SCHEMA));
+
+  private static final SszProgressiveContainerSchema<SszContainer> GAPPED_SCHEMA =
+      new SszProgressiveContainerSchema<>(
+          "GappedContainer",
+          new boolean[] {true, false, true},
+          NamedSchema.of("first", SszPrimitiveSchemas.UINT64_SCHEMA),
+          NamedSchema.of("third", SszPrimitiveSchemas.BYTE_SCHEMA));
+
+  @Test
+  void singleFieldContainer_sszRoundtrip() {
+    TreeNode tree =
+        SINGLE_FIELD_SCHEMA.createTreeFromFieldValues(List.of(SszUInt64.of(UInt64.valueOf(42))));
+    SszContainer container = SINGLE_FIELD_SCHEMA.createFromBackingNode(tree);
+
+    Bytes ssz = container.sszSerialize();
+    SszContainer deserialized = SINGLE_FIELD_SCHEMA.sszDeserialize(ssz);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
+    assertThat(((SszUInt64) deserialized.get(0)).get()).isEqualTo(UInt64.valueOf(42));
+  }
+
+  @Test
+  void multiFieldContainer_sszRoundtrip() {
+    TreeNode tree =
+        MULTI_FIELD_SCHEMA.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(UInt64.valueOf(100)),
+                SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 7),
+                SszUInt64.of(UInt64.valueOf(200))));
+    SszContainer container = MULTI_FIELD_SCHEMA.createFromBackingNode(tree);
+
+    Bytes ssz = container.sszSerialize();
+    SszContainer deserialized = MULTI_FIELD_SCHEMA.sszDeserialize(ssz);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
+    assertThat(deserialized.size()).isEqualTo(3);
+    assertThat(((SszUInt64) deserialized.get(0)).get()).isEqualTo(UInt64.valueOf(100));
+    assertThat(((SszByte) deserialized.get(1)).get()).isEqualTo((byte) 7);
+    assertThat(((SszUInt64) deserialized.get(2)).get()).isEqualTo(UInt64.valueOf(200));
+  }
+
+  @Test
+  void gappedContainer_sszRoundtrip() {
+    TreeNode tree =
+        GAPPED_SCHEMA.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(UInt64.valueOf(99)), SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 3)));
+    SszContainer container = GAPPED_SCHEMA.createFromBackingNode(tree);
+
+    Bytes ssz = container.sszSerialize();
+    SszContainer deserialized = GAPPED_SCHEMA.sszDeserialize(ssz);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
+    assertThat(deserialized.size()).isEqualTo(2);
+    assertThat(((SszUInt64) deserialized.get(0)).get()).isEqualTo(UInt64.valueOf(99));
+    assertThat(((SszByte) deserialized.get(1)).get()).isEqualTo((byte) 3);
+  }
+
+  @Test
+  void variableSizeFields_sszRoundtrip() {
+    SszProgressiveContainerSchema<SszContainer> varSchema =
+        new SszProgressiveContainerSchema<>(
+            "VarContainer",
+            new boolean[] {true, true},
+            NamedSchema.of("fixed", SszPrimitiveSchemas.UINT64_SCHEMA),
+            NamedSchema.of("varField", SszBitlistSchema.create(100)));
+
+    TreeNode tree =
+        varSchema.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(UInt64.valueOf(5)), SszBitlistSchema.create(100).ofBits(10, 0, 3, 9)));
+    SszContainer container = varSchema.createFromBackingNode(tree);
+
+    Bytes ssz = container.sszSerialize();
+    SszContainer deserialized = varSchema.sszDeserialize(ssz);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
+    assertThat(deserialized.size()).isEqualTo(2);
+  }
+
+  @Test
+  void getActiveFields_shouldReturnClonedCopy() {
+    boolean[] activeFields = GAPPED_SCHEMA.getActiveFields();
+    assertThat(activeFields).isEqualTo(new boolean[] {true, false, true});
+
+    // Modifying returned array should not affect schema
+    activeFields[0] = false;
+    assertThat(GAPPED_SCHEMA.getActiveFields()[0]).isTrue();
+  }
+
+  @Test
+  void getTreePosition_shouldMapFieldIndexToSlotPosition() {
+    // GAPPED_SCHEMA: activeFields = [true, false, true]
+    // field 0 → slot 0, field 1 → slot 2
+    assertThat(GAPPED_SCHEMA.getTreePosition(0)).isZero();
+    assertThat(GAPPED_SCHEMA.getTreePosition(1)).isEqualTo(2);
+  }
+
+  @Test
+  void getFieldIndex_byNameLookup() {
+    assertThat(MULTI_FIELD_SCHEMA.getFieldIndex("a")).isZero();
+    assertThat(MULTI_FIELD_SCHEMA.getFieldIndex("b")).isEqualTo(1);
+    assertThat(MULTI_FIELD_SCHEMA.getFieldIndex("c")).isEqualTo(2);
+    assertThat(MULTI_FIELD_SCHEMA.getFieldIndex("nonexistent")).isEqualTo(-1);
+  }
+
+  @Test
+  void getFieldNames_shouldReturnActiveFieldNames() {
+    assertThat(GAPPED_SCHEMA.getFieldNames()).containsExactly("first", "third");
+    assertThat(MULTI_FIELD_SCHEMA.getFieldNames()).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  void getFieldSchemas_shouldReturnActiveFieldSchemas() {
+    List<? extends SszSchema<?>> schemas = MULTI_FIELD_SCHEMA.getFieldSchemas();
+    assertThat(schemas).hasSize(3);
+    assertThat(schemas.get(0)).isEqualTo(SszPrimitiveSchemas.UINT64_SCHEMA);
+    assertThat(schemas.get(1)).isEqualTo(SszPrimitiveSchemas.BYTE_SCHEMA);
+    assertThat(schemas.get(2)).isEqualTo(SszPrimitiveSchemas.UINT64_SCHEMA);
+  }
+
+  @Test
+  void isFixedSize_allFixed_shouldReturnTrue() {
+    assertThat(MULTI_FIELD_SCHEMA.isFixedSize()).isTrue();
+  }
+
+  @Test
+  void isFixedSize_withVariable_shouldReturnFalse() {
+    SszProgressiveContainerSchema<SszContainer> varSchema =
+        new SszProgressiveContainerSchema<>(
+            "VarTest",
+            new boolean[] {true, true},
+            NamedSchema.of("fixed", SszPrimitiveSchemas.UINT64_SCHEMA),
+            NamedSchema.of("var", SszBitlistSchema.create(100)));
+    assertThat(varSchema.isFixedSize()).isFalse();
+  }
+
+  @Test
+  void treeDepth_shouldThrow() {
+    assertThatThrownBy(MULTI_FIELD_SCHEMA::treeDepth)
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void treeWidth_shouldThrow() {
+    assertThatThrownBy(MULTI_FIELD_SCHEMA::treeWidth)
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void createTreeFromFieldValues_wrongCount_shouldThrow() {
+    assertThatThrownBy(
+            () -> MULTI_FIELD_SCHEMA.createTreeFromFieldValues(List.of(SszUInt64.of(UInt64.ZERO))))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void equals_sameSchemas_shouldBeEqual() {
+    SszProgressiveContainerSchema<SszContainer> other =
+        new SszProgressiveContainerSchema<>(
+            "MultiField",
+            new boolean[] {true, true, true},
+            NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
+            NamedSchema.of("b", SszPrimitiveSchemas.BYTE_SCHEMA),
+            NamedSchema.of("c", SszPrimitiveSchemas.UINT64_SCHEMA));
+    assertThat(MULTI_FIELD_SCHEMA).isEqualTo(other);
+    assertThat(MULTI_FIELD_SCHEMA.hashCode()).isEqualTo(other.hashCode());
+  }
+
+  @Test
+  void equals_differentActiveFields_shouldNotBeEqual() {
+    SszProgressiveContainerSchema<SszContainer> other =
+        new SszProgressiveContainerSchema<>(
+            "MultiField",
+            new boolean[] {true, false, true, true},
+            NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
+            NamedSchema.of("b", SszPrimitiveSchemas.BYTE_SCHEMA),
+            NamedSchema.of("c", SszPrimitiveSchemas.UINT64_SCHEMA));
+    assertThat(MULTI_FIELD_SCHEMA).isNotEqualTo(other);
+  }
+
+  @Test
+  void getName_shouldReturnContainerName() {
+    assertThat(MULTI_FIELD_SCHEMA.getName()).hasValue("MultiField");
+    assertThat(GAPPED_SCHEMA.getName()).hasValue("GappedContainer");
+  }
+
+  @Test
+  void defaultTree_shouldCreateValidDefaultContainer() {
+    SszContainer defaultContainer =
+        MULTI_FIELD_SCHEMA.createFromBackingNode(MULTI_FIELD_SCHEMA.getDefaultTree());
+    assertThat(defaultContainer.size()).isEqualTo(3);
+
+    // All fields should have default values
+    SszData field0 = defaultContainer.get(0);
+    assertThat(field0).isNotNull();
+    SszData field1 = defaultContainer.get(1);
+    assertThat(field1).isNotNull();
+    SszData field2 = defaultContainer.get(2);
+    assertThat(field2).isNotNull();
+  }
+
+  @Test
+  void constructor_emptyActiveFields_shouldThrow() {
+    assertThatThrownBy(() -> new SszProgressiveContainerSchema<>("Empty", new boolean[] {}))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void constructor_lastElementFalse_shouldThrow() {
+    assertThatThrownBy(
+            () ->
+                new SszProgressiveContainerSchema<>(
+                    "Bad",
+                    new boolean[] {true, false},
+                    NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void constructor_mismatchedSchemaCount_shouldThrow() {
+    assertThatThrownBy(
+            () ->
+                new SszProgressiveContainerSchema<>(
+                    "Mismatch",
+                    new boolean[] {true, true},
+                    NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void getChildGeneralizedIndex_shouldReturnDifferentForDifferentFields() {
+    long gIdx0 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(0);
+    long gIdx1 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(1);
+    long gIdx2 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(2);
+
+    assertThat(gIdx0).isPositive();
+    assertThat(gIdx1).isPositive();
+    assertThat(gIdx2).isPositive();
+    assertThat(gIdx0).isNotEqualTo(gIdx1);
+    assertThat(gIdx1).isNotEqualTo(gIdx2);
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
@@ -53,12 +53,12 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void singleFieldContainer_sszRoundtrip() {
-    TreeNode tree =
+    final TreeNode tree =
         SINGLE_FIELD_SCHEMA.createTreeFromFieldValues(List.of(SszUInt64.of(UInt64.valueOf(42))));
-    SszContainer container = SINGLE_FIELD_SCHEMA.createFromBackingNode(tree);
+    final SszContainer container = SINGLE_FIELD_SCHEMA.createFromBackingNode(tree);
 
-    Bytes ssz = container.sszSerialize();
-    SszContainer deserialized = SINGLE_FIELD_SCHEMA.sszDeserialize(ssz);
+    final Bytes ssz = container.sszSerialize();
+    final SszContainer deserialized = SINGLE_FIELD_SCHEMA.sszDeserialize(ssz);
 
     assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
     assertThat(((SszUInt64) deserialized.get(0)).get()).isEqualTo(UInt64.valueOf(42));
@@ -66,16 +66,16 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void multiFieldContainer_sszRoundtrip() {
-    TreeNode tree =
+    final TreeNode tree =
         MULTI_FIELD_SCHEMA.createTreeFromFieldValues(
             List.of(
                 SszUInt64.of(UInt64.valueOf(100)),
                 SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 7),
                 SszUInt64.of(UInt64.valueOf(200))));
-    SszContainer container = MULTI_FIELD_SCHEMA.createFromBackingNode(tree);
+    final SszContainer container = MULTI_FIELD_SCHEMA.createFromBackingNode(tree);
 
-    Bytes ssz = container.sszSerialize();
-    SszContainer deserialized = MULTI_FIELD_SCHEMA.sszDeserialize(ssz);
+    final Bytes ssz = container.sszSerialize();
+    final SszContainer deserialized = MULTI_FIELD_SCHEMA.sszDeserialize(ssz);
 
     assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
     assertThat(deserialized.size()).isEqualTo(3);
@@ -86,14 +86,14 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void gappedContainer_sszRoundtrip() {
-    TreeNode tree =
+    final TreeNode tree =
         GAPPED_SCHEMA.createTreeFromFieldValues(
             List.of(
                 SszUInt64.of(UInt64.valueOf(99)), SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 3)));
-    SszContainer container = GAPPED_SCHEMA.createFromBackingNode(tree);
+    final SszContainer container = GAPPED_SCHEMA.createFromBackingNode(tree);
 
-    Bytes ssz = container.sszSerialize();
-    SszContainer deserialized = GAPPED_SCHEMA.sszDeserialize(ssz);
+    final Bytes ssz = container.sszSerialize();
+    final SszContainer deserialized = GAPPED_SCHEMA.sszDeserialize(ssz);
 
     assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
     assertThat(deserialized.size()).isEqualTo(2);
@@ -103,21 +103,21 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void variableSizeFields_sszRoundtrip() {
-    SszProgressiveContainerSchema<SszContainer> varSchema =
+    final SszProgressiveContainerSchema<SszContainer> varSchema =
         new SszProgressiveContainerSchema<>(
             "VarContainer",
             new boolean[] {true, true},
             NamedSchema.of("fixed", SszPrimitiveSchemas.UINT64_SCHEMA),
             NamedSchema.of("varField", SszBitlistSchema.create(100)));
 
-    TreeNode tree =
+    final TreeNode tree =
         varSchema.createTreeFromFieldValues(
             List.of(
                 SszUInt64.of(UInt64.valueOf(5)), SszBitlistSchema.create(100).ofBits(10, 0, 3, 9)));
-    SszContainer container = varSchema.createFromBackingNode(tree);
+    final SszContainer container = varSchema.createFromBackingNode(tree);
 
-    Bytes ssz = container.sszSerialize();
-    SszContainer deserialized = varSchema.sszDeserialize(ssz);
+    final Bytes ssz = container.sszSerialize();
+    final SszContainer deserialized = varSchema.sszDeserialize(ssz);
 
     assertThat(deserialized.hashTreeRoot()).isEqualTo(container.hashTreeRoot());
     assertThat(deserialized.size()).isEqualTo(2);
@@ -125,7 +125,7 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void getActiveFields_shouldReturnClonedCopy() {
-    boolean[] activeFields = GAPPED_SCHEMA.getActiveFields();
+    final boolean[] activeFields = GAPPED_SCHEMA.getActiveFields();
     assertThat(activeFields).isEqualTo(new boolean[] {true, false, true});
 
     // Modifying returned array should not affect schema
@@ -157,7 +157,7 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void getFieldSchemas_shouldReturnActiveFieldSchemas() {
-    List<? extends SszSchema<?>> schemas = MULTI_FIELD_SCHEMA.getFieldSchemas();
+    final List<? extends SszSchema<?>> schemas = MULTI_FIELD_SCHEMA.getFieldSchemas();
     assertThat(schemas).hasSize(3);
     assertThat(schemas.get(0)).isEqualTo(SszPrimitiveSchemas.UINT64_SCHEMA);
     assertThat(schemas.get(1)).isEqualTo(SszPrimitiveSchemas.BYTE_SCHEMA);
@@ -171,7 +171,7 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void isFixedSize_withVariable_shouldReturnFalse() {
-    SszProgressiveContainerSchema<SszContainer> varSchema =
+    final SszProgressiveContainerSchema<SszContainer> varSchema =
         new SszProgressiveContainerSchema<>(
             "VarTest",
             new boolean[] {true, true},
@@ -201,7 +201,7 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void equals_sameSchemas_shouldBeEqual() {
-    SszProgressiveContainerSchema<SszContainer> other =
+    final SszProgressiveContainerSchema<SszContainer> other =
         new SszProgressiveContainerSchema<>(
             "MultiField",
             new boolean[] {true, true, true},
@@ -214,7 +214,7 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void equals_differentActiveFields_shouldNotBeEqual() {
-    SszProgressiveContainerSchema<SszContainer> other =
+    final SszProgressiveContainerSchema<SszContainer> other =
         new SszProgressiveContainerSchema<>(
             "MultiField",
             new boolean[] {true, false, true, true},
@@ -232,16 +232,16 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void defaultTree_shouldCreateValidDefaultContainer() {
-    SszContainer defaultContainer =
+    final SszContainer defaultContainer =
         MULTI_FIELD_SCHEMA.createFromBackingNode(MULTI_FIELD_SCHEMA.getDefaultTree());
     assertThat(defaultContainer.size()).isEqualTo(3);
 
     // All fields should have default values
-    SszData field0 = defaultContainer.get(0);
+    final SszData field0 = defaultContainer.get(0);
     assertThat(field0).isNotNull();
-    SszData field1 = defaultContainer.get(1);
+    final SszData field1 = defaultContainer.get(1);
     assertThat(field1).isNotNull();
-    SszData field2 = defaultContainer.get(2);
+    final SszData field2 = defaultContainer.get(2);
     assertThat(field2).isNotNull();
   }
 
@@ -275,9 +275,9 @@ public class SszProgressiveContainerSchemaTest {
 
   @Test
   void getChildGeneralizedIndex_shouldReturnDifferentForDifferentFields() {
-    long gIdx0 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(0);
-    long gIdx1 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(1);
-    long gIdx2 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(2);
+    final long gIdx0 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(0);
+    final long gIdx1 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(1);
+    final long gIdx2 = MULTI_FIELD_SCHEMA.getChildGeneralizedIndex(2);
 
     assertThat(gIdx0).isPositive();
     assertThat(gIdx1).isPositive();

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszLengthBounds;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -284,5 +285,18 @@ public class SszProgressiveContainerSchemaTest {
     assertThat(gIdx2).isPositive();
     assertThat(gIdx0).isNotEqualTo(gIdx1);
     assertThat(gIdx1).isNotEqualTo(gIdx2);
+  }
+
+  // ===== SszLengthBounds tests =====
+
+  @Test
+  void getMaxLength_shouldReturnFieldCount() {
+    assertThat(MULTI_FIELD_SCHEMA.getMaxLength()).isEqualTo(3);
+  }
+
+  @Test
+  void getSszLengthBounds_maxBytesShouldBePositive() {
+    final SszLengthBounds bounds = MULTI_FIELD_SCHEMA.getSszLengthBounds();
+    assertThat(bounds.getMaxBytes()).isPositive();
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SszProgressiveListSchemaTest {
+
+  private static final SszProgressiveListSchema<SszUInt64> UINT64_LIST_SCHEMA =
+      SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA);
+
+  @Test
+  void primitiveListRoundtrip() {
+    List<SszUInt64> elements =
+        IntStream.range(0, 10)
+            .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
+            .collect(Collectors.toList());
+
+    TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
+    SszList<SszUInt64> list = UINT64_LIST_SCHEMA.createFromBackingNode(tree);
+
+    assertThat(list.size()).isEqualTo(10);
+    for (int i = 0; i < 10; i++) {
+      assertThat(list.get(i).get()).isEqualTo(UInt64.valueOf(i));
+    }
+
+    Bytes ssz = list.sszSerialize();
+    SszList<SszUInt64> deserialized = UINT64_LIST_SCHEMA.sszDeserialize(ssz);
+    assertThat(deserialized.size()).isEqualTo(10);
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
+
+    for (int i = 0; i < 10; i++) {
+      assertThat(deserialized.get(i).get()).isEqualTo(UInt64.valueOf(i));
+    }
+  }
+
+  @Test
+  void fixedSizeCompositeListRoundtrip() {
+    // Fixed-size composite elements (all fields fixed) — exercises sszSerializeFixed composite path
+    SszProgressiveContainerSchema<? extends SszContainer> elementSchema =
+        new SszProgressiveContainerSchema<>(
+            "FixedElement",
+            new boolean[] {true, true},
+            NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
+            NamedSchema.of("b", SszPrimitiveSchemas.BYTE_SCHEMA));
+
+    SszProgressiveListSchema<? extends SszData> listSchema =
+        SszProgressiveListSchema.create(elementSchema);
+
+    List<SszData> elements = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      TreeNode fieldTree =
+          elementSchema.createTreeFromFieldValues(
+              List.of(
+                  SszUInt64.of(UInt64.valueOf(i)),
+                  SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) i)));
+      elements.add(elementSchema.createFromBackingNode(fieldTree));
+    }
+
+    @SuppressWarnings("unchecked")
+    SszProgressiveListSchema<SszData> rawSchema = (SszProgressiveListSchema<SszData>) listSchema;
+    TreeNode tree = rawSchema.createTreeFromElements(elements);
+    SszList<SszData> list = rawSchema.createFromBackingNode(tree);
+
+    assertThat(list.size()).isEqualTo(3);
+
+    Bytes ssz = list.sszSerialize();
+    SszList<SszData> deserialized = rawSchema.sszDeserialize(ssz);
+    assertThat(deserialized.size()).isEqualTo(3);
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
+  }
+
+  @Test
+  void variableSizeCompositeListRoundtrip() {
+    // Variable-size composite elements — exercises sszSerializeVariable path
+    SszProgressiveContainerSchema<? extends SszContainer> elementSchema =
+        new SszProgressiveContainerSchema<>(
+            "VarElement",
+            new boolean[] {true, true},
+            NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
+            NamedSchema.of("b", new SszProgressiveBitlistSchema()));
+
+    SszProgressiveListSchema<? extends SszData> listSchema =
+        SszProgressiveListSchema.create(elementSchema);
+
+    List<SszData> elements = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      TreeNode fieldTree =
+          elementSchema.createTreeFromFieldValues(
+              List.of(
+                  SszUInt64.of(UInt64.valueOf(i)),
+                  new SszProgressiveBitlistSchema().ofBits(i + 1)));
+      elements.add(elementSchema.createFromBackingNode(fieldTree));
+    }
+
+    @SuppressWarnings("unchecked")
+    SszProgressiveListSchema<SszData> rawSchema = (SszProgressiveListSchema<SszData>) listSchema;
+    TreeNode tree = rawSchema.createTreeFromElements(elements);
+    SszList<SszData> list = rawSchema.createFromBackingNode(tree);
+
+    assertThat(list.size()).isEqualTo(3);
+
+    Bytes ssz = list.sszSerialize();
+    SszList<SszData> deserialized = rawSchema.sszDeserialize(ssz);
+    assertThat(deserialized.size()).isEqualTo(3);
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
+  }
+
+  @Test
+  void emptyList() {
+    SszList<SszUInt64> list = UINT64_LIST_SCHEMA.getDefault();
+    assertThat(list.size()).isZero();
+    assertThat(list.sszSerialize()).isEqualTo(Bytes.EMPTY);
+    assertThat(list.hashTreeRoot())
+        .isEqualTo(Hash.sha256(Bytes.concatenate(Bytes32.ZERO, Bytes32.ZERO)));
+  }
+
+  @Test
+  void getMaxLength_shouldReturnMaxValue() {
+    assertThat(UINT64_LIST_SCHEMA.getMaxLength()).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  void getElementSchema_shouldReturnElementSchema() {
+    assertThat(UINT64_LIST_SCHEMA.getElementSchema()).isEqualTo(SszPrimitiveSchemas.UINT64_SCHEMA);
+  }
+
+  @Test
+  void treeDepth_shouldThrow() {
+    assertThatThrownBy(UINT64_LIST_SCHEMA::treeDepth)
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void treeWidth_shouldThrow() {
+    assertThatThrownBy(UINT64_LIST_SCHEMA::treeWidth)
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void isFixedSize_shouldReturnFalse() {
+    assertThat(UINT64_LIST_SCHEMA.isFixedSize()).isFalse();
+  }
+
+  @Test
+  void getDefaultTree_shouldBeEmptyList() {
+    SszList<SszUInt64> defaultList =
+        UINT64_LIST_SCHEMA.createFromBackingNode(UINT64_LIST_SCHEMA.getDefaultTree());
+    assertThat(defaultList.size()).isZero();
+  }
+
+  @Test
+  void getChildGeneralizedIndex_shouldReturnCorrectGIndex() {
+    long gIdx0 = UINT64_LIST_SCHEMA.getChildGeneralizedIndex(0);
+    long gIdx1 = UINT64_LIST_SCHEMA.getChildGeneralizedIndex(1);
+    // Indices should be different for different elements
+    assertThat(gIdx0).isNotEqualTo(gIdx1);
+    // Both should be valid (positive)
+    assertThat(gIdx0).isPositive();
+    assertThat(gIdx1).isPositive();
+  }
+
+  @Test
+  void equals_sameElementSchema_shouldBeEqual() {
+    SszProgressiveListSchema<SszUInt64> other =
+        SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA);
+    assertThat(UINT64_LIST_SCHEMA).isEqualTo(other);
+    assertThat(UINT64_LIST_SCHEMA.hashCode()).isEqualTo(other.hashCode());
+  }
+
+  @Test
+  void equals_differentElementSchema_shouldNotBeEqual() {
+    SszProgressiveListSchema<?> byteListSchema =
+        SszProgressiveListSchema.create(SszPrimitiveSchemas.BYTE_SCHEMA);
+    assertThat(UINT64_LIST_SCHEMA).isNotEqualTo(byteListSchema);
+  }
+
+  @Test
+  void getName_shouldContainElementSchema() {
+    assertThat(UINT64_LIST_SCHEMA.getName()).isPresent();
+    assertThat(UINT64_LIST_SCHEMA.getName().get()).startsWith("ProgressiveList[");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends SszData> SszProgressiveListSchema<T> createProgressiveListSchema(
+      final SszSchema<? extends T> elementSchema) {
+    return new SszProgressiveListSchema<>((SszSchema<T>) elementSchema);
+  }
+
+  @Test
+  void variableSizeElements_roundtrip() {
+    // List of variable-size elements (lists inside a progressive list)
+    SszListSchema<SszUInt64, ?> innerListSchema =
+        SszListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA, 10);
+    SszProgressiveListSchema<SszList<SszUInt64>> varListSchema =
+        createProgressiveListSchema(innerListSchema);
+
+    SszList<SszUInt64> inner1 = innerListSchema.getDefault();
+    SszList<SszUInt64> inner2 =
+        innerListSchema.createFromElements(List.of(SszUInt64.of(UInt64.valueOf(42))));
+
+    List<SszList<SszUInt64>> elements = List.of(inner1, inner2);
+    TreeNode tree = varListSchema.createTreeFromElements(elements);
+    SszList<SszList<SszUInt64>> list = varListSchema.createFromBackingNode(tree);
+
+    assertThat(list.size()).isEqualTo(2);
+
+    Bytes ssz = list.sszSerialize();
+    SszList<SszList<SszUInt64>> deserialized = varListSchema.sszDeserialize(ssz);
+    assertThat(deserialized.size()).isEqualTo(2);
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
+  }
+
+  @Test
+  void invalidSsz_firstOffsetExceedsData_shouldThrow() {
+    // For variable-size elements, the first offset in SSZ cannot exceed available data
+    SszListSchema<SszUInt64, ?> innerListSchema =
+        SszListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA, 10);
+    SszProgressiveListSchema<SszList<SszUInt64>> varListSchema =
+        createProgressiveListSchema(innerListSchema);
+
+    // Build invalid SSZ: 4-byte offset that points beyond available data
+    Bytes invalidSsz = Bytes.of(0xFF, 0x00, 0x00, 0x00);
+    assertThatThrownBy(() -> varListSchema.sszDeserialize(invalidSsz))
+        .isInstanceOf(SszDeserializeException.class);
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
@@ -40,21 +40,21 @@ public class SszProgressiveListSchemaTest {
 
   @Test
   void primitiveListRoundtrip() {
-    List<SszUInt64> elements =
+    final List<SszUInt64> elements =
         IntStream.range(0, 10)
             .mapToObj(i -> SszUInt64.of(UInt64.valueOf(i)))
             .collect(Collectors.toList());
 
-    TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
-    SszList<SszUInt64> list = UINT64_LIST_SCHEMA.createFromBackingNode(tree);
+    final TreeNode tree = UINT64_LIST_SCHEMA.createTreeFromElements(elements);
+    final SszList<SszUInt64> list = UINT64_LIST_SCHEMA.createFromBackingNode(tree);
 
     assertThat(list.size()).isEqualTo(10);
     for (int i = 0; i < 10; i++) {
       assertThat(list.get(i).get()).isEqualTo(UInt64.valueOf(i));
     }
 
-    Bytes ssz = list.sszSerialize();
-    SszList<SszUInt64> deserialized = UINT64_LIST_SCHEMA.sszDeserialize(ssz);
+    final Bytes ssz = list.sszSerialize();
+    final SszList<SszUInt64> deserialized = UINT64_LIST_SCHEMA.sszDeserialize(ssz);
     assertThat(deserialized.size()).isEqualTo(10);
     assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
 
@@ -66,19 +66,19 @@ public class SszProgressiveListSchemaTest {
   @Test
   void fixedSizeCompositeListRoundtrip() {
     // Fixed-size composite elements (all fields fixed) — exercises sszSerializeFixed composite path
-    SszProgressiveContainerSchema<? extends SszContainer> elementSchema =
+    final SszProgressiveContainerSchema<? extends SszContainer> elementSchema =
         new SszProgressiveContainerSchema<>(
             "FixedElement",
             new boolean[] {true, true},
             NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
             NamedSchema.of("b", SszPrimitiveSchemas.BYTE_SCHEMA));
 
-    SszProgressiveListSchema<? extends SszData> listSchema =
+    final SszProgressiveListSchema<? extends SszData> listSchema =
         SszProgressiveListSchema.create(elementSchema);
 
-    List<SszData> elements = new ArrayList<>();
+    final List<SszData> elements = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
-      TreeNode fieldTree =
+      final TreeNode fieldTree =
           elementSchema.createTreeFromFieldValues(
               List.of(
                   SszUInt64.of(UInt64.valueOf(i)),
@@ -87,14 +87,15 @@ public class SszProgressiveListSchemaTest {
     }
 
     @SuppressWarnings("unchecked")
-    SszProgressiveListSchema<SszData> rawSchema = (SszProgressiveListSchema<SszData>) listSchema;
-    TreeNode tree = rawSchema.createTreeFromElements(elements);
-    SszList<SszData> list = rawSchema.createFromBackingNode(tree);
+    final SszProgressiveListSchema<SszData> rawSchema =
+        (SszProgressiveListSchema<SszData>) listSchema;
+    final TreeNode tree = rawSchema.createTreeFromElements(elements);
+    final SszList<SszData> list = rawSchema.createFromBackingNode(tree);
 
     assertThat(list.size()).isEqualTo(3);
 
-    Bytes ssz = list.sszSerialize();
-    SszList<SszData> deserialized = rawSchema.sszDeserialize(ssz);
+    final Bytes ssz = list.sszSerialize();
+    final SszList<SszData> deserialized = rawSchema.sszDeserialize(ssz);
     assertThat(deserialized.size()).isEqualTo(3);
     assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
   }
@@ -102,19 +103,19 @@ public class SszProgressiveListSchemaTest {
   @Test
   void variableSizeCompositeListRoundtrip() {
     // Variable-size composite elements — exercises sszSerializeVariable path
-    SszProgressiveContainerSchema<? extends SszContainer> elementSchema =
+    final SszProgressiveContainerSchema<? extends SszContainer> elementSchema =
         new SszProgressiveContainerSchema<>(
             "VarElement",
             new boolean[] {true, true},
             NamedSchema.of("a", SszPrimitiveSchemas.UINT64_SCHEMA),
             NamedSchema.of("b", new SszProgressiveBitlistSchema()));
 
-    SszProgressiveListSchema<? extends SszData> listSchema =
+    final SszProgressiveListSchema<? extends SszData> listSchema =
         SszProgressiveListSchema.create(elementSchema);
 
-    List<SszData> elements = new ArrayList<>();
+    final List<SszData> elements = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
-      TreeNode fieldTree =
+      final TreeNode fieldTree =
           elementSchema.createTreeFromFieldValues(
               List.of(
                   SszUInt64.of(UInt64.valueOf(i)),
@@ -123,21 +124,22 @@ public class SszProgressiveListSchemaTest {
     }
 
     @SuppressWarnings("unchecked")
-    SszProgressiveListSchema<SszData> rawSchema = (SszProgressiveListSchema<SszData>) listSchema;
-    TreeNode tree = rawSchema.createTreeFromElements(elements);
-    SszList<SszData> list = rawSchema.createFromBackingNode(tree);
+    final SszProgressiveListSchema<SszData> rawSchema =
+        (SszProgressiveListSchema<SszData>) listSchema;
+    final TreeNode tree = rawSchema.createTreeFromElements(elements);
+    final SszList<SszData> list = rawSchema.createFromBackingNode(tree);
 
     assertThat(list.size()).isEqualTo(3);
 
-    Bytes ssz = list.sszSerialize();
-    SszList<SszData> deserialized = rawSchema.sszDeserialize(ssz);
+    final Bytes ssz = list.sszSerialize();
+    final SszList<SszData> deserialized = rawSchema.sszDeserialize(ssz);
     assertThat(deserialized.size()).isEqualTo(3);
     assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
   }
 
   @Test
   void emptyList() {
-    SszList<SszUInt64> list = UINT64_LIST_SCHEMA.getDefault();
+    final SszList<SszUInt64> list = UINT64_LIST_SCHEMA.getDefault();
     assertThat(list.size()).isZero();
     assertThat(list.sszSerialize()).isEqualTo(Bytes.EMPTY);
     assertThat(list.hashTreeRoot())
@@ -173,7 +175,7 @@ public class SszProgressiveListSchemaTest {
 
   @Test
   void getDefaultTree_shouldBeEmptyList() {
-    SszList<SszUInt64> defaultList =
+    final SszList<SszUInt64> defaultList =
         UINT64_LIST_SCHEMA.createFromBackingNode(UINT64_LIST_SCHEMA.getDefaultTree());
     assertThat(defaultList.size()).isZero();
   }
@@ -191,7 +193,7 @@ public class SszProgressiveListSchemaTest {
 
   @Test
   void equals_sameElementSchema_shouldBeEqual() {
-    SszProgressiveListSchema<SszUInt64> other =
+    final SszProgressiveListSchema<SszUInt64> other =
         SszProgressiveListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA);
     assertThat(UINT64_LIST_SCHEMA).isEqualTo(other);
     assertThat(UINT64_LIST_SCHEMA.hashCode()).isEqualTo(other.hashCode());
@@ -199,7 +201,7 @@ public class SszProgressiveListSchemaTest {
 
   @Test
   void equals_differentElementSchema_shouldNotBeEqual() {
-    SszProgressiveListSchema<?> byteListSchema =
+    final SszProgressiveListSchema<?> byteListSchema =
         SszProgressiveListSchema.create(SszPrimitiveSchemas.BYTE_SCHEMA);
     assertThat(UINT64_LIST_SCHEMA).isNotEqualTo(byteListSchema);
   }
@@ -219,23 +221,23 @@ public class SszProgressiveListSchemaTest {
   @Test
   void variableSizeElements_roundtrip() {
     // List of variable-size elements (lists inside a progressive list)
-    SszListSchema<SszUInt64, ?> innerListSchema =
+    final SszListSchema<SszUInt64, ?> innerListSchema =
         SszListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA, 10);
-    SszProgressiveListSchema<SszList<SszUInt64>> varListSchema =
+    final SszProgressiveListSchema<SszList<SszUInt64>> varListSchema =
         createProgressiveListSchema(innerListSchema);
 
-    SszList<SszUInt64> inner1 = innerListSchema.getDefault();
-    SszList<SszUInt64> inner2 =
+    final SszList<SszUInt64> inner1 = innerListSchema.getDefault();
+    final SszList<SszUInt64> inner2 =
         innerListSchema.createFromElements(List.of(SszUInt64.of(UInt64.valueOf(42))));
 
-    List<SszList<SszUInt64>> elements = List.of(inner1, inner2);
-    TreeNode tree = varListSchema.createTreeFromElements(elements);
-    SszList<SszList<SszUInt64>> list = varListSchema.createFromBackingNode(tree);
+    final List<SszList<SszUInt64>> elements = List.of(inner1, inner2);
+    final TreeNode tree = varListSchema.createTreeFromElements(elements);
+    final SszList<SszList<SszUInt64>> list = varListSchema.createFromBackingNode(tree);
 
     assertThat(list.size()).isEqualTo(2);
 
-    Bytes ssz = list.sszSerialize();
-    SszList<SszList<SszUInt64>> deserialized = varListSchema.sszDeserialize(ssz);
+    final Bytes ssz = list.sszSerialize();
+    final SszList<SszList<SszUInt64>> deserialized = varListSchema.sszDeserialize(ssz);
     assertThat(deserialized.size()).isEqualTo(2);
     assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
   }
@@ -243,13 +245,13 @@ public class SszProgressiveListSchemaTest {
   @Test
   void invalidSsz_firstOffsetExceedsData_shouldThrow() {
     // For variable-size elements, the first offset in SSZ cannot exceed available data
-    SszListSchema<SszUInt64, ?> innerListSchema =
+    final SszListSchema<SszUInt64, ?> innerListSchema =
         SszListSchema.create(SszPrimitiveSchemas.UINT64_SCHEMA, 10);
-    SszProgressiveListSchema<SszList<SszUInt64>> varListSchema =
+    final SszProgressiveListSchema<SszList<SszUInt64>> varListSchema =
         createProgressiveListSchema(innerListSchema);
 
     // Build invalid SSZ: 4-byte offset that points beyond available data
-    Bytes invalidSsz = Bytes.of(0xFF, 0x00, 0x00, 0x00);
+    final Bytes invalidSsz = Bytes.of(0xFF, 0x00, 0x00, 0x00);
     assertThatThrownBy(() -> varListSchema.sszDeserialize(invalidSsz))
         .isInstanceOf(SszDeserializeException.class);
   }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/sos/SszLengthBoundsTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/sos/SszLengthBoundsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.sos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class SszLengthBoundsTest {
+
+  @Test
+  void ofBytes_withLargeValues_shouldNotOverflow() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBytes(0, Long.MAX_VALUE / 2);
+    // (Long.MAX_VALUE / 2) * 8 would overflow without saturation
+    assertThat(bounds.getMaxBits()).isEqualTo(Long.MAX_VALUE);
+    assertThat(bounds.getMaxBytes()).isPositive();
+  }
+
+  @Test
+  void ofBytes_withMaxValue_shouldSaturate() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBytes(0, Long.MAX_VALUE);
+    assertThat(bounds.getMaxBits()).isEqualTo(Long.MAX_VALUE);
+    assertThat(bounds.getMaxBytes()).isPositive();
+  }
+
+  @Test
+  void ofBytes_withNormalValues_shouldNotSaturate() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBytes(10, 100);
+    assertThat(bounds.getMinBits()).isEqualTo(80);
+    assertThat(bounds.getMaxBits()).isEqualTo(800);
+    assertThat(bounds.getMinBytes()).isEqualTo(10);
+    assertThat(bounds.getMaxBytes()).isEqualTo(100);
+  }
+
+  @Test
+  void add_withMaxValueMax_shouldSaturate() {
+    final SszLengthBounds a = SszLengthBounds.ofBits(0, Long.MAX_VALUE);
+    final SszLengthBounds b = SszLengthBounds.ofBits(0, 1000);
+    final SszLengthBounds result = a.add(b);
+    assertThat(result.getMaxBits()).isEqualTo(Long.MAX_VALUE);
+    assertThat(result.getMaxBytes()).isPositive();
+  }
+
+  @Test
+  void add_withNormalValues_shouldNotSaturate() {
+    final SszLengthBounds a = SszLengthBounds.ofBits(10, 100);
+    final SszLengthBounds b = SszLengthBounds.ofBits(20, 200);
+    final SszLengthBounds result = a.add(b);
+    assertThat(result.getMinBits()).isEqualTo(30);
+    assertThat(result.getMaxBits()).isEqualTo(300);
+  }
+
+  @Test
+  void mul_withLargeFactor_shouldSaturate() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBits(0, Long.MAX_VALUE);
+    final SszLengthBounds result = bounds.mul(100);
+    assertThat(result.getMaxBits()).isEqualTo(Long.MAX_VALUE);
+    assertThat(result.getMaxBytes()).isPositive();
+  }
+
+  @Test
+  void mul_withNormalValues_shouldNotSaturate() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBits(10, 100);
+    final SszLengthBounds result = bounds.mul(5);
+    assertThat(result.getMinBits()).isEqualTo(50);
+    assertThat(result.getMaxBits()).isEqualTo(500);
+  }
+
+  @Test
+  void addBits_withMaxValueBase_shouldSaturate() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBits(0, Long.MAX_VALUE);
+    final SszLengthBounds result = bounds.addBits(32);
+    assertThat(result.getMaxBits()).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  void addBytes_withMaxValueBase_shouldSaturate() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBits(0, Long.MAX_VALUE);
+    final SszLengthBounds result = bounds.addBytes(4);
+    assertThat(result.getMaxBits()).isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  void isWithinBounds_withSaturatedMax_shouldAcceptAllReasonableSizes() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBits(0, Long.MAX_VALUE);
+    assertThat(bounds.isWithinBounds(0)).isTrue();
+    assertThat(bounds.isWithinBounds(1000)).isTrue();
+    // getMaxBytes() converts Long.MAX_VALUE bits to bytes, so max bytes is ~1.15e18
+    // which is still enormous — any realistic SSZ payload fits
+    assertThat(bounds.getMaxBytes()).isGreaterThan(1_000_000_000_000L);
+  }
+
+  @Test
+  void ceilToBytes_withMaxValue_shouldNotOverflow() {
+    final SszLengthBounds bounds = SszLengthBounds.ofBits(0, Long.MAX_VALUE);
+    final SszLengthBounds ceiled = bounds.ceilToBytes();
+    assertThat(ceiled.getMaxBytes()).isPositive();
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class ProgressiveTreeUtilTest {
+
+  @Test
+  void levelCapacity_returnsCorrectValues() {
+    assertThat(ProgressiveTreeUtil.levelCapacity(0)).isEqualTo(1);
+    assertThat(ProgressiveTreeUtil.levelCapacity(1)).isEqualTo(4);
+    assertThat(ProgressiveTreeUtil.levelCapacity(2)).isEqualTo(16);
+    assertThat(ProgressiveTreeUtil.levelCapacity(3)).isEqualTo(64);
+    assertThat(ProgressiveTreeUtil.levelCapacity(4)).isEqualTo(256);
+  }
+
+  @Test
+  void cumulativeCapacity_returnsCorrectValues() {
+    assertThat(ProgressiveTreeUtil.cumulativeCapacity(0)).isEqualTo(1);
+    assertThat(ProgressiveTreeUtil.cumulativeCapacity(1)).isEqualTo(5);
+    assertThat(ProgressiveTreeUtil.cumulativeCapacity(2)).isEqualTo(21);
+    assertThat(ProgressiveTreeUtil.cumulativeCapacity(3)).isEqualTo(85);
+    assertThat(ProgressiveTreeUtil.cumulativeCapacity(4)).isEqualTo(341);
+    assertThat(ProgressiveTreeUtil.cumulativeCapacity(5)).isEqualTo(1365);
+  }
+
+  @Test
+  void levelDepth_returnsCorrectValues() {
+    assertThat(ProgressiveTreeUtil.levelDepth(0)).isEqualTo(0);
+    assertThat(ProgressiveTreeUtil.levelDepth(1)).isEqualTo(2);
+    assertThat(ProgressiveTreeUtil.levelDepth(2)).isEqualTo(4);
+    assertThat(ProgressiveTreeUtil.levelDepth(3)).isEqualTo(6);
+  }
+
+  @Test
+  void levelForIndex_returnsCorrectLevel() {
+    // Level 0: indices [0, 0]
+    assertThat(ProgressiveTreeUtil.levelForIndex(0)).isEqualTo(0);
+    // Level 1: indices [1, 4]
+    assertThat(ProgressiveTreeUtil.levelForIndex(1)).isEqualTo(1);
+    assertThat(ProgressiveTreeUtil.levelForIndex(4)).isEqualTo(1);
+    // Level 2: indices [5, 20]
+    assertThat(ProgressiveTreeUtil.levelForIndex(5)).isEqualTo(2);
+    assertThat(ProgressiveTreeUtil.levelForIndex(20)).isEqualTo(2);
+    // Level 3: indices [21, 84]
+    assertThat(ProgressiveTreeUtil.levelForIndex(21)).isEqualTo(3);
+    assertThat(ProgressiveTreeUtil.levelForIndex(84)).isEqualTo(3);
+  }
+
+  @Test
+  void createProgressiveTree_emptyChunks_returnsEmptyLeaf() {
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of());
+    assertThat(tree).isEqualTo(LeafNode.EMPTY_LEAF);
+  }
+
+  @Test
+  void createProgressiveTree_singleChunk_createsCorrectTree() {
+    LeafNode leaf = LeafNode.create(Bytes.fromHexString("0x01"));
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of(leaf));
+    // Should be BranchNode(leaf, EMPTY_LEAF)
+    assertThat(tree).isInstanceOf(BranchNode.class);
+    BranchNode branch = (BranchNode) tree;
+    assertThat(branch.left()).isEqualTo(leaf);
+    assertThat(branch.right()).isEqualTo(LeafNode.EMPTY_LEAF);
+  }
+
+  @Test
+  void createProgressiveTree_twoChunks_createsCorrectStructure() {
+    LeafNode leaf0 = LeafNode.create(Bytes.fromHexString("0x01"));
+    LeafNode leaf1 = LeafNode.create(Bytes.fromHexString("0x02"));
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of(leaf0, leaf1));
+    // Level 0 (cap=1): leaf0
+    // Level 1 (cap=4): [leaf1, zero, zero, zero] (depth=2 balanced tree)
+    // Result: BranchNode(leaf0, BranchNode(level1_tree, EMPTY_LEAF))
+    assertThat(tree).isInstanceOf(BranchNode.class);
+    BranchNode root = (BranchNode) tree;
+    assertThat(root.left()).isEqualTo(leaf0);
+    assertThat(root.right()).isInstanceOf(BranchNode.class);
+
+    BranchNode rightBranch = (BranchNode) root.right();
+    // Left child of right branch is the level-1 balanced subtree with leaf1
+    // Right child is EMPTY_LEAF (no more levels)
+    assertThat(rightBranch.right()).isEqualTo(LeafNode.EMPTY_LEAF);
+  }
+
+  @Test
+  void createProgressiveTree_fiveChunks_usesThreeLevels() {
+    List<LeafNode> chunks = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      chunks.add(LeafNode.create(Bytes.of((byte) (i + 1))));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    // Level 0 (cap=1): chunks[0]
+    // Level 1 (cap=4): chunks[1..4]
+    // Level 2 (cap=16): chunks[5..] -> empty -> not created, just EMPTY_LEAF as right
+    // Structure: BranchNode(chunk0, BranchNode(level1_tree, EMPTY_LEAF))
+    assertThat(tree).isInstanceOf(BranchNode.class);
+  }
+
+  @Test
+  void getElementGeneralizedIndex_element0_isLeftChild() {
+    long gIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(0);
+    // Element 0 is at level 0, which is the left child of root.
+    // Level 0 has depth 0, so the element is the left child directly.
+    assertThat(gIdx).isEqualTo(GIndexUtil.LEFT_CHILD_G_INDEX); // 0b10
+  }
+
+  @Test
+  void getElementGeneralizedIndex_element1_isAtLevel1() {
+    long gIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(1);
+    // Element 1 is at level 1, position 0 in a 4-element balanced subtree (depth=2)
+    // Path: right, left, then position 0 at depth 2
+    // right from root = 0b11
+    // left = 0b110
+    // position 0 at depth 2 = 0b11000
+    assertThat(gIdx).isEqualTo(0b11000);
+  }
+
+  @Test
+  void getElementGeneralizedIndex_canNavigateTree() {
+    // Create a tree with known values and verify we can navigate to each element
+    List<LeafNode> chunks = new ArrayList<>();
+    for (int i = 0; i < 6; i++) {
+      byte[] data = new byte[32];
+      data[0] = (byte) (i + 1);
+      chunks.add(LeafNode.create(Bytes32.wrap(data)));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    for (int i = 0; i < 6; i++) {
+      long gIdx = ProgressiveTreeUtil.getElementGeneralizedIndex(i);
+      TreeNode node = tree.get(gIdx);
+      assertThat(node).isInstanceOf(LeafNode.class);
+      assertThat(((LeafNode) node).getData().get(0)).isEqualTo((byte) (i + 1));
+    }
+  }
+
+  @Test
+  void hashTreeRoot_emptyTree_isZero() {
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of());
+    assertThat(tree.hashTreeRoot()).isEqualTo(Bytes32.ZERO);
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilTest.java
@@ -78,11 +78,11 @@ class ProgressiveTreeUtilTest {
       final long lastIndex = ProgressiveTreeUtil.cumulativeCapacity(level) - 1;
 
       assertThat(ProgressiveTreeUtil.levelForIndex(firstIndex))
-              .describedAs("first index of level %d", level)
-              .isEqualTo(level);
+          .describedAs("first index of level %d", level)
+          .isEqualTo(level);
       assertThat(ProgressiveTreeUtil.levelForIndex(lastIndex))
-              .describedAs("last index of level %d", level)
-              .isEqualTo(level);
+          .describedAs("last index of level %d", level)
+          .isEqualTo(level);
     }
   }
 
@@ -90,6 +90,21 @@ class ProgressiveTreeUtilTest {
   void levelForIndex_negativeIndexThrows() {
     assertThatThrownBy(() -> ProgressiveTreeUtil.levelForIndex(-1))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void spineGIndex_matchesIterativeComputation() {
+    for (int level = 0; level <= 20; level++) {
+      long expected = GIndexUtil.SELF_G_INDEX;
+      for (int i = 0; i < level; i++) {
+        expected = GIndexUtil.gIdxRightGIndex(expected);
+      }
+      expected = GIndexUtil.gIdxLeftGIndex(expected);
+
+      assertThat(ProgressiveTreeUtil.spineGIndex(level))
+          .describedAs("spineGIndex for level %d", level)
+          .isEqualTo(expected);
+    }
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilUpdateTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilUpdateTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class ProgressiveTreeUtilUpdateTest {
+
+  private static LeafNode leaf(final int value) {
+    byte[] data = new byte[32];
+    data[0] = (byte) value;
+    return LeafNode.create(Bytes32.wrap(data));
+  }
+
+  @Test
+  void emptyUpdates_returnsSameTree() {
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of(leaf(1), leaf(2)));
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 2);
+
+    assertThat(result).isSameAs(tree);
+  }
+
+  @Test
+  void emptyTree_withNewTotalChunksZero_returnsEmptyLeaf() {
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(LeafNode.EMPTY_LEAF, updates, 0);
+
+    assertThat(result).isEqualTo(LeafNode.EMPTY_LEAF);
+  }
+
+  @Test
+  void modifyExistingChunk_level0() {
+    List<LeafNode> chunks = List.of(leaf(1), leaf(2));
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(0, leaf(99));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 2);
+
+    // Verify chunk 0 was updated
+    TreeNode node0 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0));
+    assertThat(((LeafNode) node0).getData().get(0)).isEqualTo((byte) 99);
+
+    // Verify chunk 1 is unchanged
+    TreeNode node1 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(1));
+    assertThat(((LeafNode) node1).getData().get(0)).isEqualTo((byte) 2);
+  }
+
+  @Test
+  void modifyExistingChunk_level1() {
+    List<LeafNode> chunks = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      chunks.add(leaf(i + 1));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    // Modify chunk at index 3 (level 1, position 2)
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(3, leaf(99));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
+
+    // Verify the modification
+    TreeNode node3 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(3));
+    assertThat(((LeafNode) node3).getData().get(0)).isEqualTo((byte) 99);
+
+    // Verify other chunks unchanged
+    for (int i = 0; i < 5; i++) {
+      if (i == 3) {
+        continue;
+      }
+      TreeNode node = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(i));
+      assertThat(((LeafNode) node).getData().get(0)).isEqualTo((byte) (i + 1));
+    }
+  }
+
+  @Test
+  void modifyChunksAcrossMultipleLevels() {
+    List<LeafNode> chunks = new ArrayList<>();
+    for (int i = 0; i < 6; i++) {
+      chunks.add(leaf(i + 1));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    // Modify chunk 0 (level 0) and chunk 5 (level 2)
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(0, leaf(10));
+    updates.put(5, leaf(60));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 6);
+
+    assertThat(
+            ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0)))
+                .getData()
+                .get(0))
+        .isEqualTo((byte) 10);
+    assertThat(
+            ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(5)))
+                .getData()
+                .get(0))
+        .isEqualTo((byte) 60);
+
+    // Unchanged chunks
+    assertThat(
+            ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(1)))
+                .getData()
+                .get(0))
+        .isEqualTo((byte) 2);
+  }
+
+  @Test
+  void appendWithinExistingLevelCapacity() {
+    // Start with 2 chunks (levels 0 and 1 with 1 of 4 slots used)
+    List<LeafNode> chunks = List.of(leaf(1), leaf(2));
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    // Append chunk at index 2 (still level 1, within capacity)
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(2, leaf(3));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 3);
+
+    assertThat(
+            ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0)))
+                .getData()
+                .get(0))
+        .isEqualTo((byte) 1);
+    assertThat(
+            ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(1)))
+                .getData()
+                .get(0))
+        .isEqualTo((byte) 2);
+    assertThat(
+            ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(2)))
+                .getData()
+                .get(0))
+        .isEqualTo((byte) 3);
+  }
+
+  @Test
+  void appendRequiringNewLevel() {
+    // Start with 5 chunks (levels 0, 1 full)
+    List<LeafNode> chunks = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      chunks.add(leaf(i + 1));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    // Append chunk at index 5 (level 2, requires new level)
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(5, leaf(6));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 6);
+
+    // Verify all chunks
+    for (int i = 0; i < 6; i++) {
+      TreeNode node = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(i));
+      assertThat(((LeafNode) node).getData().get(0)).isEqualTo((byte) (i + 1));
+    }
+  }
+
+  @Test
+  void appendFromEmpty() {
+    TreeNode tree = LeafNode.EMPTY_LEAF;
+
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(0, leaf(1));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 1);
+
+    TreeNode node0 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0));
+    assertThat(((LeafNode) node0).getData().get(0)).isEqualTo((byte) 1);
+  }
+
+  @Test
+  void structuralSharing_unchangedSubtreesReuseSameNodeReference() {
+    List<LeafNode> chunks = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      chunks.add(leaf(i + 1));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    // Only modify chunk 0 (level 0)
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(0, leaf(99));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
+
+    // Level 1 subtree should be the same object reference (structural sharing)
+    BranchNode originalRoot = (BranchNode) tree;
+    BranchNode resultRoot = (BranchNode) result;
+
+    // Right child of root contains level 1+ spine
+    BranchNode originalRightSpine = (BranchNode) originalRoot.right();
+    BranchNode resultRightSpine = (BranchNode) resultRoot.right();
+
+    // Level 1's balanced subtree (left child of right spine) should be same reference
+    assertThat(resultRightSpine.left()).isSameAs(originalRightSpine.left());
+  }
+
+  @Test
+  void updateProducesCorrectHashTreeRoot() {
+    // Create tree from chunks, then update one and verify hash matches fresh creation
+    List<LeafNode> original = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      original.add(leaf(i + 1));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(original);
+
+    // Update chunk 1 to value 99
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(1, leaf(99));
+    TreeNode updated = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 3);
+
+    // Build expected tree from scratch
+    List<LeafNode> expected = new ArrayList<>();
+    expected.add(leaf(1));
+    expected.add(leaf(99));
+    expected.add(leaf(3));
+    TreeNode expectedTree = ProgressiveTreeUtil.createProgressiveTree(expected);
+
+    assertThat(updated.hashTreeRoot()).isEqualTo(expectedTree.hashTreeRoot());
+  }
+
+  @Test
+  void mixedModificationsAndAppends() {
+    List<LeafNode> chunks = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      chunks.add(leaf(i + 1));
+    }
+    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+
+    // Modify index 0, append indices 3 and 4
+    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    updates.put(0, leaf(10));
+    updates.put(3, leaf(4));
+    updates.put(4, leaf(5));
+
+    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
+
+    // Build expected
+    List<LeafNode> expected = List.of(leaf(10), leaf(2), leaf(3), leaf(4), leaf(5));
+    TreeNode expectedTree = ProgressiveTreeUtil.createProgressiveTree(expected);
+
+    assertThat(result.hashTreeRoot()).isEqualTo(expectedTree.hashTreeRoot());
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilUpdateTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilUpdateTest.java
@@ -25,65 +25,66 @@ import org.junit.jupiter.api.Test;
 class ProgressiveTreeUtilUpdateTest {
 
   private static LeafNode leaf(final int value) {
-    byte[] data = new byte[32];
+    final byte[] data = new byte[32];
     data[0] = (byte) value;
     return LeafNode.create(Bytes32.wrap(data));
   }
 
   @Test
   void emptyUpdates_returnsSameTree() {
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of(leaf(1), leaf(2)));
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of(leaf(1), leaf(2)));
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 2);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 2);
 
     assertThat(result).isSameAs(tree);
   }
 
   @Test
   void emptyTree_withNewTotalChunksZero_returnsEmptyLeaf() {
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(LeafNode.EMPTY_LEAF, updates, 0);
+    final TreeNode result =
+        ProgressiveTreeUtil.updateProgressiveTree(LeafNode.EMPTY_LEAF, updates, 0);
 
     assertThat(result).isEqualTo(LeafNode.EMPTY_LEAF);
   }
 
   @Test
   void modifyExistingChunk_level0() {
-    List<LeafNode> chunks = List.of(leaf(1), leaf(2));
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    final List<LeafNode> chunks = List.of(leaf(1), leaf(2));
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
 
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(0, leaf(99));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 2);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 2);
 
     // Verify chunk 0 was updated
-    TreeNode node0 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0));
+    final TreeNode node0 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0));
     assertThat(((LeafNode) node0).getData().get(0)).isEqualTo((byte) 99);
 
     // Verify chunk 1 is unchanged
-    TreeNode node1 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(1));
+    final TreeNode node1 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(1));
     assertThat(((LeafNode) node1).getData().get(0)).isEqualTo((byte) 2);
   }
 
   @Test
   void modifyExistingChunk_level1() {
-    List<LeafNode> chunks = new ArrayList<>();
+    final List<LeafNode> chunks = new ArrayList<>();
     for (int i = 0; i < 5; i++) {
       chunks.add(leaf(i + 1));
     }
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
 
     // Modify chunk at index 3 (level 1, position 2)
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(3, leaf(99));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
 
     // Verify the modification
-    TreeNode node3 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(3));
+    final TreeNode node3 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(3));
     assertThat(((LeafNode) node3).getData().get(0)).isEqualTo((byte) 99);
 
     // Verify other chunks unchanged
@@ -91,25 +92,25 @@ class ProgressiveTreeUtilUpdateTest {
       if (i == 3) {
         continue;
       }
-      TreeNode node = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(i));
+      final TreeNode node = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(i));
       assertThat(((LeafNode) node).getData().get(0)).isEqualTo((byte) (i + 1));
     }
   }
 
   @Test
   void modifyChunksAcrossMultipleLevels() {
-    List<LeafNode> chunks = new ArrayList<>();
+    final List<LeafNode> chunks = new ArrayList<>();
     for (int i = 0; i < 6; i++) {
       chunks.add(leaf(i + 1));
     }
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
 
     // Modify chunk 0 (level 0) and chunk 5 (level 2)
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(0, leaf(10));
     updates.put(5, leaf(60));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 6);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 6);
 
     assertThat(
             ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0)))
@@ -133,14 +134,14 @@ class ProgressiveTreeUtilUpdateTest {
   @Test
   void appendWithinExistingLevelCapacity() {
     // Start with 2 chunks (levels 0 and 1 with 1 of 4 slots used)
-    List<LeafNode> chunks = List.of(leaf(1), leaf(2));
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    final List<LeafNode> chunks = List.of(leaf(1), leaf(2));
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
 
     // Append chunk at index 2 (still level 1, within capacity)
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(2, leaf(3));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 3);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 3);
 
     assertThat(
             ((LeafNode) result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0)))
@@ -162,59 +163,59 @@ class ProgressiveTreeUtilUpdateTest {
   @Test
   void appendRequiringNewLevel() {
     // Start with 5 chunks (levels 0, 1 full)
-    List<LeafNode> chunks = new ArrayList<>();
+    final List<LeafNode> chunks = new ArrayList<>();
     for (int i = 0; i < 5; i++) {
       chunks.add(leaf(i + 1));
     }
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
 
     // Append chunk at index 5 (level 2, requires new level)
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(5, leaf(6));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 6);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 6);
 
     // Verify all chunks
     for (int i = 0; i < 6; i++) {
-      TreeNode node = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(i));
+      final TreeNode node = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(i));
       assertThat(((LeafNode) node).getData().get(0)).isEqualTo((byte) (i + 1));
     }
   }
 
   @Test
   void appendFromEmpty() {
-    TreeNode tree = LeafNode.EMPTY_LEAF;
+    final TreeNode tree = LeafNode.EMPTY_LEAF;
 
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(0, leaf(1));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 1);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 1);
 
-    TreeNode node0 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0));
+    final TreeNode node0 = result.get(ProgressiveTreeUtil.getElementGeneralizedIndex(0));
     assertThat(((LeafNode) node0).getData().get(0)).isEqualTo((byte) 1);
   }
 
   @Test
   void structuralSharing_unchangedSubtreesReuseSameNodeReference() {
-    List<LeafNode> chunks = new ArrayList<>();
+    final List<LeafNode> chunks = new ArrayList<>();
     for (int i = 0; i < 5; i++) {
       chunks.add(leaf(i + 1));
     }
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
 
     // Only modify chunk 0 (level 0)
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(0, leaf(99));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
 
     // Level 1 subtree should be the same object reference (structural sharing)
-    BranchNode originalRoot = (BranchNode) tree;
-    BranchNode resultRoot = (BranchNode) result;
+    final BranchNode originalRoot = (BranchNode) tree;
+    final BranchNode resultRoot = (BranchNode) result;
 
     // Right child of root contains level 1+ spine
-    BranchNode originalRightSpine = (BranchNode) originalRoot.right();
-    BranchNode resultRightSpine = (BranchNode) resultRoot.right();
+    final BranchNode originalRightSpine = (BranchNode) originalRoot.right();
+    final BranchNode resultRightSpine = (BranchNode) resultRoot.right();
 
     // Level 1's balanced subtree (left child of right spine) should be same reference
     assertThat(resultRightSpine.left()).isSameAs(originalRightSpine.left());
@@ -223,46 +224,46 @@ class ProgressiveTreeUtilUpdateTest {
   @Test
   void updateProducesCorrectHashTreeRoot() {
     // Create tree from chunks, then update one and verify hash matches fresh creation
-    List<LeafNode> original = new ArrayList<>();
+    final List<LeafNode> original = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       original.add(leaf(i + 1));
     }
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(original);
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(original);
 
     // Update chunk 1 to value 99
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(1, leaf(99));
-    TreeNode updated = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 3);
+    final TreeNode updated = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 3);
 
     // Build expected tree from scratch
-    List<LeafNode> expected = new ArrayList<>();
+    final List<LeafNode> expected = new ArrayList<>();
     expected.add(leaf(1));
     expected.add(leaf(99));
     expected.add(leaf(3));
-    TreeNode expectedTree = ProgressiveTreeUtil.createProgressiveTree(expected);
+    final TreeNode expectedTree = ProgressiveTreeUtil.createProgressiveTree(expected);
 
     assertThat(updated.hashTreeRoot()).isEqualTo(expectedTree.hashTreeRoot());
   }
 
   @Test
   void mixedModificationsAndAppends() {
-    List<LeafNode> chunks = new ArrayList<>();
+    final List<LeafNode> chunks = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       chunks.add(leaf(i + 1));
     }
-    TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(chunks);
 
     // Modify index 0, append indices 3 and 4
-    Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
+    final Int2ObjectMap<TreeNode> updates = new Int2ObjectOpenHashMap<>();
     updates.put(0, leaf(10));
     updates.put(3, leaf(4));
     updates.put(4, leaf(5));
 
-    TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
+    final TreeNode result = ProgressiveTreeUtil.updateProgressiveTree(tree, updates, 5);
 
     // Build expected
-    List<LeafNode> expected = List.of(leaf(10), leaf(2), leaf(3), leaf(4), leaf(5));
-    TreeNode expectedTree = ProgressiveTreeUtil.createProgressiveTree(expected);
+    final List<LeafNode> expected = List.of(leaf(10), leaf(2), leaf(3), leaf(4), leaf(5));
+    final TreeNode expectedTree = ProgressiveTreeUtil.createProgressiveTree(expected);
 
     assertThat(result.hashTreeRoot()).isEqualTo(expectedTree.hashTreeRoot());
   }


### PR DESCRIPTION
fixes: #9772

TODO:
- Implement `TreeNodeStore` related methods
- SuperNode hint
- We also probably need primitive versions using `CachingTreeAccessor`?
- do some benchmarking to evaluate performance impacts

---- 
The following branch
https://github.com/tbenr/teku/tree/progressive_ssz_electra_testing
implements:
- a unified Container\Progressive container, so that we can reuse the same classes but enable progressive mode just by passing the new `active_fields` param.
- introduce "progressive" constructor in `ContainerN` and `ContainerSchemaN`
- fixes progressivebitlist having size in the underlining data structure.
- implements SuperNode **hints** and `CachingTreeAccessor`.
- implements store\load functions
- introduces specialized ProgressiveUInt64List for compatibility.
- Experiment: Modifies Electra with
   1. progressiveBitList in electra attestation (aggregation bits)
   2. beaconState with validators and balances as progressive list


question: is the Unified approach the best or we want to keep Progressive classes well separated, leave common code in Util classes, and have specific `ProgressiveContainerN` and `ProgressiveBeaconState` classes too?

----

general perplexities:

- since PL are unbounded by design, our usage of schema SszLengthBounds will be partially defeated. IE: when introducing in attestation suddenly the attestation schema upperbound will be `Long.MAX_VALUE`. Which means at gossip level we wont be so restrictive anymore and the overall upperbound value we apply (10mb?) becomes applicable to more structures. I see 2 solutions: introduce the ability to "suggest" a reasonable upperbound per on PL, or haveing different limits on gossip (like 10mb for blocks only, 1mb for all the others)

- in beacon state, when upgrading the state to a PL enabled state schema, datastructures needs to be rebuilt.

- we need to be careful in types. we need to make sure we have specialized list schemas that implements the different interfaces we have (ie: `SszProgressiveUInt64ListImpl` implementing `SszUInt64List`) to be able to swap them

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
