### PR TITLE
Updated CreateAttestationData to pass optional index down

### DIFF
--- a/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -248,9 +248,8 @@ public class ValidatorApiHandlerIntegrationTest {
     assertThat(epochBoundaryBlock).isNotNull();
     final Checkpoint expectedTarget = new Checkpoint(targetEpoch, epochBoundaryBlock.getRoot());
 
-    final int committeeIndex = 0;
     final SafeFuture<Optional<AttestationData>> result =
-        handler.createAttestationData(targetSlot, committeeIndex);
+        handler.createAttestationData(targetSlot, Optional.of(0));
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
     final AttestationData attestation = safeJoin(result).orElseThrow();
     assertThat(attestation.getBeaconBlockRoot()).isEqualTo(latestBlock.getRoot());
@@ -280,9 +279,8 @@ public class ValidatorApiHandlerIntegrationTest {
     assertThat(latestBlock).isNotNull();
     final Checkpoint expectedTarget = new Checkpoint(targetEpoch, latestBlock.getRoot());
 
-    final int committeeIndex = 0;
     final SafeFuture<Optional<AttestationData>> result =
-        handler.createAttestationData(targetSlot, committeeIndex);
+        handler.createAttestationData(targetSlot, Optional.of(0));
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
     final AttestationData attestation = safeJoin(result).orElseThrow();
     assertThat(attestation.getBeaconBlockRoot()).isEqualTo(latestBlock.getRoot());

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -544,7 +544,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
 
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
@@ -622,8 +622,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   }
 
   protected int computeCommitteeIndexForAttestation(
-      final UInt64 slot, final BeaconBlock block, final int committeeIndex) {
-    return committeeIndex;
+      final UInt64 slot, final BeaconBlock block, final Optional<Integer> committeeIndex) {
+    return committeeIndex.orElse(0);
   }
 
   private AttestationData createAttestationData(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.NodeDataProvider;
@@ -44,7 +46,7 @@ import tech.pegasys.teku.validator.coordinator.publisher.BlockPublisher;
 import tech.pegasys.teku.validator.coordinator.publisher.ExecutionPayloadPublisher;
 
 public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
-
+  private static final Logger LOG = LogManager.getLogger();
   private final ExecutionPayloadBidManager executionPayloadBidManager;
 
   public ValidatorApiHandlerGloas(
@@ -122,17 +124,29 @@ public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
 
   @Override
   protected int computeCommitteeIndexForAttestation(
-      final UInt64 slot, final BeaconBlock block, final int committeeIndex) {
+      final UInt64 slot, final BeaconBlock block, final Optional<Integer> committeeIndex) {
+    if (committeeIndex.isPresent()) {
+      LOG.debug("committeeIndex passed in, using the supplied value {}", committeeIndex::get);
+      return committeeIndex.get();
+    }
+
+    // compute the index based on availability
     if (slot.equals(block.getSlot())) {
+      LOG.debug("slot {} same as block slot", slot);
       return 0;
     }
+
     return spec.atSlot(slot)
         .getForkChoiceUtil()
         .toVersionGloas()
         .map(
-            forkChoiceUtil ->
-                forkChoiceUtil.isBlockStatusFull(combinedChainDataClient.getStore(), block) ? 1 : 0)
-        .orElse(0);
+            gloasUtil -> {
+              final int index =
+                  gloasUtil.isBlockStatusFull(combinedChainDataClient.getStore(), block) ? 1 : 0;
+              LOG.debug("committee index set to {} at slot {}", index, slot);
+              return index;
+            })
+        .orElse(1);
   }
 
   private Optional<BeaconState> getExecutionPayloadStateForBlockProduction(final UInt64 slot) {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -682,7 +682,7 @@ class ValidatorApiHandlerTest {
   public void createAttestationData_shouldFailWhenNodeIsSyncing() {
     nodeIsSyncing();
     final SafeFuture<Optional<AttestationData>> result =
-        validatorApiHandler.createAttestationData(ONE, 1);
+        validatorApiHandler.createAttestationData(ONE, Optional.of(1));
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -704,9 +704,8 @@ class ValidatorApiHandlerTest {
 
     when(chainDataClient.isOptimisticBlock(blockAndState.getRoot())).thenReturn(true);
 
-    final int committeeIndex = 0;
     final SafeFuture<Optional<AttestationData>> result =
-        validatorApiHandler.createAttestationData(slot, committeeIndex);
+        validatorApiHandler.createAttestationData(slot, Optional.of(0));
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -727,9 +726,8 @@ class ValidatorApiHandlerTest {
         .thenReturn(blockAndStateResult);
     when(forkChoiceTrigger.prepareForAttestationProduction(slot)).thenReturn(SafeFuture.COMPLETE);
 
-    final int committeeIndex = 0;
     final SafeFuture<Optional<AttestationData>> result =
-        validatorApiHandler.createAttestationData(slot, committeeIndex);
+        validatorApiHandler.createAttestationData(slot, Optional.of(0));
 
     assertThat(result).isCompleted();
     final Optional<AttestationData> maybeAttestation = safeJoin(result);
@@ -741,7 +739,7 @@ class ValidatorApiHandlerTest {
                 slot,
                 blockAndState.getState(),
                 blockAndState.getBlock().getMessage(),
-                UInt64.valueOf(committeeIndex)));
+                UInt64.ZERO));
     assertThat(attestationData.getSlot()).isEqualTo(slot);
     final InOrder inOrder = inOrder(forkChoiceTrigger, chainDataClient);
 
@@ -755,9 +753,8 @@ class ValidatorApiHandlerTest {
     final UInt64 slot = spec.computeStartSlotAtEpoch(EPOCH).plus(ONE);
     when(chainDataClient.getCurrentSlot()).thenReturn(slot.minus(1));
 
-    final int committeeIndex = 0;
     final SafeFuture<Optional<AttestationData>> result =
-        validatorApiHandler.createAttestationData(slot, committeeIndex);
+        validatorApiHandler.createAttestationData(slot, Optional.of(0));
 
     assertThatSafeFuture(result).isCompletedExceptionallyWith(IllegalArgumentException.class);
   }
@@ -786,9 +783,8 @@ class ValidatorApiHandlerTest {
                     spec, new Checkpoint(EPOCH, block.getRoot()), block, rightState)));
     when(forkChoiceTrigger.prepareForAttestationProduction(slot)).thenReturn(SafeFuture.COMPLETE);
 
-    final int committeeIndex = 0;
     final SafeFuture<Optional<AttestationData>> result =
-        validatorApiHandler.createAttestationData(slot, committeeIndex);
+        validatorApiHandler.createAttestationData(slot, Optional.of(0));
 
     assertThat(result).isCompleted();
     final Optional<AttestationData> maybeAttestation = safeJoin(result);
@@ -796,8 +792,7 @@ class ValidatorApiHandlerTest {
     final AttestationData attestationData = maybeAttestation.orElseThrow();
     assertThat(attestationData)
         .isEqualTo(
-            spec.getGenericAttestationData(
-                slot, rightState, block.getMessage(), UInt64.valueOf(committeeIndex)));
+            spec.getGenericAttestationData(slot, rightState, block.getMessage(), UInt64.ZERO));
     assertThat(attestationData.getSlot()).isEqualTo(slot);
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -106,7 +106,7 @@ public class GetAttestationData extends RestApiEndpoint {
     }
 
     final SafeFuture<Optional<AttestationData>> future =
-        provider.createAttestationDataAtSlot(slot, committeeIndex.orElse(UInt64.ZERO).intValue());
+        provider.createAttestationDataAtSlot(slot, committeeIndex.map(UInt64::intValue));
 
     request.respondAsync(
         future.thenApply(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
@@ -59,7 +59,7 @@ class GetAttestationDataTest extends AbstractMigratedBeaconHandlerTest {
   void shouldReturnAttestationDataInformation() throws Exception {
     request.setQueryParameter(SLOT, "1");
     request.setOptionalQueryParameter(COMMITTEE_INDEX, "1");
-    when(validatorDataProvider.createAttestationDataAtSlot(ONE, 1))
+    when(validatorDataProvider.createAttestationDataAtSlot(ONE, Optional.of(1)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(attestationData)));
 
     handler.handleRequest(request);
@@ -72,7 +72,7 @@ class GetAttestationDataTest extends AbstractMigratedBeaconHandlerTest {
   @Test
   void shouldFail_whenCommitteeIndexIsMissingPreGloas() throws JsonProcessingException {
     request.setQueryParameter(SLOT, "1");
-    when(validatorDataProvider.createAttestationDataAtSlot(ONE, 1))
+    when(validatorDataProvider.createAttestationDataAtSlot(ONE, Optional.of(1)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(attestationData)));
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_BAD_REQUEST);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -110,7 +110,7 @@ public class ValidatorDataProvider {
   }
 
   public SafeFuture<Optional<AttestationData>> createAttestationDataAtSlot(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     if (!isStoreAvailable()) {
       return SafeFuture.failedFuture(new ChainDataUnavailableException());
     }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -208,12 +208,12 @@ public class ValidatorDataProviderTest {
   @TestTemplate
   void getAttestationDataAtSlot_shouldThrowIfFutureSlotRequested() {
     when(combinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    when(validatorApiChannel.createAttestationData(ONE, 0))
+    when(validatorApiChannel.createAttestationData(ONE, Optional.of(0)))
         .thenReturn(SafeFuture.failedFuture(new IllegalArgumentException("Computer says no")));
 
     final SafeFuture<Optional<AttestationData>> result =
-        provider.createAttestationDataAtSlot(ONE, 0);
-    verify(validatorApiChannel).createAttestationData(ONE, 0);
+        provider.createAttestationDataAtSlot(ONE, Optional.of(0));
+    verify(validatorApiChannel).createAttestationData(ONE, Optional.of(0));
     SafeFutureAssert.assertThatSafeFuture(result)
         .isCompletedExceptionallyWith(BadRequestException.class);
   }
@@ -222,7 +222,7 @@ public class ValidatorDataProviderTest {
   void getAttestationDataAtSlot_shouldThrowIfStoreNotFound() {
     when(combinedChainDataClient.isStoreAvailable()).thenReturn(false);
     final SafeFuture<Optional<AttestationData>> result =
-        provider.createAttestationDataAtSlot(ZERO, 0);
+        provider.createAttestationDataAtSlot(ZERO, Optional.of(0));
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::join).hasRootCauseInstanceOf(ChainDataUnavailableException.class);
     verify(combinedChainDataClient).isStoreAvailable();
@@ -231,12 +231,12 @@ public class ValidatorDataProviderTest {
   @TestTemplate
   void getAttestationDataAtSlot_shouldReturnEmptyIfBlockNotFound() {
     when(combinedChainDataClient.isStoreAvailable()).thenReturn(true);
-    when(validatorApiChannel.createAttestationData(ZERO, 0))
+    when(validatorApiChannel.createAttestationData(ZERO, Optional.of(0)))
         .thenReturn(completedFuture(Optional.empty()));
 
     final SafeFuture<Optional<AttestationData>> result =
-        provider.createAttestationDataAtSlot(ZERO, 0);
-    verify(validatorApiChannel).createAttestationData(ZERO, 0);
+        provider.createAttestationDataAtSlot(ZERO, Optional.of(0));
+    verify(validatorApiChannel).createAttestationData(ZERO, Optional.of(0));
     assertThat(result).isCompletedWithValue(Optional.empty());
   }
 
@@ -244,11 +244,11 @@ public class ValidatorDataProviderTest {
   void getAttestationDataAtSlot_shouldReturnAttestationData() {
     when(combinedChainDataClient.isStoreAvailable()).thenReturn(true);
     final AttestationData internalData = dataStructureUtil.randomAttestationData();
-    when(validatorApiChannel.createAttestationData(ONE, 0))
+    when(validatorApiChannel.createAttestationData(ONE, Optional.of(0)))
         .thenReturn(completedFuture(Optional.of(internalData)));
 
     final SafeFuture<Optional<AttestationData>> result =
-        provider.createAttestationDataAtSlot(ONE, 0);
+        provider.createAttestationDataAtSlot(ONE, Optional.of(0));
     assertThat(result).isCompleted();
     AttestationData data = safeJoin(result).orElseThrow();
     assertThat(data.getIndex()).isEqualTo(internalData.getIndex());

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -116,7 +116,7 @@ public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface
 
         @Override
         public SafeFuture<Optional<AttestationData>> createAttestationData(
-            final UInt64 slot, final int committeeIndex) {
+            final UInt64 slot, final Optional<Integer> committeeIndex) {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
@@ -280,7 +280,8 @@ public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface
       Optional<Bytes32> graffiti,
       Optional<UInt64> requestedBuilderBoostFactor);
 
-  SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
+  SafeFuture<Optional<AttestationData>> createAttestationData(
+      UInt64 slot, Optional<Integer> committeeIndex);
 
   SafeFuture<Optional<Attestation>> createAggregate(
       UInt64 slot, Bytes32 attestationHashTreeRoot, Optional<UInt64> committeeIndex);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -164,7 +164,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     return countOptionalDataRequest(
         delegate.createAttestationData(slot, committeeIndex),
         BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD);

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -211,7 +211,7 @@ class MetricRecordingValidatorApiChannelTest {
             dataStructureUtil.randomBlockContainerAndMetaData(slot)),
         requestDataTest(
             "createAttestationData",
-            channel -> channel.createAttestationData(slot, 4),
+            channel -> channel.createAttestationData(slot, Optional.of(4)),
             BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD,
             dataStructureUtil.randomAttestationData()),
         Arguments.of(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationProductionDuty.java
@@ -152,7 +152,7 @@ public class AttestationProductionDuty implements Duty {
       final AttestationDataProducer attestationDataProducer,
       final SignedAttestationProducer signedAttestationProducer) {
     final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture =
-        attestationDataProducer.createAttestationData(slot, committeeIndex);
+        attestationDataProducer.createAttestationData(slot, Optional.of(committeeIndex));
     unsignedAttestationFuture.propagateTo(committee.getAttestationDataFuture());
 
     return committee.getValidators().stream()
@@ -196,7 +196,8 @@ public class AttestationProductionDuty implements Duty {
       // in Electra and later, the committee index in AttestationData is always 0, so we ask for a
       // single AttestationData which will be good for all committees in the slot
       final Supplier<SafeFuture<Optional<AttestationData>>> cachedCall =
-          Suppliers.memoize(() -> createAttestationDataFromValidatorApiChannel(slot, 0));
+          Suppliers.memoize(
+              () -> createAttestationDataFromValidatorApiChannel(slot, Optional.of(0)));
 
       return (slot, committeeIndex) -> cachedCall.get();
     }
@@ -205,7 +206,7 @@ public class AttestationProductionDuty implements Duty {
   }
 
   private SafeFuture<Optional<AttestationData>> createAttestationDataFromValidatorApiChannel(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     return validatorDutyMetrics.record(
         () -> validatorApiChannel.createAttestationData(slot, committeeIndex), this, CREATE_TOTAL);
   }
@@ -326,6 +327,6 @@ public class AttestationProductionDuty implements Duty {
   @FunctionalInterface
   private interface AttestationDataProducer {
     SafeFuture<Optional<AttestationData>> createAttestationData(
-        final UInt64 slot, int committeeIndex);
+        final UInt64 slot, Optional<Integer> committeeIndex);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -118,7 +117,7 @@ class AttestationProductionDutyTest {
   @TestTemplate
   public void shouldFailWhenUnsignedAttestationCanNotBeCreated() {
     final Validator validator = createValidator();
-    when(validatorApiChannel.createAttestationData(SLOT, 0))
+    when(validatorApiChannel.createAttestationData(SLOT, Optional.of(0)))
         .thenReturn(completedFuture(Optional.empty()));
 
     final SafeFuture<Optional<AttestationData>> attestationFuture =
@@ -145,7 +144,7 @@ class AttestationProductionDutyTest {
     final Optional<AttestationData> invalidAttestationData =
         Optional.of(dataStructureUtil.randomAttestationData(SLOT.increment()));
 
-    when(validatorApiChannel.createAttestationData(SLOT, 0))
+    when(validatorApiChannel.createAttestationData(SLOT, Optional.of(0)))
         .thenReturn(completedFuture(invalidAttestationData));
 
     final SafeFuture<Optional<AttestationData>> attestationFuture =
@@ -174,7 +173,7 @@ class AttestationProductionDutyTest {
     final Optional<AttestationData> invalidAttestationData =
         Optional.of(dataStructureUtil.randomAttestationData(SLOT, UInt64.ONE));
 
-    when(validatorApiChannel.createAttestationData(SLOT, 0))
+    when(validatorApiChannel.createAttestationData(SLOT, Optional.of(0)))
         .thenReturn(completedFuture(invalidAttestationData));
 
     final SafeFuture<Optional<AttestationData>> attestationFuture =
@@ -209,7 +208,7 @@ class AttestationProductionDutyTest {
     final int validator2CommitteeIndex = 1;
     final int validator2CommitteePosition = 3;
     final int validator2CommitteeSize = 8;
-    when(validatorApiChannel.createAttestationData(SLOT, validator1CommitteeIndex))
+    when(validatorApiChannel.createAttestationData(SLOT, Optional.of(validator1CommitteeIndex)))
         .thenReturn(completedFuture(Optional.empty()));
     final AttestationData attestationData = expectCreateAttestationData(validator2CommitteeIndex);
     final Attestation expectedAttestation =
@@ -307,7 +306,7 @@ class AttestationProductionDutyTest {
 
     performAndReportDuty();
 
-    verify(validatorApiChannel).createAttestationData(SLOT, 0);
+    verify(validatorApiChannel).createAttestationData(SLOT, Optional.of(0));
 
     assertThat(attestationResult1).isCompletedWithValue(Optional.of(attestationData));
     assertThat(attestationResult2).isCompletedWithValue(Optional.of(attestationData));
@@ -342,7 +341,7 @@ class AttestationProductionDutyTest {
     final int validator2CommitteePosition = 3;
     final int validator2CommitteeSize = 12;
     final RuntimeException failure = new RuntimeException("Golly gee");
-    when(validatorApiChannel.createAttestationData(SLOT, validator1CommitteeIndex))
+    when(validatorApiChannel.createAttestationData(SLOT, Optional.of(validator1CommitteeIndex)))
         .thenReturn(failedFuture(failure));
     final AttestationData attestationData = expectCreateAttestationData(validator2CommitteeIndex);
     final Attestation expectedAttestation =
@@ -594,7 +593,7 @@ class AttestationProductionDutyTest {
             expectedAttestation1, expectedAttestation2, expectedAttestation3);
 
     // Should have only needed to create one unsigned attestation and reused it for each validator
-    verify(validatorApiChannel, times(1)).createAttestationData(any(), anyInt());
+    verify(validatorApiChannel, times(1)).createAttestationData(any(), any());
     verify(validatorLogger)
         .dutyCompleted(
             TYPE, SLOT, 3, Set.of(attestationData.getBeaconBlockRoot()), Optional.empty());
@@ -687,7 +686,7 @@ class AttestationProductionDutyTest {
             expectedAttestation1, expectedAttestation2, expectedAttestation3);
 
     // Need to create an unsigned attestation for each committee
-    verify(validatorApiChannel, times(isElectra ? 1 : 2)).createAttestationData(any(), anyInt());
+    verify(validatorApiChannel, times(isElectra ? 1 : 2)).createAttestationData(any(), any());
     verify(validatorLogger)
         .dutyCompleted(
             TYPE,
@@ -735,7 +734,8 @@ class AttestationProductionDutyTest {
 
   private AttestationData expectCreateAttestationData(final int committeeIndex) {
     final AttestationData attestationData = dataStructureUtil.randomAttestationData(SLOT);
-    when(validatorApiChannel.createAttestationData(SLOT, isElectra ? 0 : committeeIndex))
+    when(validatorApiChannel.createAttestationData(
+            SLOT, Optional.of(isElectra ? 0 : committeeIndex)))
         .thenReturn(completedFuture(Optional.of(attestationData)));
     return attestationData;
   }

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -830,7 +830,7 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
     final UInt64 slot = dataStructureUtil.randomSlot();
     final int committeeIndex = dataStructureUtil.randomPositiveInt();
 
-    typeDefClient.createAttestationData(slot, committeeIndex);
+    typeDefClient.createAttestationData(slot, Optional.of(committeeIndex));
 
     final RecordedRequest request = mockWebServer.takeRequest();
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -207,7 +207,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     return tryRequestUntilSuccess(
         apiChannel -> apiChannel.createAttestationData(slot, committeeIndex),
         BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -233,7 +233,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     return sendRequest(() -> typeDefClient.createAttestationData(slot, committeeIndex));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -134,7 +134,7 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     return dutiesProviderChannel.createAttestationData(slot, committeeIndex);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -170,7 +170,7 @@ public class OkHttpValidatorTypeDefClient extends OkHttpValidatorMinimalTypeDefC
   }
 
   public Optional<AttestationData> createAttestationData(
-      final UInt64 slot, final int committeeIndex) {
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
 
     final CreateAttestationDataRequest createAttestationDataRequest =
         new CreateAttestationDataRequest(getBaseEndpoint(), getOkHttpClient());

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAttestationDataRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateAttestationDataRequest.java
@@ -33,10 +33,11 @@ public class CreateAttestationDataRequest extends AbstractTypeDefRequest {
     super(baseEndpoint, okHttpClient);
   }
 
-  public Optional<AttestationData> submit(final UInt64 slot, final int committeeIndex) {
+  public Optional<AttestationData> submit(
+      final UInt64 slot, final Optional<Integer> committeeIndex) {
     final Map<String, String> queryParams = new HashMap<>();
     queryParams.put(SLOT, slot.toString());
-    queryParams.put(COMMITTEE_INDEX, Integer.toString(committeeIndex));
+    committeeIndex.ifPresent(index -> queryParams.put(COMMITTEE_INDEX, Integer.toString(index)));
     return get(
         ValidatorApiMethod.GET_ATTESTATION_DATA,
         queryParams,

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -743,7 +743,7 @@ class FailoverValidatorApiHandlerTest {
             Optional.of(mock(BlockContainerAndMetaData.class))),
         getArguments(
             "createAttestationData",
-            apiChannel -> apiChannel.createAttestationData(slot, 0),
+            apiChannel -> apiChannel.createAttestationData(slot, Optional.of(0)),
             BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD,
             Optional.of(mock(AttestationData.class))),
         getArguments(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -449,9 +448,10 @@ class RemoteValidatorApiHandlerTest {
 
   @Test
   public void createAttestationData_WhenNone_ReturnsEmpty() {
-    when(typeDefClient.createAttestationData(any(), anyInt())).thenReturn(Optional.empty());
+    when(typeDefClient.createAttestationData(any(), any())).thenReturn(Optional.empty());
 
-    final SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(ONE, 0);
+    final SafeFuture<Optional<AttestationData>> future =
+        apiHandler.createAttestationData(ONE, Optional.of(0));
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -460,10 +460,11 @@ class RemoteValidatorApiHandlerTest {
   public void createAttestationData_WhenFound_ReturnsAttestation() {
     final Attestation attestation = dataStructureUtil.randomAttestation();
 
-    when(typeDefClient.createAttestationData(ONE, 0))
+    when(typeDefClient.createAttestationData(ONE, Optional.of(0)))
         .thenReturn(Optional.of(attestation.getData()));
 
-    final SafeFuture<Optional<AttestationData>> future = apiHandler.createAttestationData(ONE, 0);
+    final SafeFuture<Optional<AttestationData>> future =
+        apiHandler.createAttestationData(ONE, Optional.of(0));
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(attestation.getData());
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
@@ -151,9 +151,9 @@ class SentryValidatorApiChannelTest {
 
   @Test
   void createAttestationDataShouldUseDutiesProviderChannel() {
-    sentryValidatorApiChannel.createAttestationData(UInt64.ZERO, 0);
+    sentryValidatorApiChannel.createAttestationData(UInt64.ZERO, Optional.of(0));
 
-    verify(dutiesProviderChannel).createAttestationData(eq(UInt64.ZERO), eq(0));
+    verify(dutiesProviderChannel).createAttestationData(eq(UInt64.ZERO), eq(Optional.of(0)));
     verifyNoInteractions(blockHandlerChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }


### PR DESCRIPTION
 - if the committee index is used in gloas specifically, it'll currently allow and use what was specified.
 - if we're in gloas and dont specify index, it'll be determined from the inclusion of payload (which is the gloas spec)

 I was on the fence about whether to ignore the optional passed in, could be convinced to ignore it in gloas and just always compute...

 fixes #10433

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a widely used API (`createAttestationData`) and changes default/index-selection behavior for Gloas, which could alter produced `AttestationData.index` and downstream attestation signing/publishing if callers omit or mis-handle the optional parameter.
> 
> **Overview**
> Updates the `createAttestationData` flow end-to-end (REST handler → `ValidatorDataProvider` → `ValidatorApiChannel`/handlers → remote typedef client) to accept an *optional* `committeeIndex` instead of an `int`, allowing Gloas-era requests to omit the query parameter.
> 
> Adjusts committee index selection: base `ValidatorApiHandler` defaults to `0` when not provided, while `ValidatorApiHandlerGloas` now either uses the supplied index or computes `0/1` based on payload/fullness (with added debug logging), and updates tests accordingly, including remote request building to only send `committee_index` when present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4e0afe97699f290b7aa1a46637400e84c8560b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->