### PR TITLE
Implemented Gloas attestation index

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -88,6 +88,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -103,6 +104,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
@@ -604,16 +606,34 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
                                                     block,
                                                     checkpointState.getState(),
                                                     slot,
-                                                    committeeIndex)));
+                                                    computeCommitteeIndex(
+                                                        slot, block, committeeIndex))));
                               } else {
                                 final AttestationData attestationData =
                                     createAttestationData(
-                                        block, blockAndState.getState(), slot, committeeIndex);
+                                        block,
+                                        blockAndState.getState(),
+                                        slot,
+                                        computeCommitteeIndex(slot, block, committeeIndex));
                                 return SafeFuture.completedFuture(Optional.of(attestationData));
                               }
                             }));
     result.always(context::stopTimer);
     return result;
+  }
+
+  int computeCommitteeIndex(
+      final UInt64 dutySlot, final BeaconBlock block, final int committeeIndex) {
+    if (spec.atSlot(dutySlot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      if (dutySlot.equals(block.getSlot())) {
+        return 0;
+      }
+      final ReadOnlyStore store = combinedChainDataClient.getStore();
+      final ForkChoiceUtilGloas utilGloas =
+          ForkChoiceUtilGloas.required(spec.atSlot(dutySlot).getForkChoiceUtil());
+      return utilGloas.isBlockStatusFull(store, block) ? 1 : 0;
+    }
+    return committeeIndex;
   }
 
   private AttestationData createAttestationData(
@@ -624,12 +644,19 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     final UInt64 epoch = spec.computeEpochAtSlot(slot);
     final int committeeCount = spec.getCommitteeCountPerSlot(state, epoch).intValue();
 
-    if (committeeIndex < 0 || committeeIndex >= committeeCount) {
-      throw new IllegalArgumentException(
-          "Invalid committee index "
-              + committeeIndex
-              + " - expected between 0 and "
-              + (committeeCount - 1));
+    if (spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
+      if (committeeIndex < 0 || committeeIndex > 1) {
+        throw new IllegalArgumentException(
+            "Invalid committee index " + committeeIndex + " - expected between 0 and 1");
+      }
+    } else {
+      if (committeeIndex < 0 || committeeIndex >= committeeCount) {
+        throw new IllegalArgumentException(
+            "Invalid committee index "
+                + committeeIndex
+                + " - expected between 0 and "
+                + (committeeCount - 1));
+      }
     }
     final UInt64 committeeIndexUnsigned = UInt64.valueOf(committeeIndex);
     return spec.getGenericAttestationData(slot, state, block, committeeIndexUnsigned);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -88,7 +88,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -104,7 +103,6 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
-import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
@@ -622,17 +620,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     return result;
   }
 
-  int computeCommitteeIndex(
+  protected int computeCommitteeIndex(
       final UInt64 dutySlot, final BeaconBlock block, final int committeeIndex) {
-    if (spec.atSlot(dutySlot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.GLOAS)) {
-      if (dutySlot.equals(block.getSlot())) {
-        return 0;
-      }
-      final ReadOnlyStore store = combinedChainDataClient.getStore();
-      final ForkChoiceUtilGloas utilGloas =
-          ForkChoiceUtilGloas.required(spec.atSlot(dutySlot).getForkChoiceUtil());
-      return utilGloas.isBlockStatusFull(store, block) ? 1 : 0;
-    }
     return committeeIndex;
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
@@ -25,7 +25,10 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.subnets.AttestationTopicSubscriber;
 import tech.pegasys.teku.networking.eth2.gossip.subnets.SyncCommitteeSubscriptionManager;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.versions.gloas.util.ForkChoiceUtilGloas;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
@@ -128,5 +131,17 @@ public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
                     // after the Gloas fork)
                     .getExecutionPayloadStateIfAvailable(blockRoot)
                     .flatMap(state -> combinedChainDataClient.regenerateBeaconState(state, slot)));
+  }
+
+  @Override
+  protected int computeCommitteeIndex(
+      final UInt64 dutySlot, final BeaconBlock block, final int committeeIndex) {
+    if (dutySlot.equals(block.getSlot())) {
+      return 0;
+    }
+    final ReadOnlyStore store = combinedChainDataClient.getStore();
+    final ForkChoiceUtilGloas utilGloas =
+        ForkChoiceUtilGloas.required(spec.atSlot(dutySlot).getForkChoiceUtil());
+    return utilGloas.isBlockStatusFull(store, block) ? 1 : 0;
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -123,6 +123,7 @@ import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 import tech.pegasys.teku.validator.api.PublishSignedExecutionPayloadResult;
@@ -715,11 +716,18 @@ class ValidatorApiHandlerTest {
   @Test
   public void createAttestationData_shouldCreateAttestation() {
     final UInt64 slot = spec.computeStartSlotAtEpoch(EPOCH).plus(ONE);
+    final UpdatableStore store = mock(UpdatableStore.class);
+    when(chainDataClient.getStore()).thenReturn(store);
     when(chainDataClient.getCurrentSlot()).thenReturn(slot);
 
     dataStructureUtil.randomBlockAndState(epochStartSlot);
     final SignedBlockAndState blockAndState =
         dataStructureUtil.randomSignedBlockAndState(epochStartSlot);
+    when(store.getExecutionPayloadIfAvailable(any()))
+        .thenReturn(
+            Optional.of(
+                dataStructureUtil.randomSignedExecutionPayloadEnvelopeForBlock(
+                    blockAndState.getBlock())));
 
     final SafeFuture<Optional<SignedBlockAndState>> blockAndStateResult =
         completedFuture(Optional.of(blockAndState));
@@ -766,6 +774,8 @@ class ValidatorApiHandlerTest {
   public void createAttestationData_shouldUseCorrectSourceWhenEpochTransitionRequired() {
     final UInt64 slot = spec.computeStartSlotAtEpoch(EPOCH);
     when(chainDataClient.getCurrentSlot()).thenReturn(slot);
+    final UpdatableStore store = mock(UpdatableStore.class);
+    when(chainDataClient.getStore()).thenReturn(store);
     // Slot is from before the current epoch, so we need to ensure we process the epoch transition
     final UInt64 blockSlot = slot.minus(1);
 
@@ -778,6 +788,11 @@ class ValidatorApiHandlerTest {
         completedFuture(Optional.of(blockAndState));
     when(chainDataClient.getSignedBlockAndStateInEffectAtSlot(slot))
         .thenReturn(blockAndStateResult);
+    when(store.getExecutionPayloadIfAvailable(any()))
+        .thenReturn(
+            Optional.of(
+                dataStructureUtil.randomSignedExecutionPayloadEnvelopeForBlock(
+                    blockAndState.getBlock())));
 
     when(chainDataClient.getCheckpointState(EPOCH, blockAndState))
         .thenReturn(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -307,6 +307,14 @@ public abstract class AttestationUtil {
       final BeaconState state,
       final BeaconBlockSummary block,
       final UInt64 committeeIndex) {
+    return getGenericAttestationDataPhase0(slot, state, block, committeeIndex);
+  }
+
+  protected AttestationData getGenericAttestationDataPhase0(
+      final UInt64 slot,
+      final BeaconState state,
+      final BeaconBlockSummary block,
+      final UInt64 committeeIndex) {
     final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
     // Get variables necessary that can be shared among Attestations of all validators
     final Bytes32 beaconBlockRoot = block.getRoot();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -78,6 +79,15 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
               String.format("Attestation data index must be 0 or 1 for Gloas, but was %s.", index));
     }
     return AttestationValidationResult.VALID;
+  }
+
+  @Override
+  public AttestationData getGenericAttestationData(
+      final UInt64 slot,
+      final BeaconState state,
+      final BeaconBlockSummary block,
+      final UInt64 committeeIndex) {
+    return getGenericAttestationDataPhase0(slot, state, block, committeeIndex);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -114,6 +114,10 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
     return AvailabilityChecker.NOOP_DATACOLUMN_SIDECAR;
   }
 
+  public boolean isBlockStatusFull(final ReadOnlyStore store, final BeaconBlock block) {
+    return store.getExecutionPayloadIfAvailable(block.getRoot()).isPresent();
+  }
+
   /**
    * Determines the payload status of the parent block.
    *

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloasTest.java
@@ -199,6 +199,25 @@ class ForkChoiceUtilGloasTest {
         .withMessageContaining("Parent block not found");
   }
 
+  @Test
+  void isBlockStatusFull_shouldReturnTrue_whenBlockIsFull() {
+    final SignedBeaconBlock currentBlock = dataStructureUtil.randomSignedBeaconBlock();
+    final ReadOnlyStore store = mock(ReadOnlyStore.class);
+    when(store.getExecutionPayloadIfAvailable(currentBlock.getRoot()))
+        .thenReturn(
+            Optional.of(
+                dataStructureUtil.randomSignedExecutionPayloadEnvelopeForBlock(currentBlock)));
+    assertThat(forkChoiceUtil.isBlockStatusFull(store, currentBlock.getMessage())).isTrue();
+  }
+
+  @Test
+  void isBlockStatusFull_shouldReturnFalse_whenBlockIsNotFull() {
+    final SignedBeaconBlock currentBlock = dataStructureUtil.randomSignedBeaconBlock();
+    final ReadOnlyStore store = mock(ReadOnlyStore.class);
+    when(store.getExecutionPayloadIfAvailable(currentBlock.getRoot())).thenReturn(Optional.empty());
+    assertThat(forkChoiceUtil.isBlockStatusFull(store, currentBlock.getMessage())).isFalse();
+  }
+
   // Helper methods to create blocks with specific properties
   private BeaconBlock createBlockWithBlockHash(final Bytes32 blockHash) {
     final BeaconBlock block = dataStructureUtil.randomBeaconBlock(gloasSlot);


### PR DESCRIPTION
We need to be able to determine if the execution payload is present to set the index, alternatively on old blocks we could return 1 for devnet0, but this likely is adequate...


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attestation production logic for Gloas by dynamically computing the attestation `index` from fork-choice/store execution-payload availability; incorrect index selection could cause validators to produce invalid attestations on Gloas networks.
> 
> **Overview**
> Attestation production now routes the requested committee/index through a new overridable `computeCommitteeIndex` hook, and tightens index validation for Gloas-era slots to only allow `0` or `1`.
> 
> For Gloas, `ValidatorApiHandlerGloas` computes the index based on whether the block is considered *full* (execution payload present in the store): `0` when attesting to the block’s own slot, otherwise `1` for full blocks and `0` for empty blocks. This adds `ForkChoiceUtilGloas.isBlockStatusFull` plus unit test coverage, and updates validator handler tests to mock store payload presence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1217ace6cccfac439227009a93a6bd31dc4dd16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->