### PR TITLE
clarified migrate-database help

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.storage.server.StateStorageMode;
 @CommandLine.Command(
     name = "migrate-database",
     description = "Migrate the database to a specified version.",
+    subcommands = {UnstableOptionsCommand.class},
     mixinStandardHelpOptions = true,
     abbreviateSynopsis = true,
     versionProvider = PicoCliVersionProvider.class,
@@ -86,7 +87,9 @@ public class MigrateDatabaseCommand implements Runnable {
       paramLabel = "<format>",
       hidden = true,
       description =
-          "The target database version to migrate to. 4, 5, 6 (RocksDB), leveldb1, leveldb2",
+          "The target database version to migrate to. "
+              + "Rocksdb database types supported are 4, 5, 6. "
+              + "Leveldb types supported are leveldb1, leveldb2.",
       arity = "1")
   private String toDbVersion = DatabaseVersion.V6.getValue();
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -87,9 +87,10 @@ public class MigrateDatabaseCommand implements Runnable {
       paramLabel = "<format>",
       hidden = true,
       description =
-          "The target database version to migrate to. "
-              + "Rocksdb database types supported are 4, 5, 6. "
-              + "Leveldb types supported are leveldb1, leveldb2.",
+              """
+                      The target database version to migrate to.
+                      Rocksdb database types supported are 4, 5, 6.
+                      Leveldb types supported are leveldb1, leveldb2.""",
       arity = "1")
   private String toDbVersion = DatabaseVersion.V6.getValue();
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -87,7 +87,7 @@ public class MigrateDatabaseCommand implements Runnable {
       paramLabel = "<format>",
       hidden = true,
       description =
-              """
+          """
                       The target database version to migrate to.
                       Rocksdb database types supported are 4, 5, 6.
                       Leveldb types supported are leveldb1, leveldb2.""",

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/UnstableOptionsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/UnstableOptionsCommand.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.cli.subcommand;
 
 import java.io.PrintWriter;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import picocli.CommandLine;
 import picocli.CommandLine.Help.ColorScheme;
 import picocli.CommandLine.Model.CommandSpec;
@@ -59,6 +61,19 @@ public class UnstableOptionsCommand implements Runnable, CommandLine.IHelpComman
                 optionsByModuleName.put(
                     argSpec.heading().replace("%n", ""), argSpec.allOptionsNested()));
     commandSpec.mixins().forEach((name, spec) -> optionsByModuleName.put(name, spec.options()));
+
+    // Collect options already covered by mixins and arg groups
+    final Set<OptionSpec> alreadyCovered = new HashSet<>();
+    commandSpec.mixins().values().forEach(spec -> alreadyCovered.addAll(spec.options()));
+    commandSpec.argGroups().forEach(ag -> alreadyCovered.addAll(ag.allOptionsNested()));
+
+    // Include any hidden options defined directly on the command class itself
+    final List<OptionSpec> directOptions =
+        commandSpec.options().stream().filter(opt -> !alreadyCovered.contains(opt)).toList();
+    if (!directOptions.isEmpty()) {
+      optionsByModuleName.put(commandSpec.name(), directOptions);
+    }
+
     optionsByModuleName.forEach(this::printUnstableOptions);
   }
 


### PR DESCRIPTION
Had to change UnstableOptions to allow Xhelp in migrate-database as well.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI/help-only changes: adds `Xhelp` wiring for `migrate-database` and adjusts help output/strings without affecting database migration logic.
> 
> **Overview**
> `migrate-database` now includes the hidden `Xhelp` subcommand so users can list unstable (`--X*`) flags for that command.
> 
> `UnstableOptionsCommand` is updated to also print hidden options defined directly on a command (not just mixins/arg groups), and the `--Xto` help text is reformatted/clarified to explicitly list supported RocksDB and LevelDB target versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62b8c820839b2f372fd467c2c42303853a4c70a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->