### PR TITLE
Javalin7 and virtual threads on REST API

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/CoalescingChainHeadChannel.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/CoalescingChainHeadChannel.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.beacon.sync.events;
 
 import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSync.SyncSubscriber;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
@@ -23,6 +25,7 @@ import tech.pegasys.teku.storage.api.ReorgContext;
 
 public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscriber {
 
+  private final Lock lock = new ReentrantLock();
   private final ChainHeadChannel delegate;
   private boolean syncing = false;
 
@@ -36,7 +39,7 @@ public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscri
   }
 
   @Override
-  public synchronized void chainHeadUpdated(
+  public void chainHeadUpdated(
       final UInt64 slot,
       final Bytes32 stateRoot,
       final Bytes32 bestBlockRoot,
@@ -45,60 +48,70 @@ public class CoalescingChainHeadChannel implements ChainHeadChannel, SyncSubscri
       final Bytes32 previousDutyDependentRoot,
       final Bytes32 currentDutyDependentRoot,
       final Optional<ReorgContext> optionalReorgContext) {
-    if (!syncing) {
-      optionalReorgContext.ifPresent(
-          reorg ->
-              eventLogger.reorgEvent(
-                  reorg.getOldBestBlockRoot(),
-                  reorg.getOldBestBlockSlot(),
-                  bestBlockRoot,
-                  slot,
-                  reorg.getCommonAncestorRoot(),
-                  reorg.getCommonAncestorSlot()));
-      delegate.chainHeadUpdated(
-          slot,
-          stateRoot,
-          bestBlockRoot,
-          epochTransition,
-          executionOptimistic,
-          previousDutyDependentRoot,
-          currentDutyDependentRoot,
-          optionalReorgContext);
-    } else {
-      pendingEvent =
-          pendingEvent
-              .map(
-                  current ->
-                      current.update(
-                          slot,
-                          stateRoot,
-                          bestBlockRoot,
-                          epochTransition,
-                          executionOptimistic,
-                          previousDutyDependentRoot,
-                          currentDutyDependentRoot,
-                          optionalReorgContext))
-              .or(
-                  () ->
-                      Optional.of(
-                          new PendingEvent(
-                              slot,
-                              stateRoot,
-                              bestBlockRoot,
-                              epochTransition,
-                              executionOptimistic,
-                              previousDutyDependentRoot,
-                              currentDutyDependentRoot,
-                              optionalReorgContext)));
+    lock.lock();
+    try {
+      if (!syncing) {
+        optionalReorgContext.ifPresent(
+            reorg ->
+                eventLogger.reorgEvent(
+                    reorg.getOldBestBlockRoot(),
+                    reorg.getOldBestBlockSlot(),
+                    bestBlockRoot,
+                    slot,
+                    reorg.getCommonAncestorRoot(),
+                    reorg.getCommonAncestorSlot()));
+        delegate.chainHeadUpdated(
+            slot,
+            stateRoot,
+            bestBlockRoot,
+            epochTransition,
+            executionOptimistic,
+            previousDutyDependentRoot,
+            currentDutyDependentRoot,
+            optionalReorgContext);
+      } else {
+        pendingEvent =
+            pendingEvent
+                .map(
+                    current ->
+                        current.update(
+                            slot,
+                            stateRoot,
+                            bestBlockRoot,
+                            epochTransition,
+                            executionOptimistic,
+                            previousDutyDependentRoot,
+                            currentDutyDependentRoot,
+                            optionalReorgContext))
+                .or(
+                    () ->
+                        Optional.of(
+                            new PendingEvent(
+                                slot,
+                                stateRoot,
+                                bestBlockRoot,
+                                epochTransition,
+                                executionOptimistic,
+                                previousDutyDependentRoot,
+                                currentDutyDependentRoot,
+                                optionalReorgContext)));
+      }
+    } finally {
+      lock.unlock();
     }
   }
 
   @Override
-  public synchronized void onSyncingChange(final boolean isSyncing) {
-    syncing = isSyncing;
-    if (!syncing) {
-      pendingEvent.ifPresent(PendingEvent::send);
-      pendingEvent = Optional.empty();
+  public void onSyncingChange(final boolean isSyncing) {
+    lock.lock();
+    try {
+      syncing = isSyncing;
+      if (!syncing) {
+        pendingEvent.ifPresent(PendingEvent::send);
+        pendingEvent = Optional.empty();
+      }
+    } finally {
+      lock.unlock();
     }
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/StubContext.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/StubContext.java
@@ -14,11 +14,13 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
 import io.javalin.config.Key;
+import io.javalin.config.MultipartConfig;
 import io.javalin.http.Context;
-import io.javalin.http.HandlerType;
 import io.javalin.http.HttpStatus;
 import io.javalin.json.JsonMapper;
 import io.javalin.plugin.ContextPlugin;
+import io.javalin.router.Endpoint;
+import io.javalin.router.Endpoints;
 import io.javalin.security.RouteRole;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,7 +46,13 @@ public class StubContext implements Context {
 
   @NotNull
   @Override
-  public String endpointHandlerPath() {
+  public Endpoints endpoints() {
+    return null;
+  }
+
+  @NotNull
+  @Override
+  public Endpoint endpoint() {
     return null;
   }
 
@@ -53,13 +61,7 @@ public class StubContext implements Context {
 
   @NotNull
   @Override
-  public HandlerType handlerType() {
-    return null;
-  }
-
-  @NotNull
-  @Override
-  public String matchedPath() {
+  public MultipartConfig multipartConfig() {
     return null;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -64,6 +66,7 @@ public class DasCustodyBackfiller extends Service
   private final DataColumnSidecarRetriever retriever;
   private final MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator;
 
+  private final Lock lock = new ReentrantLock();
   private Optional<Cancellable> scheduledBackfiller = Optional.empty();
 
   private final Supplier<SafeFuture<Optional<UInt64>>> earliestAvailableCustodySlotProvider;
@@ -108,29 +111,44 @@ public class DasCustodyBackfiller extends Service
   }
 
   @Override
-  protected synchronized SafeFuture<?> doStart() {
-    if (scheduledBackfiller.map(Cancellable::isCancelled).orElse(true)) {
-      scheduledBackfiller =
-          Optional.of(
-              asyncRunner.runWithFixedDelay(
-                  this::runBackfillCycle,
-                  Duration.ZERO,
-                  backfillCheckInterval,
-                  error -> LOG.error("Failed to run data column backfill", error)));
+  protected SafeFuture<?> doStart() {
+    lock.lock();
+    try {
+      if (scheduledBackfiller.map(Cancellable::isCancelled).orElse(true)) {
+        scheduledBackfiller =
+            Optional.of(
+                asyncRunner.runWithFixedDelay(
+                    this::runBackfillCycle,
+                    Duration.ZERO,
+                    backfillCheckInterval,
+                    error -> LOG.error("Failed to run data column backfill", error)));
+      }
+      return SafeFuture.COMPLETE;
+    } finally {
+      lock.unlock();
     }
-    return SafeFuture.COMPLETE;
   }
 
   @Override
-  protected synchronized SafeFuture<?> doStop() {
-    scheduledBackfiller.ifPresent(Cancellable::cancel);
-    pendingRequests.values().forEach(f -> f.cancel(true));
-    pendingRequests.clear();
-    return SafeFuture.COMPLETE;
+  protected SafeFuture<?> doStop() {
+    lock.lock();
+    try {
+      scheduledBackfiller.ifPresent(Cancellable::cancel);
+      pendingRequests.values().forEach(f -> f.cancel(true));
+      pendingRequests.clear();
+      return SafeFuture.COMPLETE;
+    } finally {
+      lock.unlock();
+    }
   }
 
-  public synchronized void onNodeSyncStateChanged(final boolean inSync) {
-    this.inSync = inSync;
+  public void onNodeSyncStateChanged(final boolean inSync) {
+    lock.lock();
+    try {
+      this.inSync = inSync;
+    } finally {
+      lock.unlock();
+    }
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -35,6 +37,7 @@ import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class SyncCommitteeContributionPool implements SlotEventsChannel {
+  private final Lock lock = new ReentrantLock();
   private final Spec spec;
   private final SignedContributionAndProofValidator validator;
   private final Subscribers<OperationAddedSubscriber<SignedContributionAndProof>> subscribers =
@@ -82,15 +85,20 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
             });
   }
 
-  private synchronized void doAdd(final SyncCommitteeContribution contribution) {
-    final int subcommitteeIndex = contribution.getSubcommitteeIndex().intValue();
-    contributionsBySlotAndBlockRoot
-        .computeIfAbsent(contribution.getSlot(), __ -> new HashMap<>())
-        .computeIfAbsent(contribution.getBeaconBlockRoot(), __ -> new Int2ObjectOpenHashMap<>())
-        .compute(
-            subcommitteeIndex,
-            (subcommittee, existingContribution) ->
-                betterContribution(existingContribution, contribution));
+  private void doAdd(final SyncCommitteeContribution contribution) {
+    lock.lock();
+    try {
+      final int subcommitteeIndex = contribution.getSubcommitteeIndex().intValue();
+      contributionsBySlotAndBlockRoot
+          .computeIfAbsent(contribution.getSlot(), __ -> new HashMap<>())
+          .computeIfAbsent(contribution.getBeaconBlockRoot(), __ -> new Int2ObjectOpenHashMap<>())
+          .compute(
+              subcommitteeIndex,
+              (subcommittee, existingContribution) ->
+                  betterContribution(existingContribution, contribution));
+    } finally {
+      lock.unlock();
+    }
   }
 
   private SyncCommitteeContribution betterContribution(
@@ -115,15 +123,20 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
    * @param parentRoot the parentRoot of the block being created.
    * @return the SyncAggregate to be included in the block.
    */
-  public synchronized SyncAggregate createSyncAggregateForBlock(
+  public SyncAggregate createSyncAggregateForBlock(
       final UInt64 blockSlot, final Bytes32 parentRoot) {
-    final UInt64 slot = blockSlot.minusMinZero(1);
-    final Collection<SyncCommitteeContribution> contributions =
-        contributionsBySlotAndBlockRoot
-            .getOrDefault(slot, emptyMap())
-            .getOrDefault(parentRoot, emptyMap())
-            .values();
-    return spec.getSyncCommitteeUtilRequired(blockSlot).createSyncAggregate(contributions);
+    lock.lock();
+    try {
+      final UInt64 slot = blockSlot.minusMinZero(1);
+      final Collection<SyncCommitteeContribution> contributions =
+          contributionsBySlotAndBlockRoot
+              .getOrDefault(slot, emptyMap())
+              .getOrDefault(parentRoot, emptyMap())
+              .values();
+      return spec.getSyncCommitteeUtilRequired(blockSlot).createSyncAggregate(contributions);
+    } finally {
+      lock.unlock();
+    }
   }
 
   /**
@@ -135,7 +148,12 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
    * @param slot the node's current slot
    */
   @Override
-  public synchronized void onSlot(final UInt64 slot) {
-    contributionsBySlotAndBlockRoot.headMap(slot.minusMinZero(2), false).clear();
+  public void onSlot(final UInt64 slot) {
+    lock.lock();
+    try {
+      contributionsBySlotAndBlockRoot.headMap(slot.minusMinZero(2), false).clear();
+    } finally {
+      lock.unlock();
+    }
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -31,9 +31,9 @@ dependencyManagement {
 
     dependency 'info.picocli:picocli:4.7.7'
 
-    dependencySet(group: 'io.javalin', version: '6.7.0') {
+    dependencySet(group: 'io.javalin', version: '7.0.0') {
       entry 'javalin'
-      entry 'javalin-rendering'
+      entry 'javalin-rendering-thymeleaf'
     }
 
     dependency 'io.libp2p:jvm-libp2p:1.2.2-RELEASE'

--- a/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannel.java
+++ b/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannel.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.infrastructure.events;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.stream.Collectors.joining;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
@@ -65,11 +64,8 @@ class EventChannel<T> {
       final MetricsSystem metricsSystem) {
     return createAsync(
         channelInterface,
-        Executors.newCachedThreadPool(
-            new ThreadFactoryBuilder()
-                .setDaemon(true)
-                .setNameFormat(channelInterface.getSimpleName() + "-%d")
-                .build()),
+        Executors.newThreadPerTaskExecutor(
+            Thread.ofVirtual().name(channelInterface.getSimpleName() + "-", 0).factory()),
         exceptionHandler,
         metricsSystem);
   }

--- a/infrastructure/restapi/build.gradle
+++ b/infrastructure/restapi/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.google.guava:guava'
   implementation 'io.javalin:javalin'
-  implementation 'io.javalin:javalin-rendering'
+  implementation 'io.javalin:javalin-rendering-thymeleaf'
   implementation 'it.unimi.dsi:fastutil'
   implementation 'org.webjars:swagger-ui'
   implementation 'org.thymeleaf:thymeleaf'

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.infrastructure.restapi;
 
-import io.javalin.Javalin;
 import io.javalin.config.JavalinConfig;
 import io.javalin.http.Handler;
 import io.javalin.http.staticfiles.Location;
@@ -35,7 +34,7 @@ public class SwaggerUIBuilder {
   private static final String SWAGGER_UI_PATH = "/swagger-ui";
   private static final String SWAGGER_HOSTED_PATH = "/webjars/swagger-ui/" + SWAGGER_UI_VERSION;
   // Be careful when modifying this, it's used in static js files for serving Swagger UI
-  private static final String SWAGGER_DOCS_PATH = "/swagger-docs";
+  static final String SWAGGER_DOCS_PATH = "/swagger-docs";
   public static final String SWAGGER_INITIALIZER_JS = "/swagger-initializer.js";
   private static final Set<String> MODIFIED_FILES =
       Set.of(SWAGGER_HOSTED_PATH + SWAGGER_INITIALIZER_JS);
@@ -81,14 +80,11 @@ public class SwaggerUIBuilder {
     config.spaRoot.addHandler(SWAGGER_UI_PATH, INDEX);
   }
 
-  public Optional<String> configureDocs(
-      final Javalin app, final OpenApiDocBuilder openApiDocBuilder) {
+  public Optional<String> buildDocs(final OpenApiDocBuilder openApiDocBuilder) {
     if (!enabled) {
       return Optional.empty();
     }
-    final String apiDocs = openApiDocBuilder.build();
-    app.get(SWAGGER_DOCS_PATH, ctx -> ctx.json(apiDocs));
-    return Optional.of(apiDocs);
+    return Optional.of(openApiDocBuilder.build());
   }
 
   private JavalinThymeleaf createThymeleafRenderer(final String templatePath) {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinEndpointAdapter.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinEndpointAdapter.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
-import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 
@@ -21,14 +20,8 @@ public class JavalinEndpointAdapter implements Handler {
 
   private final RestApiEndpoint endpoint;
 
-  private JavalinEndpointAdapter(final RestApiEndpoint endpoint) {
+  public JavalinEndpointAdapter(final RestApiEndpoint endpoint) {
     this.endpoint = endpoint;
-  }
-
-  public static void addEndpoint(final Javalin app, final RestApiEndpoint endpoint) {
-    final EndpointMetadata metadata = endpoint.getMetadata();
-    app.addHttpHandler(
-        metadata.getMethod(), metadata.getPath(), new JavalinEndpointAdapter(endpoint));
   }
 
   @Override

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException
 class RestApiTest {
   private final Javalin app = mock(Javalin.class);
 
-  private final RestApi restApi = new RestApi(app, Optional.empty(), Optional.empty());
+  private final RestApi restApi = new RestApi(app, Optional.empty());
 
   @Test
   void start_shouldThrowInvalidConfigurationExceptionWhenPortInUse() {
@@ -55,16 +55,13 @@ class RestApiTest {
 
   @Test
   @DisabledOnOs(OS.WINDOWS)
-  void start_shouldFailFastWhenTokenNotWritable(@TempDir final Path tempDir) throws IOException {
-
+  void build_shouldFailFastWhenTokenNotWritable(@TempDir final Path tempDir) throws IOException {
     final Path managerDir = tempDir.resolve("manager");
     Files.createDirectory(
         managerDir,
         PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("--x--x---")));
 
-    final RestApi restApi =
-        new RestApi(app, Optional.empty(), Optional.of(managerDir.resolve("pass")));
-    assertThatThrownBy(restApi::start).isInstanceOf(IllegalStateException.class);
-    assertThat(restApi.getRestApiDocs()).isEmpty();
+    assertThatThrownBy(() -> RestApiBuilder.ensurePasswordFile(managerDir.resolve("pass")))
+        .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AttestationTopicSubscriber.java
@@ -22,6 +22,8 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
@@ -35,6 +37,7 @@ public class AttestationTopicSubscriber implements SlotEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
   static final String GAUGE_AGGREGATION_SUBNETS_LABEL = "aggregation_subnet_%02d";
   static final String GAUGE_PERSISTENT_SUBNETS_LABEL = "persistent_subnet_%02d";
+  private final Lock lock = new ReentrantLock();
   private final Int2ObjectMap<UInt64> subnetIdToUnsubscribeSlot = new Int2ObjectOpenHashMap<>();
   private final IntSet persistentSubnetIdSet = new IntOpenHashSet();
   private final Eth2P2PNetwork eth2P2PNetwork;
@@ -51,41 +54,47 @@ public class AttestationTopicSubscriber implements SlotEventsChannel {
     this.subnetSubscriptionsGauge = subnetSubscriptionsGauge;
   }
 
-  public synchronized void subscribeToCommitteeForAggregation(
+  public void subscribeToCommitteeForAggregation(
       final int committeeIndex, final UInt64 committeesAtSlot, final UInt64 aggregationSlot) {
-    final int subnetId =
-        spec.computeSubnetForCommittee(
-            aggregationSlot, UInt64.valueOf(committeeIndex), committeesAtSlot);
-    final UInt64 currentUnsubscriptionSlot = subnetIdToUnsubscribeSlot.getOrDefault(subnetId, ZERO);
-    final UInt64 unsubscribeSlot = currentUnsubscriptionSlot.max(aggregationSlot);
-    final UInt64 maybeCurrentSlot = currentSlot.get();
-    if (maybeCurrentSlot != null && unsubscribeSlot.isLessThan(maybeCurrentSlot)) {
-      LOG.trace(
-          "Skipping outdated aggregation subnet {} with unsubscribe due at slot {}",
-          subnetId,
-          unsubscribeSlot);
-      return;
-    }
-
-    if (currentUnsubscriptionSlot.equals(ZERO)) {
-      eth2P2PNetwork.subscribeToAttestationSubnetId(subnetId);
-      toggleAggregateSubscriptionMetric(subnetId, false);
-      LOG.trace(
-          "Subscribing to aggregation subnet {} with unsubscribe due at slot {}",
-          subnetId,
-          unsubscribeSlot);
-    } else {
-      if (aggregationSlot.isGreaterThan(currentUnsubscriptionSlot)
-          && persistentSubnetIdSet.contains(subnetId)) {
-        toggleAggregateSubscriptionMetric(subnetId, true);
-        persistentSubnetIdSet.remove(subnetId);
+    lock.lock();
+    try {
+      final int subnetId =
+          spec.computeSubnetForCommittee(
+              aggregationSlot, UInt64.valueOf(committeeIndex), committeesAtSlot);
+      final UInt64 currentUnsubscriptionSlot =
+          subnetIdToUnsubscribeSlot.getOrDefault(subnetId, ZERO);
+      final UInt64 unsubscribeSlot = currentUnsubscriptionSlot.max(aggregationSlot);
+      final UInt64 maybeCurrentSlot = currentSlot.get();
+      if (maybeCurrentSlot != null && unsubscribeSlot.isLessThan(maybeCurrentSlot)) {
+        LOG.trace(
+            "Skipping outdated aggregation subnet {} with unsubscribe due at slot {}",
+            subnetId,
+            unsubscribeSlot);
+        return;
       }
-      LOG.trace(
-          "Already subscribed to aggregation subnet {}, updating unsubscription slot to {}",
-          subnetId,
-          unsubscribeSlot);
+
+      if (currentUnsubscriptionSlot.equals(ZERO)) {
+        eth2P2PNetwork.subscribeToAttestationSubnetId(subnetId);
+        toggleAggregateSubscriptionMetric(subnetId, false);
+        LOG.trace(
+            "Subscribing to aggregation subnet {} with unsubscribe due at slot {}",
+            subnetId,
+            unsubscribeSlot);
+      } else {
+        if (aggregationSlot.isGreaterThan(currentUnsubscriptionSlot)
+            && persistentSubnetIdSet.contains(subnetId)) {
+          toggleAggregateSubscriptionMetric(subnetId, true);
+          persistentSubnetIdSet.remove(subnetId);
+        }
+        LOG.trace(
+            "Already subscribed to aggregation subnet {}, updating unsubscription slot to {}",
+            subnetId,
+            unsubscribeSlot);
+      }
+      subnetIdToUnsubscribeSlot.put(subnetId, unsubscribeSlot);
+    } finally {
+      lock.unlock();
     }
-    subnetIdToUnsubscribeSlot.put(subnetId, unsubscribeSlot);
   }
 
   private void togglePersistentSubscriptionMetric(final int subnetId, final boolean reset) {
@@ -102,77 +111,88 @@ public class AttestationTopicSubscriber implements SlotEventsChannel {
     }
   }
 
-  public synchronized void subscribeToPersistentSubnets(
-      final Set<SubnetSubscription> newSubscriptions) {
-    boolean shouldUpdateENR = false;
+  public void subscribeToPersistentSubnets(final Set<SubnetSubscription> newSubscriptions) {
+    lock.lock();
+    try {
+      boolean shouldUpdateENR = false;
 
-    for (SubnetSubscription subnetSubscription : newSubscriptions) {
-      final int subnetId = subnetSubscription.subnetId();
-      final UInt64 maybeCurrentSlot = currentSlot.get();
-      if (maybeCurrentSlot != null
-          && subnetSubscription.unsubscriptionSlot().isLessThan(maybeCurrentSlot)) {
+      for (SubnetSubscription subnetSubscription : newSubscriptions) {
+        final int subnetId = subnetSubscription.subnetId();
+        final UInt64 maybeCurrentSlot = currentSlot.get();
+        if (maybeCurrentSlot != null
+            && subnetSubscription.unsubscriptionSlot().isLessThan(maybeCurrentSlot)) {
+          LOG.trace(
+              "Skipping outdated persistent subnet {} with unsubscribe due at slot {}",
+              subnetId,
+              subnetSubscription.unsubscriptionSlot());
+          continue;
+        }
+
+        shouldUpdateENR = persistentSubnetIdSet.add(subnetId) || shouldUpdateENR;
         LOG.trace(
-            "Skipping outdated persistent subnet {} with unsubscribe due at slot {}",
+            "Subscribing to persistent subnet {} with unsubscribe due at slot {}",
             subnetId,
             subnetSubscription.unsubscriptionSlot());
-        continue;
+        if (subnetIdToUnsubscribeSlot.containsKey(subnetId)) {
+          final UInt64 existingUnsubscriptionSlot = subnetIdToUnsubscribeSlot.get(subnetId);
+          final UInt64 unsubscriptionSlot =
+              existingUnsubscriptionSlot.max(subnetSubscription.unsubscriptionSlot());
+          LOG.trace(
+              "Already subscribed to subnet {}, updating unsubscription slot to {}",
+              subnetId,
+              unsubscriptionSlot);
+          togglePersistentSubscriptionMetric(subnetId, true);
+          subnetIdToUnsubscribeSlot.put(subnetId, unsubscriptionSlot);
+        } else {
+          eth2P2PNetwork.subscribeToAttestationSubnetId(subnetId);
+          togglePersistentSubscriptionMetric(subnetId, false);
+          LOG.trace("Subscribed to new persistent subnet {}", subnetId);
+          subnetIdToUnsubscribeSlot.put(subnetId, subnetSubscription.unsubscriptionSlot());
+        }
       }
 
-      shouldUpdateENR = persistentSubnetIdSet.add(subnetId) || shouldUpdateENR;
-      LOG.trace(
-          "Subscribing to persistent subnet {} with unsubscribe due at slot {}",
-          subnetId,
-          subnetSubscription.unsubscriptionSlot());
-      if (subnetIdToUnsubscribeSlot.containsKey(subnetId)) {
-        final UInt64 existingUnsubscriptionSlot = subnetIdToUnsubscribeSlot.get(subnetId);
-        final UInt64 unsubscriptionSlot =
-            existingUnsubscriptionSlot.max(subnetSubscription.unsubscriptionSlot());
-        LOG.trace(
-            "Already subscribed to subnet {}, updating unsubscription slot to {}",
-            subnetId,
-            unsubscriptionSlot);
-        togglePersistentSubscriptionMetric(subnetId, true);
-        subnetIdToUnsubscribeSlot.put(subnetId, unsubscriptionSlot);
-      } else {
-        eth2P2PNetwork.subscribeToAttestationSubnetId(subnetId);
-        togglePersistentSubscriptionMetric(subnetId, false);
-        LOG.trace("Subscribed to new persistent subnet {}", subnetId);
-        subnetIdToUnsubscribeSlot.put(subnetId, subnetSubscription.unsubscriptionSlot());
+      if (shouldUpdateENR) {
+        eth2P2PNetwork.setLongTermAttestationSubnetSubscriptions(persistentSubnetIdSet);
       }
-    }
-
-    if (shouldUpdateENR) {
-      eth2P2PNetwork.setLongTermAttestationSubnetSubscriptions(persistentSubnetIdSet);
+    } finally {
+      lock.unlock();
     }
   }
 
   @Override
-  public synchronized void onSlot(final UInt64 slot) {
-    currentSlot.set(slot);
-    boolean shouldUpdateENR = false;
+  public void onSlot(final UInt64 slot) {
+    lock.lock();
+    try {
+      currentSlot.set(slot);
+      boolean shouldUpdateENR = false;
 
-    final Iterator<Int2ObjectMap.Entry<UInt64>> iterator =
-        subnetIdToUnsubscribeSlot.int2ObjectEntrySet().iterator();
-    while (iterator.hasNext()) {
-      final Int2ObjectMap.Entry<UInt64> entry = iterator.next();
-      if (entry.getValue().compareTo(slot) < 0) {
-        final int subnetId = entry.getIntKey();
-        LOG.trace("Unsubscribing from subnet {}", subnetId);
-        eth2P2PNetwork.unsubscribeFromAttestationSubnetId(subnetId);
-        if (persistentSubnetIdSet.contains(subnetId)) {
-          persistentSubnetIdSet.remove(subnetId);
-          subnetSubscriptionsGauge.set(0, String.format(GAUGE_PERSISTENT_SUBNETS_LABEL, subnetId));
-          shouldUpdateENR = true;
-        } else {
-          subnetSubscriptionsGauge.set(0, String.format(GAUGE_AGGREGATION_SUBNETS_LABEL, subnetId));
+      final Iterator<Int2ObjectMap.Entry<UInt64>> iterator =
+          subnetIdToUnsubscribeSlot.int2ObjectEntrySet().iterator();
+      while (iterator.hasNext()) {
+        final Int2ObjectMap.Entry<UInt64> entry = iterator.next();
+        if (entry.getValue().compareTo(slot) < 0) {
+          final int subnetId = entry.getIntKey();
+          LOG.trace("Unsubscribing from subnet {}", subnetId);
+          eth2P2PNetwork.unsubscribeFromAttestationSubnetId(subnetId);
+          if (persistentSubnetIdSet.contains(subnetId)) {
+            persistentSubnetIdSet.remove(subnetId);
+            subnetSubscriptionsGauge.set(
+                0, String.format(GAUGE_PERSISTENT_SUBNETS_LABEL, subnetId));
+            shouldUpdateENR = true;
+          } else {
+            subnetSubscriptionsGauge.set(
+                0, String.format(GAUGE_AGGREGATION_SUBNETS_LABEL, subnetId));
+          }
+
+          iterator.remove();
         }
-
-        iterator.remove();
       }
-    }
 
-    if (shouldUpdateENR) {
-      eth2P2PNetwork.setLongTermAttestationSubnetSubscriptions(persistentSubnetIdSet);
+      if (shouldUpdateENR) {
+        eth2P2PNetwork.setLongTermAttestationSubnetSubscriptions(persistentSubnetIdSet);
+      }
+    } finally {
+      lock.unlock();
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.validator.client.duties.synccommittee;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.response.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -26,29 +28,40 @@ import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 public class ChainHeadTracker implements ValidatorTimingChannel {
   public static final int HEAD_TOO_OLD_THRESHOLD = 32;
 
+  private final Lock lock = new ReentrantLock();
   private UInt64 headBlockSlot = UInt64.ZERO;
   private Optional<Bytes32> headBlockRoot = Optional.empty();
 
-  public synchronized Optional<Bytes32> getCurrentChainHead(final UInt64 atSlot) {
-    if (headBlockSlot.isGreaterThan(atSlot)) {
-      // We've moved on and no longer have a reference to what the head block was at that slot
-      throw new ChainHeadBeyondSlotException(atSlot);
+  public Optional<Bytes32> getCurrentChainHead(final UInt64 atSlot) {
+    lock.lock();
+    try {
+      if (headBlockSlot.isGreaterThan(atSlot)) {
+        // We've moved on and no longer have a reference to what the head block was at that slot
+        throw new ChainHeadBeyondSlotException(atSlot);
+      }
+      if (headBlockRoot.isPresent()
+          && atSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD)) {
+        throw new ChainHeadTooOldException(headBlockSlot, atSlot);
+      }
+      return headBlockRoot;
+    } finally {
+      lock.unlock();
     }
-    if (headBlockRoot.isPresent()
-        && atSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD)) {
-      throw new ChainHeadTooOldException(headBlockSlot, atSlot);
-    }
-    return headBlockRoot;
   }
 
   @Override
-  public synchronized void onHeadUpdate(
+  public void onHeadUpdate(
       final UInt64 slot,
       final Bytes32 previousDutyDependentRoot,
       final Bytes32 currentDutyDependentRoot,
       final Bytes32 headBlockRoot) {
-    this.headBlockSlot = slot;
-    this.headBlockRoot = Optional.of(headBlockRoot);
+    lock.lock();
+    try {
+      this.headBlockSlot = slot;
+      this.headBlockRoot = Optional.of(headBlockRoot);
+    } finally {
+      lock.unlock();
+    }
   }
 
   @Override


### PR DESCRIPTION
this is on top of the Event Channel virtual threads (#10426)

the Javalin 6->7 migration and Virtual Threads activation is on 78e724202cc4482d9aaa291aebfc526911d91074

fixes #10428


## Context

Virtual threads were introduced in the event channel infrastructure (`EventChannel.createAsync()`). We want to extend this to the REST API layer to make request handling cheaper, especially for SSE long-lived connections and synchronous endpoints.

**Problem:** Unbounded virtual threads could exhaust memory under load spikes via concurrent large response serialization (e.g., `GetState` returning full `BeaconState`). We need bounded concurrency.

**Solution:** Upgrade Javalin 6.7 → 7.x (which brings Jetty 11 → 12). Jetty 12 provides a native `VirtualThreadPool` with `setMaxConcurrentTasks()` — semaphore-bounded virtual threads, no custom code needed.

### Files modified

| File | Change |
|------|--------|
| `gradle/versions.gradle` | `io.javalin` 6.7.0 → 7.0.0, `javalin-rendering` → `javalin-rendering-thymeleaf` |
| `infrastructure/restapi/build.gradle` | `javalin-rendering` → `javalin-rendering-thymeleaf` |
| `infrastructure/restapi/.../RestApiBuilder.java` | Moved all route/handler/exception registration into `Javalin.create(config)` block; `config.startup.*` for banner/watcher; `config.http.compressionStrategy` assignment; removed Conscrypt; added `VirtualThreadPool` in `modifyJettyServer`; moved password file creation from `RestApi` to `ensurePasswordFile()` |
| `infrastructure/restapi/.../JavalinEndpointAdapter.java` | Made constructor public; removed static `addEndpoint(Javalin, ...)` (endpoint registration now in RestApiBuilder config block) |
| `infrastructure/restapi/.../SwaggerUIBuilder.java` | Replaced `configureDocs(Javalin, OpenApiDocBuilder)` with `buildDocs(OpenApiDocBuilder)` returning docs string only; `SWAGGER_DOCS_PATH` now package-private; removed Javalin import |
| `infrastructure/restapi/.../RestApi.java` | Simplified: removed `passwordPath` field/constructor param, removed `checkAccessFile`, simplified error handling for `jettyServer()` → `app.port()` |
| `data/beaconrestapi/.../StubContext.java` | Updated for Javalin 7 `Context` interface: removed `endpointHandlerPath()`, `handlerType()`, `matchedPath()`; added `endpoints()`, `endpoint()`, `multipartConfig()` |
| `infrastructure/restapi/.../RestApiTest.java` | Updated `RestApi` constructor (2-arg), moved password-file-writability test to call `RestApiBuilder.ensurePasswordFile()` directly |

### Key design decisions
- **Compression**: Left `CompressionStrategy.GZIP` default (1500 byte threshold). The per-request `minSizeForCompression(0)` in `JavalinRestApiRequest` still forces compression on all endpoint responses. The original mixed-content bug is fixed in Javalin 7 via `isCompressionDecisionMade` flag.
- **Virtual threads**: `QueuedThreadPool` stays for accept/selector (platform threads), `VirtualThreadPool.setMaxConcurrentTasks(250)` delegates task execution to bounded virtual threads.
- **Password file**: Creation moved from `RestApi.doStart()` to `RestApiBuilder.build()` so `AuthorizationHandler` can be registered in the Javalin 7 config block.


#### Why this caps large response serialization

With the current `QueuedThreadPool(250)`, at most 250 concurrent `GetState` requests can serialize simultaneously. `VirtualThreadPool.setMaxConcurrentTasks(250)` preserves this exact bound. Tasks beyond the limit are queued (virtual thread parked cheaply on the semaphore) rather than hard-rejected.

#### What improves
- **SSE `/eth/v1/events`** — each connected client holds a virtual thread instead of a platform thread; hundreds of SSE clients become cheap
- **Synchronous endpoints** (~49) — parameter parsing, JSON serialization, data lookups no longer consume platform threads
- **Burst handling** — excess requests park cheaply on the semaphore rather than being rejected by `QueuedThreadPool`
- **Jetty monitoring** — `QueuedThreadPool` metrics still work; `VirtualThreadPool` adds `getMaxConcurrentTasks()` / `getThreads()`

#### Risks
- **`synchronized` audit** — virtual threads pin carrier threads in synchronized blocks. Jetty 12 was designed for virtual threads, but Teku handler code paths should be verified

## Conscrypt removal


The validator REST API TLS was never actually using Conscrypt (#4869)— the dependency was never on the classpath. Jetty 11's SslContextFactory silently caught the
  NoSuchProviderException and fell back to the JDK's default SSL provider. It just produced a debug/info log message about it.

  Removing setProvider("Conscrypt") is correct — it eliminates a dead code path and a misleading log line. The validator API TLS works the same as before, using the JDK's built-in SSL
  provider.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
