### PR TITLE
Fix backfiller behaviour when `p2p-subscribe-all-custody-subnets-enabled` is enabled

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -247,7 +247,11 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     }
     final int oldValue = custodyGroupCount.getAndSet(newCustodyGroupCount);
     if (oldValue == INITIAL_VALUE) {
-      setCustodyGroupSyncedCount(newCustodyGroupCount);
+      // Use the previously stored count as synced baseline on restart, so the backfiller detects
+      // and re-backfills if custody group count increased between restarts (e.g. when
+      // --p2p-subscribe-all-custody-subnets-enabled is added). On fresh start (no stored count),
+      // fall back to newCustodyGroupCount to preserve existing behaviour.
+      setCustodyGroupSyncedCount(maybeCustodyGroupCount.orElse(newCustodyGroupCount));
     }
     custodyGroupCountChannel.onGroupCountUpdate(newCustodyGroupCount, getSamplingGroupCount());
     custodyGroupCountGauge.set(newCustodyGroupCount);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -249,8 +249,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     if (oldValue == INITIAL_VALUE) {
       // Use the previously stored count as synced baseline on restart, so the backfiller detects
       // and re-backfills if custody group count increased between restarts (e.g. when
-      // --p2p-subscribe-all-custody-subnets-enabled is added). On fresh start (no stored count),
-      // fall back to newCustodyGroupCount to preserve existing behaviour.
+      // --p2p-subscribe-all-custody-subnets-enabled is added).
       setCustodyGroupSyncedCount(maybeCustodyGroupCount.orElse(newCustodyGroupCount));
     }
     custodyGroupCountChannel.onGroupCountUpdate(newCustodyGroupCount, getSamplingGroupCount());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
@@ -100,6 +100,12 @@ public class DasCustodyBackfiller extends Service
     this.dataColumnSidecarCustody = dataColumnSidecarCustody;
     this.custodyGroupCountManager = custodyGroupCountManager;
     this.currentSyncCustodyGroupCount = custodyGroupCountManager.getCustodyGroupSyncedCount();
+    // Trigger resync on startup if the custody group count has increased since last backfill
+    // (e.g. --p2p-subscribe-all-custody-subnets-enabled was added between restarts).
+    if (custodyGroupCountManager.getCustodyGroupCount() > this.currentSyncCustodyGroupCount) {
+      this.requiresResyncDueToCustodyGroupCountChange = true;
+      this.currentSyncCustodyGroupCount = custodyGroupCountManager.getCustodyGroupCount();
+    }
     this.batchSizeInSlots = batchSizeInSlots;
     this.retriever = retriever;
     this.minCustodyPeriodSlotCalculator = minCustodyPeriodSlotCalculator;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR changes the fix the behaviour of the the backfiller when we enable the flag to override custody group count.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10232

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backfill/resync triggering logic and cursor handling, which can affect data column availability after restarts; coverage is improved with new targeted tests.
> 
> **Overview**
> Fixes a restart edge case where enabling `--p2p-subscribe-all-custody-subnets-enabled` (increasing custody group count) could leave the DAS custody backfiller thinking it was already complete.
> 
> `CustodyGroupCountManagerImpl` now seeds the *synced/backfilled* baseline from the previously stored DB value on first init, and `DasCustodyBackfiller` additionally detects on startup when `custodyGroupCount > syncedCount` to force a cursor reset/resync. Tests are updated and expanded to cover restart scenarios and to ensure cursor resets only when the custody group count actually increases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 351b6eae12f7b753453c05c2a69a4877aec35a26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->