### PR TITLE
clarified index in attestation data

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
@@ -132,7 +132,10 @@ public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
         .map(
             forkChoiceUtil ->
                 forkChoiceUtil.isBlockStatusFull(combinedChainDataClient.getStore(), block) ? 1 : 0)
-        .orElse(0);
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    String.format("Could not get gloas fork choice util from slot %s", slot)));
   }
 
   private Optional<BeaconState> getExecutionPayloadStateForBlockProduction(final UInt64 slot) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerGloas.java
@@ -132,10 +132,7 @@ public class ValidatorApiHandlerGloas extends ValidatorApiHandler {
         .map(
             forkChoiceUtil ->
                 forkChoiceUtil.isBlockStatusFull(combinedChainDataClient.getStore(), block) ? 1 : 0)
-        .orElseThrow(
-            () ->
-                new IllegalStateException(
-                    String.format("Could not get gloas fork choice util from slot %s", slot)));
+        .orElse(0);
   }
 
   private Optional<BeaconState> getExecutionPayloadStateForBlockProduction(final UInt64 slot) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -101,10 +101,13 @@ public class GetAttestationData extends RestApiEndpoint {
     final UInt64 slot = request.getQueryParameter(SLOT_PARAM);
     final Optional<UInt64> committeeIndex =
         request.getOptionalQueryParameter(COMMITTEE_INDEX_PARAMETER);
-    if (!validate(request, spec.atSlot(slot).getMilestone(), committeeIndex)) {
+    final SpecMilestone milestone = spec.atSlot(slot).getMilestone();
+    if (!validate(request, milestone, committeeIndex)) {
       return;
     }
 
+    // committeeIndex will be ignored from gloas as it's computed,
+    // so can pass in 0 in that instance
     final SafeFuture<Optional<AttestationData>> future =
         provider.createAttestationDataAtSlot(slot, committeeIndex.orElse(UInt64.ZERO).intValue());
 


### PR DESCRIPTION
fixes #10433

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small refactor in `GetAttestationData` to compute the slot milestone once and document that `committeeIndex` is ignored from Gloas onward; no API shape or core logic changes.
> 
> **Overview**
> Clarifies `GET /eth/v1/validator/attestation_data` request handling by computing the slot’s `SpecMilestone` once and passing it into `validate`.
> 
> Adds an explicit note that from *Gloas* onward `committeeIndex` is computed/ignored, so the handler safely defaults the provider call to `0` when the query parameter is absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f99fd8350e1585e14bceaf47504253c9cc23c4e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->