### PR TITLE
Change engine API calls for Gloas

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -26,6 +26,7 @@ import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
 import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
 import static tech.pegasys.teku.spec.SpecMilestone.FULU;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -78,7 +79,7 @@ import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-@TestSpecContext(milestone = {CAPELLA, DENEB, ELECTRA, FULU})
+@TestSpecContext(milestone = {CAPELLA, DENEB, ELECTRA, FULU, GLOAS})
 public class Web3JExecutionEngineClientTest {
 
   private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -23,15 +23,18 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV5Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -56,6 +59,8 @@ public interface ExecutionEngineClient {
 
   SafeFuture<Response<GetPayloadV5Response>> getPayloadV5(Bytes8 payloadId);
 
+  SafeFuture<Response<GetPayloadV6Response>> getPayloadV6(Bytes8 payloadId);
+
   SafeFuture<Response<PayloadStatusV1>> newPayloadV1(ExecutionPayloadV1 executionPayload);
 
   SafeFuture<Response<PayloadStatusV1>> newPayloadV2(ExecutionPayloadV2 executionPayload);
@@ -71,6 +76,12 @@ public interface ExecutionEngineClient {
       Bytes32 parentBeaconBlockRoot,
       List<Bytes> executionRequests);
 
+  SafeFuture<Response<PayloadStatusV1>> newPayloadV5(
+      ExecutionPayloadV4 executionPayload,
+      List<VersionedHash> blobVersionedHashes,
+      Bytes32 parentBeaconBlockRoot,
+      List<Bytes> executionRequests);
+
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);
 
@@ -79,6 +90,9 @@ public interface ExecutionEngineClient {
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV3> payloadAttributes);
+
+  SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV4(
+      ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV4> payloadAttributes);
 
   SafeFuture<Response<List<String>>> exchangeCapabilities(List<String> capabilities);
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -26,15 +26,18 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV5Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -99,6 +102,11 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   }
 
   @Override
+  public SafeFuture<Response<GetPayloadV6Response>> getPayloadV6(final Bytes8 payloadId) {
+    return taskQueue.queueTask(() -> delegate.getPayloadV6(payloadId));
+  }
+
+  @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV1(
       final ExecutionPayloadV1 executionPayload) {
     return taskQueue.queueTask(() -> delegate.newPayloadV1(executionPayload));
@@ -132,6 +140,18 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   }
 
   @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV5(
+      final ExecutionPayloadV4 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final List<Bytes> executionRequests) {
+    return taskQueue.queueTask(
+        () ->
+            delegate.newPayloadV5(
+                executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests));
+  }
+
+  @Override
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       final ForkChoiceStateV1 forkChoiceState,
       final Optional<PayloadAttributesV1> payloadAttributes) {
@@ -153,6 +173,14 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
       final Optional<PayloadAttributesV3> payloadAttributes) {
     return taskQueue.queueTask(
         () -> delegate.forkChoiceUpdatedV3(forkChoiceState, payloadAttributes));
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV4(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV4> payloadAttributes) {
+    return taskQueue.queueTask(
+        () -> delegate.forkChoiceUpdatedV4(forkChoiceState, payloadAttributes));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4.java
@@ -59,10 +59,7 @@ public class EngineForkChoiceUpdatedV4
         payloadBuildingAttributes);
 
     final Optional<PayloadAttributesV4> maybePayloadAttributes =
-        payloadBuildingAttributes.flatMap(
-            attributes ->
-                PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(
-                    payloadBuildingAttributes));
+        payloadBuildingAttributes.map(PayloadAttributesV4::fromInternalPayloadBuildingAttributesV4);
 
     return executionEngineClient
         .forkChoiceUpdatedV4(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+
+public class EngineForkChoiceUpdatedV4
+    extends AbstractEngineJsonRpcMethod<
+        tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  public EngineForkChoiceUpdatedV4(final ExecutionEngineClient executionEngineClient) {
+    super(executionEngineClient);
+  }
+
+  @Override
+  public String getName() {
+    return EngineApiMethod.ENGINE_FORK_CHOICE_UPDATED.getName();
+  }
+
+  @Override
+  public int getVersion() {
+    return 4;
+  }
+
+  @Override
+  public SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> execute(
+      final JsonRpcRequestParams params) {
+    final ForkChoiceState forkChoiceState = params.getRequiredParameter(0, ForkChoiceState.class);
+    final Optional<PayloadBuildingAttributes> payloadBuildingAttributes =
+        params.getOptionalParameter(1, PayloadBuildingAttributes.class);
+
+    LOG.trace(
+        "Calling {}(forkChoiceState={}, payloadAttributes={})",
+        getVersionedName(),
+        forkChoiceState,
+        payloadBuildingAttributes);
+
+    final Optional<PayloadAttributesV4> maybePayloadAttributes =
+        payloadBuildingAttributes.flatMap(
+            attributes ->
+                PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(
+                    payloadBuildingAttributes));
+
+    return executionEngineClient
+        .forkChoiceUpdatedV4(
+            ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState), maybePayloadAttributes)
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
+        .thenPeek(
+            forkChoiceUpdatedResult ->
+                LOG.trace(
+                    "Response {}(forkChoiceState={}, payloadAttributes={}) -> {}",
+                    getVersionedName(),
+                    forkChoiceState,
+                    payloadBuildingAttributes,
+                    forkChoiceUpdatedResult));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
+import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
+
+public class EngineGetPayloadV6 extends AbstractEngineJsonRpcMethod<GetPayloadResponse> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+  private final ExecutionRequestsDataCodec executionRequestsDataDecoder;
+
+  public EngineGetPayloadV6(final ExecutionEngineClient executionEngineClient, final Spec spec) {
+    super(executionEngineClient);
+    this.spec = spec;
+    this.executionRequestsDataDecoder =
+        new ExecutionRequestsDataCodec(
+            SchemaDefinitionsElectra.required(
+                    spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
+                .getExecutionRequestsSchema());
+  }
+
+  @Override
+  public String getName() {
+    return EngineApiMethod.ENGINE_GET_PAYLOAD.getName();
+  }
+
+  @Override
+  public int getVersion() {
+    return 6;
+  }
+
+  @Override
+  public SafeFuture<GetPayloadResponse> execute(final JsonRpcRequestParams params) {
+    final ExecutionPayloadContext executionPayloadContext =
+        params.getRequiredParameter(0, ExecutionPayloadContext.class);
+    final UInt64 slot = params.getRequiredParameter(1, UInt64.class);
+
+    LOG.trace(
+        "Calling {}(payloadId={}, slot={})",
+        getVersionedName(),
+        executionPayloadContext.getPayloadId(),
+        slot);
+
+    return executionEngineClient
+        .getPayloadV6(executionPayloadContext.getPayloadId())
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(
+            response -> {
+              final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  SchemaDefinitionsBellatrix.required(schemaDefinitions)
+                      .getExecutionPayloadSchema();
+              final ExecutionPayload executionPayload =
+                  response.executionPayload.asInternalExecutionPayload(payloadSchema);
+              final BlobsBundle blobsBundle = getBlobsBundle(response, schemaDefinitions);
+              final ExecutionRequests executionRequests =
+                  executionRequestsDataDecoder.decode(response.executionRequests);
+              return new GetPayloadResponse(
+                  executionPayload,
+                  response.blockValue,
+                  blobsBundle,
+                  response.shouldOverrideBuilder,
+                  executionRequests);
+            })
+        .thenPeek(
+            getPayloadResponse ->
+                LOG.trace(
+                    "Response {}(payloadId={}, slot={}) -> {}",
+                    getVersionedName(),
+                    executionPayloadContext.getPayloadId(),
+                    slot,
+                    getPayloadResponse));
+  }
+
+  private BlobsBundle getBlobsBundle(
+      final GetPayloadV6Response response, final SchemaDefinitions schemaDefinitions) {
+    final BlobSchema blobSchema =
+        SchemaDefinitionsDeneb.required(schemaDefinitions).getBlobSchema();
+    return response.blobsBundle.asInternalBlobsBundle(blobSchema);
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+
+public class EngineNewPayloadV5 extends AbstractEngineJsonRpcMethod<PayloadStatus> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  public EngineNewPayloadV5(final ExecutionEngineClient executionEngineClient) {
+    super(executionEngineClient);
+  }
+
+  @Override
+  public String getName() {
+    return EngineApiMethod.ENGINE_NEW_PAYLOAD.getName();
+  }
+
+  @Override
+  public int getVersion() {
+    return 5;
+  }
+
+  @Override
+  public SafeFuture<PayloadStatus> execute(final JsonRpcRequestParams params) {
+    final ExecutionPayload executionPayload =
+        params.getRequiredParameter(0, ExecutionPayload.class);
+    final List<VersionedHash> blobVersionedHashes =
+        params.getRequiredListParameter(1, VersionedHash.class);
+    final Bytes32 parentBeaconBlockRoot = params.getRequiredParameter(2, Bytes32.class);
+    final List<Bytes> executionRequests = params.getRequiredListParameter(3, Bytes.class);
+    final UInt64 slot = params.getRequiredParameter(4, UInt64.class);
+
+    LOG.trace(
+        "Calling {}(executionPayload={}, blobVersionedHashes={}, parentBeaconBlockRoot={}, executionRequests={})",
+        getVersionedName(),
+        executionPayload,
+        blobVersionedHashes,
+        parentBeaconBlockRoot,
+        executionRequests);
+
+    final ExecutionPayloadV4 executionPayloadV4 =
+        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload, slot);
+    return executionEngineClient
+        .newPayloadV5(
+            executionPayloadV4, blobVersionedHashes, parentBeaconBlockRoot, executionRequests)
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(PayloadStatusV1::asInternalExecutionPayload)
+        .thenPeek(
+            payloadStatus ->
+                LOG.trace(
+                    "Response {}(executionPayload={}) -> {}",
+                    getVersionedName(),
+                    executionPayload,
+                    payloadStatus))
+        .exceptionally(PayloadStatus::failedExecution);
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -26,15 +26,18 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV5Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -63,11 +66,16 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   public static final String FORKCHOICE_UPDATED_V3_METHOD = "forkchoice_updatedV3";
   public static final String FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V3_METHOD =
       "forkchoice_updated_with_attributesV3";
+  public static final String FORKCHOICE_UPDATED_V4_METHOD = "forkchoice_updatedV4";
+  public static final String FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V4_METHOD =
+      "forkchoice_updated_with_attributesV4";
   public static final String GET_PAYLOAD_V3_METHOD = "get_payloadV3";
   public static final String GET_PAYLOAD_V4_METHOD = "get_payloadV4";
   public static final String GET_PAYLOAD_V5_METHOD = "get_payloadV5";
+  public static final String GET_PAYLOAD_V6_METHOD = "get_payloadV6";
   public static final String NEW_PAYLOAD_V3_METHOD = "new_payloadV3";
   public static final String NEW_PAYLOAD_V4_METHOD = "new_payloadV4";
+  public static final String NEW_PAYLOAD_V5_METHOD = "new_payloadV5";
   public static final String EXCHANGE_CAPABILITIES_METHOD = "exchange_capabilities";
   public static final String GET_CLIENT_VERSION_V1_METHOD = "get_client_versionV1";
   public static final String GET_BLOBS_V1_METHOD = "get_blobs_versionV1";
@@ -127,6 +135,11 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   }
 
   @Override
+  public SafeFuture<Response<GetPayloadV6Response>> getPayloadV6(final Bytes8 payloadId) {
+    return countRequest(() -> delegate.getPayloadV6(payloadId), GET_PAYLOAD_V6_METHOD);
+  }
+
+  @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV1(
       final ExecutionPayloadV1 executionPayload) {
     return countRequest(() -> delegate.newPayloadV1(executionPayload), NEW_PAYLOAD_METHOD);
@@ -162,6 +175,19 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   }
 
   @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV5(
+      final ExecutionPayloadV4 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final List<Bytes> executionRequests) {
+    return countRequest(
+        () ->
+            delegate.newPayloadV5(
+                executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests),
+        NEW_PAYLOAD_V5_METHOD);
+  }
+
+  @Override
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       final ForkChoiceStateV1 forkChoiceState,
       final Optional<PayloadAttributesV1> payloadAttributes) {
@@ -192,6 +218,17 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
         payloadAttributes.isPresent()
             ? FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V3_METHOD
             : FORKCHOICE_UPDATED_V3_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV4(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV4> payloadAttributes) {
+    return countRequest(
+        () -> delegate.forkChoiceUpdatedV4(forkChoiceState, payloadAttributes),
+        payloadAttributes.isPresent()
+            ? FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V4_METHOD
+            : FORKCHOICE_UPDATED_V4_METHOD);
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
@@ -26,6 +26,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.executionclient.serialization.BytesDeserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.UInt64AsHexSerializer;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -39,8 +41,8 @@ public class ExecutionPayloadV4 extends ExecutionPayloadV3 {
   @JsonDeserialize(using = BytesDeserializer.class)
   public final Bytes blockAccessList;
 
-  @JsonSerialize(using = BytesSerializer.class)
-  @JsonDeserialize(using = BytesDeserializer.class)
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
   public final UInt64 slotNumber;
 
   public ExecutionPayloadV4(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.List;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesDeserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesSerializer;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBuilder;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
+
+public class ExecutionPayloadV4 extends ExecutionPayloadV3 {
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = BytesDeserializer.class)
+  public final Bytes blockAccessList;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = BytesDeserializer.class)
+  public final UInt64 slotNumber;
+
+  public ExecutionPayloadV4(
+      final @JsonProperty("parentHash") Bytes32 parentHash,
+      final @JsonProperty("feeRecipient") Bytes20 feeRecipient,
+      final @JsonProperty("stateRoot") Bytes32 stateRoot,
+      final @JsonProperty("receiptsRoot") Bytes32 receiptsRoot,
+      final @JsonProperty("logsBloom") Bytes logsBloom,
+      final @JsonProperty("prevRandao") Bytes32 prevRandao,
+      final @JsonProperty("blockNumber") UInt64 blockNumber,
+      final @JsonProperty("gasLimit") UInt64 gasLimit,
+      final @JsonProperty("gasUsed") UInt64 gasUsed,
+      final @JsonProperty("timestamp") UInt64 timestamp,
+      final @JsonProperty("extraData") Bytes extraData,
+      final @JsonProperty("baseFeePerGas") UInt256 baseFeePerGas,
+      final @JsonProperty("blockHash") Bytes32 blockHash,
+      final @JsonProperty("transactions") List<Bytes> transactions,
+      final @JsonProperty("withdrawals") List<WithdrawalV1> withdrawals,
+      final @JsonProperty("blobGasUsed") UInt64 blobGasUsed,
+      final @JsonProperty("excessBlobGas") UInt64 excessBlobGas,
+      final @JsonProperty("blockAccessList") Bytes blockAccessList,
+      final @JsonProperty("slotNumber") UInt64 slotNumber) {
+    super(
+        parentHash,
+        feeRecipient,
+        stateRoot,
+        receiptsRoot,
+        logsBloom,
+        prevRandao,
+        blockNumber,
+        gasLimit,
+        gasUsed,
+        timestamp,
+        extraData,
+        baseFeePerGas,
+        blockHash,
+        transactions,
+        withdrawals,
+        blobGasUsed,
+        excessBlobGas);
+    this.blockAccessList = blockAccessList;
+    checkNotNull(slotNumber, "slotNumber");
+    this.slotNumber = slotNumber;
+  }
+
+  @Override
+  protected ExecutionPayloadBuilder applyToBuilder(
+      final ExecutionPayloadSchema<?> executionPayloadSchema,
+      final ExecutionPayloadBuilder builder) {
+    return super.applyToBuilder(executionPayloadSchema, builder)
+        .blockAccessList(() -> blockAccessList)
+        .slotNumber(() -> slotNumber);
+  }
+
+  public static ExecutionPayloadV4 fromInternalExecutionPayload(
+      final ExecutionPayload executionPayload, final UInt64 slot) {
+    return new ExecutionPayloadV4(
+        executionPayload.getParentHash(),
+        executionPayload.getFeeRecipient(),
+        executionPayload.getStateRoot(),
+        executionPayload.getReceiptsRoot(),
+        executionPayload.getLogsBloom(),
+        executionPayload.getPrevRandao(),
+        executionPayload.getBlockNumber(),
+        executionPayload.getGasLimit(),
+        executionPayload.getGasUsed(),
+        executionPayload.getTimestamp(),
+        executionPayload.getExtraData(),
+        executionPayload.getBaseFeePerGas(),
+        executionPayload.getBlockHash(),
+        getTransactions(executionPayload),
+        getWithdrawals(ExecutionPayloadCapella.required(executionPayload).getWithdrawals()),
+        ExecutionPayloadDeneb.required(executionPayload).getBlobGasUsed(),
+        ExecutionPayloadDeneb.required(executionPayload).getExcessBlobGas(),
+        // TODO-GLOAS: populate blockAccessList (not required for devnet-0)
+        null,
+        slot);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ExecutionPayloadV4 that = (ExecutionPayloadV4) o;
+    return Objects.equals(blockAccessList, that.blockAccessList)
+        && Objects.equals(slotNumber, that.slotNumber);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), blockAccessList, slotNumber);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("parentHash", parentHash)
+        .add("feeRecipient", feeRecipient)
+        .add("stateRoot", stateRoot)
+        .add("receiptsRoot", receiptsRoot)
+        .add("logsBloom", logsBloom)
+        .add("prevRandao", prevRandao)
+        .add("blockNumber", blockNumber)
+        .add("gasLimit", gasLimit)
+        .add("gasUsed", gasUsed)
+        .add("timestamp", timestamp)
+        .add("extraData", extraData)
+        .add("baseFeePerGas", baseFeePerGas)
+        .add("blockHash", blockHash)
+        .add("transactions", transactions)
+        .add("withdrawals", withdrawals)
+        .add("blobGasUsed", blobGasUsed)
+        .add("excessBlobGas", excessBlobGas)
+        .add("blockAccessList", blockAccessList)
+        .add("slotNumber", slotNumber)
+        .toString();
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV6Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV6Response.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesDeserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSerializer;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
+
+public class GetPayloadV6Response {
+  public final ExecutionPayloadV3 executionPayload;
+
+  @JsonSerialize(using = UInt256AsHexSerializer.class)
+  @JsonDeserialize(using = UInt256AsHexDeserializer.class)
+  public final UInt256 blockValue;
+
+  public final BlobsBundleV2 blobsBundle;
+
+  public final boolean shouldOverrideBuilder;
+
+  @JsonSerialize(contentUsing = BytesSerializer.class)
+  @JsonDeserialize(contentUsing = BytesDeserializer.class)
+  public final List<Bytes> executionRequests;
+
+  public GetPayloadV6Response(
+      final @JsonProperty("executionPayload") ExecutionPayloadV4 executionPayload,
+      final @JsonProperty("blockValue") UInt256 blockValue,
+      final @JsonProperty("blobsBundle") BlobsBundleV2 blobsBundle,
+      final @JsonProperty("shouldOverrideBuilder") boolean shouldOverrideBuilder,
+      final @JsonProperty("executionRequests") List<Bytes> executionRequests) {
+    checkNotNull(executionPayload, "executionPayload");
+    checkNotNull(blockValue, "blockValue");
+    checkNotNull(blobsBundle, "blobsBundle");
+    checkNotNull(executionRequests, "executionRequests");
+    this.executionPayload = executionPayload;
+    this.blockValue = blockValue;
+    this.blobsBundle = blobsBundle;
+    this.shouldOverrideBuilder = shouldOverrideBuilder;
+    this.executionRequests = executionRequests;
+  }
+
+  public GetPayloadResponse asInternalGetPayloadResponse(
+      final ExecutionPayloadSchema<?> executionPayloadSchema,
+      final BlobSchema blobSchema,
+      final ExecutionRequestsSchema executionRequestsSchema) {
+    return new GetPayloadResponse(
+        executionPayload.asInternalExecutionPayload(executionPayloadSchema),
+        blockValue,
+        blobsBundle.asInternalBlobsBundle(blobSchema),
+        shouldOverrideBuilder,
+        new ExecutionRequestsDataCodec(executionRequestsSchema).decode(executionRequests));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV6Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV6Response.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 
 public class GetPayloadV6Response {
-  public final ExecutionPayloadV3 executionPayload;
+  public final ExecutionPayloadV4 executionPayload;
 
   @JsonSerialize(using = UInt256AsHexSerializer.class)
   @JsonDeserialize(using = UInt256AsHexDeserializer.class)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.schema;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionclient.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+
+public class PayloadAttributesV4 extends PayloadAttributesV3 {
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 slotNumber;
+
+  public PayloadAttributesV4(
+      final @JsonProperty("timestamp") UInt64 timestamp,
+      final @JsonProperty("prevRandao") Bytes32 prevRandao,
+      final @JsonProperty("suggestedFeeRecipient") Bytes20 suggestedFeeRecipient,
+      final @JsonProperty("withdrawals") List<WithdrawalV1> withdrawals,
+      final @JsonProperty("parentBeaconBlockRoot") Bytes32 parentBeaconBlockRoot,
+      final @JsonProperty("slotNumber") UInt64 slotNumber) {
+    super(timestamp, prevRandao, suggestedFeeRecipient, withdrawals, parentBeaconBlockRoot);
+    this.slotNumber = slotNumber;
+  }
+
+  public static Optional<PayloadAttributesV4> fromInternalPayloadBuildingAttributesV4(
+      final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
+    return payloadBuildingAttributes.map(
+        payloadAttributes ->
+            new PayloadAttributesV4(
+                payloadAttributes.getTimestamp(),
+                payloadAttributes.getPrevRandao(),
+                payloadAttributes.getFeeRecipient(),
+                getWithdrawals(payloadAttributes),
+                payloadAttributes.getParentBeaconBlockRoot(),
+                payloadAttributes.getProposalSlot()));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final PayloadAttributesV4 that = (PayloadAttributesV4) o;
+    return Objects.equals(slotNumber, that.slotNumber);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), slotNumber);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("timestamp", timestamp)
+        .add("prevRandao", prevRandao)
+        .add("suggestedFeeRecipient", suggestedFeeRecipient)
+        .add("withdrawals", withdrawals)
+        .add("parentBeaconBlockRoot", parentBeaconBlockRoot)
+        .add("slotNumber", slotNumber)
+        .toString();
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.MoreObjects;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt64AsHexDeserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt64AsHexSerializer;
@@ -44,17 +43,15 @@ public class PayloadAttributesV4 extends PayloadAttributesV3 {
     this.slotNumber = slotNumber;
   }
 
-  public static Optional<PayloadAttributesV4> fromInternalPayloadBuildingAttributesV4(
-      final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
-    return payloadBuildingAttributes.map(
-        payloadAttributes ->
-            new PayloadAttributesV4(
-                payloadAttributes.getTimestamp(),
-                payloadAttributes.getPrevRandao(),
-                payloadAttributes.getFeeRecipient(),
-                getWithdrawals(payloadAttributes),
-                payloadAttributes.getParentBeaconBlockRoot(),
-                payloadAttributes.getProposalSlot()));
+  public static PayloadAttributesV4 fromInternalPayloadBuildingAttributesV4(
+      final PayloadBuildingAttributes payloadBuildingAttributes) {
+    return new PayloadAttributesV4(
+        payloadBuildingAttributes.getTimestamp(),
+        payloadBuildingAttributes.getPrevRandao(),
+        payloadBuildingAttributes.getFeeRecipient(),
+        getWithdrawals(payloadBuildingAttributes),
+        payloadBuildingAttributes.getParentBeaconBlockRoot(),
+        payloadBuildingAttributes.getProposalSlot());
   }
 
   @Override

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4Test.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineForkChoiceUpdatedV4Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private EngineForkChoiceUpdatedV4 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineForkChoiceUpdatedV4(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_forkchoiceUpdated");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(4);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_forkchoiceUpdatedV4");
+  }
+
+  @Test
+  public void forkChoiceStateParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void payloadBuildingAttributesParamIsOptional() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+
+    when(executionEngineClient.forkChoiceUpdatedV4(any(), eq(Optional.empty())))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV4(any(), eq(Optional.empty()));
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWithMessageWhenEngineClientRequestFails() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.forkChoiceUpdatedV4(any(), any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(InvalidRemoteResponseException.class)
+        .withMessageContaining(
+            "Invalid remote response from the execution client: %s", errorResponseFromClient);
+  }
+
+  @Test
+  public void shouldCallForkChoiceUpdateV4WithPayloadAttributesV4WhenInGloas() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final PayloadBuildingAttributes payloadBuildingAttributes =
+        dataStructureUtil.randomPayloadBuildingAttributes(false);
+    final ForkChoiceStateV1 forkChoiceStateV1 =
+        ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final Optional<PayloadAttributesV4> payloadAttributesV4 =
+        PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(
+            Optional.of(payloadBuildingAttributes));
+
+    jsonRpcMethod = new EngineForkChoiceUpdatedV4(executionEngineClient);
+
+    when(executionEngineClient.forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributesV4))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(forkChoiceState)
+            .add(payloadBuildingAttributes)
+            .build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributesV4);
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummySuccessfulResponse() {
+    return SafeFuture.completedFuture(
+        Response.fromPayloadReceivedAsJson(
+            new ForkChoiceUpdatedResult(
+                new PayloadStatusV1(
+                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+                dataStructureUtil.randomBytes8())));
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(
+      final String errorMessage) {
+    return SafeFuture.completedFuture(Response.fromErrorMessage(errorMessage));
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4Test.java
@@ -113,13 +113,13 @@ class EngineForkChoiceUpdatedV4Test {
         dataStructureUtil.randomPayloadBuildingAttributes(false);
     final ForkChoiceStateV1 forkChoiceStateV1 =
         ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
-    final Optional<PayloadAttributesV4> payloadAttributesV4 =
-        PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(
-            Optional.of(payloadBuildingAttributes));
+    final PayloadAttributesV4 payloadAttributesV4 =
+        PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(payloadBuildingAttributes);
 
     jsonRpcMethod = new EngineForkChoiceUpdatedV4(executionEngineClient);
 
-    when(executionEngineClient.forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributesV4))
+    when(executionEngineClient.forkChoiceUpdatedV4(
+            forkChoiceStateV1, Optional.of(payloadAttributesV4)))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV4Test.java
@@ -130,7 +130,8 @@ class EngineForkChoiceUpdatedV4Test {
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
 
-    verify(executionEngineClient).forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributesV4);
+    verify(executionEngineClient)
+        .forkChoiceUpdatedV4(forkChoiceStateV1, Optional.of(payloadAttributesV4));
   }
 
   private SafeFuture<Response<ForkChoiceUpdatedResult>> dummySuccessfulResponse() {

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6Test.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsDataCodec;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineGetPayloadV6Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private final ExecutionRequestsDataCodec executionRequestsDataCodec =
+      new ExecutionRequestsDataCodec(
+          SchemaDefinitionsFulu.required(
+                  spec.forMilestone(SpecMilestone.GLOAS).getSchemaDefinitions())
+              .getExecutionRequestsSchema());
+  private EngineGetPayloadV6 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineGetPayloadV6(executionEngineClient, spec);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_getPayload");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(6);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_getPayloadV6");
+  }
+
+  @Test
+  public void executionPayloadContextParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void slotParamIsRequired() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 1");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnFailedExecutionWhenEngineClientRequestFails() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.getPayloadV6(any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(InvalidRemoteResponseException.class)
+        .withMessageContaining(
+            "Invalid remote response from the execution client: %s", errorResponseFromClient);
+  }
+
+  @Test
+  public void shouldCallGetPayloadV6AndParseResponseSuccessfully() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+    final UInt256 blockValue = UInt256.MAX_VALUE;
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle();
+    final UInt64 slot = UInt64.ONE;
+    final ExecutionPayload executionPayloadFulu = dataStructureUtil.randomExecutionPayload(slot);
+    final ExecutionRequests executionRequests = dataStructureUtil.randomExecutionRequests();
+    final List<Bytes> encodedExecutionRequests =
+        executionRequestsDataCodec.encode(executionRequests);
+    assertThat(executionPayloadFulu).isInstanceOf(ExecutionPayloadDeneb.class);
+
+    when(executionEngineClient.getPayloadV6(eq(executionPayloadContext.getPayloadId())))
+        .thenReturn(
+            dummySuccessfulResponse(
+                executionPayloadFulu, blockValue, blobsBundle, encodedExecutionRequests, slot));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    jsonRpcMethod = new EngineGetPayloadV6(executionEngineClient, spec);
+
+    final GetPayloadResponse expectedGetPayloadResponse =
+        new GetPayloadResponse(
+            executionPayloadFulu, blockValue, blobsBundle, false, executionRequests);
+    assertThat(jsonRpcMethod.execute(params)).isCompletedWithValue(expectedGetPayloadResponse);
+
+    verify(executionEngineClient).getPayloadV6(eq(executionPayloadContext.getPayloadId()));
+    verifyNoMoreInteractions(executionEngineClient);
+  }
+
+  private SafeFuture<Response<GetPayloadV6Response>> dummySuccessfulResponse(
+      final ExecutionPayload executionPayload,
+      final UInt256 blockValue,
+      final BlobsBundle blobsBundle,
+      final List<Bytes> encodedExecutionRequests,
+      final UInt64 slot) {
+    return SafeFuture.completedFuture(
+        Response.fromPayloadReceivedAsJson(
+            new GetPayloadV6Response(
+                ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload, slot),
+                blockValue,
+                BlobsBundleV2.fromInternalBlobsBundle(blobsBundle),
+                false,
+                encodedExecutionRequests)));
+  }
+
+  private SafeFuture<Response<GetPayloadV6Response>> dummyFailedResponse(
+      final String errorMessage) {
+    return SafeFuture.completedFuture(Response.fromErrorMessage(errorMessage));
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5Test.java
@@ -118,7 +118,8 @@ class EngineNewPayloadV5Test {
 
   @Test
   public void shouldReturnFailedExecutionWhenEngineClientRequestFails() {
-    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
+    final UInt64 slot = dataStructureUtil.randomSlot();
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload(slot);
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
     final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
     final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
@@ -133,6 +134,7 @@ class EngineNewPayloadV5Test {
             .add(blobVersionedHashes)
             .add(parentBeaconBlockRoot)
             .add(executionRequests)
+            .add(slot)
             .build();
 
     assertThat(jsonRpcMethod.execute(params))
@@ -167,6 +169,7 @@ class EngineNewPayloadV5Test {
             .add(blobVersionedHashes)
             .add(parentBeaconBlockRoot)
             .add(executionRequests)
+            .add(slot)
             .build();
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5Test.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineNewPayloadV5Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private EngineNewPayloadV5 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineNewPayloadV5(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_newPayload");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(5);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_newPayloadV5");
+  }
+
+  @Test
+  public void executionPayloadParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void blobVersionedHashesParamIsRequired() {
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(dataStructureUtil.randomExecutionPayload()).build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 1");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void parentBeaconBlockRootParamIsRequired() {
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(dataStructureUtil.randomExecutionPayload())
+            .add(dataStructureUtil.randomVersionedHashes(3))
+            .build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 2");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void executionRequestHashParamIsRequired() {
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(dataStructureUtil.randomExecutionPayload())
+            .add(dataStructureUtil.randomVersionedHashes(3))
+            .add(dataStructureUtil.randomBytes32())
+            .build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 3");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnFailedExecutionWhenEngineClientRequestFails() {
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
+    final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
+    final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.newPayloadV5(any(), any(), any(), any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(executionPayload)
+            .add(blobVersionedHashes)
+            .add(parentBeaconBlockRoot)
+            .add(executionRequests)
+            .build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .matches(PayloadStatus::hasFailedExecution);
+  }
+
+  @Test
+  public void shouldCallNewPayloadV5WithExecutionPayloadV4AndCorrectParameters() {
+    final UInt64 slot = UInt64.ONE;
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload(slot);
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(4);
+    final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
+    final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
+
+    final ExecutionPayloadV4 executionPayloadV4 =
+        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload, slot);
+    assertThat(executionPayloadV4).isExactlyInstanceOf(ExecutionPayloadV4.class);
+
+    jsonRpcMethod = new EngineNewPayloadV5(executionEngineClient);
+
+    when(executionEngineClient.newPayloadV5(
+            eq(executionPayloadV4),
+            eq(blobVersionedHashes),
+            eq(parentBeaconBlockRoot),
+            eq(executionRequests)))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(executionPayload)
+            .add(blobVersionedHashes)
+            .add(parentBeaconBlockRoot)
+            .add(executionRequests)
+            .build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient)
+        .newPayloadV5(
+            eq(executionPayloadV4),
+            eq(blobVersionedHashes),
+            eq(parentBeaconBlockRoot),
+            eq(executionRequests));
+    verifyNoMoreInteractions(executionEngineClient);
+  }
+
+  private SafeFuture<Response<PayloadStatusV1>> dummySuccessfulResponse() {
+    return SafeFuture.completedFuture(
+        Response.fromPayloadReceivedAsJson(
+            new PayloadStatusV1(
+                ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
+  }
+
+  private SafeFuture<Response<PayloadStatusV1>> dummyFailedResponse(final String errorMessage) {
+    return SafeFuture.completedFuture(Response.fromErrorMessage(errorMessage));
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -114,7 +114,8 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
             .add(executionPayload)
             .addOptional(newPayloadRequest.getVersionedHashes())
             .addOptional(newPayloadRequest.getParentBeaconBlockRoot())
-            .addOptional(newPayloadRequest.getExecutionRequests());
+            .addOptional(newPayloadRequest.getExecutionRequests())
+            .add(slot);
 
     return engineMethodsResolver
         .getMethod(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -29,16 +29,19 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV5;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV6;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineJsonRpcMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV5;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
@@ -67,7 +70,8 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
                 case CAPELLA -> methodsByMilestone.put(milestone, capellaSupportedMethods());
                 case DENEB -> methodsByMilestone.put(milestone, denebSupportedMethods());
                 case ELECTRA -> methodsByMilestone.put(milestone, electraSupportedMethods());
-                case FULU, GLOAS -> methodsByMilestone.put(milestone, fuluSupportedMethods());
+                case FULU -> methodsByMilestone.put(milestone, fuluSupportedMethods());
+                case GLOAS -> methodsByMilestone.put(milestone, gloasSupportedMethods());
               }
             });
   }
@@ -118,6 +122,16 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV4(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV5(executionEngineClient, spec));
     methods.put(ENGINE_FORK_CHOICE_UPDATED, new EngineForkChoiceUpdatedV3(executionEngineClient));
+
+    return methods;
+  }
+
+  private Map<EngineApiMethod, EngineJsonRpcMethod<?>> gloasSupportedMethods() {
+    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
+
+    methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV5(executionEngineClient));
+    methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV6(executionEngineClient, spec));
+    methods.put(ENGINE_FORK_CHOICE_UPDATED, new EngineForkChoiceUpdatedV4(executionEngineClient));
 
     return methods;
   }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
@@ -147,8 +147,8 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             Optional.empty(),
             Optional.of(List.of()),
             dataStructureUtil.randomBytes32());
-    final Optional<PayloadAttributesV4> payloadAttributes =
-        PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(Optional.of(attributes));
+    final PayloadAttributesV4 payloadAttributes =
+        PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(attributes);
     final ForkChoiceUpdatedResult responseData =
         new ForkChoiceUpdatedResult(
             new PayloadStatusV1(
@@ -156,11 +156,13 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             dataStructureUtil.randomBytes8());
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
         SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(responseData));
-    when(executionEngineClient.forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributes))
+    when(executionEngineClient.forkChoiceUpdatedV4(
+            forkChoiceStateV1, Optional.of(payloadAttributes)))
         .thenReturn(dummyResponse);
     final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
         handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
-    verify(executionEngineClient).forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributes);
+    verify(executionEngineClient)
+        .forkChoiceUpdatedV4(forkChoiceStateV1, Optional.of(payloadAttributes));
     assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZGProof;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigDeneb;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
+import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
+import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest {
+
+  @BeforeEach
+  void setup() {
+    spec = TestSpecFactory.createMinimalGloas();
+    dataStructureUtil = new DataStructureUtil(spec);
+  }
+
+  @Test
+  void engineGetPayload_shouldCallGetPayloadV6() {
+    final ExecutionClientHandler handler = getHandler();
+    final ExecutionPayloadContext context = randomContext();
+    final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
+    ;
+    final GetPayloadV6Response responseData =
+        new GetPayloadV6Response(
+            ExecutionPayloadV4.fromInternalExecutionPayload(
+                dataStructureUtil.randomExecutionPayload(slot), slot),
+            UInt256.MAX_VALUE,
+            BlobsBundleV2.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
+            true,
+            dataStructureUtil.randomEncodedExecutionRequests());
+    final SafeFuture<Response<GetPayloadV6Response>> dummyResponse =
+        SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(responseData));
+    when(executionEngineClient.getPayloadV6(context.getPayloadId())).thenReturn(dummyResponse);
+
+    final SafeFuture<GetPayloadResponse> future = handler.engineGetPayload(context, slot);
+    verify(executionEngineClient).getPayloadV6(context.getPayloadId());
+    final SchemaDefinitionsFulu schemaDefinitionGloas =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    final ExecutionPayloadSchema<?> executionPayloadSchema =
+        schemaDefinitionGloas.getExecutionPayloadSchema();
+    final BlobSchema blobSchema = schemaDefinitionGloas.getBlobSchema();
+    final GetPayloadResponse expectedGetPayloadResponse =
+        responseData.asInternalGetPayloadResponse(
+            executionPayloadSchema, blobSchema, schemaDefinitionGloas.getExecutionRequestsSchema());
+    assertThat(future).isCompletedWithValue(expectedGetPayloadResponse);
+  }
+
+  @Test
+  void engineNewPayload_shouldCallNewPayloadV5() {
+    final ExecutionClientHandler handler = getHandler();
+    final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
+    final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload(slot);
+    final List<VersionedHash> versionedHashes = dataStructureUtil.randomVersionedHashes(3);
+    final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
+    final List<Bytes> encodedExecutionRequests = dataStructureUtil.randomEncodedExecutionRequests();
+    final NewPayloadRequest newPayloadRequest =
+        new NewPayloadRequest(
+            payload, versionedHashes, parentBeaconBlockRoot, encodedExecutionRequests);
+    final ExecutionPayloadV4 payloadV4 =
+        ExecutionPayloadV4.fromInternalExecutionPayload(payload, slot);
+    final PayloadStatusV1 responseData =
+        new PayloadStatusV1(
+            ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null);
+    final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
+        SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(responseData));
+    when(executionEngineClient.newPayloadV5(
+            eq(payloadV4),
+            eq(versionedHashes),
+            eq(parentBeaconBlockRoot),
+            eq(encodedExecutionRequests)))
+        .thenReturn(dummyResponse);
+    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest, slot);
+    verify(executionEngineClient)
+        .newPayloadV5(
+            eq(payloadV4),
+            eq(versionedHashes),
+            eq(parentBeaconBlockRoot),
+            eq(encodedExecutionRequests));
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
+  }
+
+  @Test
+  void engineForkChoiceUpdated_shouldCallEngineForkChoiceUpdatedV4() {
+    final ExecutionClientHandler handler = getHandler();
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final ForkChoiceStateV1 forkChoiceStateV1 =
+        ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final PayloadBuildingAttributes attributes =
+        new PayloadBuildingAttributes(
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomEth1Address(),
+            Optional.empty(),
+            Optional.of(List.of()),
+            dataStructureUtil.randomBytes32());
+    final Optional<PayloadAttributesV4> payloadAttributes =
+        PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(Optional.of(attributes));
+    final ForkChoiceUpdatedResult responseData =
+        new ForkChoiceUpdatedResult(
+            new PayloadStatusV1(
+                ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+            dataStructureUtil.randomBytes8());
+    final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
+        SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(responseData));
+    when(executionEngineClient.forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributes))
+        .thenReturn(dummyResponse);
+    final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
+        handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
+    verify(executionEngineClient).forkChoiceUpdatedV4(forkChoiceStateV1, payloadAttributes);
+    assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
+  }
+
+  @Test
+  void engineGetBlobs_shouldCallGetBlobsV2() {
+    final ExecutionClientHandler handler = getHandler();
+    final int maxBlobsPerBlock =
+        SpecConfigDeneb.required(spec.getGenesisSpecConfig()).getMaxBlobsPerBlock();
+    final List<VersionedHash> versionedHashes =
+        dataStructureUtil.randomVersionedHashes(maxBlobsPerBlock);
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(maxBlobsPerBlock);
+    final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
+    final List<BlobAndProofV2> responseData =
+        IntStream.range(0, blobsBundle.getBlobs().size())
+            .mapToObj(
+                i ->
+                    new BlobAndProofV2(
+                        blobsBundle.getBlobs().get(i).getBytes(),
+                        blobsBundle
+                            .getProofs()
+                            .subList(i * CELLS_PER_EXT_BLOB, (i + 1) * CELLS_PER_EXT_BLOB)
+                            .stream()
+                            .map(KZGProof::getBytesCompressed)
+                            .toList()))
+            .toList();
+
+    final SafeFuture<Response<List<BlobAndProofV2>>> dummyResponse =
+        SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(responseData));
+    when(executionEngineClient.getBlobsV2(versionedHashes)).thenReturn(dummyResponse);
+    final SafeFuture<List<BlobAndCellProofs>> future =
+        handler.engineGetBlobsV2(versionedHashes, slot);
+    verify(executionEngineClient).getBlobsV2(versionedHashes);
+    final BlobSchema blobSchema =
+        SchemaDefinitionsFulu.required(spec.atSlot(slot).getSchemaDefinitions()).getBlobSchema();
+    assertThat(future)
+        .isCompletedWithValue(
+            responseData.stream()
+                .map(blobAndProofV2 -> blobAndProofV2.asInternalBlobAndProofs(blobSchema))
+                .toList());
+  }
+
+  private ExecutionPayloadContext randomContext() {
+    return new ExecutionPayloadContext(
+        dataStructureUtil.randomBytes8(),
+        dataStructureUtil.randomForkChoiceState(false),
+        dataStructureUtil.randomPayloadBuildingAttributes(false));
+  }
+}

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -33,16 +33,19 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV5;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV6;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineJsonRpcMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV5;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -238,10 +241,46 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
   }
 
   @Test
+  void gloasMilestoneMethodIsNotSupportedInFulu() {
+    final Spec fuluSpec = TestSpecFactory.createMinimalFulu();
+
+    final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
+        new MilestoneBasedEngineJsonRpcMethodsResolver(fuluSpec, executionEngineClient);
+
+    assertThatThrownBy(
+            () ->
+                engineMethodsResolver.getMethod(
+                    ENGINE_GET_PAYLOAD, () -> SpecMilestone.GLOAS, Object.class))
+        .hasMessage("Can't find method with name engine_getPayload for milestone GLOAS");
+  }
+
+  @ParameterizedTest
+  @MethodSource("gloasMethods")
+  void shouldProvideExpectedMethodsForGloas(
+      final EngineApiMethod method, final Class<EngineJsonRpcMethod<?>> expectedMethodClass) {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+
+    final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
+        new MilestoneBasedEngineJsonRpcMethodsResolver(gloasSpec, executionEngineClient);
+
+    final EngineJsonRpcMethod<Object> providedMethod =
+        engineMethodsResolver.getMethod(method, () -> SpecMilestone.GLOAS, Object.class);
+
+    assertThat(providedMethod).isExactlyInstanceOf(expectedMethodClass);
+  }
+
+  private static Stream<Arguments> gloasMethods() {
+    return Stream.of(
+        arguments(ENGINE_NEW_PAYLOAD, EngineNewPayloadV5.class),
+        arguments(ENGINE_GET_PAYLOAD, EngineGetPayloadV6.class),
+        arguments(ENGINE_FORK_CHOICE_UPDATED, EngineForkChoiceUpdatedV4.class));
+  }
+
+  @Test
   void getsCapabilities() {
     final Spec spec =
-        TestSpecFactory.createMinimalWithCapellaDenebElectraAndFuluForkEpoch(
-            UInt64.ONE, UInt64.valueOf(2), UInt64.valueOf(3), UInt64.valueOf(4));
+        TestSpecFactory.createMinimalWithCapellaDenebElectraFuluAndGloasForkEpoch(
+            UInt64.ONE, UInt64.valueOf(2), UInt64.valueOf(3), UInt64.valueOf(4), UInt64.valueOf(5));
 
     final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
         new MilestoneBasedEngineJsonRpcMethodsResolver(spec, executionEngineClient);
@@ -261,6 +300,8 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
             "engine_forkchoiceUpdatedV3",
             "engine_newPayloadV4",
             "engine_getPayloadV4",
-            "engine_getPayloadV5");
+            "engine_newPayloadV5",
+            "engine_getPayloadV5",
+            "engine_getPayloadV6");
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -300,6 +300,7 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
             "engine_forkchoiceUpdatedV3",
             "engine_newPayloadV4",
             "engine_getPayloadV4",
+            "engine_forkchoiceUpdatedV4",
             "engine_newPayloadV5",
             "engine_getPayloadV5",
             "engine_getPayloadV6");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBuilder.java
@@ -59,7 +59,7 @@ public interface ExecutionPayloadBuilder {
 
   ExecutionPayloadBuilder blockAccessList(Supplier<Bytes> blockAccessListSupplier);
 
-  ExecutionPayloadBuilder slotNumber(Supplier<UInt64> slotNUmberSupplier);
+  ExecutionPayloadBuilder slotNumber(Supplier<UInt64> slotNumberSupplier);
 
   ExecutionPayload build();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBuilder.java
@@ -57,5 +57,9 @@ public interface ExecutionPayloadBuilder {
 
   ExecutionPayloadBuilder excessBlobGas(Supplier<UInt64> excessBlobGasSupplier);
 
+  ExecutionPayloadBuilder blockAccessList(Supplier<Bytes> blockAccessListSupplier);
+
+  ExecutionPayloadBuilder slotNumber(Supplier<UInt64> slotNUmberSupplier);
+
   ExecutionPayload build();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBuilderBellatrix.java
@@ -152,6 +152,16 @@ public class ExecutionPayloadBuilderBellatrix implements ExecutionPayloadBuilder
     return this;
   }
 
+  @Override
+  public ExecutionPayloadBuilder blockAccessList(final Supplier<Bytes> blockAccessListSupplier) {
+    return this;
+  }
+
+  @Override
+  public ExecutionPayloadBuilder slotNumber(final Supplier<UInt64> slotNUmberSupplier) {
+    return this;
+  }
+
   protected void validateSchema() {
     checkNotNull(schema, "schema must be specified");
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBuilderBellatrix.java
@@ -158,7 +158,7 @@ public class ExecutionPayloadBuilderBellatrix implements ExecutionPayloadBuilder
   }
 
   @Override
-  public ExecutionPayloadBuilder slotNumber(final Supplier<UInt64> slotNUmberSupplier) {
+  public ExecutionPayloadBuilder slotNumber(final Supplier<UInt64> slotNumberSupplier) {
     return this;
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -606,6 +606,23 @@ public class TestSpecFactory {
     return create(config, SpecMilestone.FULU);
   }
 
+  public static Spec createMinimalWithCapellaDenebElectraFuluAndGloasForkEpoch(
+      final UInt64 capellaForkEpoch,
+      final UInt64 denebForkEpoch,
+      final UInt64 electraForkEpoch,
+      final UInt64 fuluForkEpoch,
+      final UInt64 gloasForkEpoch) {
+    final SpecConfigAndParent<? extends SpecConfig> config =
+        getGloasSpecConfig(
+            Eth2Network.MINIMAL,
+            capellaForkEpoch,
+            denebForkEpoch,
+            electraForkEpoch,
+            fuluForkEpoch,
+            gloasForkEpoch);
+    return create(config, SpecMilestone.GLOAS);
+  }
+
   // Our current config files contain Fulu params.
   // So all specConfigs created from them will be Fulu.
   // Here we just want to make sure that a given config supports the given milestone


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Changes as per https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md

## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/9819

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus↔execution engine RPC version selection and payload serialization for a new milestone; mistakes could cause EL interoperability failures around Gloas while being mostly additive and well-covered by tests.
> 
> **Overview**
> Updates Teku’s execution-layer Engine API wiring for the `GLOAS` milestone by introducing new versioned RPCs: `engine_getPayloadV6`, `engine_newPayloadV5`, and `engine_forkchoiceUpdatedV4`, including new request/response schemas (`ExecutionPayloadV4`, `PayloadAttributesV4`, `GetPayloadV6Response`) and Web3J client support.
> 
> The milestone resolver now maps `GLOAS` to these new method implementations (separate from `FULU`), the execution-layer handler passes `slot` through to `engine_newPayload`, and metrics/throttling wrappers count/queue the new calls. Adds targeted unit/integration tests and a new `TestSpecFactory` helper to exercise Gloas fork-epoch configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a12176dc889c684587bdc7d3d76ea24485925982. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->