### PR TITLE
Throttling columns by root rpc

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -100,7 +100,6 @@ import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobParameters;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 import tech.pegasys.teku.statetransition.CustodyGroupCountChannel;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.gossip.DasGossipLogger;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
@@ -120,7 +119,6 @@ public class Eth2P2PNetworkBuilder {
   protected P2PConfig config;
   protected EventChannels eventChannels;
   protected CombinedChainDataClient combinedChainDataClient;
-  protected Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier;
   protected Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
   protected MetadataMessagesFactory metadataMessagesFactory = new MetadataMessagesFactory();
   protected OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
@@ -189,7 +187,6 @@ public class Eth2P2PNetworkBuilder {
         Eth2PeerManager.create(
             asyncRunner,
             combinedChainDataClient,
-            dataColumnSidecarCustodySupplier,
             custodyGroupCountManagerSupplier,
             metadataMessagesFactory,
             metricsSystem,
@@ -613,7 +610,6 @@ public class Eth2P2PNetworkBuilder {
     assertNotNull("eventChannels", eventChannels);
     assertNotNull("metricsSystem", metricsSystem);
     assertNotNull("combinedChainDataClient", combinedChainDataClient);
-    assertNotNull("dataColumnSidecarCustodySupplier", dataColumnSidecarCustodySupplier);
     assertNotNull("custodyGroupCountManagerSupplier", custodyGroupCountManagerSupplier);
     assertNotNull("metadataMessagesFactory", metadataMessagesFactory);
     assertNotNull("keyValueStore", keyValueStore);
@@ -658,13 +654,6 @@ public class Eth2P2PNetworkBuilder {
       final CombinedChainDataClient combinedChainDataClient) {
     checkNotNull(combinedChainDataClient);
     this.combinedChainDataClient = combinedChainDataClient;
-    return this;
-  }
-
-  public Eth2P2PNetworkBuilder dataColumnSidecarCustody(
-      final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier) {
-    checkNotNull(dataColumnSidecarCustodySupplier);
-    this.dataColumnSidecarCustodySupplier = dataColumnSidecarCustodySupplier;
     return this;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -45,7 +45,6 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.Meta
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -75,7 +74,6 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final Spec spec,
       final AsyncRunner asyncRunner,
       final CombinedChainDataClient combinedChainDataClient,
-      final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final RecentChainData recentChainData,
       final MetricsSystem metricsSystem,
@@ -97,7 +95,6 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
             asyncRunner,
             this,
             combinedChainDataClient,
-            dataColumnSidecarCustodySupplier,
             custodyGroupCountManagerSupplier,
             recentChainData,
             metricsSystem,
@@ -113,7 +110,6 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
   public static Eth2PeerManager create(
       final AsyncRunner asyncRunner,
       final CombinedChainDataClient combinedChainDataClient,
-      final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final MetadataMessagesFactory metadataMessagesFactory,
       final MetricsSystem metricsSystem,
@@ -141,7 +137,6 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
         spec,
         asyncRunner,
         combinedChainDataClient,
-        dataColumnSidecarCustodySupplier,
         custodyGroupCountManagerSupplier,
         combinedChainDataClient.getRecentChainData(),
         metricsSystem,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -75,7 +75,6 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -163,7 +162,6 @@ public class BeaconChainMethods {
       final AsyncRunner asyncRunner,
       final PeerLookup peerLookup,
       final CombinedChainDataClient combinedChainDataClient,
-      final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final RecentChainData recentChainData,
       final MetricsSystem metricsSystem,
@@ -205,7 +203,6 @@ public class BeaconChainMethods {
             metricsSystem,
             asyncRunner,
             combinedChainDataClient,
-            dataColumnSidecarCustodySupplier,
             custodyGroupCountManagerSupplier,
             peerLookup,
             rpcEncoding,
@@ -462,7 +459,6 @@ public class BeaconChainMethods {
           final MetricsSystem metricsSystem,
           final AsyncRunner asyncRunner,
           final CombinedChainDataClient combinedChainDataClient,
-          final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier,
           final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
           final PeerLookup peerLookup,
           final RpcEncoding rpcEncoding,
@@ -481,7 +477,6 @@ public class BeaconChainMethods {
             spec,
             metricsSystem,
             combinedChainDataClient,
-            dataColumnSidecarCustodySupplier,
             custodyGroupCountManagerSupplier,
             dasLogger);
     final DataColumnSidecarsByRootRequestMessageSchema

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -191,18 +191,23 @@ public class DataColumnSidecarsByRootMessageHandler
                             .filter(myCustodyColumns::contains)
                             .map(
                                 column ->
-                                    retrieveDataColumnSidecar(blockRoot, slot, column)
-                                        .thenCompose(
-                                            maybeSidecar ->
-                                                maybeSidecar
-                                                    .map(
-                                                        sidecar ->
-                                                            callback
-                                                                .respond(sidecar)
-                                                                .thenRun(
-                                                                    sentCount::incrementAndGet))
-                                                    .orElse(SafeFuture.COMPLETE))))
+                                    retrieveAndRespondForColumn(
+                                        blockRoot, slot, column, callback, sentCount)))
                     .thenCompose(___ -> SafeFuture.COMPLETE));
+  }
+
+  private SafeFuture<Void> retrieveAndRespondForColumn(
+      final Bytes32 blockRoot,
+      final UInt64 slot,
+      final UInt64 column,
+      final ResponseCallback<DataColumnSidecar> callback,
+      final AtomicLong sentCount) {
+    return retrieveDataColumnSidecar(blockRoot, slot, column)
+        .thenCompose(
+            maybeSidecar ->
+                maybeSidecar
+                    .map(sidecar -> callback.respond(sidecar).thenRun(sentCount::incrementAndGet))
+                    .orElse(SafeFuture.COMPLETE));
   }
 
   private SafeFuture<Optional<DataColumnSidecar>> retrieveDataColumnSidecar(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
@@ -52,9 +53,12 @@ public class DataColumnSidecarsByRootMessageHandler
     extends PeerRequiredLocalMessageHandler<
         DataColumnSidecarsByRootRequestMessage, DataColumnSidecar> {
 
+  private static final int ROOT_SLOT_CACHE_SIZE = 256;
+
   private final Spec spec;
   private final CombinedChainDataClient combinedChainDataClient;
   private final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
+  private final LRUCache<Bytes32, UInt64> blockRootSlotCache = LRUCache.create(ROOT_SLOT_CACHE_SIZE);
 
   private final LabelledMetric<Counter> requestCounter;
   private final Counter totalDataColumnSidecarsRequestedCounter;
@@ -167,9 +171,17 @@ public class DataColumnSidecarsByRootMessageHandler
   }
 
   private SafeFuture<Optional<UInt64>> resolveBlockRootSlot(final Bytes32 blockRoot) {
+    final Optional<UInt64> cached = blockRootSlotCache.getCached(blockRoot);
+    if (cached.isPresent()) {
+      return SafeFuture.completedFuture(cached);
+    }
     return combinedChainDataClient
         .getBlockByBlockRoot(blockRoot)
-        .thenApply(maybeBlock -> maybeBlock.map(SignedBeaconBlock::getSlot));
+        .thenApply(maybeBlock -> maybeBlock.map(SignedBeaconBlock::getSlot))
+        .thenPeek(
+            maybeSlot ->
+                maybeSlot.ifPresent(
+                    slot -> blockRootSlotCache.invalidateWithNewValue(blockRoot, slot)));
   }
 
   private SafeFuture<Void> retrieveAndRespondForBlockRoot(
@@ -186,14 +198,13 @@ public class DataColumnSidecarsByRootMessageHandler
     return validateMinimumRequestEpoch(blockRoot, slot)
         .thenCompose(
             __ ->
-                SafeFuture.collectAll(
+                SafeFuture.allOf(
                         columns.stream()
                             .filter(myCustodyColumns::contains)
                             .map(
                                 column ->
                                     retrieveAndRespondForColumn(
-                                        blockRoot, slot, column, callback, sentCount)))
-                    .thenCompose(___ -> SafeFuture.COMPLETE));
+                                        blockRoot, slot, column, callback, sentCount))));
   }
 
   private SafeFuture<Void> retrieveAndRespondForColumn(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -19,8 +19,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
@@ -36,10 +37,8 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRootRequestMessage;
-import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.LoggingPeerId;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.ReqRespResponseLogger;
@@ -55,7 +54,6 @@ public class DataColumnSidecarsByRootMessageHandler
 
   private final Spec spec;
   private final CombinedChainDataClient combinedChainDataClient;
-  private final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier;
   private final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
 
   private final LabelledMetric<Counter> requestCounter;
@@ -66,13 +64,11 @@ public class DataColumnSidecarsByRootMessageHandler
       final Spec spec,
       final MetricsSystem metricsSystem,
       final CombinedChainDataClient combinedChainDataClient,
-      final Supplier<? extends DataColumnSidecarByRootCustody> dataColumnSidecarCustodySupplier,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final DasReqRespLogger dasLogger) {
     this.spec = spec;
     this.combinedChainDataClient = combinedChainDataClient;
     this.custodyGroupCountManagerSupplier = custodyGroupCountManagerSupplier;
-    this.dataColumnSidecarCustodySupplier = dataColumnSidecarCustodySupplier;
     this.dasLogger = dasLogger;
     this.requestCounter =
         metricsSystem.createLabelledCounter(
@@ -86,18 +82,6 @@ public class DataColumnSidecarsByRootMessageHandler
             "rpc_data_column_sidecars_by_root_requested_sidecars_total",
             "Total number of data column sidecars requested in accepted data column sidecars by root requests from "
                 + "peers");
-  }
-
-  private SafeFuture<Boolean> validateAndMaybeRespond(
-      final DataColumnIdentifier identifier,
-      final Optional<DataColumnSidecar> maybeSidecar,
-      final ResponseCallback<DataColumnSidecar> callback) {
-    return validateMinimumRequestEpoch(identifier, maybeSidecar)
-        .thenCompose(
-            __ ->
-                maybeSidecar
-                    .map(sideCar -> callback.respond(sideCar).thenApply(___ -> true))
-                    .orElse(SafeFuture.completedFuture(false)));
   }
 
   @Override
@@ -133,56 +117,32 @@ public class DataColumnSidecarsByRootMessageHandler
 
     final Set<UInt64> myCustodyColumns =
         new HashSet<>(custodyGroupCountManagerSupplier.get().getCustodyColumnIndices());
-    final Stream<SafeFuture<Boolean>> responseStream =
-        message.stream()
-            .flatMap(
-                byRootIdentifier ->
-                    byRootIdentifier.getColumns().stream()
-                        .filter(myCustodyColumns::contains)
-                        .map(
-                            column ->
-                                new DataColumnIdentifier(byRootIdentifier.getBlockRoot(), column)))
-            .map(
-                dataColumnIdentifier ->
-                    retrieveDataColumnSidecar(dataColumnIdentifier)
-                        .thenCompose(
-                            maybeSidecar ->
-                                validateAndMaybeRespond(
-                                    dataColumnIdentifier,
-                                    maybeSidecar,
-                                    responseCallbackWithLogging)));
+    final AtomicLong sentCount = new AtomicLong(0);
 
-    final SafeFuture<List<Boolean>> listOfResponses = SafeFuture.collectAll(responseStream);
-
-    listOfResponses
-        .thenApply(list -> list.stream().filter(isSent -> isSent).count())
+    SafeFuture.collectAll(
+            message.stream()
+                .map(
+                    byRootIdentifier ->
+                        resolveBlockRootSlot(byRootIdentifier.getBlockRoot())
+                            .thenCompose(
+                                maybeSlot ->
+                                    retrieveAndRespondForBlockRoot(
+                                        byRootIdentifier.getBlockRoot(),
+                                        maybeSlot,
+                                        byRootIdentifier.getColumns(),
+                                        myCustodyColumns,
+                                        responseCallbackWithLogging,
+                                        sentCount))))
         .thenAccept(
-            sentDataColumnSidecarsCount -> {
-              if (sentDataColumnSidecarsCount != requestedDataColumnSidecarsCount) {
-                peer.adjustDataColumnSidecarsRequest(
-                    maybeRequestKey.get(), sentDataColumnSidecarsCount);
+            __ -> {
+              final long sent = sentCount.get();
+              if (sent != requestedDataColumnSidecarsCount) {
+                peer.adjustDataColumnSidecarsRequest(maybeRequestKey.get(), sent);
               }
               responseCallbackWithLogging.completeSuccessfully();
             })
         .finish(
             err -> handleError(err, responseCallbackWithLogging, "data column sidecars by root"));
-  }
-
-  private SafeFuture<Optional<DataColumnSidecar>> getNonCanonicalDataColumnSidecar(
-      final DataColumnIdentifier identifier) {
-    return combinedChainDataClient
-        .getBlockByBlockRoot(identifier.blockRoot())
-        .thenApply(maybeBlock -> maybeBlock.map(SignedBeaconBlock::getSlot))
-        .thenCompose(
-            maybeSlot -> {
-              if (maybeSlot.isPresent()) {
-                return combinedChainDataClient.getNonCanonicalSidecar(
-                    new DataColumnSlotAndIdentifier(
-                        maybeSlot.get(), identifier.blockRoot(), identifier.columnIndex()));
-              } else {
-                return SafeFuture.completedFuture(Optional.empty());
-              }
-            });
   }
 
   /**
@@ -193,43 +153,75 @@ public class DataColumnSidecarsByRootMessageHandler
    * </ul>
    */
   private SafeFuture<Void> validateMinimumRequestEpoch(
-      final DataColumnIdentifier identifier, final Optional<DataColumnSidecar> maybeSidecar) {
-    return maybeSidecar
-        .map(sidecar -> SafeFuture.completedFuture(Optional.of(sidecar.getSlot())))
-        .orElseGet(
-            () ->
-                combinedChainDataClient
-                    .getBlockByBlockRoot(identifier.blockRoot())
-                    .thenApply(maybeBlock -> maybeBlock.map(SignedBeaconBlock::getSlot)))
-        .thenAcceptChecked(
-            maybeSlot -> {
+      final Bytes32 blockRoot, final Optional<UInt64> maybeSlot) {
+    if (maybeSlot.isEmpty()) {
+      return SafeFuture.COMPLETE;
+    }
+    final UInt64 requestedEpoch = spec.computeEpochAtSlot(maybeSlot.get());
+    if (!spec.isAvailabilityOfDataColumnSidecarsRequiredAtEpoch(
+        combinedChainDataClient.getStore(), requestedEpoch)) {
+      return SafeFuture.failedFuture(
+          new RpcException(
+              INVALID_REQUEST_CODE,
+              String.format(
+                  "Block root (%s) references a block earlier than the minimum_request_epoch",
+                  blockRoot)));
+    }
+    return SafeFuture.COMPLETE;
+  }
+
+  private SafeFuture<Optional<UInt64>> resolveBlockRootSlot(final Bytes32 blockRoot) {
+    return combinedChainDataClient
+        .getBlockByBlockRoot(blockRoot)
+        .thenApply(maybeBlock -> maybeBlock.map(SignedBeaconBlock::getSlot));
+  }
+
+  private SafeFuture<Void> retrieveAndRespondForBlockRoot(
+      final Bytes32 blockRoot,
+      final Optional<UInt64> maybeSlot,
+      final List<UInt64> columns,
+      final Set<UInt64> myCustodyColumns,
+      final ResponseCallback<DataColumnSidecar> callback,
+      final AtomicLong sentCount) {
+    return validateMinimumRequestEpoch(blockRoot, maybeSlot)
+        .thenCompose(
+            __ -> {
               if (maybeSlot.isEmpty()) {
-                return;
+                return SafeFuture.COMPLETE;
               }
-              final UInt64 requestedEpoch = spec.computeEpochAtSlot(maybeSlot.get());
-              if (!spec.isAvailabilityOfDataColumnSidecarsRequiredAtEpoch(
-                  combinedChainDataClient.getStore(), requestedEpoch)) {
-                throw new RpcException(
-                    INVALID_REQUEST_CODE,
-                    String.format(
-                        "Block root (%s) references a block earlier than the minimum_request_epoch",
-                        identifier.blockRoot()));
-              }
+              final UInt64 slot = maybeSlot.get();
+              return SafeFuture.collectAll(
+                      columns.stream()
+                          .filter(myCustodyColumns::contains)
+                          .map(
+                              column ->
+                                  retrieveDataColumnSidecar(blockRoot, slot, column)
+                                      .thenCompose(
+                                          maybeSidecar ->
+                                              maybeSidecar
+                                                  .map(
+                                                      sidecar ->
+                                                          callback
+                                                              .respond(sidecar)
+                                                              .thenRun(sentCount::incrementAndGet))
+                                                  .orElse(SafeFuture.COMPLETE))))
+                  .thenCompose(___ -> SafeFuture.COMPLETE);
             });
   }
 
   private SafeFuture<Optional<DataColumnSidecar>> retrieveDataColumnSidecar(
-      final DataColumnIdentifier identifier) {
-    return dataColumnSidecarCustodySupplier
-        .get()
-        .getCustodyDataColumnSidecarByRoot(identifier)
+      final Bytes32 blockRoot, final UInt64 slot, final UInt64 column) {
+    final DataColumnSlotAndIdentifier slotAndIdentifier =
+        new DataColumnSlotAndIdentifier(slot, blockRoot, column);
+    return combinedChainDataClient
+        .getSidecar(slotAndIdentifier)
         .thenCompose(
             maybeSidecar -> {
               if (maybeSidecar.isPresent()) {
                 return SafeFuture.completedFuture(maybeSidecar);
               }
               // Fallback to non-canonical sidecar if the canonical one is not found
-              return getNonCanonicalDataColumnSidecar(identifier);
+              return combinedChainDataClient.getNonCanonicalSidecar(slotAndIdentifier);
             });
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
+
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -121,7 +121,6 @@ public class DataColumnSidecarsByRootMessageHandler
 
     final Set<UInt64> myCustodyColumns =
         new HashSet<>(custodyGroupCountManagerSupplier.get().getCustodyColumnIndices());
-    final AtomicLong sentCount = new AtomicLong(0);
 
     SafeFuture.collectAll(
             message.stream()
@@ -135,11 +134,10 @@ public class DataColumnSidecarsByRootMessageHandler
                                         maybeSlot,
                                         byRootIdentifier.getColumns(),
                                         myCustodyColumns,
-                                        responseCallbackWithLogging,
-                                        sentCount))))
+                                        responseCallbackWithLogging))))
         .thenAccept(
-            __ -> {
-              final long sent = sentCount.get();
+            counts -> {
+              final long sent = counts.stream().mapToLong(Long::longValue).sum();
               if (sent != requestedDataColumnSidecarsCount) {
                 peer.adjustDataColumnSidecarsRequest(maybeRequestKey.get(), sent);
               }
@@ -184,41 +182,41 @@ public class DataColumnSidecarsByRootMessageHandler
                     slot -> blockRootSlotCache.invalidateWithNewValue(blockRoot, slot)));
   }
 
-  private SafeFuture<Void> retrieveAndRespondForBlockRoot(
+  private SafeFuture<Long> retrieveAndRespondForBlockRoot(
       final Bytes32 blockRoot,
       final Optional<UInt64> maybeSlot,
       final List<UInt64> columns,
       final Set<UInt64> myCustodyColumns,
-      final ResponseCallback<DataColumnSidecar> callback,
-      final AtomicLong sentCount) {
+      final ResponseCallback<DataColumnSidecar> callback) {
     if (maybeSlot.isEmpty()) {
-      return SafeFuture.COMPLETE;
+      return SafeFuture.completedFuture(0L);
     }
     final UInt64 slot = maybeSlot.get();
     return validateMinimumRequestEpoch(blockRoot, slot)
         .thenCompose(
             __ ->
-                SafeFuture.allOf(
+                SafeFuture.collectAll(
                         columns.stream()
                             .filter(myCustodyColumns::contains)
                             .map(
                                 column ->
                                     retrieveAndRespondForColumn(
-                                        blockRoot, slot, column, callback, sentCount))));
+                                        blockRoot, slot, column, callback)))
+                    .thenApply(
+                        counts -> counts.stream().mapToLong(Long::longValue).sum()));
   }
 
-  private SafeFuture<Void> retrieveAndRespondForColumn(
+  private SafeFuture<Long> retrieveAndRespondForColumn(
       final Bytes32 blockRoot,
       final UInt64 slot,
       final UInt64 column,
-      final ResponseCallback<DataColumnSidecar> callback,
-      final AtomicLong sentCount) {
+      final ResponseCallback<DataColumnSidecar> callback) {
     return retrieveDataColumnSidecar(blockRoot, slot, column)
         .thenCompose(
             maybeSidecar ->
                 maybeSidecar
-                    .map(sidecar -> callback.respond(sidecar).thenRun(sentCount::incrementAndGet))
-                    .orElse(SafeFuture.COMPLETE));
+                    .map(sidecar -> callback.respond(sidecar).thenApply(__ -> 1L))
+                    .orElse(SafeFuture.completedFuture(0L)));
   }
 
   private SafeFuture<Optional<DataColumnSidecar>> retrieveDataColumnSidecar(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
 import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -58,7 +57,8 @@ public class DataColumnSidecarsByRootMessageHandler
   private final Spec spec;
   private final CombinedChainDataClient combinedChainDataClient;
   private final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
-  private final LRUCache<Bytes32, UInt64> blockRootSlotCache = LRUCache.create(ROOT_SLOT_CACHE_SIZE);
+  private final LRUCache<Bytes32, UInt64> blockRootSlotCache =
+      LRUCache.create(ROOT_SLOT_CACHE_SIZE);
 
   private final LabelledMetric<Counter> requestCounter;
   private final Counter totalDataColumnSidecarsRequestedCounter;
@@ -200,10 +200,8 @@ public class DataColumnSidecarsByRootMessageHandler
                             .filter(myCustodyColumns::contains)
                             .map(
                                 column ->
-                                    retrieveAndRespondForColumn(
-                                        blockRoot, slot, column, callback)))
-                    .thenApply(
-                        counts -> counts.stream().mapToLong(Long::longValue).sum()));
+                                    retrieveAndRespondForColumn(blockRoot, slot, column, callback)))
+                    .thenApply(counts -> counts.stream().mapToLong(Long::longValue).sum()));
   }
 
   private SafeFuture<Long> retrieveAndRespondForColumn(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -152,12 +152,8 @@ public class DataColumnSidecarsByRootMessageHandler
    *   <li>The block root references a block greater than or equal to the minimum_request_epoch
    * </ul>
    */
-  private SafeFuture<Void> validateMinimumRequestEpoch(
-      final Bytes32 blockRoot, final Optional<UInt64> maybeSlot) {
-    if (maybeSlot.isEmpty()) {
-      return SafeFuture.COMPLETE;
-    }
-    final UInt64 requestedEpoch = spec.computeEpochAtSlot(maybeSlot.get());
+  private SafeFuture<Void> validateMinimumRequestEpoch(final Bytes32 blockRoot, final UInt64 slot) {
+    final UInt64 requestedEpoch = spec.computeEpochAtSlot(slot);
     if (!spec.isAvailabilityOfDataColumnSidecarsRequiredAtEpoch(
         combinedChainDataClient.getStore(), requestedEpoch)) {
       return SafeFuture.failedFuture(
@@ -183,30 +179,30 @@ public class DataColumnSidecarsByRootMessageHandler
       final Set<UInt64> myCustodyColumns,
       final ResponseCallback<DataColumnSidecar> callback,
       final AtomicLong sentCount) {
-    return validateMinimumRequestEpoch(blockRoot, maybeSlot)
+    if (maybeSlot.isEmpty()) {
+      return SafeFuture.COMPLETE;
+    }
+    final UInt64 slot = maybeSlot.get();
+    return validateMinimumRequestEpoch(blockRoot, slot)
         .thenCompose(
-            __ -> {
-              if (maybeSlot.isEmpty()) {
-                return SafeFuture.COMPLETE;
-              }
-              final UInt64 slot = maybeSlot.get();
-              return SafeFuture.collectAll(
-                      columns.stream()
-                          .filter(myCustodyColumns::contains)
-                          .map(
-                              column ->
-                                  retrieveDataColumnSidecar(blockRoot, slot, column)
-                                      .thenCompose(
-                                          maybeSidecar ->
-                                              maybeSidecar
-                                                  .map(
-                                                      sidecar ->
-                                                          callback
-                                                              .respond(sidecar)
-                                                              .thenRun(sentCount::incrementAndGet))
-                                                  .orElse(SafeFuture.COMPLETE))))
-                  .thenCompose(___ -> SafeFuture.COMPLETE);
-            });
+            __ ->
+                SafeFuture.collectAll(
+                        columns.stream()
+                            .filter(myCustodyColumns::contains)
+                            .map(
+                                column ->
+                                    retrieveDataColumnSidecar(blockRoot, slot, column)
+                                        .thenCompose(
+                                            maybeSidecar ->
+                                                maybeSidecar
+                                                    .map(
+                                                        sidecar ->
+                                                            callback
+                                                                .respond(sidecar)
+                                                                .thenRun(
+                                                                    sentCount::incrementAndGet))
+                                                    .orElse(SafeFuture.COMPLETE))))
+                    .thenCompose(___ -> SafeFuture.COMPLETE));
   }
 
   private SafeFuture<Optional<DataColumnSidecar>> retrieveDataColumnSidecar(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -204,18 +204,15 @@ public class DataColumnSidecarsByRootMessageHandler
                 SafeFuture.collectAll(
                         columns.stream()
                             .filter(myCustodyColumns::contains)
-                            .map(
-                                column ->
-                                    retrieveAndRespondForColumn(blockRoot, slot, column, callback)))
+                            .map(column -> new DataColumnSlotAndIdentifier(slot, blockRoot, column))
+                            .map(identifier -> retrieveAndRespondForColumn(identifier, callback)))
                     .thenApply(counts -> counts.stream().mapToLong(Long::longValue).sum()));
   }
 
   private SafeFuture<Long> retrieveAndRespondForColumn(
-      final Bytes32 blockRoot,
-      final UInt64 slot,
-      final UInt64 column,
+      final DataColumnSlotAndIdentifier dataColumnSlotAndIdentifier,
       final ResponseCallback<DataColumnSidecar> callback) {
-    return retrieveDataColumnSidecar(blockRoot, slot, column)
+    return retrieveDataColumnSidecar(dataColumnSlotAndIdentifier)
         .thenCompose(
             maybeSidecar ->
                 maybeSidecar
@@ -224,18 +221,16 @@ public class DataColumnSidecarsByRootMessageHandler
   }
 
   private SafeFuture<Optional<DataColumnSidecar>> retrieveDataColumnSidecar(
-      final Bytes32 blockRoot, final UInt64 slot, final UInt64 column) {
-    final DataColumnSlotAndIdentifier slotAndIdentifier =
-        new DataColumnSlotAndIdentifier(slot, blockRoot, column);
+      final DataColumnSlotAndIdentifier dataColumnSlotAndIdentifier) {
     return combinedChainDataClient
-        .getSidecar(slotAndIdentifier)
+        .getSidecar(dataColumnSlotAndIdentifier)
         .thenCompose(
             maybeSidecar -> {
               if (maybeSidecar.isPresent()) {
                 return SafeFuture.completedFuture(maybeSidecar);
               }
               // Fallback to non-canonical sidecar if the canonical one is not found
-              return combinedChainDataClient.getNonCanonicalSidecar(slotAndIdentifier);
+              return combinedChainDataClient.getNonCanonicalSidecar(dataColumnSlotAndIdentifier);
             });
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -125,16 +125,22 @@ public class DataColumnSidecarsByRootMessageHandler
     SafeFuture.collectAll(
             message.stream()
                 .map(
-                    byRootIdentifier ->
-                        resolveBlockRootSlot(byRootIdentifier.getBlockRoot())
-                            .thenCompose(
-                                maybeSlot ->
-                                    retrieveAndRespondForBlockRoot(
-                                        byRootIdentifier.getBlockRoot(),
-                                        maybeSlot,
-                                        byRootIdentifier.getColumns(),
-                                        myCustodyColumns,
-                                        responseCallbackWithLogging))))
+                    byRootIdentifier -> {
+                      if (byRootIdentifier.getColumns().stream()
+                          .noneMatch(myCustodyColumns::contains)) {
+                        // we don't custody any of the requested columns
+                        return SafeFuture.completedFuture(0L);
+                      }
+                      return resolveBlockRootSlot(byRootIdentifier.getBlockRoot())
+                          .thenCompose(
+                              maybeSlot ->
+                                  retrieveAndRespondForBlockRoot(
+                                      byRootIdentifier.getBlockRoot(),
+                                      maybeSlot,
+                                      byRootIdentifier.getColumns(),
+                                      myCustodyColumns,
+                                      responseCallbackWithLogging));
+                    }))
         .thenAccept(
             counts -> {
               final long sent = counts.stream().mapToLong(Long::longValue).sum();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManagerTest.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -75,7 +74,6 @@ public class Eth2PeerManagerTest {
           spec,
           asyncRunner,
           combinedChainDataClient,
-          () -> DataColumnSidecarByRootCustody.NOOP,
           () -> CustodyGroupCountManager.NOOP,
           recentChainData,
           new NoOpMetricsSystem(),

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethodsTest.java
@@ -39,7 +39,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.StatusMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.versions.phase0.StatusMessagePhase0;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -211,7 +210,6 @@ public class BeaconChainMethodsTest {
         asyncRunner,
         peerLookup,
         combinedChainDataClient,
-        () -> DataColumnSidecarByRootCustody.NOOP,
         () -> CustodyGroupCountManager.NOOP,
         recentChainData,
         metricsSystem,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -411,6 +411,27 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     verify(peer, never()).adjustDataColumnSidecarsRequest(any(), anyLong());
   }
 
+  @TestTemplate
+  public void shouldCacheBlockRootSlotResolutionAcrossRequests() {
+    final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+    final DataColumnsByRootIdentifier[] identifiers = {
+      identifierSchema.create(blockRoot, List.of(UInt64.valueOf(0)))
+    };
+
+    when(combinedChainDataClient.getSidecar(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(Optional.of(dataStructureUtil.randomDataColumnSidecar())));
+
+    // First request
+    handler.onIncomingMessage(protocolId, peer, messageSchema.of(identifiers), callback);
+    verify(combinedChainDataClient, times(1)).getBlockByBlockRoot(blockRoot);
+
+    // Second request with the same block root
+    handler.onIncomingMessage(protocolId, peer, messageSchema.of(identifiers), callback);
+    // Still only one call - the second request used the cache
+    verify(combinedChainDataClient, times(1)).getBlockByBlockRoot(blockRoot);
+  }
+
   private DataColumnsByRootIdentifier[] generateDataColumnsByRootIdentifiers(
       final int numberOfBlocks, final int columnIndicesPerBlock) {
     return IntStream.range(0, numberOfBlocks)

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -61,11 +61,10 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSid
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRootRequestMessageSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifierSchema;
-import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
+import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -94,8 +93,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final NodeId nodeId = new MockNodeId(1);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
-  private final DataColumnSidecarByRootCustody custody = mock(DataColumnSidecarByRootCustody.class);
-  private final Supplier<? extends DataColumnSidecarByRootCustody> custodySupplier = () -> custody;
   private final CustodyGroupCountManager custodyGroupCountManager =
       mock(CustodyGroupCountManager.class);
   private final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier =
@@ -129,7 +126,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
             spec,
             metricsSystem,
             combinedChainDataClient,
-            custodySupplier,
             custodyGroupCountManagerSupplier,
             DasReqRespLogger.NOOP);
 
@@ -201,17 +197,17 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     when(combinedChainDataClient.getBlockByBlockRoot(secondBlockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
-    when(custody.getCustodyDataColumnSidecarByRoot(any()))
+    when(combinedChainDataClient.getSidecar(any()))
         .thenAnswer(
             invocation -> {
-              final DataColumnIdentifier dataColumnIdentifier = invocation.getArgument(0);
-              if (dataColumnIdentifier.blockRoot().equals(secondBlockRoot)) {
+              final DataColumnSlotAndIdentifier slotAndIdentifier = invocation.getArgument(0);
+              if (slotAndIdentifier.blockRoot().equals(secondBlockRoot)) {
                 return SafeFuture.completedFuture(Optional.empty());
               }
               for (int i = 0; i < 4; ++i) {
                 if (dataColumnsByRootIdentifiers[i]
                     .getBlockRoot()
-                    .equals(dataColumnIdentifier.blockRoot())) {
+                    .equals(slotAndIdentifier.blockRoot())) {
                   return SafeFuture.completedFuture(Optional.of(generatedSidecars.get(i)));
                 }
               }
@@ -261,10 +257,9 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
         dataStructureUtil.randomSignedBeaconBlock(UInt64.valueOf(100));
     when(combinedChainDataClient.getBlockByBlockRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(signedBeaconBlock)));
-    when(combinedChainDataClient.getNonCanonicalSidecar(any()))
+    when(combinedChainDataClient.getSidecar(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-
-    when(custody.getCustodyDataColumnSidecarByRoot(any()))
+    when(combinedChainDataClient.getNonCanonicalSidecar(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     handler.onIncomingMessage(
@@ -304,17 +299,17 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     when(custodyGroupCountManager.getCustodyColumnIndices())
         .thenReturn(List.of(dataColumnsByRootIdentifiers[0].getColumns().getFirst()));
 
-    when(custody.getCustodyDataColumnSidecarByRoot(any()))
+    when(combinedChainDataClient.getSidecar(any()))
         .thenAnswer(
             invocation -> {
-              final DataColumnIdentifier dataColumnIdentifier = invocation.getArgument(0);
+              final DataColumnSlotAndIdentifier slotAndIdentifier = invocation.getArgument(0);
               // it will not reach this step
-              assertThat(dataColumnIdentifier.blockRoot())
+              assertThat(slotAndIdentifier.blockRoot())
                   .isNotEqualTo(dataColumnsByRootIdentifiers[3].getBlockRoot());
               for (int i = 0; i < 3; ++i) {
                 if (dataColumnsByRootIdentifiers[i]
                     .getBlockRoot()
-                    .equals(dataColumnIdentifier.blockRoot())) {
+                    .equals(slotAndIdentifier.blockRoot())) {
                   return SafeFuture.completedFuture(Optional.of(generatedSidecars.get(i)));
                 }
               }
@@ -355,14 +350,14 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     final List<DataColumnSidecar> generatedSidecars =
         IntStream.range(0, 4).mapToObj(__ -> dataStructureUtil.randomDataColumnSidecar()).toList();
 
-    when(custody.getCustodyDataColumnSidecarByRoot(any()))
+    when(combinedChainDataClient.getSidecar(any()))
         .thenAnswer(
             invocation -> {
-              final DataColumnIdentifier dataColumnIdentifier = invocation.getArgument(0);
+              final DataColumnSlotAndIdentifier slotAndIdentifier = invocation.getArgument(0);
               for (int i = 0; i < 4; ++i) {
                 if (dataColumnsByRootIdentifiers[i]
                     .getBlockRoot()
-                    .equals(dataColumnIdentifier.blockRoot())) {
+                    .equals(slotAndIdentifier.blockRoot())) {
                   return SafeFuture.completedFuture(Optional.of(generatedSidecars.get(i)));
                 }
               }
@@ -406,8 +401,7 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
 
     final RuntimeException error = new RuntimeException("Fatal error");
 
-    when(custody.getCustodyDataColumnSidecarByRoot(any()))
-        .thenReturn(SafeFuture.failedFuture(error));
+    when(combinedChainDataClient.getSidecar(any())).thenReturn(SafeFuture.failedFuture(error));
 
     handler.onIncomingMessage(
         protocolId, peer, messageSchema.of(dataColumnsByRootIdentifiers), callback);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/AbstractRequestHandlerTest.java
@@ -40,7 +40,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -71,7 +70,6 @@ abstract class AbstractRequestHandlerTest<T extends RpcRequestHandler> {
             asyncRunner,
             peerLookup,
             combinedChainDataClient,
-            () -> DataColumnSidecarByRootCustody.NOOP,
             () -> CustodyGroupCountManager.NOOP,
             recentChainData,
             new NoOpMetricsSystem(),

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -115,7 +115,6 @@ import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.CustodyGroupCountChannel;
 import tech.pegasys.teku.statetransition.block.VerifiedBlockOperationsListener;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarByRootCustody;
 import tech.pegasys.teku.statetransition.datacolumns.log.gossip.DasGossipLogger;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
@@ -256,7 +255,6 @@ public class Eth2P2PNetworkFactory {
             Eth2PeerManager.create(
                 asyncRunner,
                 combinedChainDataClient,
-                () -> DataColumnSidecarByRootCustody.NOOP,
                 () -> CustodyGroupCountManager.NOOP,
                 metadataMessagesFactory,
                 METRICS_SYSTEM,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1959,7 +1959,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .eventChannels(eventChannels)
             .combinedChainDataClient(
                 throttlingCombinedChainDataClient.orElse(combinedChainDataClient))
-            .dataColumnSidecarCustody(this::getDataColumnSidecarCustody)
             .custodyGroupCountManagerSupplier(() -> custodyGroupCountManager)
             .gossipedBlockProcessor(blockManager::validateAndImportBlock)
             .gossipedBlobSidecarProcessor(blobSidecarManager::validateAndPrepareForBlockImport)
@@ -2306,10 +2305,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
     }
 
     return defaultFeeRecipient;
-  }
-
-  private DataColumnSidecarRecoveringCustody getDataColumnSidecarCustody() {
-    return dataColumnSidecarCustodyRef.get();
   }
 
   protected void setupInitialState(final RecentChainData client) {


### PR DESCRIPTION
This PR makes the column by root handler retrieving columns from the throttling combinedChainDataClient.
It restructures the handler so that slot lookup is done only once per DataColumnsByRootIdentifier.

Added a tiny cache to overcome the lost cache from DataColumnSidecarByRootCustody

Other simplifications too.

If we merge this we could delete `DataColumnSidecarByRootCustody` and `DataColumnSidecarByRootCustodyImpl`

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core P2P req/resp handling for Fulu data-column sidecars, changing how sidecars and block slots are resolved and cached. Risk is moderate because regressions could impact RPC responsiveness/rate-limiting behavior and DAS data availability serving.
> 
> **Overview**
> **Changes `DataColumnSidecarsByRoot` RPC to retrieve sidecars through `CombinedChainDataClient` instead of the `DataColumnSidecarByRootCustody` abstraction**, so the handler benefits from any configured throttling and uses canonical + non-canonical lookups via the same client.
> 
> The handler is **restructured to resolve the block slot once per block root**, adds a small LRU cache for `blockRoot -> slot`, and updates wiring/tests accordingly by removing the now-unused `dataColumnSidecarCustody` plumbing from `Eth2P2PNetworkBuilder`, `Eth2PeerManager`, `BeaconChainMethods`, and `BeaconChainController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a11858051cb30220a5c77be68d42cc0cdb4a758. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->