### PR TITLE
Do not recompute custody and sampling indices

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFulu.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.coordinator.publisher;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.HashSet;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -94,8 +93,7 @@ public class BlockPublisherFulu extends BlockPublisherPhase0 {
     if (mustPublishAll(dataColumnSidecars.getFirst().getSlot())) {
       dataColumnSidecarsToPublish = dataColumnSidecars;
     } else {
-      final Set<UInt64> custodyColumnIndices =
-          new HashSet<>(custodyGroupCountManager.getCustodyColumnIndices());
+      final Set<UInt64> custodyColumnIndices = custodyGroupCountManager.getCustodyColumnIndices();
       dataColumnSidecarsToPublish =
           dataColumnSidecars.stream()
               .filter(sidecar -> custodyColumnIndices.contains(sidecar.getIndex()))

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
@@ -19,10 +19,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.OptionalInt;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -109,8 +108,7 @@ class BlockPublisherFuluTest {
     }
 
     // when trying to publish in any slot, non-custodied columns will be withheld
-    final NavigableSet<UInt64> custodiedColumns =
-        ImmutableSortedSet.of(UInt64.valueOf(1), UInt64.valueOf(3));
+    final Set<UInt64> custodiedColumns = Set.of(UInt64.valueOf(1), UInt64.valueOf(3));
     when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(custodiedColumns);
     blockPublisherFuluTest.publishDataColumnSidecars(
         dataColumnSidecars, BlockPublishingPerformance.NOOP);
@@ -127,8 +125,7 @@ class BlockPublisherFuluTest {
   void mustPublishAll_isResetAfterPublish() {
     assertThat(blockPublisherFuluTest.mustPublishAll(UInt64.ZERO)).isFalse();
 
-    final NavigableSet<UInt64> custodiedColumns =
-        ImmutableSortedSet.of(UInt64.valueOf(1), UInt64.valueOf(3));
+    final Set<UInt64> custodiedColumns = Set.of(UInt64.valueOf(1), UInt64.valueOf(3));
     when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(custodiedColumns);
     blockPublisherFuluTest.publishDataColumnSidecars(
         dataColumnSidecars, BlockPublishingPerformance.NOOP);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherFuluTest.java
@@ -19,7 +19,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
@@ -107,7 +109,8 @@ class BlockPublisherFuluTest {
     }
 
     // when trying to publish in any slot, non-custodied columns will be withheld
-    final List<UInt64> custodiedColumns = List.of(UInt64.valueOf(1), UInt64.valueOf(3));
+    final NavigableSet<UInt64> custodiedColumns =
+        ImmutableSortedSet.of(UInt64.valueOf(1), UInt64.valueOf(3));
     when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(custodiedColumns);
     blockPublisherFuluTest.publishDataColumnSidecars(
         dataColumnSidecars, BlockPublishingPerformance.NOOP);
@@ -124,7 +127,8 @@ class BlockPublisherFuluTest {
   void mustPublishAll_isResetAfterPublish() {
     assertThat(blockPublisherFuluTest.mustPublishAll(UInt64.ZERO)).isFalse();
 
-    final List<UInt64> custodiedColumns = List.of(UInt64.valueOf(1), UInt64.valueOf(3));
+    final NavigableSet<UInt64> custodiedColumns =
+        ImmutableSortedSet.of(UInt64.valueOf(1), UInt64.valueOf(3));
     when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(custodiedColumns);
     blockPublisherFuluTest.publishDataColumnSidecars(
         dataColumnSidecars, BlockPublishingPerformance.NOOP);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetCustodyOverview.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetCustodyOverview.java
@@ -66,7 +66,8 @@ public class GetCustodyOverview extends RestApiEndpoint {
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     request.header(Header.CACHE_CONTROL, CACHE_NONE);
-    request.respondOk(new CustodyOverview(provider.getCustodyColumnIndices().stream().toList()));
+    request.respondOk(
+        new CustodyOverview(provider.getCustodyColumnIndices().stream().sorted().toList()));
   }
 
   record CustodyOverview(List<UInt64> columns) {}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetCustodyOverview.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetCustodyOverview.java
@@ -66,7 +66,7 @@ public class GetCustodyOverview extends RestApiEndpoint {
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     request.header(Header.CACHE_CONTROL, CACHE_NONE);
-    request.respondOk(new CustodyOverview(provider.getCustodyColumnIndices()));
+    request.respondOk(new CustodyOverview(provider.getCustodyColumnIndices().stream().toList()));
   }
 
   record CustodyOverview(List<UInt64> columns) {}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -132,7 +133,7 @@ public class NodeDataProvider {
         attestationPool.getAttestations(maybeSlot, maybeCommitteeIndex), maybeSlot);
   }
 
-  public List<UInt64> getCustodyColumnIndices() {
+  public Set<UInt64> getCustodyColumnIndices() {
     return custodyGroupCountManager.getCustodyColumnIndices();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint256ToB
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.primitives.Bytes;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
@@ -26,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -157,16 +155,15 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
 
   public List<UInt64> computeDataColumnSidecarBackboneSubnets(
       final UInt256 nodeId, final int groupCount) {
-    final NavigableSet<UInt64> columns = computeCustodyColumnIndices(nodeId, groupCount);
+    final Set<UInt64> columns = computeCustodyColumnIndices(nodeId, groupCount);
     return columns.stream().map(this::computeSubnetForDataColumnSidecar).toList();
   }
 
-  public NavigableSet<UInt64> computeCustodyColumnIndices(
-      final UInt256 nodeId, final int groupCount) {
+  public Set<UInt64> computeCustodyColumnIndices(final UInt256 nodeId, final int groupCount) {
     final List<UInt64> custodyGroups = getCustodyGroups(nodeId, groupCount);
     return custodyGroups.stream()
         .flatMap(group -> computeColumnsForCustodyGroup(group).stream())
-        .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   public List<UInt64> computeColumnsForCustodyGroup(final UInt64 custodyGroup) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint256ToB
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.primitives.Bytes;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -155,15 +157,16 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
 
   public List<UInt64> computeDataColumnSidecarBackboneSubnets(
       final UInt256 nodeId, final int groupCount) {
-    final List<UInt64> columns = computeCustodyColumnIndices(nodeId, groupCount);
+    final NavigableSet<UInt64> columns = computeCustodyColumnIndices(nodeId, groupCount);
     return columns.stream().map(this::computeSubnetForDataColumnSidecar).toList();
   }
 
-  public List<UInt64> computeCustodyColumnIndices(final UInt256 nodeId, final int groupCount) {
+  public NavigableSet<UInt64> computeCustodyColumnIndices(
+      final UInt256 nodeId, final int groupCount) {
     final List<UInt64> custodyGroups = getCustodyGroups(nodeId, groupCount);
     return custodyGroups.stream()
         .flatMap(group -> computeColumnsForCustodyGroup(group).stream())
-        .toList();
+        .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
   }
 
   public List<UInt64> computeColumnsForCustodyGroup(final UInt64 custodyGroup) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManager.java
@@ -13,8 +13,7 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
-import com.google.common.collect.ImmutableSortedSet;
-import java.util.NavigableSet;
+import java.util.Set;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface CustodyGroupCountManager {
@@ -26,8 +25,8 @@ public interface CustodyGroupCountManager {
         }
 
         @Override
-        public NavigableSet<UInt64> getCustodyColumnIndices() {
-          return ImmutableSortedSet.of();
+        public Set<UInt64> getCustodyColumnIndices() {
+          return Set.of();
         }
 
         @Override
@@ -36,16 +35,16 @@ public interface CustodyGroupCountManager {
         }
 
         @Override
-        public NavigableSet<UInt64> getSamplingColumnIndices() {
-          return ImmutableSortedSet.of();
+        public Set<UInt64> getSamplingColumnIndices() {
+          return Set.of();
         }
       };
 
   int getCustodyGroupCount();
 
-  NavigableSet<UInt64> getCustodyColumnIndices();
+  Set<UInt64> getCustodyColumnIndices();
 
   int getSamplingGroupCount();
 
-  NavigableSet<UInt64> getSamplingColumnIndices();
+  Set<UInt64> getSamplingColumnIndices();
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManager.java
@@ -13,7 +13,8 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
-import java.util.List;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.NavigableSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface CustodyGroupCountManager {
@@ -25,8 +26,8 @@ public interface CustodyGroupCountManager {
         }
 
         @Override
-        public List<UInt64> getCustodyColumnIndices() {
-          return List.of();
+        public NavigableSet<UInt64> getCustodyColumnIndices() {
+          return ImmutableSortedSet.of();
         }
 
         @Override
@@ -35,16 +36,16 @@ public interface CustodyGroupCountManager {
         }
 
         @Override
-        public List<UInt64> getSamplingColumnIndices() {
-          return List.of();
+        public NavigableSet<UInt64> getSamplingColumnIndices() {
+          return ImmutableSortedSet.of();
         }
       };
 
   int getCustodyGroupCount();
 
-  List<UInt64> getCustodyColumnIndices();
+  NavigableSet<UInt64> getCustodyColumnIndices();
 
   int getSamplingGroupCount();
 
-  List<UInt64> getSamplingColumnIndices();
+  NavigableSet<UInt64> getSamplingColumnIndices();
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -49,6 +49,8 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   private boolean isMaxCustodyGroups = false;
 
   private volatile boolean genesisInitialized = false;
+  private volatile NavigableSet<UInt64> custodyColumnIndices;
+  private volatile NavigableSet<UInt64> samplingColumnIndices;
 
   public CustodyGroupCountManagerImpl(
       final Spec spec,
@@ -194,8 +196,8 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   }
 
   @Override
-  public List<UInt64> getCustodyColumnIndices() {
-    return miscHelpersFulu.computeCustodyColumnIndices(nodeId, getCustodyGroupCount());
+  public NavigableSet<UInt64> getCustodyColumnIndices() {
+    return custodyColumnIndices;
   }
 
   @Override
@@ -204,8 +206,8 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   }
 
   @Override
-  public List<UInt64> getSamplingColumnIndices() {
-    return miscHelpersFulu.computeCustodyColumnIndices(nodeId, getSamplingGroupCount());
+  public NavigableSet<UInt64> getSamplingColumnIndices() {
+    return samplingColumnIndices;
   }
 
   private void updateCustodyGroupCount(
@@ -220,8 +222,13 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
 
     final int oldCustodyGroupCount = custodyGroupCount.getAndSet(newCustodyGroupCount);
     if (oldCustodyGroupCount != newCustodyGroupCount) {
+      int samplingGroupCount = getSamplingGroupCount();
+      custodyColumnIndices =
+          miscHelpersFulu.computeCustodyColumnIndices(nodeId, samplingGroupCount);
+      samplingColumnIndices =
+          miscHelpersFulu.computeCustodyColumnIndices(nodeId, samplingGroupCount);
       isMaxCustodyGroups = miscHelpersFulu.isSuperNode(newCustodyGroupCount);
-      custodyGroupCountChannel.onGroupCountUpdate(newCustodyGroupCount, getSamplingGroupCount());
+      custodyGroupCountChannel.onGroupCountUpdate(newCustodyGroupCount, samplingGroupCount);
       custodyGroupCountGauge.set(newCustodyGroupCount);
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -165,6 +165,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     return true;
   }
 
+  @VisibleForTesting
   SafeFuture<Optional<Integer>> computeAndUpdateCustodyGroupCount(
       final Map<UInt64, PreparedProposerInfo> preparedProposerInfo) {
     final Optional<Integer> maybeCustodyGroupCount =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -37,8 +36,14 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyGroupCountManager {
   private static final Logger LOG = LogManager.getLogger();
-  private static final int INITIAL_VALUE = -1;
-  private final AtomicInteger custodyGroupCount = new AtomicInteger(INITIAL_VALUE);
+
+  private record CustodySnapshot(
+      int custodyGroupCount,
+      int samplingGroupCount,
+      NavigableSet<UInt64> custodyColumnIndices,
+      NavigableSet<UInt64> samplingColumnIndices,
+      boolean isMaxCustodyGroups) {}
+
   private final Spec spec;
   private final MiscHelpersFulu miscHelpersFulu;
   private final ProposersDataManager proposersDataManager;
@@ -46,11 +51,9 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   private final CombinedChainDataClient combinedChainDataClient;
   private final UInt256 nodeId;
   private final SettableGauge custodyGroupCountGauge;
-  private boolean isMaxCustodyGroups = false;
 
   private volatile boolean genesisInitialized = false;
-  private volatile NavigableSet<UInt64> custodyColumnIndices;
-  private volatile NavigableSet<UInt64> samplingColumnIndices;
+  private volatile CustodySnapshot snapshot;
 
   public CustodyGroupCountManagerImpl(
       final Spec spec,
@@ -92,6 +95,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
     this.proposersDataManager = proposersDataManager;
     this.combinedChainDataClient = combinedChainDataClient;
     this.custodyGroupCountChannel = custodyGroupCountChannel;
+    this.nodeId = nodeId;
     final Optional<Integer> maybeCustodyCount =
         combinedChainDataClient.getCustodyGroupCount().map(UInt64::intValue);
     if (maybeCustodyCount.isEmpty() || maybeCustodyCount.get() < initCustodyGroupCount) {
@@ -100,13 +104,11 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
       LOG.info("Using custody group count {} from store", maybeCustodyCount.get());
       updateCustodyGroupCount(maybeCustodyCount.get(), maybeCustodyCount);
     }
-
-    this.nodeId = nodeId;
   }
 
   @Override
   public void onSlot(final UInt64 slot) {
-    if (isMaxCustodyGroups) {
+    if (snapshot.isMaxCustodyGroups()) {
       return;
     }
 
@@ -192,22 +194,22 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
 
   @Override
   public int getCustodyGroupCount() {
-    return custodyGroupCount.get();
+    return snapshot.custodyGroupCount();
   }
 
   @Override
   public NavigableSet<UInt64> getCustodyColumnIndices() {
-    return custodyColumnIndices;
+    return snapshot.custodyColumnIndices();
   }
 
   @Override
   public int getSamplingGroupCount() {
-    return miscHelpersFulu.getSamplingGroupCount(custodyGroupCount.get());
+    return snapshot.samplingGroupCount();
   }
 
   @Override
   public NavigableSet<UInt64> getSamplingColumnIndices() {
-    return samplingColumnIndices;
+    return snapshot.samplingColumnIndices();
   }
 
   private void updateCustodyGroupCount(
@@ -220,14 +222,16 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
       combinedChainDataClient.updateCustodyGroupCount(newCustodyGroupCount);
     }
 
-    final int oldCustodyGroupCount = custodyGroupCount.getAndSet(newCustodyGroupCount);
-    if (oldCustodyGroupCount != newCustodyGroupCount) {
-      int samplingGroupCount = getSamplingGroupCount();
-      custodyColumnIndices =
-          miscHelpersFulu.computeCustodyColumnIndices(nodeId, samplingGroupCount);
-      samplingColumnIndices =
-          miscHelpersFulu.computeCustodyColumnIndices(nodeId, samplingGroupCount);
-      isMaxCustodyGroups = miscHelpersFulu.isSuperNode(newCustodyGroupCount);
+    final CustodySnapshot current = this.snapshot;
+    if (current == null || current.custodyGroupCount() != newCustodyGroupCount) {
+      final int samplingGroupCount = miscHelpersFulu.getSamplingGroupCount(newCustodyGroupCount);
+      this.snapshot =
+          new CustodySnapshot(
+              newCustodyGroupCount,
+              samplingGroupCount,
+              miscHelpersFulu.computeCustodyColumnIndices(nodeId, newCustodyGroupCount),
+              miscHelpersFulu.computeCustodyColumnIndices(nodeId, samplingGroupCount),
+              miscHelpersFulu.isSuperNode(newCustodyGroupCount));
       custodyGroupCountChannel.onGroupCountUpdate(newCustodyGroupCount, samplingGroupCount);
       custodyGroupCountGauge.set(newCustodyGroupCount);
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImpl.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -40,8 +40,8 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   private record CustodySnapshot(
       int custodyGroupCount,
       int samplingGroupCount,
-      NavigableSet<UInt64> custodyColumnIndices,
-      NavigableSet<UInt64> samplingColumnIndices,
+      Set<UInt64> custodyColumnIndices,
+      Set<UInt64> samplingColumnIndices,
       boolean isMaxCustodyGroups) {}
 
   private final Spec spec;
@@ -199,7 +199,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   }
 
   @Override
-  public NavigableSet<UInt64> getCustodyColumnIndices() {
+  public Set<UInt64> getCustodyColumnIndices() {
     return snapshot.custodyColumnIndices();
   }
 
@@ -209,7 +209,7 @@ public class CustodyGroupCountManagerImpl implements SlotEventsChannel, CustodyG
   }
 
   @Override
-  public NavigableSet<UInt64> getSamplingColumnIndices() {
+  public Set<UInt64> getSamplingColumnIndices() {
     return snapshot.samplingColumnIndices();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
@@ -536,7 +536,7 @@ public class DasCustodyBackfiller extends Service
                   identifiers.stream()
                       .map(DataColumnSlotAndIdentifier::columnIndex)
                       .collect(Collectors.toSet());
-              final List<UInt64> requiredIndices =
+              final Set<UInt64> requiredIndices =
                   custodyGroupCountManager.getCustodyColumnIndices();
 
               final int syncedColumnCount =
@@ -577,7 +577,7 @@ public class DasCustodyBackfiller extends Service
       UInt64 fromSlot,
       UInt64 toSlot,
       UInt64 minCustodyPeriodSlot,
-      List<UInt64> requiredColumnsInCustody,
+      Set<UInt64> requiredColumnsInCustody,
       int custodyGroupCount,
       Set<DataColumnSlotAndIdentifier> columnsInCustody,
       List<SlotAndBlockRootWithBlobsPresence> blocksInfo,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,7 +30,7 @@ import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 record DataColumnSamplingTracker(
     UInt64 slot,
     Bytes32 blockRoot,
-    List<UInt64> samplingRequirement,
+    NavigableSet<UInt64> samplingRequirement,
     Set<UInt64> missingColumns,
     AtomicBoolean rpcFetchInProgress,
     SafeFuture<List<UInt64>> completionFuture,
@@ -42,7 +43,8 @@ record DataColumnSamplingTracker(
       final Bytes32 blockRoot,
       final CustodyGroupCountManager custodyGroupCountManager,
       final Optional<Integer> completionColumnCount) {
-    final List<UInt64> samplingRequirement = custodyGroupCountManager.getSamplingColumnIndices();
+    final NavigableSet<UInt64> samplingRequirement =
+        custodyGroupCountManager.getSamplingColumnIndices();
     final Set<UInt64> missingColumns = ConcurrentHashMap.newKeySet(samplingRequirement.size());
     missingColumns.addAll(samplingRequirement);
     final SafeFuture<List<UInt64>> completionFuture = new SafeFuture<>();
@@ -77,7 +79,7 @@ record DataColumnSamplingTracker(
           blockRoot,
           columnIdentifier.columnIndex(),
           origin);
-      completionFuture.complete(samplingRequirement);
+      completionFuture.complete(samplingRequirement.stream().toList());
       fullySampled.set(true);
       return true;
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,7 +29,7 @@ import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 record DataColumnSamplingTracker(
     UInt64 slot,
     Bytes32 blockRoot,
-    NavigableSet<UInt64> samplingRequirement,
+    Set<UInt64> samplingRequirement,
     Set<UInt64> missingColumns,
     AtomicBoolean rpcFetchInProgress,
     SafeFuture<List<UInt64>> completionFuture,
@@ -43,8 +42,7 @@ record DataColumnSamplingTracker(
       final Bytes32 blockRoot,
       final CustodyGroupCountManager custodyGroupCountManager,
       final Optional<Integer> completionColumnCount) {
-    final NavigableSet<UInt64> samplingRequirement =
-        custodyGroupCountManager.getSamplingColumnIndices();
+    final Set<UInt64> samplingRequirement = custodyGroupCountManager.getSamplingColumnIndices();
     final Set<UInt64> missingColumns = ConcurrentHashMap.newKeySet(samplingRequirement.size());
     missingColumns.addAll(samplingRequirement);
     final SafeFuture<List<UInt64>> completionFuture = new SafeFuture<>();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -267,7 +267,7 @@ public class DataColumnSidecarCustodyImpl
               slot, Optional.empty(), Collections.emptyList(), Collections.emptyList()));
     }
     final SafeFuture<Optional<Bytes32>> maybeCanonicalBlockRoot = getBlockRootWithBlobs(slot);
-    final List<UInt64> requiredColumns = custodyGroupCountManager.getCustodyColumnIndices();
+    final Set<UInt64> requiredColumns = custodyGroupCountManager.getCustodyColumnIndices();
     final SafeFuture<List<DataColumnSlotAndIdentifier>> existingColumns =
         db.getColumnIdentifiers(slot);
     return SafeFuture.allOf(maybeCanonicalBlockRoot, existingColumns)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -341,8 +340,7 @@ public class SimpleSidecarRetriever
     }
 
     private Set<UInt64> calcNodeCustodyIndices(final CacheKey cacheKey) {
-      return new HashSet<>(
-          miscHelpersFulu.computeCustodyColumnIndices(nodeId, cacheKey.custodyCount()));
+      return miscHelpersFulu.computeCustodyColumnIndices(nodeId, cacheKey.custodyCount());
     }
 
     private Set<UInt64> getNodeCustodyIndices(final SpecVersion specVersion) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImpl.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -347,8 +346,7 @@ public class DataColumnSidecarELManagerImpl extends AbstractIgnoringFutureHistor
     if (samplingGroupCount == maxCustodyGroups) {
       localCustodySidecars = dataColumnSidecars;
     } else {
-      final Set<UInt64> localCustodyIndices =
-          new HashSet<>(custodyGroupCountManager.getSamplingColumnIndices());
+      final Set<UInt64> localCustodyIndices = custodyGroupCountManager.getSamplingColumnIndices();
       localCustodySidecars =
           dataColumnSidecars.stream()
               .filter(sidecar -> localCustodyIndices.contains(sidecar.getIndex()))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
@@ -16,8 +16,10 @@ package tech.pegasys.teku.statetransition.datacolumns;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -189,6 +191,91 @@ public class CustodyGroupCountManagerImplTest {
         .containsAll(custodyGroupCountManager.getCustodyColumnIndices());
     assertThat(metricsSystem.getGauge(TekuMetricCategory.BEACON, "custody_groups").getValue())
         .isEqualTo(10);
+  }
+
+  @Test
+  public void onSlot_shouldStopRecomputingWhenSuperNode() {
+    // custodyGroupCount = numberOfCustodyGroups = 128, so isSuperNode returns true
+    setUpManager(128, 8, 8);
+    assertThat(custodyGroupCountManager.getCustodyGroupCount()).isEqualTo(128);
+
+    custodyGroupCountManager.onSlot(UInt64.ZERO);
+
+    // onSlot should exit immediately before calling getPreparedProposerInfo
+    verifyNoMoreInteractions(proposersDataManager);
+  }
+
+  @Test
+  public void onSlot_shouldDeferGenesisInitUntilValidatorsAppear() {
+    setUpManager(4, 8, 8);
+
+    // First call at genesis with no validators
+    when(proposersDataManager.getPreparedProposerInfo()).thenReturn(Map.of());
+    custodyGroupCountManager.onSlot(UInt64.ZERO);
+
+    // No genesis init — getBestFinalizedState not called
+    verify(combinedChainDataClient, never()).getBestFinalizedState();
+
+    // Validators appear, still epoch 0 (slot 1, minimal config has 8 slots/epoch)
+    when(proposersDataManager.getPreparedProposerInfo())
+        .thenReturn(Map.of(UInt64.ZERO, mock(PreparedProposerInfo.class)));
+    custodyGroupCountManager.onSlot(UInt64.ONE);
+
+    // Genesis initialization now fires
+    verify(combinedChainDataClient, times(1)).getBestFinalizedState();
+  }
+
+  @Test
+  public void snapshotShouldBeConsistentAfterUpdate() {
+    setUpManager(4, 8, 8);
+    assertThat(custodyGroupCountManager.getCustodyGroupCount()).isEqualTo(4);
+
+    // Trigger update to custody=10
+    when(miscHelpersFulu.getValidatorsCustodyRequirement(any(), anySet()))
+        .thenReturn(UInt64.valueOf(10));
+
+    final SafeFuture<Optional<Integer>> result =
+        custodyGroupCountManager.computeAndUpdateCustodyGroupCount(
+            Map.of(UInt64.ZERO, mock(PreparedProposerInfo.class)));
+
+    assertThat(result).isCompletedWithValue(Optional.of(10));
+
+    // All getters must reflect values computed from the same custody count
+    assertThat(custodyGroupCountManager.getCustodyGroupCount()).isEqualTo(10);
+
+    final int expectedSamplingGroupCount = miscHelpersFulu.getSamplingGroupCount(10);
+    assertThat(custodyGroupCountManager.getSamplingGroupCount())
+        .isEqualTo(expectedSamplingGroupCount);
+
+    final NavigableSet<UInt64> custodyColumns = custodyGroupCountManager.getCustodyColumnIndices();
+    final NavigableSet<UInt64> samplingColumns =
+        custodyGroupCountManager.getSamplingColumnIndices();
+
+    assertThat(custodyColumns).isNotEmpty();
+    assertThat(samplingColumns).isNotEmpty();
+    // Sampling columns must be a superset of custody columns
+    assertThat(samplingColumns).containsAll(custodyColumns);
+  }
+
+  @Test
+  public void shouldNotFireChannelNotificationWhenCustodyCountUnchanged() {
+    setUpManager(4, 8, 8);
+
+    // Initial construction fires the channel notification
+    verify(custodyGroupCountChannel, times(1)).onGroupCountUpdate(anyInt(), anyInt());
+    reset(custodyGroupCountChannel);
+
+    // Compute again with same result (custody stays at 4)
+    when(miscHelpersFulu.getValidatorsCustodyRequirement(any(), anySet()))
+        .thenReturn(UInt64.valueOf(4));
+
+    assertThat(
+            custodyGroupCountManager.computeAndUpdateCustodyGroupCount(
+                Map.of(UInt64.ZERO, mock(PreparedProposerInfo.class))))
+        .isCompleted();
+
+    // Channel should NOT be notified since count didn't change
+    verifyNoMoreInteractions(custodyGroupCountChannel);
   }
 
   private void setUpManager(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -60,7 +60,8 @@ public class CustodyGroupCountManagerImplTest {
 
     setUpManager(4, 8, 8);
 
-    final List<UInt64> samplingColumnIndices = custodyGroupCountManager.getSamplingColumnIndices();
+    final NavigableSet<UInt64> samplingColumnIndices =
+        custodyGroupCountManager.getSamplingColumnIndices();
     // Sampling column groups should always include all custody columns at the minimum.
     assertThat(samplingColumnIndices)
         .containsAll(custodyGroupCountManager.getCustodyColumnIndices());
@@ -181,7 +182,8 @@ public class CustodyGroupCountManagerImplTest {
 
     assertThat(custodyGroupCountManager.getCustodyGroupCount()).isEqualTo(10);
 
-    final List<UInt64> samplingColumnIndices = custodyGroupCountManager.getSamplingColumnIndices();
+    final NavigableSet<UInt64> samplingColumnIndices =
+        custodyGroupCountManager.getSamplingColumnIndices();
 
     assertThat(samplingColumnIndices)
         .containsAll(custodyGroupCountManager.getCustodyColumnIndices());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/CustodyGroupCountManagerImplTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
@@ -62,8 +62,7 @@ public class CustodyGroupCountManagerImplTest {
 
     setUpManager(4, 8, 8);
 
-    final NavigableSet<UInt64> samplingColumnIndices =
-        custodyGroupCountManager.getSamplingColumnIndices();
+    final Set<UInt64> samplingColumnIndices = custodyGroupCountManager.getSamplingColumnIndices();
     // Sampling column groups should always include all custody columns at the minimum.
     assertThat(samplingColumnIndices)
         .containsAll(custodyGroupCountManager.getCustodyColumnIndices());
@@ -184,8 +183,7 @@ public class CustodyGroupCountManagerImplTest {
 
     assertThat(custodyGroupCountManager.getCustodyGroupCount()).isEqualTo(10);
 
-    final NavigableSet<UInt64> samplingColumnIndices =
-        custodyGroupCountManager.getSamplingColumnIndices();
+    final Set<UInt64> samplingColumnIndices = custodyGroupCountManager.getSamplingColumnIndices();
 
     assertThat(samplingColumnIndices)
         .containsAll(custodyGroupCountManager.getCustodyColumnIndices());
@@ -247,9 +245,8 @@ public class CustodyGroupCountManagerImplTest {
     assertThat(custodyGroupCountManager.getSamplingGroupCount())
         .isEqualTo(expectedSamplingGroupCount);
 
-    final NavigableSet<UInt64> custodyColumns = custodyGroupCountManager.getCustodyColumnIndices();
-    final NavigableSet<UInt64> samplingColumns =
-        custodyGroupCountManager.getSamplingColumnIndices();
+    final Set<UInt64> custodyColumns = custodyGroupCountManager.getCustodyColumnIndices();
+    final Set<UInt64> samplingColumns = custodyGroupCountManager.getSamplingColumnIndices();
 
     assertThat(custodyColumns).isNotEmpty();
     assertThat(samplingColumns).isNotEmpty();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfillerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfillerTest.java
@@ -26,8 +26,10 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.time.Duration;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -83,7 +85,8 @@ class DasCustodyBackfillerTest {
 
   private static final int BATCH_SIZE = 10;
   private static final int CUSTODY_GROUP_COUNT = 2;
-  private static final List<UInt64> CUSTODY_INDICES = List.of(UInt64.ZERO, UInt64.ONE);
+  private static final NavigableSet<UInt64> CUSTODY_INDICES =
+      ImmutableSortedSet.of(UInt64.ZERO, UInt64.ONE);
 
   @BeforeEach
   void setUp() {
@@ -406,7 +409,8 @@ class DasCustodyBackfillerTest {
 
     // Override custody settings for this test to only require 1 column (Index 0).
     // This ensures 'retrieve' is called exactly ONCE per block, matching the verify expectation.
-    when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(List.of(UInt64.ZERO));
+    when(custodyGroupCountManager.getCustodyColumnIndices())
+        .thenReturn(ImmutableSortedSet.of(UInt64.ZERO));
     when(custodyGroupCountManager.getCustodyGroupCount()).thenReturn(1);
     backfiller =
         new DasCustodyBackfiller(
@@ -559,7 +563,7 @@ class DasCustodyBackfillerTest {
     earliestAvailableColumnSlotStore.set(Optional.of(UInt64.valueOf(500)));
     // same 2 indices but they are different to what is synced
     when(custodyGroupCountManager.getCustodyColumnIndices())
-        .thenReturn(List.of(UInt64.valueOf(3), UInt64.valueOf(4)));
+        .thenReturn(ImmutableSortedSet.of(UInt64.valueOf(3), UInt64.valueOf(4)));
     safeJoin(backfiller.start());
 
     // Run the triggered task

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfillerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfillerTest.java
@@ -26,11 +26,10 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
-import com.google.common.collect.ImmutableSortedSet;
 import java.time.Duration;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -85,8 +84,7 @@ class DasCustodyBackfillerTest {
 
   private static final int BATCH_SIZE = 10;
   private static final int CUSTODY_GROUP_COUNT = 2;
-  private static final NavigableSet<UInt64> CUSTODY_INDICES =
-      ImmutableSortedSet.of(UInt64.ZERO, UInt64.ONE);
+  private static final Set<UInt64> CUSTODY_INDICES = Set.of(UInt64.ZERO, UInt64.ONE);
 
   @BeforeEach
   void setUp() {
@@ -109,9 +107,7 @@ class DasCustodyBackfillerTest {
     when(combinedChainDataClient.getDataColumnIdentifiers(any(), any(), any()))
         .thenReturn(
             SafeFuture.completedFuture(
-                List.of(
-                    new DataColumnSlotAndIdentifier(
-                        UInt64.ZERO, Bytes32.ZERO, CUSTODY_INDICES.getFirst()))));
+                List.of(new DataColumnSlotAndIdentifier(UInt64.ZERO, Bytes32.ZERO, UInt64.ZERO))));
     when(combinedChainDataClient.getDataColumnIdentifiers(any()))
         .thenReturn(
             SafeFuture.completedFuture(
@@ -409,8 +405,7 @@ class DasCustodyBackfillerTest {
 
     // Override custody settings for this test to only require 1 column (Index 0).
     // This ensures 'retrieve' is called exactly ONCE per block, matching the verify expectation.
-    when(custodyGroupCountManager.getCustodyColumnIndices())
-        .thenReturn(ImmutableSortedSet.of(UInt64.ZERO));
+    when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(Set.of(UInt64.ZERO));
     when(custodyGroupCountManager.getCustodyGroupCount()).thenReturn(1);
     backfiller =
         new DasCustodyBackfiller(
@@ -563,7 +558,7 @@ class DasCustodyBackfillerTest {
     earliestAvailableColumnSlotStore.set(Optional.of(UInt64.valueOf(500)));
     // same 2 indices but they are different to what is synced
     when(custodyGroupCountManager.getCustodyColumnIndices())
-        .thenReturn(ImmutableSortedSet.of(UInt64.valueOf(3), UInt64.valueOf(4)));
+        .thenReturn(Set.of(UInt64.valueOf(3), UInt64.valueOf(4)));
     safeJoin(backfiller.start());
 
     // Run the triggered task

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
@@ -25,10 +25,9 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_OLD_EPOCH;
 import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED;
 
-import com.google.common.collect.ImmutableSortedSet;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NavigableSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -83,7 +82,7 @@ public class DasPreSamplerTest {
         .thenReturn(NOT_REQUIRED_OLD_EPOCH);
 
     // Setup for the block that will be sampled
-    when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(ImmutableSortedSet.of());
+    when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(Set.of());
     when(sampler.checkDataAvailability(blockToSample.getSlot(), blockToSample.getRoot()))
         .thenReturn(SafeFuture.completedFuture(null));
 
@@ -105,8 +104,7 @@ public class DasPreSamplerTest {
   @Test
   void shouldPreSampleBlockWhenRequiredAndNoColumnsInCustody() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
-    final NavigableSet<UInt64> columnIndices =
-        ImmutableSortedSet.of(UInt64.valueOf(1), UInt64.valueOf(5));
+    final Set<UInt64> columnIndices = Set.of(UInt64.valueOf(1), UInt64.valueOf(5));
     final DataColumnSlotAndIdentifier col1 =
         new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), UInt64.valueOf(1));
     final DataColumnSlotAndIdentifier col5 =
@@ -131,8 +129,7 @@ public class DasPreSamplerTest {
   @Test
   void shouldNotifySamplerOfColumnsAlreadyInCustody() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
-    final NavigableSet<UInt64> columnIndices =
-        ImmutableSortedSet.of(UInt64.valueOf(2), UInt64.valueOf(4));
+    final Set<UInt64> columnIndices = Set.of(UInt64.valueOf(2), UInt64.valueOf(4));
     final DataColumnSlotAndIdentifier col2 =
         new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), UInt64.valueOf(2));
     final DataColumnSlotAndIdentifier col4 =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
@@ -25,8 +25,10 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler.SamplingEligibilityStatus.NOT_REQUIRED_OLD_EPOCH;
 import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler.SamplingEligibilityStatus.REQUIRED;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NavigableSet;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -81,7 +83,7 @@ public class DasPreSamplerTest {
         .thenReturn(NOT_REQUIRED_OLD_EPOCH);
 
     // Setup for the block that will be sampled
-    when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(List.of());
+    when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(ImmutableSortedSet.of());
     when(sampler.checkDataAvailability(blockToSample.getSlot(), blockToSample.getRoot()))
         .thenReturn(SafeFuture.completedFuture(null));
 
@@ -103,11 +105,12 @@ public class DasPreSamplerTest {
   @Test
   void shouldPreSampleBlockWhenRequiredAndNoColumnsInCustody() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
-    final List<UInt64> columnIndices = List.of(UInt64.valueOf(1), UInt64.valueOf(5));
+    final NavigableSet<UInt64> columnIndices =
+        ImmutableSortedSet.of(UInt64.valueOf(1), UInt64.valueOf(5));
     final DataColumnSlotAndIdentifier col1 =
-        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), columnIndices.get(0));
+        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), UInt64.valueOf(1));
     final DataColumnSlotAndIdentifier col5 =
-        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), columnIndices.get(1));
+        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), UInt64.valueOf(5));
 
     when(sampler.checkSamplingEligibility(block.getMessage())).thenReturn(REQUIRED);
     when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(columnIndices);
@@ -128,11 +131,12 @@ public class DasPreSamplerTest {
   @Test
   void shouldNotifySamplerOfColumnsAlreadyInCustody() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
-    final List<UInt64> columnIndices = List.of(UInt64.valueOf(2), UInt64.valueOf(4));
+    final NavigableSet<UInt64> columnIndices =
+        ImmutableSortedSet.of(UInt64.valueOf(2), UInt64.valueOf(4));
     final DataColumnSlotAndIdentifier col2 =
-        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), columnIndices.get(0));
+        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), UInt64.valueOf(2));
     final DataColumnSlotAndIdentifier col4 =
-        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), columnIndices.get(1));
+        new DataColumnSlotAndIdentifier(block.getSlot(), block.getRoot(), UInt64.valueOf(4));
 
     when(sampler.checkSamplingEligibility(block.getMessage())).thenReturn(REQUIRED);
     when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(columnIndices);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -26,9 +26,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -56,8 +58,8 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class DasSamplerBasicTest {
   private static final Spec SPEC = TestSpecFactory.createMinimalFulu();
-  private static final List<UInt64> SAMPLING_INDICES =
-      List.of(UInt64.valueOf(5), UInt64.ZERO, UInt64.valueOf(2));
+  private static final NavigableSet<UInt64> SAMPLING_INDICES =
+      ImmutableSortedSet.of(UInt64.valueOf(5), UInt64.ZERO, UInt64.valueOf(2));
 
   private final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(0);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(stubTimeProvider);
@@ -105,7 +107,8 @@ public class DasSamplerBasicTest {
         dataStructureUtil.randomDataColumnSidecar(
             dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDICES.getFirst());
 
-    final List<UInt64> remainingColumns = SAMPLING_INDICES.subList(1, SAMPLING_INDICES.size());
+    final NavigableSet<UInt64> remainingColumns =
+        SAMPLING_INDICES.tailSet(SAMPLING_INDICES.getFirst(), false);
 
     sampler.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC);
 
@@ -118,7 +121,8 @@ public class DasSamplerBasicTest {
         dataStructureUtil.randomDataColumnSidecar(
             dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDICES.getFirst());
 
-    final List<UInt64> remainingColumns = SAMPLING_INDICES.subList(1, SAMPLING_INDICES.size());
+    final NavigableSet<UInt64> remainingColumns =
+        SAMPLING_INDICES.tailSet(SAMPLING_INDICES.getFirst(), false);
 
     when(rpcFetchDelayProvider.calculate(sidecar.getSlot())).thenReturn(Duration.ofSeconds(1));
 
@@ -187,8 +191,8 @@ public class DasSamplerBasicTest {
 
     final DataColumnSidecar lateArrivedSidecar =
         missingColumnSidecars.get(SAMPLING_INDICES.getFirst());
-    final List<UInt64> remainingColumnsIndices =
-        SAMPLING_INDICES.subList(1, SAMPLING_INDICES.size());
+    final NavigableSet<UInt64> remainingColumnsIndices =
+        SAMPLING_INDICES.tailSet(SAMPLING_INDICES.getFirst(), false);
 
     // prepare retriever mock to return futures when called
     doAnswer(
@@ -514,7 +518,7 @@ public class DasSamplerBasicTest {
   }
 
   private void assertSamplerTracker(
-      final Bytes32 blockRoot, final UInt64 slot, final List<UInt64> missingColumns) {
+      final Bytes32 blockRoot, final UInt64 slot, final NavigableSet<UInt64> missingColumns) {
     assertThat(sampler.getRecentlySampledColumnsByRoot())
         .hasEntrySatisfying(
             blockRoot,
@@ -543,7 +547,7 @@ public class DasSamplerBasicTest {
   private void assertRPCFetchInMillis(
       final UInt64 slot,
       final Bytes32 blockRoot,
-      final List<UInt64> missingColumns,
+      final NavigableSet<UInt64> missingColumns,
       final int millisFromNow) {
 
     if (millisFromNow > 0) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -26,12 +26,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableSortedSet;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -58,8 +57,11 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class DasSamplerBasicTest {
   private static final Spec SPEC = TestSpecFactory.createMinimalFulu();
-  private static final NavigableSet<UInt64> SAMPLING_INDICES =
-      ImmutableSortedSet.of(UInt64.valueOf(5), UInt64.ZERO, UInt64.valueOf(2));
+  private static final UInt64 SAMPLING_INDEX_0 = UInt64.ZERO;
+  private static final UInt64 SAMPLING_INDEX_2 = UInt64.valueOf(2);
+  private static final UInt64 SAMPLING_INDEX_5 = UInt64.valueOf(5);
+  private static final Set<UInt64> SAMPLING_INDICES =
+      Set.of(SAMPLING_INDEX_0, SAMPLING_INDEX_2, SAMPLING_INDEX_5);
 
   private final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(0);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(stubTimeProvider);
@@ -105,10 +107,9 @@ public class DasSamplerBasicTest {
   void onNewValidatedDataColumnSidecar_shouldAddToTracker() {
     final DataColumnSidecar sidecar =
         dataStructureUtil.randomDataColumnSidecar(
-            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDICES.getFirst());
+            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDEX_0);
 
-    final NavigableSet<UInt64> remainingColumns =
-        SAMPLING_INDICES.tailSet(SAMPLING_INDICES.getFirst(), false);
+    final Set<UInt64> remainingColumns = Set.of(SAMPLING_INDEX_2, SAMPLING_INDEX_5);
 
     sampler.onNewValidatedDataColumnSidecar(sidecar, RemoteOrigin.RPC);
 
@@ -119,10 +120,9 @@ public class DasSamplerBasicTest {
   void onNewValidatedDataColumnSidecar_shouldScheduleRPCFetchWhenDelayIsNonZero() {
     final DataColumnSidecar sidecar =
         dataStructureUtil.randomDataColumnSidecar(
-            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDICES.getFirst());
+            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDEX_0);
 
-    final NavigableSet<UInt64> remainingColumns =
-        SAMPLING_INDICES.tailSet(SAMPLING_INDICES.getFirst(), false);
+    final Set<UInt64> remainingColumns = Set.of(SAMPLING_INDEX_2, SAMPLING_INDEX_5);
 
     when(rpcFetchDelayProvider.calculate(sidecar.getSlot())).thenReturn(Duration.ofSeconds(1));
 
@@ -139,7 +139,7 @@ public class DasSamplerBasicTest {
   void onNewValidatedDataColumnSidecar_shouldScheduleRPCFetchWhenDelayIsZero() {
     final DataColumnSidecar sidecar =
         dataStructureUtil.randomDataColumnSidecar(
-            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDICES.getFirst());
+            dataStructureUtil.randomSignedBeaconBlockHeader(), SAMPLING_INDEX_0);
 
     when(rpcFetchDelayProvider.calculate(sidecar.getSlot())).thenReturn(Duration.ZERO);
 
@@ -189,10 +189,8 @@ public class DasSamplerBasicTest {
             .map(index -> entry(index, new SafeFuture<DataColumnSidecar>()))
             .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
-    final DataColumnSidecar lateArrivedSidecar =
-        missingColumnSidecars.get(SAMPLING_INDICES.getFirst());
-    final NavigableSet<UInt64> remainingColumnsIndices =
-        SAMPLING_INDICES.tailSet(SAMPLING_INDICES.getFirst(), false);
+    final DataColumnSidecar lateArrivedSidecar = missingColumnSidecars.get(SAMPLING_INDEX_0);
+    final Set<UInt64> remainingColumnsIndices = Set.of(SAMPLING_INDEX_2, SAMPLING_INDEX_5);
 
     // prepare retriever mock to return futures when called
     doAnswer(
@@ -518,7 +516,7 @@ public class DasSamplerBasicTest {
   }
 
   private void assertSamplerTracker(
-      final Bytes32 blockRoot, final UInt64 slot, final NavigableSet<UInt64> missingColumns) {
+      final Bytes32 blockRoot, final UInt64 slot, final Set<UInt64> missingColumns) {
     assertThat(sampler.getRecentlySampledColumnsByRoot())
         .hasEntrySatisfying(
             blockRoot,
@@ -547,7 +545,7 @@ public class DasSamplerBasicTest {
   private void assertRPCFetchInMillis(
       final UInt64 slot,
       final Bytes32 blockRoot,
-      final NavigableSet<UInt64> missingColumns,
+      final Set<UInt64> missingColumns,
       final int millisFromNow) {
 
     if (millisFromNow > 0) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
@@ -17,12 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableSortedSet;
-import java.util.Comparator;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,8 +35,11 @@ class DataColumnSamplingTrackerTest {
   private static final Bytes32 BLOCK_ROOT =
       Bytes32.fromHexString("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
   private static final RemoteOrigin MOCK_ORIGIN = mock(RemoteOrigin.class);
-  private static final NavigableSet<UInt64> SAMPLING_REQUIREMENT =
-      ImmutableSortedSet.of(UInt64.valueOf(5), UInt64.valueOf(10), UInt64.valueOf(15));
+  private static final UInt64 COLUMN_INDEX_5 = UInt64.valueOf(5);
+  private static final UInt64 COLUMN_INDEX_10 = UInt64.valueOf(10);
+  private static final UInt64 COLUMN_INDEX_15 = UInt64.valueOf(15);
+  private static final Set<UInt64> SAMPLING_REQUIREMENT =
+      Set.of(COLUMN_INDEX_5, COLUMN_INDEX_10, COLUMN_INDEX_15);
   private static final int HALF_COLUMN_COUNT = 64;
 
   private final CustodyGroupCountManager custodyGroupCountManager =
@@ -67,9 +69,8 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void add_shouldReturnTrueAndRemoveColumnWhenItIsMissing() {
-    final UInt64 columnIndexToAdd = SAMPLING_REQUIREMENT.first(); // Index 5
-    final NavigableSet<UInt64> remainingColumns =
-        SAMPLING_REQUIREMENT.tailSet(SAMPLING_REQUIREMENT.first(), false);
+    final UInt64 columnIndexToAdd = COLUMN_INDEX_5;
+    final Set<UInt64> remainingColumns = Set.of(COLUMN_INDEX_10, COLUMN_INDEX_15);
     final DataColumnSlotAndIdentifier columnIdentifier =
         new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, columnIndexToAdd);
 
@@ -83,15 +84,14 @@ class DataColumnSamplingTrackerTest {
   @Test
   void add_shouldCompleteFetchFutureWhenLastColumnIsAdded()
       throws ExecutionException, InterruptedException {
-    SAMPLING_REQUIREMENT
-        .headSet(SAMPLING_REQUIREMENT.last(), false)
+    final UInt64 lastColumnIndex = COLUMN_INDEX_15;
+    SAMPLING_REQUIREMENT.stream()
+        .filter(index -> !index.equals(lastColumnIndex))
         .forEach(
             index ->
                 tracker.add(new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, index), MOCK_ORIGIN));
     assertThat(tracker.missingColumns()).hasSize(1);
     assertThat(tracker.completionFuture()).isNotDone();
-
-    final UInt64 lastColumnIndex = SAMPLING_REQUIREMENT.last();
     final DataColumnSlotAndIdentifier lastColumnIdentifier =
         new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, lastColumnIndex);
     final boolean result = tracker.add(lastColumnIdentifier, MOCK_ORIGIN);
@@ -106,10 +106,10 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void add_shouldCompleteEarly_whenHalfColumnsSamplingCompletionIsSet() {
-    final NavigableSet<UInt64> samplingRequirement =
+    final Set<UInt64> samplingRequirement =
         Stream.iterate(UInt64.ZERO, UInt64::increment)
             .limit(128)
-            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+            .collect(Collectors.toUnmodifiableSet());
     when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(samplingRequirement);
     tracker =
         DataColumnSamplingTracker.create(
@@ -140,10 +140,10 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void add_shouldNotCompleteEarly_whenHalfColumnsSamplingCompletionDisabled() {
-    final NavigableSet<UInt64> samplingRequirement =
+    final Set<UInt64> samplingRequirement =
         Stream.iterate(UInt64.ZERO, UInt64::increment)
             .limit(128)
-            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+            .collect(Collectors.toUnmodifiableSet());
     when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(samplingRequirement);
     tracker =
         DataColumnSamplingTracker.create(
@@ -170,7 +170,7 @@ class DataColumnSamplingTrackerTest {
   void add_shouldReturnFalseForMismatchedSlot() {
     final UInt64 mismatchedSlot = SLOT.plus(1);
     final DataColumnSlotAndIdentifier columnIdentifier =
-        new DataColumnSlotAndIdentifier(mismatchedSlot, BLOCK_ROOT, SAMPLING_REQUIREMENT.first());
+        new DataColumnSlotAndIdentifier(mismatchedSlot, BLOCK_ROOT, COLUMN_INDEX_5);
 
     final boolean result = tracker.add(columnIdentifier, MOCK_ORIGIN);
 
@@ -183,7 +183,7 @@ class DataColumnSamplingTrackerTest {
   void add_shouldReturnFalseForMismatchedBlockRoot() {
     final Bytes32 mismatchedRoot = Bytes32.fromHexString("0xff");
     final DataColumnSlotAndIdentifier columnIdentifier =
-        new DataColumnSlotAndIdentifier(SLOT, mismatchedRoot, SAMPLING_REQUIREMENT.first());
+        new DataColumnSlotAndIdentifier(SLOT, mismatchedRoot, COLUMN_INDEX_5);
 
     final boolean result = tracker.add(columnIdentifier, MOCK_ORIGIN);
 
@@ -194,7 +194,7 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void add_shouldReturnFalseWhenAddingSameColumnTwice() {
-    final UInt64 columnIndexToAdd = SAMPLING_REQUIREMENT.first();
+    final UInt64 columnIndexToAdd = COLUMN_INDEX_5;
     final DataColumnSlotAndIdentifier columnIdentifier =
         new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, columnIndexToAdd);
 
@@ -235,7 +235,7 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void getMissingColumnIdentifiers_shouldReturnPartialListAfterAddingOne() {
-    final UInt64 addedIndex = UInt64.valueOf(10); // middle element
+    final UInt64 addedIndex = COLUMN_INDEX_10;
     tracker.add(new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, addedIndex), MOCK_ORIGIN);
 
     final List<DataColumnSlotAndIdentifier> missing = tracker.getMissingColumnIdentifiers();
@@ -243,7 +243,7 @@ class DataColumnSamplingTrackerTest {
     assertThat(missing)
         .hasSize(SAMPLING_REQUIREMENT.size() - 1)
         .extracting(DataColumnSlotAndIdentifier::columnIndex)
-        .containsExactly(UInt64.valueOf(5), UInt64.valueOf(15));
+        .containsExactly(COLUMN_INDEX_5, COLUMN_INDEX_15);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
@@ -235,15 +235,14 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void getMissingColumnIdentifiers_shouldReturnPartialListAfterAddingOne() {
-    final UInt64 addedIndex = COLUMN_INDEX_10;
-    tracker.add(new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, addedIndex), MOCK_ORIGIN);
+    tracker.add(new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, COLUMN_INDEX_10), MOCK_ORIGIN);
 
     final List<DataColumnSlotAndIdentifier> missing = tracker.getMissingColumnIdentifiers();
 
     assertThat(missing)
         .hasSize(SAMPLING_REQUIREMENT.size() - 1)
         .extracting(DataColumnSlotAndIdentifier::columnIndex)
-        .containsExactly(COLUMN_INDEX_5, COLUMN_INDEX_15);
+        .containsExactlyInAnyOrder(COLUMN_INDEX_5, COLUMN_INDEX_15);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTrackerTest.java
@@ -17,7 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Comparator;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -33,8 +36,8 @@ class DataColumnSamplingTrackerTest {
   private static final Bytes32 BLOCK_ROOT =
       Bytes32.fromHexString("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
   private static final RemoteOrigin MOCK_ORIGIN = mock(RemoteOrigin.class);
-  private static final List<UInt64> SAMPLING_REQUIREMENT =
-      List.of(UInt64.valueOf(5), UInt64.valueOf(10), UInt64.valueOf(15));
+  private static final NavigableSet<UInt64> SAMPLING_REQUIREMENT =
+      ImmutableSortedSet.of(UInt64.valueOf(5), UInt64.valueOf(10), UInt64.valueOf(15));
   private static final int HALF_COLUMN_COUNT = 64;
 
   private final CustodyGroupCountManager custodyGroupCountManager =
@@ -64,9 +67,9 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void add_shouldReturnTrueAndRemoveColumnWhenItIsMissing() {
-    final UInt64 columnIndexToAdd = SAMPLING_REQUIREMENT.get(0); // Index 5
-    final List<UInt64> remainingColumns =
-        SAMPLING_REQUIREMENT.subList(1, SAMPLING_REQUIREMENT.size());
+    final UInt64 columnIndexToAdd = SAMPLING_REQUIREMENT.first(); // Index 5
+    final NavigableSet<UInt64> remainingColumns =
+        SAMPLING_REQUIREMENT.tailSet(SAMPLING_REQUIREMENT.first(), false);
     final DataColumnSlotAndIdentifier columnIdentifier =
         new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, columnIndexToAdd);
 
@@ -80,14 +83,15 @@ class DataColumnSamplingTrackerTest {
   @Test
   void add_shouldCompleteFetchFutureWhenLastColumnIsAdded()
       throws ExecutionException, InterruptedException {
-    for (int i = 0; i < SAMPLING_REQUIREMENT.size() - 1; i++) {
-      final UInt64 index = SAMPLING_REQUIREMENT.get(i);
-      tracker.add(new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, index), MOCK_ORIGIN);
-    }
+    SAMPLING_REQUIREMENT
+        .headSet(SAMPLING_REQUIREMENT.last(), false)
+        .forEach(
+            index ->
+                tracker.add(new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, index), MOCK_ORIGIN));
     assertThat(tracker.missingColumns()).hasSize(1);
     assertThat(tracker.completionFuture()).isNotDone();
 
-    final UInt64 lastColumnIndex = SAMPLING_REQUIREMENT.get(SAMPLING_REQUIREMENT.size() - 1);
+    final UInt64 lastColumnIndex = SAMPLING_REQUIREMENT.last();
     final DataColumnSlotAndIdentifier lastColumnIdentifier =
         new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, lastColumnIndex);
     final boolean result = tracker.add(lastColumnIdentifier, MOCK_ORIGIN);
@@ -95,14 +99,17 @@ class DataColumnSamplingTrackerTest {
     assertThat(result).isTrue();
     assertThat(tracker.missingColumns()).isEmpty();
     assertThat(tracker.completionFuture()).isCompleted();
-    assertThat(tracker.completionFuture().get()).isEqualTo(SAMPLING_REQUIREMENT);
+    assertThat(tracker.completionFuture().get())
+        .containsExactlyInAnyOrderElementsOf(SAMPLING_REQUIREMENT);
     assertThat(tracker.fullySampled()).isTrue();
   }
 
   @Test
   void add_shouldCompleteEarly_whenHalfColumnsSamplingCompletionIsSet() {
-    final List<UInt64> samplingRequirement =
-        Stream.iterate(UInt64.ZERO, UInt64::increment).limit(128).toList();
+    final NavigableSet<UInt64> samplingRequirement =
+        Stream.iterate(UInt64.ZERO, UInt64::increment)
+            .limit(128)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
     when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(samplingRequirement);
     tracker =
         DataColumnSamplingTracker.create(
@@ -133,8 +140,10 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void add_shouldNotCompleteEarly_whenHalfColumnsSamplingCompletionDisabled() {
-    final List<UInt64> samplingRequirement =
-        Stream.iterate(UInt64.ZERO, UInt64::increment).limit(128).toList();
+    final NavigableSet<UInt64> samplingRequirement =
+        Stream.iterate(UInt64.ZERO, UInt64::increment)
+            .limit(128)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
     when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(samplingRequirement);
     tracker =
         DataColumnSamplingTracker.create(
@@ -161,7 +170,7 @@ class DataColumnSamplingTrackerTest {
   void add_shouldReturnFalseForMismatchedSlot() {
     final UInt64 mismatchedSlot = SLOT.plus(1);
     final DataColumnSlotAndIdentifier columnIdentifier =
-        new DataColumnSlotAndIdentifier(mismatchedSlot, BLOCK_ROOT, SAMPLING_REQUIREMENT.get(0));
+        new DataColumnSlotAndIdentifier(mismatchedSlot, BLOCK_ROOT, SAMPLING_REQUIREMENT.first());
 
     final boolean result = tracker.add(columnIdentifier, MOCK_ORIGIN);
 
@@ -174,7 +183,7 @@ class DataColumnSamplingTrackerTest {
   void add_shouldReturnFalseForMismatchedBlockRoot() {
     final Bytes32 mismatchedRoot = Bytes32.fromHexString("0xff");
     final DataColumnSlotAndIdentifier columnIdentifier =
-        new DataColumnSlotAndIdentifier(SLOT, mismatchedRoot, SAMPLING_REQUIREMENT.get(0));
+        new DataColumnSlotAndIdentifier(SLOT, mismatchedRoot, SAMPLING_REQUIREMENT.first());
 
     final boolean result = tracker.add(columnIdentifier, MOCK_ORIGIN);
 
@@ -185,7 +194,7 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void add_shouldReturnFalseWhenAddingSameColumnTwice() {
-    final UInt64 columnIndexToAdd = SAMPLING_REQUIREMENT.get(0);
+    final UInt64 columnIndexToAdd = SAMPLING_REQUIREMENT.first();
     final DataColumnSlotAndIdentifier columnIdentifier =
         new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, columnIndexToAdd);
 
@@ -226,7 +235,7 @@ class DataColumnSamplingTrackerTest {
 
   @Test
   void getMissingColumnIdentifiers_shouldReturnPartialListAfterAddingOne() {
-    final UInt64 addedIndex = SAMPLING_REQUIREMENT.get(1); // index 10
+    final UInt64 addedIndex = UInt64.valueOf(10); // middle element
     tracker.add(new DataColumnSlotAndIdentifier(SLOT, BLOCK_ROOT, addedIndex), MOCK_ORIGIN);
 
     final List<DataColumnSlotAndIdentifier> missing = tracker.getMissingColumnIdentifiers();
@@ -234,7 +243,7 @@ class DataColumnSamplingTrackerTest {
     assertThat(missing)
         .hasSize(SAMPLING_REQUIREMENT.size() - 1)
         .extracting(DataColumnSlotAndIdentifier::columnIndex)
-        .containsExactly(SAMPLING_REQUIREMENT.get(0), SAMPLING_REQUIREMENT.get(2));
+        .containsExactly(UInt64.valueOf(5), UInt64.valueOf(15));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -97,7 +98,8 @@ public class DataColumnSidecarCustodyImplTest {
             custodyGroupCountManager);
     when(custodyGroupCountManager.getCustodyColumnIndices())
         .thenReturn(
-            List.of(UInt64.valueOf(0), UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
+            ImmutableSortedSet.of(
+                UInt64.valueOf(0), UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
     verify(custodyGroupCountManager).getCustodyGroupCount();
     Mockito.clearInvocations(custodyGroupCountManager);
   }
@@ -243,7 +245,8 @@ public class DataColumnSidecarCustodyImplTest {
         .thenReturn(
             SafeFuture.completedFuture(
                 List.of(new DataColumnSlotAndIdentifier(fuluSlot, dataColumnIdentifier))));
-    when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(List.of(ZERO, ONE));
+    when(custodyGroupCountManager.getCustodyColumnIndices())
+        .thenReturn(ImmutableSortedSet.of(ZERO, ONE));
     custody =
         new DataColumnSidecarCustodyImpl(
             spec, resolver, sidecarDb, minCustodyPeriodSlotCalculator, custodyGroupCountManager);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -24,10 +24,10 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
-import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -98,8 +98,7 @@ public class DataColumnSidecarCustodyImplTest {
             custodyGroupCountManager);
     when(custodyGroupCountManager.getCustodyColumnIndices())
         .thenReturn(
-            ImmutableSortedSet.of(
-                UInt64.valueOf(0), UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
+            Set.of(UInt64.valueOf(0), UInt64.valueOf(1), UInt64.valueOf(2), UInt64.valueOf(3)));
     verify(custodyGroupCountManager).getCustodyGroupCount();
     Mockito.clearInvocations(custodyGroupCountManager);
   }
@@ -245,8 +244,7 @@ public class DataColumnSidecarCustodyImplTest {
         .thenReturn(
             SafeFuture.completedFuture(
                 List.of(new DataColumnSlotAndIdentifier(fuluSlot, dataColumnIdentifier))));
-    when(custodyGroupCountManager.getCustodyColumnIndices())
-        .thenReturn(ImmutableSortedSet.of(ZERO, ONE));
+    when(custodyGroupCountManager.getCustodyColumnIndices()).thenReturn(Set.of(ZERO, ONE));
     custody =
         new DataColumnSidecarCustodyImpl(
             spec, resolver, sidecarDb, minCustodyPeriodSlotCalculator, custodyGroupCountManager);
@@ -261,7 +259,7 @@ public class DataColumnSidecarCustodyImplTest {
         future.get(100, TimeUnit.MILLISECONDS);
 
     assertThat(slotCustody.slot()).isEqualTo(fuluSlot);
-    assertThat(slotCustody.requiredColumnIndices()).isEqualTo(List.of(ZERO, ONE));
+    assertThat(slotCustody.requiredColumnIndices()).containsExactlyInAnyOrder(ZERO, ONE);
     assertThat(slotCustody.getIncompleteColumns())
         .containsExactly(
             new DataColumnSlotAndIdentifier(fuluSlot, beaconBlock.getRoot(), UInt64.valueOf(1)));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -19,8 +19,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -102,7 +102,7 @@ public class SimpleSidecarRetrieverTest {
         block.getSlot(), block.getRoot(), UInt64.valueOf(colIdx));
   }
 
-  NavigableSet<UInt64> nodeCustodyColumns(final UInt256 nodeId) {
+  Set<UInt64> nodeCustodyColumns(final UInt256 nodeId) {
     return miscHelpers.computeCustodyColumnIndices(
         nodeId, custodyCountSupplier.getCustodyGroupCountForPeer(nodeId));
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -101,7 +102,7 @@ public class SimpleSidecarRetrieverTest {
         block.getSlot(), block.getRoot(), UInt64.valueOf(colIdx));
   }
 
-  List<UInt64> nodeCustodyColumns(final UInt256 nodeId) {
+  NavigableSet<UInt64> nodeCustodyColumns(final UInt256 nodeId) {
     return miscHelpers.computeCustodyColumnIndices(
         nodeId, custodyCountSupplier.getCustodyGroupCountForPeer(nodeId));
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImplGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImplGloasTest.java
@@ -109,7 +109,7 @@ public class DataColumnSidecarELManagerImplGloasTest
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.new RandomDataColumnSidecarBuilder()
             .slot(currentSlot)
-            .index(custodyGroupCountManager.getSamplingColumnIndices().get(0))
+            .index(custodyGroupCountManager.getSamplingColumnIndices().getFirst())
             .build();
 
     dataColumnSidecarELManager.onSlot(currentSlot);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImplGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImplGloasTest.java
@@ -109,7 +109,7 @@ public class DataColumnSidecarELManagerImplGloasTest
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.new RandomDataColumnSidecarBuilder()
             .slot(currentSlot)
-            .index(custodyGroupCountManager.getSamplingColumnIndices().getFirst())
+            .index(custodyGroupCountManager.getSamplingColumnIndices().iterator().next())
             .build();
 
     dataColumnSidecarELManager.onSlot(currentSlot);

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
@@ -15,10 +15,13 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.IntStream;
@@ -259,8 +262,10 @@ public class DasCustodyStand {
       }
 
       @Override
-      public List<UInt64> getCustodyColumnIndices() {
-        return IntStream.range(0, custodyGroupCount).mapToObj(UInt64::valueOf).toList();
+      public NavigableSet<UInt64> getCustodyColumnIndices() {
+        return IntStream.range(0, custodyGroupCount)
+            .mapToObj(UInt64::valueOf)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
       }
 
       @Override
@@ -269,8 +274,10 @@ public class DasCustodyStand {
       }
 
       @Override
-      public List<UInt64> getSamplingColumnIndices() {
-        return IntStream.range(0, sampleGroupCount).mapToObj(UInt64::valueOf).toList();
+      public NavigableSet<UInt64> getSamplingColumnIndices() {
+        return IntStream.range(0, sampleGroupCount)
+            .mapToObj(UInt64::valueOf)
+            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
       }
     };
   }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
@@ -15,15 +15,14 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableSortedSet;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -262,10 +261,10 @@ public class DasCustodyStand {
       }
 
       @Override
-      public NavigableSet<UInt64> getCustodyColumnIndices() {
+      public Set<UInt64> getCustodyColumnIndices() {
         return IntStream.range(0, custodyGroupCount)
             .mapToObj(UInt64::valueOf)
-            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+            .collect(Collectors.toUnmodifiableSet());
       }
 
       @Override
@@ -274,10 +273,10 @@ public class DasCustodyStand {
       }
 
       @Override
-      public NavigableSet<UInt64> getSamplingColumnIndices() {
+      public Set<UInt64> getSamplingColumnIndices() {
         return IntStream.range(0, sampleGroupCount)
             .mapToObj(UInt64::valueOf)
-            .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+            .collect(Collectors.toUnmodifiableSet());
       }
     };
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -120,7 +119,7 @@ public class DataColumnSidecarsByRootMessageHandler
     totalDataColumnSidecarsRequestedCounter.inc(requestedDataColumnSidecarsCount);
 
     final Set<UInt64> myCustodyColumns =
-        new HashSet<>(custodyGroupCountManagerSupplier.get().getCustodyColumnIndices());
+        custodyGroupCountManagerSupplier.get().getCustodyColumnIndices();
 
     SafeFuture.collectAll(
             message.stream()

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -32,6 +32,8 @@ import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -156,7 +158,10 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
 
     // custodying everything by default
     when(custodyGroupCountManager.getCustodyColumnIndices())
-        .thenReturn(IntStream.of(0, 128).mapToObj(UInt64::valueOf).toList());
+        .thenReturn(
+            IntStream.of(0, 128)
+                .mapToObj(UInt64::valueOf)
+                .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
   }
 
   @TestTemplate
@@ -297,7 +302,7 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     final List<DataColumnSidecar> generatedSidecars =
         IntStream.range(0, 4).mapToObj(__ -> dataStructureUtil.randomDataColumnSidecar()).toList();
     when(custodyGroupCountManager.getCustodyColumnIndices())
-        .thenReturn(List.of(dataColumnsByRootIdentifiers[0].getColumns().getFirst()));
+        .thenReturn(ImmutableSortedSet.of(dataColumnsByRootIdentifiers[0].getColumns().getFirst()));
 
     when(combinedChainDataClient.getSidecar(any()))
         .thenAnswer(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -32,10 +32,10 @@ import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableSortedSet;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,9 +159,7 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     // custodying everything by default
     when(custodyGroupCountManager.getCustodyColumnIndices())
         .thenReturn(
-            IntStream.of(0, 128)
-                .mapToObj(UInt64::valueOf)
-                .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
+            IntStream.of(0, 128).mapToObj(UInt64::valueOf).collect(Collectors.toUnmodifiableSet()));
   }
 
   @TestTemplate
@@ -302,7 +300,7 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     final List<DataColumnSidecar> generatedSidecars =
         IntStream.range(0, 4).mapToObj(__ -> dataStructureUtil.randomDataColumnSidecar()).toList();
     when(custodyGroupCountManager.getCustodyColumnIndices())
-        .thenReturn(ImmutableSortedSet.of(dataColumnsByRootIdentifiers[0].getColumns().getFirst()));
+        .thenReturn(Set.of(dataColumnsByRootIdentifiers[0].getColumns().getFirst()));
 
     when(combinedChainDataClient.getSidecar(any()))
         .thenAnswer(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3259,7 +3259,7 @@
 - name: get_custody_groups#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
-      search: public NavigableSet<UInt64> computeCustodyColumnIndices(
+      search: public Set<UInt64> computeCustodyColumnIndices(
   spec: |
     <spec fn="get_custody_groups" fork="fulu" hash="2e6b71d3">
     def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence[CustodyIndex]:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3259,7 +3259,7 @@
 - name: get_custody_groups#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
-      search: public List<UInt64> computeCustodyColumnIndices(
+      search: public NavigableSet<UInt64> computeCustodyColumnIndices(
   spec: |
     <spec fn="get_custody_groups" fork="fulu" hash="2e6b71d3">
     def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence[CustodyIndex]:


### PR DESCRIPTION
Avoids custody\sampling requirement recreation at each call
Changes types to be a Set to have fast lookups
Implement atomic changes when custody changes


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DAS custody/sampling APIs from `List` to `Set` and caches computed indices, which affects multiple call sites and can subtly change ordering/serialization behavior. Logic is mostly refactor/perf-focused but touches custody backfilling, sampling, and RPC filtering paths.
> 
> **Overview**
> Avoids recomputing custody/sampling column indices on every call by switching `CustodyGroupCountManager`/`MiscHelpersFulu.computeCustodyColumnIndices` to return `Set<UInt64>` and having `CustodyGroupCountManagerImpl` maintain a precomputed, atomically-swapped `CustodySnapshot` (counts + indices + super-node flag).
> 
> Updates DAS-related components (publisher withholding filter, sampling tracker completion, custody backfiller/custody store, sidecar retriever, and RPC `DataColumnSidecarsByRoot` handler) to consume the new `Set` APIs directly and drop defensive `HashSet` copies; the Teku REST endpoint now sorts the set before responding for stable output. Tests are updated accordingly and expanded to cover super-node short-circuiting, deferred genesis init until validators appear, snapshot consistency, and no channel notification when the custody count is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c3bdd4fd9919d8491051f99b965576c940003ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->