### PR TITLE
make kzg commitments optional in data column sidecar event

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/DataColumnSidecarEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/DataColumnSidecarEvent.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
@@ -35,20 +36,20 @@ public class DataColumnSidecarEvent extends Event<DataColumnSidecarEvent.DataCol
               .withField("block_root", BYTES32_TYPE, DataColumnSidecarData::getBlockRoot)
               .withField("index", UINT64_TYPE, DataColumnSidecarData::getIndex)
               .withField("slot", UINT64_TYPE, DataColumnSidecarData::getSlot)
-              .withField(
+              .withOptionalField(
                   "kzg_commitments",
                   DeserializableTypeDefinition.listOf(KZG_COMMITMENT_TYPE),
-                  DataColumnSidecarData::getKzgCommitments)
+                  DataColumnSidecarData::getMaybeKzgCommitments)
               .build();
 
   private DataColumnSidecarEvent(
       final Bytes32 blockRoot,
       final UInt64 index,
       final UInt64 slot,
-      final List<KZGCommitment> kzgCommitments) {
+      final Optional<List<KZGCommitment>> maybeKzgCommitments) {
     super(
         DATA_COLUMN_SIDECAR_EVENT_TYPE,
-        new DataColumnSidecarData(blockRoot, index, slot, kzgCommitments));
+        new DataColumnSidecarData(blockRoot, index, slot, maybeKzgCommitments));
   }
 
   public static DataColumnSidecarEvent create(final DataColumnSidecar dataColumnSidecar) {
@@ -62,25 +63,24 @@ public class DataColumnSidecarEvent extends Event<DataColumnSidecarEvent.DataCol
                 kzgCommitments ->
                     kzgCommitments.asList().stream()
                         .map(SszKZGCommitment::getKZGCommitment)
-                        .toList())
-            .orElse(List.of()));
+                        .toList()));
   }
 
   public static class DataColumnSidecarData {
     private final Bytes32 blockRoot;
     private final UInt64 index;
     private final UInt64 slot;
-    private final List<KZGCommitment> kzgCommitments;
+    private final Optional<List<KZGCommitment>> maybeKzgCommitments;
 
     DataColumnSidecarData(
         final Bytes32 blockRoot,
         final UInt64 index,
         final UInt64 slot,
-        final List<KZGCommitment> kzgCommitments) {
+        final Optional<List<KZGCommitment>> maybeKzgCommitments) {
       this.blockRoot = blockRoot;
       this.index = index;
       this.slot = slot;
-      this.kzgCommitments = kzgCommitments;
+      this.maybeKzgCommitments = maybeKzgCommitments;
     }
 
     public Bytes32 getBlockRoot() {
@@ -95,8 +95,8 @@ public class DataColumnSidecarEvent extends Event<DataColumnSidecarEvent.DataCol
       return slot;
     }
 
-    public List<KZGCommitment> getKzgCommitments() {
-      return kzgCommitments;
+    public Optional<List<KZGCommitment>> getMaybeKzgCommitments() {
+      return maybeKzgCommitments;
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Make the `kzg_commitments` optional in `DataColumnSidecarEvent`. They will present in FULU but removed in GLOAS

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Implements https://github.com/ethereum/beacon-APIs/pull/583

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes the JSON shape of the `data_column_sidecar` SSE payload by omitting `kzg_commitments` when unavailable, which may affect downstream consumers expecting the field to always exist.
> 
> **Overview**
> Updates `DataColumnSidecarEvent` so `kzg_commitments` is **optional** in the serialized event payload.
> 
> Internally, the event now carries `Optional<List<KZGCommitment>>` (and exposes `getMaybeKzgCommitments()`), and `create()` no longer forces a missing value to serialize as an empty list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e582fc0ffba88335b7c14e0879d29c27e71598b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->