### PR TITLE
[Gloas] Update head on imported execution payload

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
@@ -568,6 +569,20 @@ public class ForkChoiceUtil {
 
   public boolean shouldNotifyForkChoiceUpdatedOnBlock() {
     return true;
+  }
+
+  public SafeFuture<StateAndBlockSummary> retrieveNewChainHeadStateAndBlockSummary(
+      final Bytes32 root, final UInt64 chainHeadSlot, final ReadOnlyStore store) {
+    return store
+        .retrieveStateAndBlockSummary(root)
+        .thenApply(
+            maybeHead ->
+                maybeHead.orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            String.format(
+                                "Unable to update head block as of slot %s.  Block is unavailable: %s.",
+                                chainHeadSlot, root))));
   }
 
   public Optional<ForkChoiceUtilDeneb> toVersionDeneb() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -19,10 +19,12 @@ import static tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatus.PAY
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
@@ -123,6 +125,33 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
   @Override
   public boolean shouldNotifyForkChoiceUpdatedOnBlock() {
     return false;
+  }
+
+  @Override
+  public SafeFuture<StateAndBlockSummary> retrieveNewChainHeadStateAndBlockSummary(
+      final Bytes32 root, final UInt64 chainHeadSlot, final ReadOnlyStore store) {
+    return store
+        .retrieveStateAndBlockSummary(root)
+        .thenApply(
+            maybeHead ->
+                maybeHead.orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            String.format(
+                                "Unable to update head block as of slot %s.  Block is unavailable: %s.",
+                                chainHeadSlot, root))))
+        // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 this is just a workaround
+        // for devnet-0, we may require a more proper implementation, when the complete fork
+        // choice is implemented
+        .thenApply(
+            stateAndBlockSummary ->
+                store
+                    .getExecutionPayloadStateIfAvailable(root)
+                    .map(
+                        executionPayloadState ->
+                            StateAndBlockSummary.create(
+                                stateAndBlockSummary.getBlockSummary(), executionPayloadState))
+                    .orElse(stateAndBlockSummary));
   }
 
   public boolean isBlockStatusFull(final ReadOnlyStore store, final BeaconBlock block) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -765,6 +765,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // devnet-0, we need a proper fork choice implementation
     forkChoiceStrategy.processExecutionPayload(signedEnvelope);
 
+    updateForkChoiceForImportedExecutionPayload(signedEnvelope, forkChoiceStrategy);
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
 
     return ExecutionPayloadImportResult.successful(signedEnvelope);
@@ -926,6 +927,20 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       // VC side and requires head event to be sent before attestationDue.
       processHead().finish(error -> LOG.error("Fork choice updating head failed", error));
     }
+  }
+
+  // TODO-GLOAS: https://github.com/Consensys/teku/issues/9878 this is just a workaround for
+  // devnet-0, we need a proper fork choice implementation
+  private void updateForkChoiceForImportedExecutionPayload(
+      final SignedExecutionPayloadEnvelope signedEnvelope,
+      final ForkChoiceStrategy forkChoiceStrategy) {
+    recentChainData.updateHead(signedEnvelope.getBeaconBlockRoot(), signedEnvelope.getSlot());
+    final SlotAndBlockRoot bestHeadBlock = findNewChainHead(forkChoiceStrategy);
+    if (!bestHeadBlock.getBlockRoot().equals(signedEnvelope.getBeaconBlockRoot())) {
+      processHead().finish(error -> LOG.error("Fork choice updating head failed", error));
+      return;
+    }
+    recentChainData.updateHead(bestHeadBlock.getBlockRoot(), bestHeadBlock.getSlot());
   }
 
   private SlotAndBlockRoot findNewChainHead(final ForkChoiceStrategy forkChoiceStrategy) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -48,7 +48,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -62,6 +61,7 @@ import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobParameters;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
@@ -351,7 +351,10 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
             "Unable to update head block as of slot {}. Unknown block: {}", currentSlot, root);
         return;
       }
-      final ChainHead newChainHead = createNewChainHead(root, currentSlot, maybeBlockData.get());
+      final SpecVersion specVersion = spec.atSlot(currentSlot);
+      final ChainHead newChainHead =
+          createNewChainHead(
+              root, currentSlot, specVersion.getForkChoiceUtil(), maybeBlockData.get());
       this.chainHead = Optional.of(newChainHead);
       final Optional<ReorgContext> optionalReorgContext =
           computeReorgContext(forkChoiceStrategy, originalChainHead, newChainHead);
@@ -362,8 +365,7 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
                       spec.computeEpochAtSlot(previousChainHead.getSlot())
                           .isLessThan(spec.computeEpochAtSlot(newChainHead.getSlot())))
               .orElse(false);
-      final BeaconStateUtil beaconStateUtil =
-          spec.atSlot(newChainHead.getSlot()).getBeaconStateUtil();
+      final BeaconStateUtil beaconStateUtil = specVersion.getBeaconStateUtil();
 
       chainHeadChannel.chainHeadUpdated(
           newChainHead.getSlot(),
@@ -388,11 +390,6 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
           optionalReorgContext);
     }
     bestBlockInitialized.complete(null);
-  }
-
-  public Optional<SlotAndBlockRoot> findCommonAncestor(
-      final Bytes32 blockRoot1, final Bytes32 blockRoot2) {
-    return store.getForkChoiceStrategy().findCommonAncestor(blockRoot1, blockRoot2);
   }
 
   private Optional<ReorgContext> computeReorgContext(
@@ -425,19 +422,13 @@ public abstract class RecentChainData implements StoreUpdateHandler, ValidatorIs
   }
 
   private ChainHead createNewChainHead(
-      final Bytes32 root, final UInt64 currentSlot, final ProtoNodeData blockData) {
-    final SafeFuture<StateAndBlockSummary> chainHeadStateFuture =
-        store
-            .retrieveStateAndBlockSummary(root)
-            .thenApply(
-                maybeHead ->
-                    maybeHead.orElseThrow(
-                        () ->
-                            new IllegalStateException(
-                                String.format(
-                                    "Unable to update head block as of slot %s.  Block is unavailable: %s.",
-                                    currentSlot, root))));
-    return ChainHead.create(blockData, chainHeadStateFuture);
+      final Bytes32 root,
+      final UInt64 currentSlot,
+      final ForkChoiceUtil forkChoiceUtil,
+      final ProtoNodeData blockData) {
+    return ChainHead.create(
+        blockData,
+        forkChoiceUtil.retrieveNewChainHeadStateAndBlockSummary(root, currentSlot, store));
   }
 
   private Bytes32 getFinalizedBlockParentRoot() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Updating head on execution payload and creating new chain head (after applying execution payload) changes for Gloas. Fixes some of the compatibility issues for devnet-0.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes head-selection/update behavior during Gloas execution-payload imports and how chain head state is retrieved, which can affect fork choice and reorg handling. Scoped to Gloas/devnet workarounds but touches consensus-critical head update paths.
> 
> **Overview**
> **Improves Gloas devnet compatibility by updating the chain head when an execution payload is imported.** After `processExecutionPayload`, `ForkChoice` now forces a head update/re-evaluation and triggers `processHead()` if fork choice would select a different head.
> 
> **Makes chain-head state retrieval fork-aware.** `RecentChainData.updateHead` now delegates creation of the new `ChainHead` to the active `ForkChoiceUtil` via a new `retrieveNewChainHeadStateAndBlockSummary` hook, with a Gloas override that prefers an execution-payload state when available (workaround noted in TODOs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f86a3c5d7d0f73c489169f97ed313855c52efc65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->