### PR TITLE
[Gloas] Cache early received payload for future processing

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/BlockRootAndBuilderIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/BlockRootAndBuilderIndex.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.epbs;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public record BlockRootAndBuilderIndex(Bytes32 blockRoot, UInt64 builderIndex) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelope.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 
@@ -81,6 +82,10 @@ public class ExecutionPayloadEnvelope
 
   public SlotAndBlockRoot getSlotAndBlockRoot() {
     return new SlotAndBlockRoot(getSlot(), getBeaconBlockRoot());
+  }
+
+  public BlockRootAndBuilderIndex getBlockRootAndBuilderIndex() {
+    return new BlockRootAndBuilderIndex(getBeaconBlockRoot(), getBuilderIndex());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/SignedExecutionPayloadEnvelope.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class SignedExecutionPayloadEnvelope
@@ -60,6 +61,10 @@ public class SignedExecutionPayloadEnvelope
 
   public SlotAndBlockRoot getSlotAndBlockRoot() {
     return getMessage().getSlotAndBlockRoot();
+  }
+
+  public BlockRootAndBuilderIndex getBlockRootAndBuilderIndex() {
+    return getMessage().getBlockRootAndBuilderIndex();
   }
 
   public String toLogString() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -126,6 +126,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.Sy
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDeneb;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
 import tech.pegasys.teku.spec.datastructures.builder.BlobsBundleSchema;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
@@ -3297,7 +3298,10 @@ public final class DataStructureUtil {
         .create(
             randomExecutionPayload(),
             randomExecutionRequests(),
-            randomBuilderIndex(),
+            BeaconBlockBodyGloas.required(block.getMessage().getBody())
+                .getSignedExecutionPayloadBid()
+                .getMessage()
+                .getBuilderIndex(),
             block.getRoot(),
             block.getSlot(),
             randomBytes32());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -156,7 +156,6 @@ public class DefaultExecutionPayloadManager
         .map(
             bid ->
                 new BlockRootAndBuilderIndex(block.getRoot(), bid.getMessage().getBuilderIndex()))
-        .filter(executionPayloadsSavedForFutureProcessing::containsKey)
         .map(executionPayloadsSavedForFutureProcessing::remove)
         .ifPresent(
             executionPayloadToProcess -> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static tech.pegasys.teku.spec.config.Constants.RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -22,21 +23,33 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
+import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
+import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.validation.ExecutionPayloadGossipValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
-public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
+public class DefaultExecutionPayloadManager
+    implements ExecutionPayloadManager, ReceivedBlockEventsChannel {
 
   private static final Logger LOG = LogManager.getLogger();
 
   private final Set<Bytes32> recentSeenExecutionPayloads =
       LimitedSet.createSynchronized(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+
+  // keeping a cache of execution payloads that have been received earlier than the block
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 fine-tune the maxSize (not required
+  // for devnet-0)
+  private final Map<BlockRootAndBuilderIndex, SignedExecutionPayloadEnvelope>
+      executionPayloadsSavedForFutureProcessing = LimitedMap.createSynchronizedLRU(32);
 
   private final AsyncRunner asyncRunner;
   private final ExecutionPayloadGossipValidator executionPayloadGossipValidator;
@@ -78,11 +91,20 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
               // cache the seen `beacon_block_root`
               recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
               importExecutionPayload(signedExecutionPayload)
-                  .finish(err -> LOG.error("Failed to process received execution payload.", err));
+                  .finish(
+                      err ->
+                          LOG.error(
+                              "Failed to process received execution payload for slot {} and block root {}",
+                              signedExecutionPayload.getSlot(),
+                              signedExecutionPayload.getBeaconBlockRoot(),
+                              err));
             }
-            // TODO-GLOAS: what do we do in these cases??
-            // https://github.com/Consensys/teku/issues/9878
-            case REJECT, SAVE_FOR_FUTURE, IGNORE -> {}
+            case SAVE_FOR_FUTURE ->
+                executionPayloadsSavedForFutureProcessing.put(
+                    signedExecutionPayload.getBlockRootAndBuilderIndex(), signedExecutionPayload);
+            // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 what should we do in these
+            // cases?? (not required for devnet-0)
+            case REJECT, IGNORE -> {}
           }
         });
     return validationResult;
@@ -117,6 +139,32 @@ public class DefaultExecutionPayloadManager implements ExecutionPayloadManager {
                       signedExecutionPayload.sszSerialize().toHexString());
               LOG.error(internalErrorMessage, ex);
               return ExecutionPayloadImportResult.internalError(ex);
+            });
+  }
+
+  @Override
+  public void onBlockValidated(final SignedBeaconBlock block) {}
+
+  @Override
+  public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
+    // Processing execution payloads which have been received before the block has been imported
+    block
+        .getMessage()
+        .getBody()
+        .toVersionGloas()
+        .map(BeaconBlockBodyGloas::getSignedExecutionPayloadBid)
+        .map(
+            bid ->
+                new BlockRootAndBuilderIndex(block.getRoot(), bid.getMessage().getBuilderIndex()))
+        .filter(executionPayloadsSavedForFutureProcessing::containsKey)
+        .map(executionPayloadsSavedForFutureProcessing::remove)
+        .ifPresent(
+            executionPayloadToProcess -> {
+              LOG.debug(
+                  "Processing execution payload for slot {} and block root {} which has been received before the block",
+                  executionPayloadToProcess.getSlot(),
+                  executionPayloadToProcess.getBeaconBlockRoot());
+              validateAndImportExecutionPayload(executionPayloadToProcess).finishError(LOG);
             });
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
@@ -152,9 +153,7 @@ public class ExecutionPayloadGossipValidator {
     /*
      * [IGNORE] The node has not seen another valid SignedExecutionPayloadEnvelope for this block root from this builder.
      */
-    final BlockRootAndBuilderIndex key =
-        new BlockRootAndBuilderIndex(envelope.getBeaconBlockRoot(), envelope.getBuilderIndex());
-    if (seenPayloads.contains(key)) {
+    if (seenPayloads.contains(envelope.getBlockRootAndBuilderIndex())) {
       return Optional.of(ignoreExecutionPayloadAlreadySeen(envelope));
     }
 
@@ -252,9 +251,7 @@ public class ExecutionPayloadGossipValidator {
   private InternalValidationResult markAsSeen(
       final InternalValidationResult result, final ExecutionPayloadEnvelope envelope) {
     if (result.isAccept()) {
-      final BlockRootAndBuilderIndex key =
-          new BlockRootAndBuilderIndex(envelope.getBeaconBlockRoot(), envelope.getBuilderIndex());
-      if (!seenPayloads.add(key)) {
+      if (!seenPayloads.add(envelope.getBlockRootAndBuilderIndex())) {
         return ignoreExecutionPayloadAlreadySeen(envelope);
       }
     }
@@ -271,6 +268,4 @@ public class ExecutionPayloadGossipValidator {
         "Already received execution payload envelope with block root %s from builder with index %s",
         envelope.getBeaconBlockRoot(), envelope.getBuilderIndex());
   }
-
-  private record BlockRootAndBuilderIndex(Bytes32 blockRoot, UInt64 builderIndex) {}
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -22,9 +22,11 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
@@ -135,5 +137,32 @@ class DefaultExecutionPayloadManagerTest {
             executionPayloadManager.isExecutionPayloadRecentlySeen(
                 signedExecutionPayload.getBeaconBlockRoot()))
         .isTrue();
+  }
+
+  @Test
+  public void shouldProcessExecutionPayloadWhichHaveBeenReceivedBeforeTheBlock() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
+    final SignedExecutionPayloadEnvelope signedExecutionPayload =
+        dataStructureUtil.randomSignedExecutionPayloadEnvelopeForBlock(block);
+    when(executionPayloadGossipValidator.validate(signedExecutionPayload))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
+    when(forkChoice.onExecutionPayload(signedExecutionPayload, executionLayer))
+        .thenReturn(SafeFuture.completedFuture(successfulImportResult));
+
+    // should just cache the payload for future processing
+    SafeFutureAssert.safeJoin(
+        executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload));
+
+    asyncRunner.executeDueActions();
+    verifyNoInteractions(forkChoice, receivedExecutionPayloadEventsChannelPublisher);
+
+    when(executionPayloadGossipValidator.validate(signedExecutionPayload))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+    executionPayloadManager.onBlockImported(block, false);
+
+    asyncRunner.executeDueActions();
+    // verify the payload has been processed
+    verify(receivedExecutionPayloadEventsChannelPublisher)
+        .onExecutionPayloadImported(signedExecutionPayload);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
@@ -45,11 +45,12 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.signatures.LocalSigner;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.BeaconChainUtil;
+import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -62,7 +63,7 @@ public class VoluntaryExitValidatorTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private RecentChainData recentChainData;
-  private BeaconChainUtil beaconChainUtil;
+  private ChainUpdater chainUpdater;
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(1_000_000_000);
 
   private VoluntaryExitValidator voluntaryExitValidator;
@@ -70,15 +71,15 @@ public class VoluntaryExitValidatorTest {
   @BeforeEach
   void beforeEach() {
     recentChainData = MemoryOnlyRecentChainData.create(spec);
-    beaconChainUtil = BeaconChainUtil.create(spec, recentChainData, VALIDATOR_KEYS, true);
-
+    final ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
+    chainUpdater = new ChainUpdater(recentChainData, chainBuilder, spec);
+    chainUpdater.initializeGenesis();
     voluntaryExitValidator = new VoluntaryExitValidator(mockSpec, recentChainData, timeProvider);
   }
 
   @Test
-  public void shouldAcceptValidVoluntaryExit() throws Exception {
-    beaconChainUtil.initializeStorage();
-    beaconChainUtil.createAndImportBlockAtSlot(6);
+  public void shouldAcceptValidVoluntaryExit() {
+    advanceChainAndUpdateBestBlock(6);
     SignedVoluntaryExit exit = dataStructureUtil.randomSignedVoluntaryExit();
     when(mockSpec.validateVoluntaryExit(getBestState(), exit)).thenReturn(Optional.empty());
     when(mockSpec.verifyVoluntaryExitSignature(getBestState(), exit, BLSSignatureVerifier.SIMPLE))
@@ -87,9 +88,8 @@ public class VoluntaryExitValidatorTest {
   }
 
   @Test
-  public void shouldAcceptVoluntaryExitThatWasSeenTooLongAgo() throws Exception {
-    beaconChainUtil.initializeStorage();
-    beaconChainUtil.createAndImportBlockAtSlot(6);
+  public void shouldAcceptVoluntaryExitThatWasSeenTooLongAgo() {
+    advanceChainAndUpdateBestBlock(6);
     SignedVoluntaryExit exit = dataStructureUtil.randomSignedVoluntaryExit();
     when(mockSpec.validateVoluntaryExit(getBestState(), exit)).thenReturn(Optional.empty());
     when(mockSpec.verifyVoluntaryExitSignature(getBestState(), exit, BLSSignatureVerifier.SIMPLE))
@@ -100,27 +100,23 @@ public class VoluntaryExitValidatorTest {
     assertValidationResult(exit, ACCEPT);
   }
 
-  // TODO-GLOAS: https://github.com/Consensys/teku/pull/10398
   @ParameterizedTest
-  @EnumSource(
-      value = SpecMilestone.class,
-      names = {"GLOAS", "HEZE"},
-      mode = EnumSource.Mode.EXCLUDE)
-  public void shouldAcceptOwnSignedVoluntaryExitNoMocks(final SpecMilestone specMilestone)
-      throws Exception {
+  @EnumSource(value = SpecMilestone.class)
+  public void shouldAcceptOwnSignedVoluntaryExitNoMocks(final SpecMilestone specMilestone) {
     final Spec spec = TestSpecFactory.create(specMilestone, Eth2Network.MINIMAL);
     recentChainData = MemoryOnlyRecentChainData.create(spec);
-    beaconChainUtil = BeaconChainUtil.create(spec, recentChainData, VALIDATOR_KEYS, true);
-    beaconChainUtil.initializeStorage();
+    final ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
+    chainUpdater = new ChainUpdater(recentChainData, chainBuilder, spec);
+    chainUpdater.initializeGenesis();
     // cannot exit before epoch 64
-    beaconChainUtil.createAndImportBlockAtSlot(spec.slotsPerEpoch(UInt64.ZERO) * 64L);
+    advanceChainAndUpdateBestBlock(spec.slotsPerEpoch(UInt64.ZERO) * 64L);
     this.voluntaryExitValidator = new VoluntaryExitValidator(spec, recentChainData, timeProvider);
 
     final UInt64 currentEpoch = spec.getCurrentEpoch(getBestState());
     assertThat(spec.atEpoch(currentEpoch).getMilestone()).isEqualTo(specMilestone);
 
     final VoluntaryExit voluntaryExit = new VoluntaryExit(currentEpoch, UInt64.ZERO);
-    BLSSignature exitSignature =
+    final BLSSignature exitSignature =
         new LocalSigner(spec, VALIDATOR_KEYS.get(0), SyncAsyncRunner.SYNC_RUNNER)
             .signVoluntaryExit(
                 voluntaryExit,
@@ -134,9 +130,8 @@ public class VoluntaryExitValidatorTest {
   }
 
   @Test
-  public void shouldIgnoreExitsAfterTheFirstForValidator() throws Exception {
-    beaconChainUtil.initializeStorage();
-    beaconChainUtil.createAndImportBlockAtSlot(6);
+  public void shouldIgnoreExitsAfterTheFirstForValidator() {
+    advanceChainAndUpdateBestBlock(6);
 
     SignedVoluntaryExit exit1 = dataStructureUtil.randomSignedVoluntaryExit();
     SignedVoluntaryExit exit2 = new SignedVoluntaryExit(exit1.getMessage(), exit1.getSignature());
@@ -153,9 +148,8 @@ public class VoluntaryExitValidatorTest {
   }
 
   @Test
-  public void shouldRejectInvalidExit() throws Exception {
-    beaconChainUtil.initializeStorage();
-    beaconChainUtil.createAndImportBlockAtSlot(6);
+  public void shouldRejectInvalidExit() {
+    advanceChainAndUpdateBestBlock(6);
     SignedVoluntaryExit exit = dataStructureUtil.randomSignedVoluntaryExit();
     when(mockSpec.validateVoluntaryExit(getBestState(), exit))
         .thenReturn(Optional.of(ExitInvalidReason.exitInitiated()));
@@ -166,9 +160,8 @@ public class VoluntaryExitValidatorTest {
   }
 
   @Test
-  public void shouldRejectExitWithInvalidSignature() throws Exception {
-    beaconChainUtil.initializeStorage();
-    beaconChainUtil.createAndImportBlockAtSlot(6);
+  public void shouldRejectExitWithInvalidSignature() {
+    advanceChainAndUpdateBestBlock(6);
     SignedVoluntaryExit exit = dataStructureUtil.randomSignedVoluntaryExit();
     when(mockSpec.validateVoluntaryExit(getBestState(), exit)).thenReturn(Optional.empty());
     when(mockSpec.verifyVoluntaryExitSignature(getBestState(), exit, BLSSignatureVerifier.SIMPLE))
@@ -192,6 +185,10 @@ public class VoluntaryExitValidatorTest {
             result ->
                 result.code() == expectedCode
                     && result.getDescription().orElse("").contains(description));
+  }
+
+  private void advanceChainAndUpdateBestBlock(final long slot) {
+    chainUpdater.updateBestBlock(chainUpdater.advanceChain(slot));
   }
 
   private BeaconState getBestState() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -908,13 +908,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
           new ExecutionPayloadGossipValidator(spec, gossipValidationHelper, invalidBlockRoots);
       final ReceivedExecutionPayloadEventsChannel receivedExecutionPayloadEventsChannelPublisher =
           eventChannels.getPublisher(ReceivedExecutionPayloadEventsChannel.class);
-      executionPayloadManager =
+      final DefaultExecutionPayloadManager executionPayloadManager =
           new DefaultExecutionPayloadManager(
               beaconAsyncRunner,
               executionPayloadGossipValidator,
               forkChoice,
               executionLayer,
               receivedExecutionPayloadEventsChannelPublisher);
+      eventChannels.subscribe(ReceivedBlockEventsChannel.class, executionPayloadManager);
+      this.executionPayloadManager = executionPayloadManager;
     } else {
       executionPayloadManager = ExecutionPayloadManager.NOOP;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Cache a payload that we have received earlier than a block so we can process it once the block has been processed.

Also fixed one TODO (+ migrated to ChainUpdater for the test instead of the deprecated BeaconChainUtil)

## Fixed Issue(s)
related to #9819 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new caching and deferred-processing flow for execution payload envelopes keyed by `(blockRoot,builderIndex)` and wires it into block import events; incorrect keying or event timing could lead to missed or duplicate payload processing, though scope is limited by a small LRU cache.
> 
> **Overview**
> Enables **deferred processing** of Gloas `SignedExecutionPayloadEnvelope`s that arrive before their corresponding block: `DefaultExecutionPayloadManager` now caches `SAVE_FOR_FUTURE` payloads in a small synchronized LRU map and, on `onBlockImported`, looks up and re-validates/imports any matching cached payload.
> 
> Introduces a shared `BlockRootAndBuilderIndex` key (and convenience accessors on `ExecutionPayloadEnvelope`/`SignedExecutionPayloadEnvelope`) and updates the gossip validator to use it. Updates wiring so the execution payload manager subscribes to `ReceivedBlockEventsChannel`, adjusts test fixtures to generate envelopes matching a block’s builder index, adds a new unit test for the early-payload flow, and modernizes `VoluntaryExitValidatorTest` to use `ChainUpdater` instead of deprecated `BeaconChainUtil`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a49f4cbf091c1b56d9f32c7ea941fc9897aef2af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->