### PR TITLE
Fix mainnet state serialization

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -110,7 +110,7 @@ public abstract class AbstractSszListSchema<
         // BitlistImpl is handled specially
         return length / 8 + 1;
       } else {
-        return bitsCeilToBytes(length * getSszElementBitSize());
+        return Math.toIntExact(bitsCeilToBytes((long) length * getSszElementBitSize()));
       }
     } else {
       return getCompatibleVectorSchema().getVariablePartSize(getVectorNode(node), length)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSZ size calculation used for serialization, so an error could impact encoding/decoding of consensus-critical data, though the change is small and primarily makes overflow behavior explicit.
> 
> **Overview**
> Fixes potential integer overflow in `AbstractSszListSchema.getSszVariablePartSize` for fixed-size list elements by performing the `length * elementBitSize` calculation in `long` and converting back with `Math.toIntExact`.
> 
> This prevents silent wraparound when computing the byte length (`bitsCeilToBytes`) and makes oversized encodings fail fast instead of producing incorrect sizes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcf9ab6e9d105e8f1f9817159f36fe5821d6892a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->