### PR TITLE
Change getPayload timeout to 2s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@
 
 - Added `/eth/v2/node/version` endpoint to retrieve structured version information for both beacon node and execution client.
 - Added deprecation warning on startup for any leveldb database types.
+- Increased default timeout of Engine API Get Payload requests to 2 seconds.
 
 ### Bug Fixes

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -58,6 +58,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   private static final Duration EXCHANGE_CAPABILITIES_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration GET_CLIENT_VERSION_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration GET_BLOBS_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(2);
 
   private final Web3JClient web3JClient;
 
@@ -102,7 +103,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             ExecutionPayloadV1Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+    return web3JClient.doRequest(web3jRequest, GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -113,7 +114,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             GetPayloadV2Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+    return web3JClient.doRequest(web3jRequest, GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -124,7 +125,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             GetPayloadV3Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+    return web3JClient.doRequest(web3jRequest, GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -135,7 +136,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             GetPayloadV4Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+    return web3JClient.doRequest(web3jRequest, GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -146,7 +147,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             GetPayloadV5Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+    return web3JClient.doRequest(web3jRequest, GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -157,7 +158,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             GetPayloadV6Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+    return web3JClient.doRequest(web3jRequest, GET_PAYLOAD_TIMEOUT);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Update the default timeout of getPayload to 2s. In our testing, that was enough to increase the successful requests even under stress scenarios (e.g. higher blob count).

At this moment, I am not adding a CLI flag to configure this. I'll plan something for the new Engine API client that will be introduced soon.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated timeout change for a specific set of RPC calls; main risk is slightly longer waits before failing when the execution client is unresponsive.
> 
> **Overview**
> Increases the default timeout used for Engine API `engine_getPayloadV1`–`engine_getPayloadV6` calls in `Web3JExecutionEngineClient` from the shared `EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT` (1s) to a dedicated 2-second `GET_PAYLOAD_TIMEOUT`.
> 
> Adds a matching `CHANGELOG.md` entry documenting the new default timeout for Get Payload requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e4086c9b5cf8a7b2aec14451b510cb069490a7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->