### PR TITLE
Update DB migration according to the current state (main direction of migration LevelDB -> RocksDB)

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -76,8 +76,7 @@ public class MigrateDatabaseCommand implements Runnable {
   private String network = "mainnet";
 
   // Use Cases
-  // - I have a rocksdb database and want to update to the latest leveldb database version
-  // - I have leveldb 1 and want to have leveldb2
+  // - I have a leveldb2 database and want to update to the latest RocksDB database version
   // - I have updated to the latest db but I've decided i want to go back to an older database
   // format
   //   (eg. testing upgrades!)
@@ -87,9 +86,9 @@ public class MigrateDatabaseCommand implements Runnable {
       paramLabel = "<format>",
       hidden = true,
       description =
-          "The file to export the slashing protection database to. (rocksdb: 4,5,6), leveldb1, leveldb2",
+          "The target database version to migrate to. 4, 5, 6 (RocksDB), leveldb1, leveldb2",
       arity = "1")
-  private String toDbVersion = DatabaseVersion.LEVELDB2.getValue();
+  private String toDbVersion = DatabaseVersion.V6.getValue();
 
   // batch size param
   @CommandLine.Option(


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default target version for `migrate-database` from LevelDB2 to RocksDB `v6`, which can alter the outcome for users/scripts relying on the previous implicit default. Scope is limited to CLI option defaults/documentation.
> 
> **Overview**
> **`migrate-database` now defaults to migrating to RocksDB `v6`.** The hidden `--Xto` option description and in-code use-case comments were updated to reflect the LevelDB2 → RocksDB upgrade path, and the default `toDbVersion` was switched from `leveldb2` to `v6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 650a9d42ce4ea04c6af7c5d55a9cad3f94393ab7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->