### PR TITLE
adjusted duties slot for proposal duties

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFulu.java
@@ -45,6 +45,9 @@ public class BlockProposalUtilFulu extends BlockProposalUtilPhase0 {
   @Override
   public UInt64 getStateSlotForProposerDuties(
       final Spec spec, final UInt64 stateEpoch, final UInt64 dutiesEpoch) {
+    if (stateEpoch.isLessThan(dutiesEpoch) && stateEpoch.increment().isLessThan(dutiesEpoch)) {
+      return spec.computeStartSlotAtEpoch(dutiesEpoch.minusMinZero(1));
+    }
     return dutiesEpoch.isGreaterThan(stateEpoch)
         ? spec.computeStartSlotAtEpoch(stateEpoch)
         : spec.computeStartSlotAtEpoch(dutiesEpoch);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/util/BlockProposalUtilFuluTest.java
@@ -47,8 +47,9 @@ class BlockProposalUtilFuluTest {
         Arguments.of(1, 1, 8),
         Arguments.of(2, 2, 16),
         Arguments.of(2, 1, 8),
-        Arguments.of(3, 1, 8),
-        Arguments.of(3, 3, 24));
+        Arguments.of(3, 1, 16),
+        Arguments.of(3, 3, 24),
+        Arguments.of(4, 1, 24));
   }
 
   enum ExpectedResult {
@@ -62,12 +63,20 @@ class BlockProposalUtilFuluTest {
   @MethodSource("getStateSlotForProposerDutiesTestCases")
   public void getStateSlotForProposerDuties(
       final int requestedEpoch, final int headEpochIn, final int expectedSlot) {
+    final UInt64 expectedEpoch = spec.computeEpochAtSlot(UInt64.valueOf(expectedSlot));
     final UInt64 headEpoch = UInt64.valueOf(headEpochIn);
     final UInt64 querySlot =
         spec.getGenesisSpec()
             .getBlockProposalUtil()
             .getStateSlotForProposerDuties(spec, headEpoch, UInt64.valueOf(requestedEpoch));
 
+    LOG.debug(
+        "headEpoch={}, dutiesEpoch={}, expectedSlot={} (epoch={})",
+        headEpoch,
+        requestedEpoch,
+        expectedSlot,
+        expectedEpoch);
+    LOG.debug("resultSlot={}. epoch={}", querySlot, spec.computeEpochAtSlot(querySlot));
     assertThat(querySlot.intValue()).isEqualTo(expectedSlot);
   }
 


### PR DESCRIPTION
After making proposer duties compatible, it was possible to get a state slot more than one epoch from the duties, which would result in failure.

Added test case also. the function is less restrictive than the calling code so we can pass more obvious numbers in to see the result.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proposer-duties state-slot selection logic for Fulu, which can affect block production/proposer duty calculation near epoch boundaries; scope is small and covered by updated tests.
> 
> **Overview**
> Adjusts Fulu `getStateSlotForProposerDuties` to avoid selecting a state slot more than one epoch behind the requested duties epoch by falling back to the *previous* duties epoch start slot when `stateEpoch` lags by 2+ epochs.
> 
> Updates `BlockProposalUtilFuluTest` expectations and adds a new coverage case to validate the revised epoch/slot mapping (plus extra debug logging for troubleshooting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b799444821e197b5a3afbc7214db5868aba26c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->