### PR TITLE
cleanup NO_OP instances

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -41,7 +41,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
 
   private final Spec spec =
       TestSpecFactory.createMinimalDeneb(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryFuluTest.java
@@ -49,7 +49,7 @@ public class BlockFactoryFuluTest extends AbstractBlockFactoryTest {
 
   private final Spec spec =
       TestSpecFactory.createMinimalFulu(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryGloasTest.java
@@ -33,7 +33,7 @@ public class BlockFactoryGloasTest extends AbstractBlockFactoryTest {
 
   private final Spec spec =
       TestSpecFactory.createMinimalGloas(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
   private final Consumer<SpecConfigBuilder> configAdapter =
-      builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP);
+      builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP);
 
   @Test
   public void shouldCreateBlockAfterNormalSlot() {

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -101,8 +101,7 @@ public class EpochTransitionBenchmark {
 
     spec =
         TestSpecFactory.createMainnetAltair(
-            specConfigBuilder ->
-                specConfigBuilder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+            specConfigBuilder -> specConfigBuilder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
     asyncRunner = DelayedExecutorAsyncRunner.create();
     String blocksFile =
         "/blocks/blocks_epoch_"

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/IndexedAttestationValidationBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/IndexedAttestationValidationBenchmark.java
@@ -65,7 +65,7 @@ public class IndexedAttestationValidationBenchmark {
             .sszDeserialize(Bytes.of(indexedAttestationBytes));
 
     fork = spec.getForkSchedule().getFork(spec.computeEpochAtSlot(beaconState.getSlot()));
-    asyncBLSSignatureVerifier = AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NO_OP);
+    asyncBLSSignatureVerifier = AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP);
   }
 
   @Benchmark

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProcessSyncAggregateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProcessSyncAggregateBenchmark.java
@@ -62,7 +62,7 @@ public class ProcessSyncAggregateBenchmark {
   public void init() throws Exception {
     spec =
         TestSpecFactory.createMainnetAltair(
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
 
     final List<BLSKeyPair> validatorKeys = KeyFileGenerator.readValidatorKeys(validatorsCount);
 
@@ -110,6 +110,6 @@ public class ProcessSyncAggregateBenchmark {
   public void processSyncAggregate() throws Exception {
     final BlockProcessor blockProcessor = spec.getGenesisSpec().getBlockProcessor();
     blockProcessor.processSyncAggregate(
-        state.createWritableCopy(), syncAggregates.next(), BLSSignatureVerifier.NO_OP);
+        state.createWritableCopy(), syncAggregates.next(), BLSSignatureVerifier.NOOP);
   }
 }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -62,7 +62,7 @@ public class ProfilingRun {
   public static Consumer<Object> blackHole = o -> {};
   private Spec spec =
       TestSpecFactory.createMainnetPhase0(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
 
   private final MetricsSystem metricsSystem = new StubMetricsSystem();
   private final AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -79,7 +79,7 @@ public abstract class TransitionBenchmark {
   public void init() throws Exception {
     spec =
         TestSpecFactory.createMainnetAltair(
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
     AsyncRunner asyncRunner = DelayedExecutorAsyncRunner.create();
 
     String blocksFile =

--- a/eth-benchmark-tests/src/testFixtures/java/tech/pegasys/teku/benchmarks/gen/BlockArchiveGenerator.java
+++ b/eth-benchmark-tests/src/testFixtures/java/tech/pegasys/teku/benchmarks/gen/BlockArchiveGenerator.java
@@ -39,7 +39,7 @@ public class BlockArchiveGenerator {
   private final int epochCount;
   private final Spec spec =
       TestSpecFactory.createMainnetAltair(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final List<BLSKeyPair> validatorKeys;
   private final RecentChainData localStorage;
   private final AttestationGenerator attestationGenerator;

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/altair/fork/TransitionTestExecutor.java
@@ -124,7 +124,7 @@ public class TransitionTestExecutor implements TestExecutor {
       try {
 
         final BLSSignatureVerifier signatureVerifier =
-            metadata.blsSetting == 2 ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE;
+            metadata.blsSetting == 2 ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE;
         result = spec.processBlock(result, block, signatureVerifier, Optional.empty());
       } catch (final StateTransitionException e) {
         Assertions.fail(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -192,7 +192,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             DebugDataDumper.NOOP,
             storageSystem.getMetricsSystem(),
             AsyncBLSSignatureVerifier.wrap(
-                blsDisabled ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE));
+                blsDisabled ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE));
     final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
 
     try {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
@@ -114,7 +114,7 @@ public class SanityBlocksTestExecutor implements TestExecutor {
                 result,
                 block,
                 metaData.getBlsSetting() == IGNORED
-                    ? BLSSignatureVerifier.NO_OP
+                    ? BLSSignatureVerifier.NOOP
                     : BLSSignatureVerifier.SIMPLE,
                 Optional.empty());
       }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -86,11 +86,11 @@ public class TestDefinition {
           default -> throw new IllegalArgumentException("Unknown fork: " + fork);
         };
     final BLSSignatureVerifier blsSignatureVerifier =
-        blsSignatureVerificationEnabled ? BLSSignatureVerifier.SIMPLE : BLSSignatureVerifier.NO_OP;
+        blsSignatureVerificationEnabled ? BLSSignatureVerifier.SIMPLE : BLSSignatureVerifier.NOOP;
     final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier =
         blsSignatureVerificationEnabled
             ? BatchSignatureVerifierImpl::new
-            : () -> BatchSignatureVerifier.NO_OP;
+            : () -> BatchSignatureVerifier.NOOP;
     spec =
         TestSpecFactory.create(
             milestone,

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
@@ -33,7 +33,7 @@ public class BuilderCircuitBreakerImplTest {
 
   private final Spec spec =
       TestSpecFactory.createMinimalBellatrix(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
 
   private final BuilderCircuitBreakerImpl builderCircuitBreaker =
       new BuilderCircuitBreakerImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -1049,7 +1049,7 @@ public class Spec {
               blockSlotState,
               block.getMessage(),
               IndexedAttestationCache.NOOP,
-              BLSSignatureVerifier.NO_OP,
+              BLSSignatureVerifier.NOOP,
               Optional.empty());
     } catch (SlotProcessingException | EpochProcessingException | BlockProcessingException e) {
       throw new StateTransitionException(e);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/blockvalidator/BatchSignatureVerifier.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 
 public interface BatchSignatureVerifier extends BLSSignatureVerifier {
 
-  BatchSignatureVerifier NO_OP =
+  BatchSignatureVerifier NOOP =
       new BatchSignatureVerifier() {
         @Override
         public boolean verify(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/BlockProposalUtilPhase0.java
@@ -120,7 +120,7 @@ public class BlockProposalUtilPhase0 implements BlockProposalUtil {
                       blockSlotState,
                       block,
                       IndexedAttestationCache.NOOP,
-                      BLSSignatureVerifier.NO_OP,
+                      BLSSignatureVerifier.NOOP,
                       Optional.empty());
 
               blockProductionPerformance.stateTransition();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateCachesTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateCachesTest.java
@@ -112,7 +112,7 @@ public class StateCachesTest {
                 stateAtSlot3,
                 blockAtSlot3.getMessage(),
                 IndexedAttestationCache.NOOP,
-                BLSSignatureVerifier.NO_OP,
+                BLSSignatureVerifier.NOOP,
                 Optional.empty());
 
     final UInt64 expectedRewards =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapellaTest.java
@@ -145,7 +145,7 @@ public class BlockProcessorCapellaTest extends BlockProcessorBellatrixTest {
 
     final BlockValidationResult validationResult =
         capellaBlockProcessor.verifyBlsToExecutionChangesPreProcessing(
-            state, blsToExecutionChangesListWithDuplicate, BLSSignatureVerifier.NO_OP);
+            state, blsToExecutionChangesListWithDuplicate, BLSSignatureVerifier.NOOP);
     assertThat(validationResult.isValid()).isFalse();
     assertThat(validationResult.getFailureReason())
         .contains("does not match withdrawal credentials");
@@ -192,7 +192,7 @@ public class BlockProcessorCapellaTest extends BlockProcessorBellatrixTest {
 
     final BlockValidationResult validationResult =
         capellaBlockProcessor.verifyBlsToExecutionChangesPreProcessing(
-            state, blsToExecutionChangesListWithDuplicate, BLSSignatureVerifier.NO_OP);
+            state, blsToExecutionChangesListWithDuplicate, BLSSignatureVerifier.NOOP);
     assertThat(validationResult.isValid()).isTrue();
   }
 
@@ -218,7 +218,7 @@ public class BlockProcessorCapellaTest extends BlockProcessorBellatrixTest {
 
     final BlockValidationResult validationResult =
         capellaBlockProcessor.verifyBlsToExecutionChangesPreProcessing(
-            state, blsToExecutionChangesListWithDuplicate, BLSSignatureVerifier.NO_OP);
+            state, blsToExecutionChangesListWithDuplicate, BLSSignatureVerifier.NOOP);
 
     assertThat(validationResult.isValid()).isFalse();
     assertThat(validationResult.getFailureReason())

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecInvocationContextProvider.java
@@ -121,10 +121,10 @@ public class TestSpecInvocationContextProvider implements TestTemplateInvocation
         schemaDefinitions = null;
       } else {
         final BLSSignatureVerifier blsSignatureVerifier =
-            signatureVerifierNoop ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE;
+            signatureVerifierNoop ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE;
         final Supplier<BatchSignatureVerifier> batchSignatureVerifierSupplier =
             signatureVerifierNoop
-                ? () -> BatchSignatureVerifier.NO_OP
+                ? () -> BatchSignatureVerifier.NOOP
                 : BatchSignatureVerifierImpl::new;
         this.spec =
             TestSpecFactory.create(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -81,7 +81,7 @@ public class BlockImporterTest {
   private final AsyncRunner asyncRunner = mock(AsyncRunner.class);
   private final Spec spec =
       TestSpecFactory.createMinimalPhase0(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final SpecConfig genesisConfig = spec.getGenesisSpecConfig();
   private final AttestationSchema<?> attestationSchema =
       spec.getGenesisSchemaDefinitions().getAttestationSchema();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -159,7 +159,7 @@ public class BlockManagerTest {
 
     setupWithSpec(
         TestSpecFactory.createMinimalDeneb(
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
+            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP)));
   }
 
   private void setupWithSpec(final Spec spec) {
@@ -836,8 +836,7 @@ public class BlockManagerTest {
     // If we start genesis with Deneb, 0 will be earliestBlobSidecarSlot, so started on epoch 1
     setupWithSpec(
         TestSpecFactory.createMinimalWithDenebForkEpoch(
-            UInt64.valueOf(1),
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
+            UInt64.valueOf(1), builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
     incrementSlotTo(slotsPerEpoch);
 
@@ -939,8 +938,7 @@ public class BlockManagerTest {
   void onDeneb_shouldStoreEarliestBlobSidecarSlotCorrectlyWhenThereIsGap() {
     setupWithSpec(
         TestSpecFactory.createMinimalWithDenebForkEpoch(
-            UInt64.valueOf(1),
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
+            UInt64.valueOf(1), builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
 
     currentSlot = currentSlot.plus(slotsPerEpoch.plus(2));
@@ -971,8 +969,7 @@ public class BlockManagerTest {
     // If we start genesis with Deneb, 0 will be earliestBlobSidecarSlot, so started on epoch 1
     setupWithSpec(
         TestSpecFactory.createMinimalWithDenebForkEpoch(
-            UInt64.valueOf(1),
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
+            UInt64.valueOf(1), builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
     incrementSlotTo(slotsPerEpoch);
 
@@ -1005,8 +1002,7 @@ public class BlockManagerTest {
     // If we start genesis with Deneb, 0 will be earliestBlobSidecarSlot, so started on epoch 1
     setupWithSpec(
         TestSpecFactory.createMinimalWithDenebForkEpoch(
-            UInt64.valueOf(1),
-            builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP)));
+            UInt64.valueOf(1), builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP)));
     final UInt64 slotsPerEpoch = UInt64.valueOf(spec.slotsPerEpoch(UInt64.ZERO));
     incrementSlotTo(slotsPerEpoch);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -72,7 +72,7 @@ class ForkChoiceNotifierTest {
   private final InlineEventThread eventThread = new InlineEventThread();
   private final Spec spec =
       TestSpecFactory.createMinimalBellatrix(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(10_000);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorGloasTest.java
@@ -39,7 +39,7 @@ class ForkChoicePayloadExecutorGloasTest {
 
   private final Spec spec =
       TestSpecFactory.createMinimalGloas(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final SafeFuture<PayloadStatus> executionResult = new SafeFuture<>();
   private final ExecutionLayerChannel executionLayer = mock(ExecutionLayerChannel.class);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutorTest.java
@@ -42,7 +42,7 @@ class ForkChoicePayloadExecutorTest {
 
   private final Spec spec =
       TestSpecFactory.createMinimalBellatrix(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final SchemaDefinitionsBellatrix schemaDefinitionsBellatrix =
       spec.getGenesisSchemaDefinitions().toVersionBellatrix().orElseThrow();
   private final ExecutionPayload defaultPayload =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -44,7 +44,7 @@ class MergeTransitionBlockValidatorTest {
   private final Spec spec =
       TestSpecFactory.createMinimalBellatrix(
           b -> {
-            b.blsSignatureVerifier(BLSSignatureVerifier.NO_OP);
+            b.blsSignatureVerifier(BLSSignatureVerifier.NOOP);
             b.bellatrixBuilder(
                 bb ->
                     bb.terminalBlockHash(terminalBlockHash)

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
@@ -87,7 +87,7 @@ public class TerminalPowBlockMonitorTest {
                 "minimal",
                 phase0Builder ->
                     phase0Builder
-                        .blsSignatureVerifier(BLSSignatureVerifier.NO_OP)
+                        .blsSignatureVerifier(BLSSignatureVerifier.NOOP)
                         .altairForkEpoch(UInt64.ZERO)
                         .bellatrixForkEpoch(BELLATRIX_FORK_EPOCH)
                         .bellatrixBuilder(bellatrixBuilder)));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractAttestationValidatorTest.java
@@ -73,7 +73,7 @@ abstract class AbstractAttestationValidatorTest {
   private static final Logger LOG = LogManager.getLogger();
 
   protected final Spec spec =
-      createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+      createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   protected final AttestationSchema<?> attestationSchema =
       spec.getGenesisSchemaDefinitions().getAttestationSchema();
   protected final StorageSystem storageSystem =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
@@ -162,7 +162,7 @@ class AggregateAttestationValidatorTest {
   private void disableSignatureVerification() {
     validator =
         new AggregateAttestationValidator(
-            spec, attestationValidator, AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NO_OP));
+            spec, attestationValidator, AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.NOOP));
   }
 
   @TestTemplate

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelectorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelectorTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 class AttestationStateSelectorTest {
   private final Spec spec =
       TestSpecFactory.createDefault(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
   private final ChainBuilder chainBuilder = storageSystem.chainBuilder();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorFuluTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorFuluTest.java
@@ -65,7 +65,7 @@ public class DataColumnSidecarGossipValidatorFuluTest
   @BeforeEach
   protected void setupForkSpecific() {
     final Spec spec =
-        createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+        createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
     this.dataStructureUtil = new DataStructureUtil(spec);
 
     this.dataColumnSidecarGossipValidator =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorGloasTest.java
@@ -54,7 +54,7 @@ public class DataColumnSidecarGossipValidatorGloasTest
   @BeforeEach
   void setup() {
     final Spec spec =
-        createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+        createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
     this.dataStructureUtil = new DataStructureUtil(spec);
 
     this.dataColumnSidecarGossipValidator =

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -96,7 +96,7 @@ public class FuzzUtil {
         (BeaconBlockBodySchemaElectra<?>)
             specVersion.getSchemaDefinitions().getBeaconBlockBodySchema();
     initialize(disableBls);
-    this.signatureVerifier = disableBls ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE;
+    this.signatureVerifier = disableBls ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE;
 
     final PredicatesElectra predicates = new PredicatesElectra(spec.getGenesisSpecConfig());
     final SchemaDefinitionsFulu schemaDefinitionsFulu =

--- a/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSSignatureVerifier.java
+++ b/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSSignatureVerifier.java
@@ -43,7 +43,7 @@ public interface BLSSignatureVerifier {
         }
       };
 
-  BLSSignatureVerifier NO_OP =
+  BLSSignatureVerifier NOOP =
       new BLSSignatureVerifier() {
         @Override
         public boolean verify(

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -39,7 +39,7 @@ public class PeerStatusIntegrationTest {
   private static final int VALIDATOR_COUNT = 16;
   private final Spec spec =
       TestSpecFactory.createMinimalPhase0(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
   private final RpcEncoding rpcEncoding =
       RpcEncoding.createSszSnappyEncoding(spec.getNetworkingConfig().getMaxPayloadSize());

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -66,7 +66,7 @@ class RecentChainDataTest {
   private static final Logger LOG = LogManager.getLogger();
   private final Spec spec =
       TestSpecFactory.createMinimalDeneb(
-          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NO_OP));
+          builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final SpecConfig genesisSpecConfig = spec.getGenesisSpecConfig();
   private StorageSystem storageSystem;

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -171,8 +171,8 @@ public class DebugToolsCommand implements Runnable {
         ValidatorRestApi.create(
             spec,
             config,
-            ValidatorApiChannel.NO_OP,
-            new GenesisDataProvider(asyncRunner, ValidatorApiChannel.NO_OP),
+            ValidatorApiChannel.NOOP,
+            new GenesisDataProvider(asyncRunner, ValidatorApiChannel.NOOP),
             Optional.empty(),
             keyManager,
             dataDirLayout,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -57,7 +57,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 
 public interface ValidatorApiChannel extends BuilderApiChannel, ChannelInterface {
-  ValidatorApiChannel NO_OP =
+  ValidatorApiChannel NOOP =
       new ValidatorApiChannel() {
         @Override
         public SafeFuture<Optional<GenesisData>> getGenesisData() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.signatures.SignerNotActiveException;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 
 public class DutyResult {
-  public static final DutyResult NO_OP = new DutyResult(0, 0, emptySet(), emptyMap(), List.of());
+  public static final DutyResult NOOP = new DutyResult(0, 0, emptySet(), emptyMap(), List.of());
   public static final DutyResult NODE_SYNCING =
       new DutyResult(0, 1, emptySet(), emptyMap(), List.of());
 
@@ -114,7 +114,7 @@ public class DutyResult {
                 futures.stream()
                     .map(future -> future.exceptionally(DutyResult::forError).getNow(null))
                     .reduce(DutyResult::combine)
-                    .orElse(NO_OP));
+                    .orElse(NOOP));
   }
 
   public DutyResult combine(final DutyResult other) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
@@ -66,11 +66,11 @@ public class ProductionResult<T> {
   }
 
   public static <T> ProductionResult<T> noop(final BLSPublicKey validatorPublicKey) {
-    return new ProductionResult<>(Set.of(validatorPublicKey), DutyResult.NO_OP);
+    return new ProductionResult<>(Set.of(validatorPublicKey), DutyResult.NOOP);
   }
 
   public static <T> ProductionResult<T> noop(final Set<BLSPublicKey> validatorPublicKeys) {
-    return new ProductionResult<>(validatorPublicKeys, DutyResult.NO_OP);
+    return new ProductionResult<>(validatorPublicKeys, DutyResult.NOOP);
   }
 
   public static <T> SafeFuture<DutyResult> send(
@@ -120,7 +120,7 @@ public class ProductionResult<T> {
     return results.stream()
         .map(ProductionResult::getResult)
         .reduce(DutyResult::combine)
-        .orElse(DutyResult.NO_OP);
+        .orElse(DutyResult.NOOP);
   }
 
   public Set<BLSPublicKey> getValidatorPublicKeys() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/SlotBasedScheduledDuties.java
@@ -103,7 +103,7 @@ public class SlotBasedScheduledDuties<P extends Duty, A extends Duty> implements
 
     final Duty duty = duties.remove(slot);
     if (duty == null) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     return dutyFunction.apply(duty);
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AggregationDuty.java
@@ -99,7 +99,7 @@ public class AggregationDuty implements Duty {
   public SafeFuture<DutyResult> performDuty() {
     LOG.trace("Aggregating attestations at slot {}", slot);
     if (!aggregators.hasAggregators()) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     return sendingStrategy.send(aggregators.streamAggregators().map(this::aggregateCommittee));
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/AttestationProductionDuty.java
@@ -108,7 +108,7 @@ public class AttestationProductionDuty implements Duty {
   public SafeFuture<DutyResult> performDuty() {
     LOG.trace("Creating attestations at slot {}", slot);
     if (validatorsByCommitteeIndex.isEmpty()) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     return forkProvider
         .getForkInfo(slot)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/payloadattestations/PayloadAttestationProductionDuty.java
@@ -84,7 +84,7 @@ public class PayloadAttestationProductionDuty implements Duty {
     LOG.trace("Creating payload attestations at slot {}", slot);
 
     if (validators.isEmpty()) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
 
     return forkProvider

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
@@ -63,7 +63,7 @@ public class SyncCommitteeAggregationDuty {
       final UInt64 slot, final Bytes32 beaconBlockRoot) {
     final Optional<SyncCommitteeUtil> maybeSyncCommitteeUtils = spec.getSyncCommitteeUtil(slot);
     if (assignments.isEmpty() || maybeSyncCommitteeUtils.isEmpty()) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     final SyncCommitteeUtil syncCommitteeUtil = maybeSyncCommitteeUtils.get();
 
@@ -156,7 +156,7 @@ public class SyncCommitteeAggregationDuty {
                     selectionProof);
               } else {
                 return SafeFuture.completedFuture(
-                    new AggregationResult(validator.getPublicKey(), DutyResult.NO_OP));
+                    new AggregationResult(validator.getPublicKey(), DutyResult.NOOP));
               }
             })
         .exceptionally(
@@ -182,7 +182,7 @@ public class SyncCommitteeAggregationDuty {
               if (maybeContribution.isEmpty()) {
                 validatorLogger.syncCommitteeAggregationSkipped(slot);
                 return SafeFuture.completedFuture(
-                    new AggregationResult(validatorPublicKey, DutyResult.NO_OP));
+                    new AggregationResult(validatorPublicKey, DutyResult.NOOP));
               }
               return signContribution(
                   syncCommitteeUtil,
@@ -220,14 +220,14 @@ public class SyncCommitteeAggregationDuty {
                         aggregationResult ->
                             DutyResult.forError(aggregationResult.validatorPublicKey, error))
                     .reduce(DutyResult::combine)
-                    .orElse(DutyResult.NO_OP));
+                    .orElse(DutyResult.NOOP));
   }
 
   private DutyResult combineResults(final List<AggregationResult> results) {
     return results.stream()
         .map(result -> result.result)
         .reduce(DutyResult::combine)
-        .orElse(DutyResult.NO_OP);
+        .orElse(DutyResult.NOOP);
   }
 
   private SafeFuture<AggregationResult> signContribution(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDuty.java
@@ -50,7 +50,7 @@ public class SyncCommitteeProductionDuty {
 
   public SafeFuture<DutyResult> produceMessages(final UInt64 slot, final Bytes32 blockRoot) {
     if (assignments.isEmpty()) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     return forkProvider
         .getForkInfo(slot)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -84,7 +84,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     LOG.trace(
         "Performing sync committee duties at slot {}, {} assignments", slot, assignments.size());
     if (assignments.isEmpty()) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     try {
       lastSignatureBlockRoot = chainHeadTracker.getCurrentChainHead(slot);
@@ -115,13 +115,13 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
   @Override
   public SafeFuture<DutyResult> performAggregationDuty(final UInt64 slot) {
     if (getAllValidatorKeys().isEmpty()) {
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     if (lastSignatureSlot.isEmpty()
         || lastSignatureBlockRoot.isEmpty()
         || !lastSignatureSlot.get().equals(slot)) {
       validatorLogger.syncCommitteeAggregationSkipped(slot);
-      return SafeFuture.completedFuture(DutyResult.NO_OP);
+      return SafeFuture.completedFuture(DutyResult.NOOP);
     }
     return aggregationDuty.produceAggregates(slot, lastSignatureBlockRoot.get());
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -85,9 +85,9 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
                 Optional.of(
                     new AttesterDuties(false, dataStructureUtil.randomBytes32(), emptyList()))));
     when(scheduledDuties.performProductionDuty(any()))
-        .thenReturn(SafeFuture.completedFuture(DutyResult.NO_OP));
+        .thenReturn(SafeFuture.completedFuture(DutyResult.NOOP));
     when(scheduledDuties.performAggregationDuty(any()))
-        .thenReturn(SafeFuture.completedFuture(DutyResult.NO_OP));
+        .thenReturn(SafeFuture.completedFuture(DutyResult.NOOP));
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetricsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ValidatorDutyMetricsTest.java
@@ -73,7 +73,7 @@ class ValidatorDutyMetricsTest {
 
     assertThatSafeFuture(dutyResultSafeFuture).isNotDone();
 
-    dutyFuture.complete(DutyResult.NO_OP);
+    dutyFuture.complete(DutyResult.NOOP);
 
     assertThatSafeFuture(dutyResultSafeFuture).isCompleted();
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -118,7 +118,7 @@ class SyncCommitteeAggregationDutyTest {
   void shouldDoNothingWhenAssignmentsAreEmpty() {
     final SyncCommitteeAggregationDuty duty = createDuty();
     final SafeFuture<DutyResult> result = duty.produceAggregates(slot, beaconBlockRoot);
-    assertThat(result).isCompletedWithValue(DutyResult.NO_OP);
+    assertThat(result).isCompletedWithValue(DutyResult.NOOP);
     verifyNoInteractions(validatorApiChannel);
   }
 
@@ -151,7 +151,7 @@ class SyncCommitteeAggregationDutyTest {
         .thenReturn(SafeFuture.completedFuture(nonAggregatorSignature));
 
     final SafeFuture<DutyResult> result = duty.produceAggregates(slot, beaconBlockRoot);
-    assertThat(result).isCompletedWithValue(DutyResult.NO_OP);
+    assertThat(result).isCompletedWithValue(DutyResult.NOOP);
   }
 
   @Test
@@ -225,7 +225,7 @@ class SyncCommitteeAggregationDutyTest {
     final SyncCommitteeAggregationDuty duty = createDuty(committeeAssignment(validator1, 11, 0));
 
     final SafeFuture<DutyResult> result = duty.produceAggregates(slot, beaconBlockRoot);
-    assertThat(result).isCompletedWithValue(DutyResult.NO_OP);
+    assertThat(result).isCompletedWithValue(DutyResult.NOOP);
 
     verify(validatorLogger).syncCommitteeAggregationSkipped(slot);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
@@ -74,8 +74,7 @@ class SyncCommitteeProductionDutyTest {
   @Test
   void shouldReturnNoOpWhenNoValidatorsAssigned() {
     final SyncCommitteeProductionDuty duties = createDuty();
-    assertThat(duties.produceMessages(UInt64.ONE, blockRoot))
-        .isCompletedWithValue(DutyResult.NO_OP);
+    assertThat(duties.produceMessages(UInt64.ONE, blockRoot)).isCompletedWithValue(DutyResult.NOOP);
     verifyNoInteractions(validatorApiChannel);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorOpenApiTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorOpenApiTest.java
@@ -63,7 +63,7 @@ class ValidatorOpenApiTest {
         ValidatorRestApi.create(
             spec,
             config,
-            ValidatorApiChannel.NO_OP,
+            ValidatorApiChannel.NOOP,
             genesisDataProvider,
             Optional.of(proposerConfigManager),
             keyManager,


### PR DESCRIPTION
To help with consistency, cleaning up a few instances of `NO_OP` where most of our code seems to use `NOOP`.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical renames, but it changes public constant names (e.g., `BLSSignatureVerifier`, `BatchSignatureVerifier`, `ValidatorApiChannel`, `DutyResult`), which can break downstream compilation if referenced externally.
> 
> **Overview**
> Standardizes *noop* sentinel naming by renaming `NO_OP` constants to `NOOP` across the codebase.
> 
> Updates all call sites in validator duties, spec/state-transition helpers, reference tests, and benchmarks to use the new constant names (including signature verification and batch verification no-op paths).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6b40613140d1f2e7eac009ca2e5a3c4034beef5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->