### PR TITLE
bundle ref tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,15 +457,16 @@ jobs:
         with:
           path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
           key: reftests-${{ hashFiles('build.gradle') }}
+      - name: Compress reftests
+        shell: bash
+        run: |
+          tar -cf reftests.tar ./eth-reference-tests/
       - name: Upload reftests
         uses: actions/upload-artifact@v6
         with:
           name: reftests
-          path: |
-            ./eth-reference-tests/
-            !./eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
+          path: reftests.tar
           retention-days: 1
-          include-hidden-files: 'true'
 
   referenceTests:
     needs: referenceTestsPrep
@@ -494,7 +495,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}          
+          key: reftests-${{ hashFiles('build.gradle') }}
       - name: Download reftests
         uses: actions/download-artifact@v7
         with:
@@ -502,8 +503,11 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ github.run_id }}
           name: reftests
-          merge-multiple: true
-          path: ./eth-reference-tests
+      - name: Extract reftests
+        shell: bash
+        run: |
+          tar -xf reftests.tar
+          rm reftests.tar
       - name: Compute shard ${{ matrix.shard }} of ${{ matrix.total }} for ReferenceTests
         id: shard
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,7 @@ jobs:
           name: reftests
           path: |
             ./eth-reference-tests/
+            !./eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
           retention-days: 1
           include-hidden-files: 'true'
 
@@ -501,12 +502,8 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ github.run_id }}
           name: reftests
-          merge-multiple: true 
+          merge-multiple: true
           path: ./eth-reference-tests
-      - uses: actions/cache/restore@v4
-        with:
-          path: eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/
-          key: reftests-${{ hashFiles('build.gradle') }}
       - name: Compute shard ${{ matrix.shard }} of ${{ matrix.total }} for ReferenceTests
         id: shard
         shell: bash


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
bundle ref tests before uploading them: saves us around 14 minutes in `referenceTestsPrep`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only change, but it modifies how reference test data is packaged and transferred between jobs, which could break `referenceTests` if the tar/extract paths diverge or artifacts are missing.
> 
> **Overview**
> Speeds up CI reference-test preparation by **bundling `eth-reference-tests/` into a single `reftests.tar` artifact** instead of uploading the entire directory tree.
> 
> Updates the `referenceTests` job to download that tarball and **extract/cleanup** it before sharding and running the Gradle `referenceTest` tasks, and tidies the cache key formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e01aa83ef83383ae8aa2f6ae373b86b8c7495d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->