### PR TITLE
Reqresp remove noncanonical sidecars

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessage;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -153,8 +152,7 @@ public class BlobSidecarsByRootMessageHandler
 
   private UInt64 getFinalizedEpoch() {
     return combinedChainDataClient
-        .getFinalizedBlock()
-        .map(SignedBeaconBlock::getSlot)
+        .getFinalizedBlockSlot()
         .map(spec::computeEpochAtSlot)
         .orElse(UInt64.ZERO);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -161,7 +161,7 @@ public class DataColumnSidecarsByRootMessageHandler
         .finish(err -> handleError(err, completionCallback, "data column sidecars by root"));
   }
 
-  private SafeFuture<Optional<DataColumnSidecar>> getArchiveOrNonCanonicalDataColumnSidecar(
+  private SafeFuture<Optional<DataColumnSidecar>> tryArchiveReconstruction(
       final DataColumnSlotAndIdentifier identifier, final int messageId) {
     final boolean isSuperNodePruned =
         dataColumnSidecarArchiveReconstructor.isSidecarPruned(
@@ -179,7 +179,8 @@ public class DataColumnSidecarsByRootMessageHandler
                     maybeBlock.get(), identifier.columnIndex(), messageId);
               });
     }
-    return combinedChainDataClient.getNonCanonicalSidecar(identifier);
+
+    return SafeFuture.completedFuture(Optional.empty());
   }
 
   /**
@@ -261,10 +262,8 @@ public class DataColumnSidecarsByRootMessageHandler
               if (maybeSidecar.isPresent()) {
                 return SafeFuture.completedFuture(maybeSidecar);
               }
-              // Fallback to compacted archive or non-canonical sidecar if the canonical one is not
-              // found
-              return getArchiveOrNonCanonicalDataColumnSidecar(
-                  dataColumnSlotAndIdentifier, messageId);
+              // Fallback to compacted archive reconstruction if the canonical one is not found
+              return tryArchiveReconstruction(dataColumnSlotAndIdentifier, messageId);
             });
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootFuluDeprecationTest.java
@@ -97,11 +97,8 @@ public class BlobSidecarsByRootFuluDeprecationTest {
     when(combinedChainDataClient.getSlotByBlockRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(fuluForkFirstSlot)));
     // epoch 1 = electra is finalized, epochs 2+ not
-    when(combinedChainDataClient.getFinalizedBlock())
-        .thenReturn(
-            Optional.of(
-                dataStructureUtil.randomSignedBeaconBlock(
-                    spec.computeStartSlotAtEpoch(UInt64.ZERO))));
+    when(combinedChainDataClient.getFinalizedBlockSlot())
+        .thenReturn(Optional.of(spec.computeStartSlotAtEpoch(UInt64.ZERO)));
     when(combinedChainDataClient.getStore()).thenReturn(store);
     when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
     when(callback.respond(any())).thenReturn(SafeFuture.COMPLETE);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -129,8 +129,8 @@ public class BlobSidecarsByRootMessageHandlerTest {
     when(combinedChainDataClient.getSlotByBlockRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(currentForkFirstSlot)));
     // deneb fork epoch is finalized
-    when(combinedChainDataClient.getFinalizedBlock())
-        .thenReturn(Optional.of(dataStructureUtil.randomSignedBeaconBlock(currentForkFirstSlot)));
+    when(combinedChainDataClient.getFinalizedBlockSlot())
+        .thenReturn(Optional.of(currentForkFirstSlot));
     when(combinedChainDataClient.getStore()).thenReturn(store);
     when(combinedChainDataClient.getRecentChainData()).thenReturn(recentChainData);
     when(callback.respond(any())).thenReturn(SafeFuture.COMPLETE);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -205,9 +205,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     final Bytes32 secondBlockRoot = dataColumnsByRootIdentifiers[1].getBlockRoot();
     when(combinedChainDataClient.getSlotByBlockRoot(secondBlockRoot))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-    when(combinedChainDataClient.getNonCanonicalSidecar(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-
     when(combinedChainDataClient.getSidecar(any()))
         .thenAnswer(
             invocation -> {
@@ -266,8 +263,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     when(combinedChainDataClient.getSlotByBlockRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(UInt64.valueOf(100))));
     when(combinedChainDataClient.getSidecar(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-    when(combinedChainDataClient.getNonCanonicalSidecar(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     handler.onIncomingMessage(
@@ -333,7 +328,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     // Sending 3 data column sidecars
     verify(peer).adjustDataColumnSidecarsRequest(eq(allowedRequest.get()), eq(Long.valueOf(3)));
 
-    verify(combinedChainDataClient, never()).getNonCanonicalSidecar(any());
     verify(callback, times(3)).respond(datacolumnSidecarCaptor.capture());
     verify(callback).completeSuccessfully();
 
@@ -380,7 +374,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     // Sending 3 data column sidecars
     verify(peer, never()).adjustDataColumnSidecarsRequest(any(), anyLong());
 
-    verify(combinedChainDataClient, never()).getNonCanonicalSidecar(any());
     verify(combinedChainDataClient, never()).getFinalizedBlockSlot();
     verify(combinedChainDataClient, never()).getFinalizedBlock();
     verify(callback, times(4)).respond(datacolumnSidecarCaptor.capture());
@@ -419,7 +412,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     // Sending 0 data column sidecars, archive reconstructed empty
     verify(peer).adjustDataColumnSidecarsRequest(any(), eq(Long.valueOf(0)));
 
-    verify(combinedChainDataClient, never()).getNonCanonicalSidecar(any());
     verify(combinedChainDataClient, never()).getFinalizedBlockSlot();
     verify(combinedChainDataClient, never()).getFinalizedBlock();
     verify(callback).completeSuccessfully();
@@ -436,38 +428,6 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
     verify(dataColumnSidecarArchiveReconstructor, times(4))
         .reconstructDataColumnSidecar(any(), any(), anyInt());
     verify(dataColumnSidecarArchiveReconstructor).onRequestCompleted(anyInt());
-  }
-
-  @TestTemplate
-  public void shouldFallbackToNonCanonicalSidecarWhenBlockIsPruned() {
-    final DataColumnsByRootIdentifier[] dataColumnsByRootIdentifiers =
-        generateDataColumnsByRootIdentifiers(1, 1);
-    final DataColumnSidecar nonCanonicalSidecar = dataStructureUtil.randomDataColumnSidecar();
-
-    // canonical sidecar not found
-    when(combinedChainDataClient.getSidecar(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-    // slot resolution returns the slot
-    final UInt64 currentForkFirstSlot = spec.computeStartSlotAtEpoch(currentForkEpoch);
-    when(combinedChainDataClient.getSlotByBlockRoot(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(currentForkFirstSlot)));
-    // archive fallback finds block pruned
-    when(combinedChainDataClient.getBlockByBlockRoot(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-    // non-canonical sidecar is available
-    when(combinedChainDataClient.getNonCanonicalSidecar(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(nonCanonicalSidecar)));
-
-    handler.onIncomingMessage(
-        protocolId, peer, messageSchema.of(dataColumnsByRootIdentifiers), callback);
-
-    verify(combinedChainDataClient).getNonCanonicalSidecar(any());
-    verify(callback, times(1)).respond(datacolumnSidecarCaptor.capture());
-    verify(callback).completeSuccessfully();
-
-    assertThat(datacolumnSidecarCaptor.getValue()).isEqualTo(nonCanonicalSidecar);
-    verify(dataColumnSidecarArchiveReconstructor, never())
-        .reconstructDataColumnSidecar(any(), any(), anyInt());
   }
 
   @TestTemplate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We were not answering with non-canonical `BlobSidecars` and spec doesn't require us to response with non-canonical `DataColumnSidecars` as well. So the fallback is removed.
Also found usage of block only to get slot in BlobSidecars handler. Fixed.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes req/resp behavior for `DataColumnSidecarsByRoot` by removing the non-canonical sidecar fallback, which could reduce responses peers previously received and impact interoperability if assumptions differed. Blob sidecar handling is a small refactor to use finalized slot directly, with low functional risk on its own.
> 
> **Overview**
> Updates req/resp handlers to **stop serving non-canonical sidecars**: `DataColumnSidecarsByRootMessageHandler` now only falls back to *archive reconstruction when pruned* and otherwise returns empty when canonical sidecars are missing.
> 
> Simplifies `BlobSidecarsByRootMessageHandler` finalized-range checks by using `CombinedChainDataClient.getFinalizedBlockSlot()` (instead of fetching the full block), and updates tests accordingly, including removing the non-canonical sidecar fallback test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8e47d8ad99b7fd950a3f4ec2c15dc4ce0b57463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->