### PR TITLE
New engine api client

### DIFF
--- a/ethereum/executionclient/build.gradle
+++ b/ethereum/executionclient/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:time'))
   testImplementation testFixtures(project(':infrastructure:metrics'))
   testImplementation testFixtures(project(':ethereum:spec'))
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
 
   integrationTestImplementation testFixtures(project(':infrastructure:json'))
   integrationTestImplementation testFixtures(project(':infrastructure:time'))

--- a/ethereum/executionclient/build.gradle
+++ b/ethereum/executionclient/build.gradle
@@ -14,6 +14,8 @@ dependencies {
   implementation project(':ethereum:events')
 
   api 'org.web3j:core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
+  implementation 'com.squareup.okhttp3:okhttp'
   implementation 'io.consensys.tuweni:tuweni-units'
   implementation 'io.jsonwebtoken:jjwt-api'
   implementation 'com.fasterxml.jackson.module:jackson-module-blackbird'

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClientTest.java
@@ -61,7 +61,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
@@ -80,7 +79,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @TestSpecContext(milestone = {CAPELLA, DENEB, ELECTRA, FULU, GLOAS})
 public class OkHttpExecutionEngineClientTest {
-
+  private static final Logger LOG = LogManager.getLogger();
   private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
 
   private final MockWebServer mockWebServer = new MockWebServer();
@@ -88,12 +87,12 @@ public class OkHttpExecutionEngineClientTest {
   private final ExecutionClientEventsChannel executionClientEventsPublisher =
       mock(ExecutionClientEventsChannel.class);
 
-  ObjectMapper objectMapper;
-  DataStructureUtil dataStructureUtil;
-  Spec spec;
-  SpecMilestone specMilestone;
+  private ObjectMapper objectMapper;
+  private DataStructureUtil dataStructureUtil;
+  private Spec spec;
+  private SpecMilestone specMilestone;
 
-  OkHttpExecutionEngineClient eeClient;
+  private OkHttpExecutionEngineClient eeClient;
 
   @BeforeEach
   void setUp(final SpecContext specContext) throws IOException {
@@ -112,8 +111,6 @@ public class OkHttpExecutionEngineClientTest {
             OkHttpExecutionEngineClient.NON_CRITICAL_METHODS);
   }
 
-  private static final Logger LOG = LogManager.getLogger();
-
   @AfterEach
   public void afterEach() throws Exception {
     mockWebServer.shutdown();
@@ -122,8 +119,7 @@ public class OkHttpExecutionEngineClientTest {
   @TestTemplate
   @SuppressWarnings("unchecked")
   void forkChoiceUpdated_shouldRoundtripWithMockedWebServer() throws Exception {
-    final Bytes32 latestValidHash =
-        Bytes32.fromHexString("0x135bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
+    final Bytes32 latestValidHash = dataStructureUtil.randomBytes32();
     final String validationError = "error";
     final PayloadStatus payloadStatusResponse =
         PayloadStatus.invalid(Optional.of(latestValidHash), Optional.of(validationError));
@@ -138,21 +134,17 @@ public class OkHttpExecutionEngineClientTest {
 
     mockSuccessfulResponse(bodyResponse);
 
+    final Bytes32 headBlockHash = dataStructureUtil.randomBytes32();
+    final Bytes32 safeBlockHash = dataStructureUtil.randomBytes32();
+    final Bytes32 finalizedBlockHash = dataStructureUtil.randomBytes32();
     final ForkChoiceStateV1 forkChoiceStateV1Request =
-        new ForkChoiceStateV1(
-            Bytes32.fromHexString(
-                "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464"),
-            Bytes32.fromHexString(
-                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
-            Bytes32.fromHexString(
-                "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"));
+        new ForkChoiceStateV1(headBlockHash, safeBlockHash, finalizedBlockHash);
 
     final PayloadAttributesV1 payloadAttributesV1Request =
         new PayloadAttributesV1(
             UInt64.valueOf(10),
-            Bytes32.fromHexString(
-                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
-            Bytes20.fromHexString("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d"));
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomBytes20());
 
     final SafeFuture<Response<ForkChoiceUpdatedResult>> futureResponseForkChoiceUpdatedResult =
         eeClient.forkChoiceUpdatedV1(
@@ -170,18 +162,16 @@ public class OkHttpExecutionEngineClientTest {
 
     verifyJsonRpcMethodCall(data, "engine_forkchoiceUpdatedV1");
 
-    assertThat(forkChoiceState.get("headBlockHash"))
-        .isEqualTo("0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
-    assertThat(forkChoiceState.get("safeBlockHash"))
-        .isEqualTo("0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef");
+    assertThat(forkChoiceState.get("headBlockHash")).isEqualTo(headBlockHash.toHexString());
+    assertThat(forkChoiceState.get("safeBlockHash")).isEqualTo(safeBlockHash.toHexString());
     assertThat(forkChoiceState.get("finalizedBlockHash"))
-        .isEqualTo("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e");
+        .isEqualTo(finalizedBlockHash.toHexString());
 
     assertThat(payloadAttributes.get("timestamp")).isEqualTo("0xa");
     assertThat(payloadAttributes.get("prevRandao"))
-        .isEqualTo("0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef");
+        .isEqualTo(payloadAttributesV1Request.prevRandao.toHexString());
     assertThat(payloadAttributes.get("suggestedFeeRecipient"))
-        .isEqualTo("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d");
+        .isEqualTo(payloadAttributesV1Request.suggestedFeeRecipient.toHexString());
 
     assertThat(futureResponseForkChoiceUpdatedResult)
         .succeedsWithin(1, TimeUnit.SECONDS)

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClientTest.java
@@ -1,0 +1,502 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.mockito.Mockito.mock;
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
+import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
+import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
+import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.FULU;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZGProof;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+@TestSpecContext(milestone = {CAPELLA, DENEB, ELECTRA, FULU, GLOAS})
+public class OkHttpExecutionEngineClientTest {
+
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
+
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+  private final ExecutionClientEventsChannel executionClientEventsPublisher =
+      mock(ExecutionClientEventsChannel.class);
+
+  ObjectMapper objectMapper;
+  DataStructureUtil dataStructureUtil;
+  Spec spec;
+  SpecMilestone specMilestone;
+
+  OkHttpExecutionEngineClient eeClient;
+
+  @BeforeEach
+  void setUp(final SpecContext specContext) throws IOException {
+    objectMapper = new ObjectMapper();
+    dataStructureUtil = specContext.getDataStructureUtil();
+    spec = specContext.getSpec();
+    specMilestone = specContext.getSpecMilestone();
+    mockWebServer.start();
+    eeClient =
+        new OkHttpExecutionEngineClient(
+            OkHttpClientCreator.create(DEFAULT_TIMEOUT, LOG, Optional.empty(), timeProvider),
+            "http://localhost:" + mockWebServer.getPort(),
+            EVENT_LOG,
+            timeProvider,
+            executionClientEventsPublisher,
+            OkHttpExecutionEngineClient.NON_CRITICAL_METHODS);
+  }
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @TestTemplate
+  @SuppressWarnings("unchecked")
+  void forkChoiceUpdated_shouldRoundtripWithMockedWebServer() throws Exception {
+    final Bytes32 latestValidHash =
+        Bytes32.fromHexString("0x135bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
+    final String validationError = "error";
+    final PayloadStatus payloadStatusResponse =
+        PayloadStatus.invalid(Optional.of(latestValidHash), Optional.of(validationError));
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":"
+            + "{\"payloadStatus\" : { \"status\": \"INVALID\", \"latestValidHash\": \""
+            + latestValidHash
+            + "\", \"validationError\": \""
+            + validationError
+            + "\"}}}";
+
+    mockSuccessfulResponse(bodyResponse);
+
+    final ForkChoiceStateV1 forkChoiceStateV1Request =
+        new ForkChoiceStateV1(
+            Bytes32.fromHexString(
+                "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464"),
+            Bytes32.fromHexString(
+                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
+            Bytes32.fromHexString(
+                "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"));
+
+    final PayloadAttributesV1 payloadAttributesV1Request =
+        new PayloadAttributesV1(
+            UInt64.valueOf(10),
+            Bytes32.fromHexString(
+                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
+            Bytes20.fromHexString("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d"));
+
+    final SafeFuture<Response<ForkChoiceUpdatedResult>> futureResponseForkChoiceUpdatedResult =
+        eeClient.forkChoiceUpdatedV1(
+            forkChoiceStateV1Request, Optional.of(payloadAttributesV1Request));
+
+    final RecordedRequest request = mockWebServer.takeRequest();
+
+    final Map<String, Object> data =
+        JsonTestUtil.parse(request.getBody().readString(StandardCharsets.UTF_8));
+
+    final Map<String, Object> forkChoiceState =
+        (Map<String, Object>) ((List<Object>) data.get("params")).get(0);
+    final Map<String, Object> payloadAttributes =
+        (Map<String, Object>) ((List<Object>) data.get("params")).get(1);
+
+    verifyJsonRpcMethodCall(data, "engine_forkchoiceUpdatedV1");
+
+    assertThat(forkChoiceState.get("headBlockHash"))
+        .isEqualTo("0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
+    assertThat(forkChoiceState.get("safeBlockHash"))
+        .isEqualTo("0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef");
+    assertThat(forkChoiceState.get("finalizedBlockHash"))
+        .isEqualTo("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e");
+
+    assertThat(payloadAttributes.get("timestamp")).isEqualTo("0xa");
+    assertThat(payloadAttributes.get("prevRandao"))
+        .isEqualTo("0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef");
+    assertThat(payloadAttributes.get("suggestedFeeRecipient"))
+        .isEqualTo("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d");
+
+    assertThat(futureResponseForkChoiceUpdatedResult)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .matches(
+            forkChoiceUpdatedResultResponse ->
+                forkChoiceUpdatedResultResponse
+                    .payload()
+                    .asInternalExecutionPayload()
+                    .getPayloadStatus()
+                    .equals(payloadStatusResponse));
+  }
+
+  @TestTemplate
+  public void exchangeCapabilities_shouldBuildRequestAndResponseSuccessfully() throws Exception {
+    final List<String> consensusCapabilities = List.of("foo", "bar");
+    final List<String> executionCapabilities = List.of("ziz");
+
+    final JsonRpcResponse responseBody = new JsonRpcResponse(executionCapabilities);
+    mockSuccessfulResponse(objectMapper.writeValueAsString(responseBody));
+
+    final SafeFuture<Response<List<String>>> response =
+        eeClient.exchangeCapabilities(consensusCapabilities);
+    assertThat(response)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .isEqualTo(Response.fromPayloadReceivedAsJson(executionCapabilities));
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_exchangeCapabilities");
+    assertThat(requestData.get("params")).asInstanceOf(LIST).containsExactly(consensusCapabilities);
+  }
+
+  @TestTemplate
+  public void getClientVersionV1_shouldBuildRequestAndResponseSuccessfully() throws Exception {
+    final ClientVersionV1 consensusClientVersion =
+        new ClientVersionV1("TK", "teku", "1.0.0", Bytes4.fromHexString("87fa8ca7"));
+    final ClientVersionV1 executionClientVersion =
+        new ClientVersionV1("BU", "besu", "1.0.0", Bytes4.fromHexString("8dba2981"));
+
+    final JsonRpcResponse responseBody = new JsonRpcResponse(List.of(executionClientVersion));
+    mockSuccessfulResponse(objectMapper.writeValueAsString(responseBody));
+
+    final SafeFuture<Response<List<ClientVersionV1>>> response =
+        eeClient.getClientVersionV1(consensusClientVersion);
+    assertThat(response)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .isEqualTo(Response.fromPayloadReceivedAsJson(List.of(executionClientVersion)));
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_getClientVersionV1");
+    assertThat(requestData.get("params"))
+        .asInstanceOf(LIST)
+        .hasSize(1)
+        .first()
+        .asInstanceOf(MAP)
+        .hasSize(4)
+        .containsEntry("code", "TK")
+        .containsEntry("name", "teku")
+        .containsEntry("version", "1.0.0")
+        .containsEntry("commit", "0x87fa8ca7");
+  }
+
+  @TestTemplate
+  @SuppressWarnings("unchecked")
+  public void newPayloadV3_shouldBuildRequestAndResponseSuccessfully() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(DENEB);
+    final Bytes32 latestValidHash = dataStructureUtil.randomBytes32();
+    final PayloadStatus payloadStatusResponse =
+        PayloadStatus.valid(Optional.of(latestValidHash), Optional.empty());
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":"
+            + "{ \"status\": \"VALID\", \"latestValidHash\": \""
+            + latestValidHash
+            + "\", \"validationError\": null}}";
+
+    mockSuccessfulResponse(bodyResponse);
+
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
+    final ExecutionPayloadV3 executionPayloadV3 =
+        ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
+
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
+    final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
+
+    final SafeFuture<Response<PayloadStatusV1>> futureResponse =
+        eeClient.newPayloadV3(executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot);
+
+    assertThat(futureResponse)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .matches(
+            response ->
+                response.payload().asInternalExecutionPayload().equals(payloadStatusResponse));
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_newPayloadV3");
+
+    final Map<String, Object> executionPayloadV3Parameter =
+        (Map<String, Object>) ((List<Object>) requestData.get("params")).get(0);
+    // 17 fields in ExecutionPayloadV3
+    assertThat(executionPayloadV3Parameter).hasSize(17);
+    // sanity check
+    assertThat(executionPayloadV3Parameter.get("parentHash"))
+        .isEqualTo(executionPayloadV3.parentHash.toHexString());
+
+    assertThat(executionPayloadV3Parameter.get("blobGasUsed"))
+        .isEqualTo(
+            Bytes.ofUnsignedLong(executionPayloadV3.blobGasUsed.longValue()).toQuantityHexString());
+    assertThat(executionPayloadV3Parameter.get("excessBlobGas"))
+        .isEqualTo(
+            Bytes.ofUnsignedLong(executionPayloadV3.excessBlobGas.longValue())
+                .toQuantityHexString());
+    assertThat(((List<Object>) requestData.get("params")).get(1))
+        .asInstanceOf(LIST)
+        .containsExactlyElementsOf(
+            blobVersionedHashes.stream()
+                .map(VersionedHash::toHexString)
+                .collect(Collectors.toList()));
+    assertThat(((List<Object>) requestData.get("params")).get(2))
+        .asString()
+        .isEqualTo(parentBeaconBlockRoot.toHexString());
+  }
+
+  @TestTemplate
+  @SuppressWarnings("unchecked")
+  public void newPayloadV4_shouldBuildRequestAndResponseSuccessfully() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(ELECTRA);
+    final Bytes32 latestValidHash = dataStructureUtil.randomBytes32();
+    final PayloadStatus payloadStatusResponse =
+        PayloadStatus.valid(Optional.of(latestValidHash), Optional.empty());
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":"
+            + "{ \"status\": \"VALID\", \"latestValidHash\": \""
+            + latestValidHash
+            + "\", \"validationError\": null}}";
+
+    mockSuccessfulResponse(bodyResponse);
+
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
+    final ExecutionPayloadV3 executionPayloadV3 =
+        ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
+
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
+    final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
+    final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
+
+    final SafeFuture<Response<PayloadStatusV1>> futureResponse =
+        eeClient.newPayloadV4(
+            executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot, executionRequests);
+
+    assertThat(futureResponse)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .matches(
+            response ->
+                response.payload().asInternalExecutionPayload().equals(payloadStatusResponse));
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_newPayloadV4");
+
+    final Map<String, Object> executionPayloadV3Parameter =
+        (Map<String, Object>) ((List<Object>) requestData.get("params")).get(0);
+    // 17 fields in ExecutionPayloadV4
+    assertThat(executionPayloadV3Parameter).hasSize(17);
+    // sanity check
+    assertThat(executionPayloadV3Parameter.get("parentHash"))
+        .isEqualTo(executionPayloadV3.parentHash.toHexString());
+
+    assertThat(((List<Object>) requestData.get("params")).get(1))
+        .asInstanceOf(LIST)
+        .containsExactlyElementsOf(
+            blobVersionedHashes.stream()
+                .map(VersionedHash::toHexString)
+                .collect(Collectors.toList()));
+    assertThat(((List<Object>) requestData.get("params")).get(2))
+        .asString()
+        .isEqualTo(parentBeaconBlockRoot.toHexString());
+    assertThat(((List<Object>) requestData.get("params")).get(3))
+        .asInstanceOf(LIST)
+        .containsExactlyElementsOf(
+            executionRequests.stream().map(Bytes::toHexString).collect(Collectors.toList()));
+  }
+
+  @TestTemplate
+  @SuppressWarnings("unchecked")
+  public void getBlobsV1_shouldBuildRequestAndResponseSuccessfully() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(DENEB);
+    final List<BlobSidecar> blobSidecars =
+        dataStructureUtil.randomBlobSidecars(
+            spec.getMaxBlobsPerBlockForHighestMilestone().orElseThrow());
+    final List<BlobAndProofV1> blobsAndProofsV1 =
+        blobSidecars.stream()
+            .map(
+                blobSidecar ->
+                    new BlobAndProofV1(
+                        blobSidecar.getBlob().getBytes(),
+                        blobSidecar.getKZGProof().getBytesCompressed()))
+            .toList();
+    final String blobsAndProofsJson =
+        blobSidecars.stream()
+            .map(
+                blobSidecar ->
+                    String.format(
+                        "{ \"blob\": \"%s\", \"proof\": \"%s\" }",
+                        blobSidecar.getBlob().getBytes().toHexString(),
+                        blobSidecar.getKZGProof().getBytesCompressed().toHexString()))
+            .collect(Collectors.joining(", "));
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\": [" + blobsAndProofsJson + "]}";
+
+    mockSuccessfulResponse(bodyResponse);
+
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
+
+    final SafeFuture<Response<List<BlobAndProofV1>>> futureResponse =
+        eeClient.getBlobsV1(blobVersionedHashes);
+
+    assertThat(futureResponse)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .matches(response -> response.payload().equals(blobsAndProofsV1));
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_getBlobsV1");
+    assertThat(requestData.get("params"))
+        .asInstanceOf(LIST)
+        .containsExactly(blobVersionedHashes.stream().map(VersionedHash::toHexString).toList());
+  }
+
+  @TestTemplate
+  public void getBlobsV2_shouldBuildRequestAndResponseSuccessfully() throws Exception {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(FULU);
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle();
+    assertThat(blobsBundle.getBlobs()).isNotEmpty();
+
+    final List<BlobAndProofV2> blobsAndProofsV2 =
+        IntStream.range(0, blobsBundle.getBlobs().size())
+            .mapToObj(
+                blobIndex ->
+                    new BlobAndProofV2(
+                        blobsBundle.getBlobs().get(blobIndex).getBytes(),
+                        blobsBundle.getProofs().stream()
+                            .map(KZGProof::getBytesCompressed)
+                            .skip((long) blobIndex * CELLS_PER_EXT_BLOB)
+                            .limit(CELLS_PER_EXT_BLOB)
+                            .toList()))
+            .toList();
+    final String blobsAndProofsV2Json = objectMapper.writeValueAsString(blobsAndProofsV2);
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":" + blobsAndProofsV2Json + "}";
+
+    mockSuccessfulResponse(bodyResponse);
+
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(2);
+
+    final SafeFuture<Response<List<BlobAndProofV2>>> futureResponse =
+        eeClient.getBlobsV2(blobVersionedHashes);
+
+    assertThat(futureResponse)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .matches(response -> response.payload().equals(blobsAndProofsV2));
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_getBlobsV2");
+    assertThat(requestData.get("params"))
+        .asInstanceOf(LIST)
+        .containsExactly(blobVersionedHashes.stream().map(VersionedHash::toHexString).toList());
+  }
+
+  private void mockSuccessfulResponse(final String responseBody) {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(200)
+            .setBody(responseBody)
+            .addHeader("Content-Type", "application/json"));
+  }
+
+  private Map<String, Object> takeRequest() {
+    try {
+      final RecordedRequest request = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
+      return JsonTestUtil.parse(request.getBody().readString(StandardCharsets.UTF_8));
+    } catch (final Exception e) {
+      fail("Error taking request from mock server", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void verifyJsonRpcMethodCall(final Map<String, Object> data, final String method) {
+    assertThat(data.get("method")).asInstanceOf(STRING).isEqualTo(method);
+    assertThat(data.get("id")).asInstanceOf(INTEGER).isGreaterThanOrEqualTo(0);
+    assertThat(data.get("jsonrpc")).asInstanceOf(STRING).isEqualTo("2.0");
+  }
+
+  public static class JsonRpcResponse {
+
+    private final String jsonrpc = "2.0";
+    private final String id = "0";
+    private final Object result;
+
+    public JsonRpcResponse(final Object result) {
+      this.result = result;
+    }
+
+    @JsonProperty
+    public String getJsonrpc() {
+      return jsonrpc;
+    }
+
+    @JsonProperty
+    public String getId() {
+      return id;
+    }
+
+    @JsonProperty
+    public Object getResult() {
+      return result;
+    }
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpClientCreator.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpClientCreator.java
@@ -25,6 +25,15 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public class OkHttpClientCreator {
 
+  // The timeout used by default for call and read timeouts when not specified
+  // Note: this can be overridden per-request (e.g. for getPayload or newPayload
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(1);
+
+  public static OkHttpClient create(
+      final Logger logger, final Optional<JwtConfig> jwtConfig, final TimeProvider timeProvider) {
+    return create(DEFAULT_TIMEOUT, logger, jwtConfig, timeProvider);
+  }
+
   public static OkHttpClient create(
       final Duration timeout,
       final Logger logger,

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
@@ -19,10 +19,14 @@ import static tech.pegasys.teku.spec.config.Constants.EL_ENGINE_NON_BLOCK_EXECUT
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.ConnectException;
@@ -118,7 +122,12 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
     this.timeProvider = timeProvider;
     this.executionClientEventsPublisher = executionClientEventsPublisher;
     this.nonCriticalMethods = new HashSet<>(nonCriticalMethods);
-    this.objectMapper = new ObjectMapper();
+    this.objectMapper =
+        JsonMapper.builder()
+            .addModule(new BlackbirdModule())
+            .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .build();
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
@@ -1,0 +1,550 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient;
+
+import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessageOrSimpleName;
+import static tech.pegasys.teku.spec.config.Constants.EL_ENGINE_BLOCK_EXECUTION_TIMEOUT;
+import static tech.pegasys.teku.spec.config.Constants.EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.BlobAndProofV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV5Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes8;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+
+public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
+
+  private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json");
+
+  private static final int ERROR_REPEAT_DELAY_MILLIS = 30 * 1000;
+  private static final int NO_ERROR_TIME = -1;
+  private static final long STARTUP_LAST_ERROR_TIME = 0;
+
+  private static final Duration EXCHANGE_CAPABILITIES_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration GET_CLIENT_VERSION_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration GET_BLOBS_TIMEOUT = Duration.ofSeconds(1);
+
+  public static final List<String> NON_CRITICAL_METHODS =
+      List.of(
+          "engine_exchangeCapabilities",
+          "engine_getClientVersionV1",
+          "engine_getBlobsV1",
+          "engine_getBlobsV2");
+
+  private final OkHttpClient httpClient;
+  private final HttpUrl endpointUrl;
+  private final EventLogger eventLog;
+  private final TimeProvider timeProvider;
+  private final ExecutionClientEventsChannel executionClientEventsPublisher;
+  private final Set<String> nonCriticalMethods;
+  private final ObjectMapper objectMapper;
+  private final AtomicLong requestIdCounter = new AtomicLong(0);
+
+  private long lastErrorTime = STARTUP_LAST_ERROR_TIME;
+
+  public OkHttpExecutionEngineClient(
+      final OkHttpClient httpClient,
+      final String endpoint,
+      final EventLogger eventLog,
+      final TimeProvider timeProvider,
+      final ExecutionClientEventsChannel executionClientEventsPublisher,
+      final Collection<String> nonCriticalMethods) {
+    this.httpClient = httpClient;
+    this.endpointUrl = HttpUrl.get(endpoint);
+    this.eventLog = eventLog;
+    this.timeProvider = timeProvider;
+    this.executionClientEventsPublisher = executionClientEventsPublisher;
+    this.nonCriticalMethods = new HashSet<>(nonCriticalMethods);
+    this.objectMapper = new ObjectMapper();
+  }
+
+  @Override
+  public SafeFuture<PowBlock> getPowBlock(final Bytes32 blockHash) {
+    return doEthBlockRequest("eth_getBlockByHash", list(blockHash.toHexString(), false));
+  }
+
+  @Override
+  public SafeFuture<PowBlock> getPowChainHead() {
+    return doEthBlockRequest("eth_getBlockByNumber", list("latest", false));
+  }
+
+  @Override
+  public SafeFuture<Response<ExecutionPayloadV1>> getPayloadV1(final Bytes8 payloadId) {
+    return doRequest(
+        "engine_getPayloadV1",
+        Collections.singletonList(payloadId.toHexString()),
+        ExecutionPayloadV1.class,
+        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV2Response>> getPayloadV2(final Bytes8 payloadId) {
+    return doRequest(
+        "engine_getPayloadV2",
+        Collections.singletonList(payloadId.toHexString()),
+        GetPayloadV2Response.class,
+        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV3Response>> getPayloadV3(final Bytes8 payloadId) {
+    return doRequest(
+        "engine_getPayloadV3",
+        Collections.singletonList(payloadId.toHexString()),
+        GetPayloadV3Response.class,
+        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV4Response>> getPayloadV4(final Bytes8 payloadId) {
+    return doRequest(
+        "engine_getPayloadV4",
+        Collections.singletonList(payloadId.toHexString()),
+        GetPayloadV4Response.class,
+        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV5Response>> getPayloadV5(final Bytes8 payloadId) {
+    return doRequest(
+        "engine_getPayloadV5",
+        Collections.singletonList(payloadId.toHexString()),
+        GetPayloadV5Response.class,
+        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<GetPayloadV6Response>> getPayloadV6(final Bytes8 payloadId) {
+    return doRequest(
+        "engine_getPayloadV6",
+        Collections.singletonList(payloadId.toHexString()),
+        GetPayloadV6Response.class,
+        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV1(
+      final ExecutionPayloadV1 executionPayload) {
+    return doRequest(
+        "engine_newPayloadV1",
+        Collections.singletonList(executionPayload),
+        PayloadStatusV1.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV2(
+      final ExecutionPayloadV2 executionPayload) {
+    return doRequest(
+        "engine_newPayloadV2",
+        Collections.singletonList(executionPayload),
+        PayloadStatusV1.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot) {
+    final List<String> versionedHashHexes =
+        blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
+    return doRequest(
+        "engine_newPayloadV3",
+        list(executionPayload, versionedHashHexes, parentBeaconBlockRoot.toHexString()),
+        PayloadStatusV1.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV4(
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final List<Bytes> executionRequests) {
+    final List<String> versionedHashHexes =
+        blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
+    final List<String> executionRequestHexes =
+        executionRequests.stream().map(Bytes::toHexString).toList();
+    return doRequest(
+        "engine_newPayloadV4",
+        list(
+            executionPayload,
+            versionedHashHexes,
+            parentBeaconBlockRoot.toHexString(),
+            executionRequestHexes),
+        PayloadStatusV1.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<PayloadStatusV1>> newPayloadV5(
+      final ExecutionPayloadV4 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot,
+      final List<Bytes> executionRequests) {
+    final List<String> versionedHashHexes =
+        blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
+    final List<String> executionRequestHexes =
+        executionRequests.stream().map(Bytes::toHexString).toList();
+    return doRequest(
+        "engine_newPayloadV5",
+        list(
+            executionPayload,
+            versionedHashHexes,
+            parentBeaconBlockRoot.toHexString(),
+            executionRequestHexes),
+        PayloadStatusV1.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV1> payloadAttributes) {
+    return doRequest(
+        "engine_forkchoiceUpdatedV1",
+        list(forkChoiceState, payloadAttributes.orElse(null)),
+        ForkChoiceUpdatedResult.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV2> payloadAttributes) {
+    return doRequest(
+        "engine_forkchoiceUpdatedV2",
+        list(forkChoiceState, payloadAttributes.orElse(null)),
+        ForkChoiceUpdatedResult.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV3> payloadAttributes) {
+    return doRequest(
+        "engine_forkchoiceUpdatedV3",
+        list(forkChoiceState, payloadAttributes.orElse(null)),
+        ForkChoiceUpdatedResult.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV4(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV4> payloadAttributes) {
+    return doRequest(
+        "engine_forkchoiceUpdatedV4",
+        list(forkChoiceState, payloadAttributes.orElse(null)),
+        ForkChoiceUpdatedResult.class,
+        EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<List<String>>> exchangeCapabilities(final List<String> capabilities) {
+    return doRequest(
+        "engine_exchangeCapabilities",
+        Collections.singletonList(capabilities),
+        objectMapper.getTypeFactory().constructCollectionType(List.class, String.class),
+        EXCHANGE_CAPABILITIES_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<List<ClientVersionV1>>> getClientVersionV1(
+      final ClientVersionV1 clientVersion) {
+    return doRequest(
+        "engine_getClientVersionV1",
+        Collections.singletonList(clientVersion),
+        objectMapper.getTypeFactory().constructCollectionType(List.class, ClientVersionV1.class),
+        GET_CLIENT_VERSION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<List<BlobAndProofV1>>> getBlobsV1(
+      final List<VersionedHash> blobVersionedHashes) {
+    final List<String> versionedHashHexes =
+        blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
+    return doRequest(
+        "engine_getBlobsV1",
+        list(versionedHashHexes),
+        objectMapper.getTypeFactory().constructCollectionType(List.class, BlobAndProofV1.class),
+        GET_BLOBS_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<List<BlobAndProofV2>>> getBlobsV2(
+      final List<VersionedHash> blobVersionedHashes) {
+    final List<String> versionedHashHexes =
+        blobVersionedHashes.stream().map(VersionedHash::toHexString).toList();
+    return doRequest(
+        "engine_getBlobsV2",
+        list(versionedHashHexes),
+        objectMapper.getTypeFactory().constructCollectionType(List.class, BlobAndProofV2.class),
+        GET_BLOBS_TIMEOUT);
+  }
+
+  // ----------------------------- Core infrastructure -----------------------------
+
+  private SafeFuture<PowBlock> doEthBlockRequest(final String method, final List<Object> params) {
+    return doRequest(method, params, EthBlockResult.class, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT)
+        .thenApply(Response::payload)
+        .thenApply(OkHttpExecutionEngineClient::ethBlockToPowBlock);
+  }
+
+  private static PowBlock ethBlockToPowBlock(final EthBlockResult block) {
+    return block == null
+        ? null
+        : new PowBlock(
+            Bytes32.fromHexStringStrict(block.hash),
+            Bytes32.fromHexStringStrict(block.parentHash),
+            UInt64.valueOf(new BigInteger(block.timestamp.substring(2), 16)));
+  }
+
+  private <T> SafeFuture<Response<T>> doRequest(
+      final String method,
+      final List<Object> params,
+      final Class<T> resultClass,
+      final Duration timeout) {
+    return doRequest(method, params, objectMapper.constructType(resultClass), timeout);
+  }
+
+  private <T> SafeFuture<Response<T>> doRequest(
+      final String method,
+      final List<Object> params,
+      final JavaType resultType,
+      final Duration timeout) {
+    final boolean isCritical = !nonCriticalMethods.contains(method);
+
+    final byte[] requestBodyBytes;
+    try {
+      requestBodyBytes = buildRequestBody(method, params);
+    } catch (final Exception e) {
+      handleError(isCritical, e, false);
+      return SafeFuture.completedFuture(Response.fromErrorMessage(getMessageOrSimpleName(e)));
+    }
+
+    final Request httpRequest =
+        new Request.Builder()
+            .url(endpointUrl)
+            .post(RequestBody.create(requestBodyBytes, JSON_MEDIA_TYPE))
+            .build();
+
+    final SafeFuture<Response<T>> future = new SafeFuture<>();
+    final Call call = httpClient.newCall(httpRequest);
+    call.timeout().timeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
+
+    call.enqueue(
+        new Callback() {
+          @Override
+          public void onFailure(final Call call, final IOException e) {
+            handleError(isCritical, e, false);
+            future.complete(Response.fromErrorMessage(getMessageOrSimpleName(e)));
+          }
+
+          @Override
+          public void onResponse(final Call call, final okhttp3.Response httpResponse) {
+            try (httpResponse) {
+              final ResponseBody body = httpResponse.body();
+              if (!httpResponse.isSuccessful() || body == null) {
+                final boolean couldBeAuthError =
+                    httpResponse.code() == 401 || httpResponse.code() == 403;
+                final String errorMsg =
+                    body != null
+                        ? body.string()
+                        : (httpResponse.code() + ": " + httpResponse.message());
+                handleError(isCritical, new Exception(errorMsg), couldBeAuthError);
+                future.complete(Response.fromErrorMessage(errorMsg));
+                return;
+              }
+
+              final JsonNode jsonResponse = objectMapper.readTree(body.string());
+              final JsonNode errorNode = jsonResponse.get("error");
+              if (errorNode != null && !errorNode.isNull()) {
+                final int code = errorNode.path("code").asInt();
+                final String msg = errorNode.path("message").asText();
+                final String formattedError =
+                    String.format(
+                        "JSON-RPC error: %s (%d): %s", describeJsonRpcErrorCode(code), code, msg);
+                if (isCritical) {
+                  eventLog.executionClientRequestFailed(new Exception(formattedError), false);
+                }
+                future.complete(Response.fromErrorMessage(formattedError));
+                return;
+              }
+
+              handleSuccess(isCritical);
+              final JsonNode resultNode = jsonResponse.get("result");
+              final T result =
+                  resultNode == null || resultNode.isNull()
+                      ? null
+                      : objectMapper.treeToValue(resultNode, resultType);
+              future.complete(Response.fromPayloadReceivedAsJson(result));
+            } catch (final Exception e) {
+              handleError(isCritical, e, false);
+              future.complete(Response.fromErrorMessage(getMessageOrSimpleName(e)));
+            }
+          }
+        });
+
+    return future;
+  }
+
+  private byte[] buildRequestBody(final String method, final List<Object> params)
+      throws JsonProcessingException {
+    final Map<String, Object> request = new LinkedHashMap<>();
+    request.put("jsonrpc", "2.0");
+    request.put("method", method);
+    request.put("params", params);
+    request.put("id", requestIdCounter.incrementAndGet());
+    return objectMapper.writeValueAsBytes(request);
+  }
+
+  private static String describeJsonRpcErrorCode(final int code) {
+    if (code == -32700) {
+      return "Parse error";
+    }
+    if (code == -32600) {
+      return "Invalid Request";
+    }
+    if (code == -32601) {
+      return "Method not found";
+    }
+    if (code == -32602) {
+      return "Invalid params";
+    }
+    if (code == -32603) {
+      return "Internal error";
+    }
+    if (code >= -32099 && code <= -32000) {
+      return "Server error";
+    }
+    return "Internal error";
+  }
+
+  private synchronized void handleSuccess(final boolean isCritical) {
+    if (isCritical) {
+      if (lastErrorTime == STARTUP_LAST_ERROR_TIME) {
+        eventLog.executionClientIsOnline();
+        executionClientEventsPublisher.onAvailabilityUpdated(true);
+      } else if (lastErrorTime != NO_ERROR_TIME) {
+        eventLog.executionClientRecovered();
+        executionClientEventsPublisher.onAvailabilityUpdated(true);
+      }
+      lastErrorTime = NO_ERROR_TIME;
+    }
+  }
+
+  private synchronized void handleError(
+      final boolean isCritical, final Throwable error, final boolean couldBeAuthError) {
+    if (isCritical && shouldReportError()) {
+      logExecutionClientError(error, couldBeAuthError);
+      executionClientEventsPublisher.onAvailabilityUpdated(false);
+    }
+  }
+
+  private synchronized boolean shouldReportError() {
+    final long timeNow = timeProvider.getTimeInMillis().longValue();
+    if (lastErrorTime == NO_ERROR_TIME || timeNow - lastErrorTime > ERROR_REPEAT_DELAY_MILLIS) {
+      lastErrorTime = timeNow;
+      return true;
+    }
+    return false;
+  }
+
+  private void logExecutionClientError(final Throwable error, final boolean couldBeAuthError) {
+    if (ExceptionUtil.hasCause(error, ConnectException.class)) {
+      eventLog.executionClientConnectFailure();
+    } else if (error instanceof TimeoutException) {
+      eventLog.executionClientRequestTimedOut();
+    } else {
+      eventLog.executionClientRequestFailed(error, couldBeAuthError);
+    }
+  }
+
+  private List<Object> list(final Object... items) {
+    final List<Object> list = new ArrayList<>();
+    Collections.addAll(list, items);
+    return list;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class EthBlockResult {
+    @JsonProperty("hash")
+    public String hash;
+
+    @JsonProperty("parentHash")
+    public String parentHash;
+
+    @JsonProperty("timestamp")
+    public String timestamp;
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
@@ -92,7 +92,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
 
   private static final Duration EXCHANGE_CAPABILITIES_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration GET_CLIENT_VERSION_TIMEOUT = Duration.ofSeconds(1);
-  private static final Duration GET_BLOBS_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration GET_BLOBS_TIMEOUT = Duration.ofSeconds(2);
   private static final Duration GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(2);
 
   public static final List<String> NON_CRITICAL_METHODS =
@@ -435,7 +435,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
                 return;
               }
 
-              final JsonNode jsonResponse = objectMapper.readTree(body.string());
+              final JsonNode jsonResponse = objectMapper.readTree(body.byteStream());
               final JsonNode errorNode = jsonResponse.get("error");
               if (errorNode != null && !errorNode.isNull()) {
                 final int code = errorNode.path("code").asInt();

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import okhttp3.Call;
@@ -90,13 +89,10 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
   private static final Duration EXCHANGE_CAPABILITIES_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration GET_CLIENT_VERSION_TIMEOUT = Duration.ofSeconds(1);
   private static final Duration GET_BLOBS_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(2);
 
   public static final List<String> NON_CRITICAL_METHODS =
-      List.of(
-          "engine_exchangeCapabilities",
-          "engine_getClientVersionV1",
-          "engine_getBlobsV1",
-          "engine_getBlobsV2");
+      List.of("engine_exchangeCapabilities", "engine_getClientVersionV1", "engine_getBlobsV1");
 
   private final OkHttpClient httpClient;
   private final HttpUrl endpointUrl;
@@ -141,7 +137,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
         "engine_getPayloadV1",
         Collections.singletonList(payloadId.toHexString()),
         ExecutionPayloadV1.class,
-        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+        GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -150,7 +146,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
         "engine_getPayloadV2",
         Collections.singletonList(payloadId.toHexString()),
         GetPayloadV2Response.class,
-        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+        GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -159,7 +155,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
         "engine_getPayloadV3",
         Collections.singletonList(payloadId.toHexString()),
         GetPayloadV3Response.class,
-        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+        GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -168,7 +164,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
         "engine_getPayloadV4",
         Collections.singletonList(payloadId.toHexString()),
         GetPayloadV4Response.class,
-        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+        GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -177,7 +173,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
         "engine_getPayloadV5",
         Collections.singletonList(payloadId.toHexString()),
         GetPayloadV5Response.class,
-        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+        GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -186,7 +182,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
         "engine_getPayloadV6",
         Collections.singletonList(payloadId.toHexString()),
         GetPayloadV6Response.class,
-        EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+        GET_PAYLOAD_TIMEOUT);
   }
 
   @Override
@@ -399,8 +395,12 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
             .build();
 
     final SafeFuture<Response<T>> future = new SafeFuture<>();
-    final Call call = httpClient.newCall(httpRequest);
-    call.timeout().timeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    final Call call;
+    if (timeout.toMillis() != httpClient.callTimeoutMillis()) {
+      call = httpClient.newBuilder().callTimeout(timeout).build().newCall(httpRequest);
+    } else {
+      call = httpClient.newCall(httpRequest);
+    }
 
     call.enqueue(
         new Callback() {
@@ -538,6 +538,7 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   static class EthBlockResult {
+
     @JsonProperty("hash")
     public String hash;
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClient.java
@@ -357,8 +357,6 @@ public class OkHttpExecutionEngineClient implements ExecutionEngineClient {
         GET_BLOBS_TIMEOUT);
   }
 
-  // ----------------------------- Core infrastructure -----------------------------
-
   private SafeFuture<PowBlock> doEthBlockRequest(final String method, final List<Object> params) {
     return doRequest(method, params, EthBlockResult.class, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT)
         .thenApply(Response::payload)

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/OkHttpExecutionEngineClientTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes8;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+
+class OkHttpExecutionEngineClientTest {
+
+  private static final String VALID_JSONRPC_RESPONSE =
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":null}";
+
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(1000);
+  private final EventLogger eventLog = mock(EventLogger.class);
+  private final ExecutionClientEventsChannel executionClientEventsPublisher =
+      mock(ExecutionClientEventsChannel.class);
+
+  private OkHttpClient spyOkHttpClient;
+  private OkHttpExecutionEngineClient engineClient;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockWebServer.start();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  void usesExistingClient_whenTimeoutMatchesDefault() throws Exception {
+    // getPayloadV1 uses GET_PAYLOAD_TIMEOUT = 2s
+    createClientWithCallTimeout(Duration.ofSeconds(2));
+
+    mockWebServer.enqueue(new MockResponse().setBody(VALID_JSONRPC_RESPONSE));
+
+    final SafeFuture<Response<ExecutionPayloadV1>> future =
+        engineClient.getPayloadV1(Bytes8.fromHexStringLenient("0x1"));
+    final Response<ExecutionPayloadV1> response = future.get(5, TimeUnit.SECONDS);
+
+    assertThat(response).isNotNull();
+    verify(spyOkHttpClient, never()).newBuilder();
+  }
+
+  @Test
+  void createsNewClientWithCustomTimeout_whenTimeoutDiffers() throws Exception {
+    // Set client default to 12s, but getPayloadV1 uses GET_PAYLOAD_TIMEOUT = 2s
+    createClientWithCallTimeout(Duration.ofSeconds(12));
+
+    mockWebServer.enqueue(new MockResponse().setBody(VALID_JSONRPC_RESPONSE));
+
+    final SafeFuture<Response<ExecutionPayloadV1>> future =
+        engineClient.getPayloadV1(Bytes8.fromHexStringLenient("0x1"));
+    final Response<ExecutionPayloadV1> response = future.get(5, TimeUnit.SECONDS);
+
+    assertThat(response).isNotNull();
+    verify(spyOkHttpClient).newBuilder();
+  }
+
+  @Test
+  void requestIsSuccessfullyEnqueued_regardlessOfTimeoutBranch() throws Exception {
+    createClientWithCallTimeout(Duration.ofSeconds(12));
+
+    mockWebServer.enqueue(new MockResponse().setBody(VALID_JSONRPC_RESPONSE));
+
+    final SafeFuture<Response<ExecutionPayloadV1>> future =
+        engineClient.getPayloadV1(Bytes8.fromHexStringLenient("0x1"));
+    future.get(5, TimeUnit.SECONDS);
+
+    assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
+    final RecordedRequest recorded = mockWebServer.takeRequest();
+    assertThat(recorded.getBody().readUtf8()).contains("engine_getPayloadV1");
+  }
+
+  @Test
+  void multipleRequestsWithDifferentTimeouts_usesCorrectBranch() throws Exception {
+    // exchangeCapabilities uses EXCHANGE_CAPABILITIES_TIMEOUT = 1s
+    // getPayloadV1 uses GET_PAYLOAD_TIMEOUT = 2s
+    // Set default to 1s to match exchangeCapabilities
+    createClientWithCallTimeout(Duration.ofSeconds(1));
+
+    // First request: exchangeCapabilities with 1s timeout (matches default)
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setBody("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[\"engine_newPayloadV1\"]}"));
+
+    final SafeFuture<Response<List<String>>> capabilitiesFuture =
+        engineClient.exchangeCapabilities(List.of("engine_newPayloadV1"));
+    capabilitiesFuture.get(5, TimeUnit.SECONDS);
+
+    // exchangeCapabilities timeout (1s) matches default → uses existing client
+    verify(spyOkHttpClient).newCall(any());
+    verify(spyOkHttpClient, never()).newBuilder();
+
+    reset(spyOkHttpClient);
+
+    // Second request: getPayloadV1 with 2s timeout (different from default 1s)
+    mockWebServer.enqueue(new MockResponse().setBody(VALID_JSONRPC_RESPONSE));
+
+    final SafeFuture<Response<ExecutionPayloadV1>> payloadFuture =
+        engineClient.getPayloadV1(Bytes8.fromHexStringLenient("0x1"));
+    payloadFuture.get(5, TimeUnit.SECONDS);
+
+    // getPayloadV1 timeout (2s) differs from default (1s) → creates new builder
+    verify(spyOkHttpClient).newBuilder();
+  }
+
+  private void createClientWithCallTimeout(final Duration callTimeout) {
+    final OkHttpClient httpClient = new OkHttpClient.Builder().callTimeout(callTimeout).build();
+    spyOkHttpClient = spy(httpClient);
+    engineClient =
+        new OkHttpExecutionEngineClient(
+            spyOkHttpClient,
+            mockWebServer.url("/").toString(),
+            eventLog,
+            timeProvider,
+            executionClientEventsPublisher,
+            OkHttpExecutionEngineClient.NON_CRITICAL_METHODS);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -36,8 +36,6 @@ import tech.pegasys.teku.ethereum.executionclient.metrics.MetricRecordingExecuti
 import tech.pegasys.teku.ethereum.executionclient.rest.RestBuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestBuilderClientOptions;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestClient;
-import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient;
-import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JExecutionEngineClient;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
@@ -116,12 +114,11 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   public static ExecutionEngineClient createEngineClient(
-      final Web3JClient web3JClient,
+      final ExecutionEngineClient rawEngineClient,
       final TimeProvider timeProvider,
       final MetricsSystem metricsSystem) {
-    final ExecutionEngineClient engineClient = new Web3JExecutionEngineClient(web3JClient);
     final ExecutionEngineClient metricEngineClient =
-        new MetricRecordingExecutionEngineClient(engineClient, timeProvider, metricsSystem);
+        new MetricRecordingExecutionEngineClient(rawEngineClient, timeProvider, metricsSystem);
     return new ThrottlingExecutionEngineClient(
         metricEngineClient, MAXIMUM_CONCURRENT_EE_REQUESTS, metricsSystem);
   }

--- a/services/executionlayer/build.gradle
+++ b/services/executionlayer/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   implementation project(':infrastructure:serviceutils')
   implementation project(':validator:client')
 
+  implementation 'com.squareup.okhttp3:okhttp'
   implementation 'io.consensys.tuweni:tuweni-units'
 
   testImplementation testFixtures(project(':ethereum:spec'))

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -53,6 +53,7 @@ public class ExecutionLayerConfiguration {
   private final boolean builderSetUserAgentHeader;
   private final boolean useShouldOverrideBuilderFlag;
   private final boolean exchangeCapabilitiesMonitoringEnabled;
+  private final boolean useNewEngineApiClient;
 
   private ExecutionLayerConfiguration(
       final Spec spec,
@@ -67,7 +68,8 @@ public class ExecutionLayerConfiguration {
       final UInt64 builderBidCompareFactor,
       final boolean builderSetUserAgentHeader,
       final boolean useShouldOverrideBuilderFlag,
-      final boolean exchangeCapabilitiesMonitoringEnabled) {
+      final boolean exchangeCapabilitiesMonitoringEnabled,
+      final boolean useNewEngineApiClient1) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
     this.engineJwtSecretFile = engineJwtSecretFile;
@@ -82,6 +84,7 @@ public class ExecutionLayerConfiguration {
     this.builderSetUserAgentHeader = builderSetUserAgentHeader;
     this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
     this.exchangeCapabilitiesMonitoringEnabled = exchangeCapabilitiesMonitoringEnabled;
+    this.useNewEngineApiClient = useNewEngineApiClient1;
   }
 
   public static Builder builder() {
@@ -147,6 +150,10 @@ public class ExecutionLayerConfiguration {
     return exchangeCapabilitiesMonitoringEnabled;
   }
 
+  public boolean isUseNewEngineApiClient() {
+    return useNewEngineApiClient;
+  }
+
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
@@ -163,6 +170,7 @@ public class ExecutionLayerConfiguration {
     private boolean useShouldOverrideBuilderFlag = DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
     private boolean exchangeCapabilitiesMonitoringEnabled =
         DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
+    private boolean useNewEngineApiClient = false;
 
     private Builder() {}
 
@@ -200,7 +208,8 @@ public class ExecutionLayerConfiguration {
           builderBidCompareFactor,
           builderSetUserAgentHeader,
           useShouldOverrideBuilderFlag,
-          exchangeCapabilitiesMonitoringEnabled);
+          exchangeCapabilitiesMonitoringEnabled,
+          useNewEngineApiClient);
     }
 
     public Builder engineEndpoint(final String engineEndpoint) {
@@ -269,6 +278,11 @@ public class ExecutionLayerConfiguration {
     public Builder exchangeCapabilitiesMonitoringEnabled(
         final boolean exchangeCapabilitiesMonitoringEnabled) {
       this.exchangeCapabilitiesMonitoringEnabled = exchangeCapabilitiesMonitoringEnabled;
+      return this;
+    }
+
+    public Builder useNewEngineApiClient(final boolean useNewEngineApiClient) {
+      this.useNewEngineApiClient = useNewEngineApiClient;
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -69,7 +69,7 @@ public class ExecutionLayerConfiguration {
       final boolean builderSetUserAgentHeader,
       final boolean useShouldOverrideBuilderFlag,
       final boolean exchangeCapabilitiesMonitoringEnabled,
-      final boolean useNewEngineApiClient1) {
+      final boolean useNewEngineApiClient) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
     this.engineJwtSecretFile = engineJwtSecretFile;
@@ -84,7 +84,7 @@ public class ExecutionLayerConfiguration {
     this.builderSetUserAgentHeader = builderSetUserAgentHeader;
     this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
     this.exchangeCapabilitiesMonitoringEnabled = exchangeCapabilitiesMonitoringEnabled;
-    this.useNewEngineApiClient = useNewEngineApiClient1;
+    this.useNewEngineApiClient = useNewEngineApiClient;
   }
 
   public static Builder builder() {

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -130,9 +130,6 @@ public class ExecutionLayerService extends Service {
           createStubExecutionLayerManager(serviceConfig, config, builderCircuitBreaker);
     } else {
       if (!config.isUseNewEngineApiClient()) {
-
-        LOG.info("Using legacy Web3j Engine API client");
-
         executionLayerManager =
             createRealExecutionLayerManager(
                 serviceConfig,
@@ -142,17 +139,14 @@ public class ExecutionLayerService extends Service {
                 builderRestClientProvider,
                 builderCircuitBreaker);
       } else {
-        LOG.info("Using new Engine API client");
-
+        LOG.info("Using new experimental Engine API client");
         final Optional<JwtConfig> jwtConfig =
             JwtConfig.createIfNeeded(
                 true,
                 config.getEngineJwtSecretFile(),
                 config.getEngineJwtClaimId(),
                 beaconDataDirectory);
-        final OkHttpClient okHttpClient =
-            OkHttpClientCreator.create(
-                EL_ENGINE_BLOCK_EXECUTION_TIMEOUT, LOG, jwtConfig, timeProvider);
+        final OkHttpClient okHttpClient = OkHttpClientCreator.create(LOG, jwtConfig, timeProvider);
         final ExecutionEngineClient newEngineApiClient =
             new OkHttpExecutionEngineClient(
                 okHttpClient,

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -22,6 +22,7 @@ import com.google.common.base.Splitter;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import okhttp3.OkHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -29,6 +30,9 @@ import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.BuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.OkHttpClientCreator;
+import tech.pegasys.teku.ethereum.executionclient.OkHttpExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestClientProvider;
 import tech.pegasys.teku.ethereum.executionclient.web3j.ExecutionWeb3jClientProvider;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderBidValidatorImpl;
@@ -121,12 +125,29 @@ public class ExecutionLayerService extends Service {
       executionLayerManager =
           createStubExecutionLayerManager(serviceConfig, config, builderCircuitBreaker);
     } else {
+      final Optional<JwtConfig> jwtConfig =
+          JwtConfig.createIfNeeded(
+              true,
+              config.getEngineJwtSecretFile(),
+              config.getEngineJwtClaimId(),
+              beaconDataDirectory);
+      final OkHttpClient okHttpClient =
+          OkHttpClientCreator.create(
+              EL_ENGINE_BLOCK_EXECUTION_TIMEOUT, LOG, jwtConfig, timeProvider);
+      final ExecutionEngineClient rawEngineClient =
+          new OkHttpExecutionEngineClient(
+              okHttpClient,
+              config.getEngineEndpoint(),
+              EVENT_LOG,
+              timeProvider,
+              executionClientEventsPublisher,
+              OkHttpExecutionEngineClient.NON_CRITICAL_METHODS);
       executionLayerManager =
           createRealExecutionLayerManager(
               serviceConfig,
               config,
               spec,
-              engineWeb3jClientProvider,
+              rawEngineClient,
               builderRestClientProvider,
               builderCircuitBreaker);
     }
@@ -158,15 +179,14 @@ public class ExecutionLayerService extends Service {
       final ServiceConfig serviceConfig,
       final ExecutionLayerConfiguration config,
       final Spec spec,
-      final ExecutionWeb3jClientProvider engineWeb3jClientProvider,
+      final ExecutionEngineClient rawEngineClient,
       final Optional<RestClientProvider> builderRestClientProvider,
       final BuilderCircuitBreaker builderCircuitBreaker) {
     final MetricsSystem metricsSystem = serviceConfig.getMetricsSystem();
     final TimeProvider timeProvider = serviceConfig.getTimeProvider();
 
     final ExecutionEngineClient executionEngineClient =
-        ExecutionLayerManagerImpl.createEngineClient(
-            engineWeb3jClientProvider.getWeb3JClient(), timeProvider, metricsSystem);
+        ExecutionLayerManagerImpl.createEngineClient(rawEngineClient, timeProvider, metricsSystem);
 
     final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
         new MilestoneBasedEngineJsonRpcMethodsResolver(config.getSpec(), executionEngineClient);

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.ethereum.executionclient.OkHttpExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestClientProvider;
 import tech.pegasys.teku.ethereum.executionclient.web3j.ExecutionWeb3jClientProvider;
+import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderBidValidatorImpl;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderCircuitBreaker;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderCircuitBreakerImpl;
@@ -72,6 +73,9 @@ public class ExecutionLayerService extends Service {
     final ExecutionClientEventsChannel executionClientEventsPublisher =
         serviceConfig.getEventChannels().getPublisher(ExecutionClientEventsChannel.class);
 
+    // TODO-lucas This is eventually used on PowchainService. However this is likely legacy and can
+    // be removed as we
+    // don't care about fetching deposits from chain anymore.
     final ExecutionWeb3jClientProvider engineWeb3jClientProvider =
         ExecutionWeb3jClientProvider.create(
             config.getEngineEndpoint(),
@@ -125,31 +129,47 @@ public class ExecutionLayerService extends Service {
       executionLayerManager =
           createStubExecutionLayerManager(serviceConfig, config, builderCircuitBreaker);
     } else {
-      final Optional<JwtConfig> jwtConfig =
-          JwtConfig.createIfNeeded(
-              true,
-              config.getEngineJwtSecretFile(),
-              config.getEngineJwtClaimId(),
-              beaconDataDirectory);
-      final OkHttpClient okHttpClient =
-          OkHttpClientCreator.create(
-              EL_ENGINE_BLOCK_EXECUTION_TIMEOUT, LOG, jwtConfig, timeProvider);
-      final ExecutionEngineClient rawEngineClient =
-          new OkHttpExecutionEngineClient(
-              okHttpClient,
-              config.getEngineEndpoint(),
-              EVENT_LOG,
-              timeProvider,
-              executionClientEventsPublisher,
-              OkHttpExecutionEngineClient.NON_CRITICAL_METHODS);
-      executionLayerManager =
-          createRealExecutionLayerManager(
-              serviceConfig,
-              config,
-              spec,
-              rawEngineClient,
-              builderRestClientProvider,
-              builderCircuitBreaker);
+      if (!config.isUseNewEngineApiClient()) {
+
+        LOG.info("Using legacy Web3j Engine API client");
+
+        executionLayerManager =
+            createRealExecutionLayerManager(
+                serviceConfig,
+                config,
+                spec,
+                new Web3JExecutionEngineClient(engineWeb3jClientProvider.getWeb3JClient()),
+                builderRestClientProvider,
+                builderCircuitBreaker);
+      } else {
+        LOG.info("Using new Engine API client");
+
+        final Optional<JwtConfig> jwtConfig =
+            JwtConfig.createIfNeeded(
+                true,
+                config.getEngineJwtSecretFile(),
+                config.getEngineJwtClaimId(),
+                beaconDataDirectory);
+        final OkHttpClient okHttpClient =
+            OkHttpClientCreator.create(
+                EL_ENGINE_BLOCK_EXECUTION_TIMEOUT, LOG, jwtConfig, timeProvider);
+        final ExecutionEngineClient newEngineApiClient =
+            new OkHttpExecutionEngineClient(
+                okHttpClient,
+                config.getEngineEndpoint(),
+                EVENT_LOG,
+                timeProvider,
+                executionClientEventsPublisher,
+                OkHttpExecutionEngineClient.NON_CRITICAL_METHODS);
+        executionLayerManager =
+            createRealExecutionLayerManager(
+                serviceConfig,
+                config,
+                spec,
+                newEngineApiClient,
+                builderRestClientProvider,
+                builderCircuitBreaker);
+      }
     }
 
     return new ExecutionLayerService(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -146,6 +146,16 @@ public class ExecutionLayerOptions {
   private boolean exchangeCapabilitiesMonitoringEnabled =
       DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
 
+  @Option(
+      names = {"--Xnew-engine-api-client-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enables the new Engine API client.",
+      arity = "0..1",
+      showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
+      hidden = true)
+  private boolean useNewEngineApiClient = false;
+
   public void configure(final Builder builder) {
     builder.executionLayer(
         b ->
@@ -161,7 +171,8 @@ public class ExecutionLayerOptions {
                 .builderBidCompareFactor(builderBidCompareFactor)
                 .builderSetUserAgentHeader(builderSetUserAgentHeader)
                 .useShouldOverrideBuilderFlag(useShouldOverrideBuilderFlag)
-                .exchangeCapabilitiesMonitoringEnabled(exchangeCapabilitiesMonitoringEnabled));
+                .exchangeCapabilitiesMonitoringEnabled(exchangeCapabilitiesMonitoringEnabled)
+                .useNewEngineApiClient(useNewEngineApiClient));
     depositOptions.configure(builder);
   }
 }


### PR DESCRIPTION
## PR Description

Implement a new `OkHttpExecutionEngineClient` that can replace the Web3j-based Engine API client with an experimental CLI flag.

For now, the default client will still be the web3j-based one. In the future, we can change that.

The new client uses a simpler OkHttp + Jackson implementation, reducing overhead and improving EL communication performance. It also gives us finer control over the channel.

## Fixed Issue(s)
#10875

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new implementation of the Execution Engine JSON-RPC client and an experimental flag to switch production EL communication away from Web3j, which could affect block production/EL availability reporting if behavior differs.
> 
> **Overview**
> Introduces a new `OkHttpExecutionEngineClient` (OkHttp + Jackson) for Engine API JSON-RPC calls, including per-method timeouts, JSON-RPC error parsing, and availability/error logging behavior.
> 
> Wires the new client into `ExecutionLayerService` behind hidden flag `--Xnew-engine-api-client-enabled`, refactoring `ExecutionLayerManagerImpl.createEngineClient` to accept an already-constructed `ExecutionEngineClient` (Web3j wrapper or OkHttp client).
> 
> Adds required dependencies (`okhttp`, `jackson-databind`, `mockwebserver`) and new unit/integration tests that validate request/response roundtrips and timeout-branch behavior with a `MockWebServer`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e35d9db2c328c050a04e814b8b70663e034bfba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->