### PR TITLE
updated ptc duties description

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -13,4 +13,4 @@ runs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -13,4 +13,4 @@ runs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostPtcDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostPtcDutiesIntegrationTest.java
@@ -85,4 +85,28 @@ public class PostPtcDutiesIntegrationTest extends AbstractDataBackedRestAPIInteg
     assertThat(duties.executionOptimistic()).isFalse();
     assertThat(duties.duties().getFirst()).isEqualTo(duty);
   }
+
+  @Test
+  void shouldReturnDutiesForNextEpoch() throws IOException {
+    startRestAPIAtGenesis(SpecMilestone.GLOAS);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    final Bytes32 dependentRoot = dataStructureUtil.randomBytes32();
+    final UInt64 nextEpoch = UInt64.valueOf(2);
+    final PtcDuty duty = new PtcDuty(VALIDATOR_KEYS.get(1).getPublicKey(), ONE, UInt64.valueOf(13));
+    final SafeFuture<Optional<PtcDuties>> out =
+        SafeFuture.completedFuture(Optional.of(new PtcDuties(false, dependentRoot, List.of(duty))));
+    when(validatorApiChannel.getPtcDuties(eq(nextEpoch), any())).thenReturn(out);
+
+    final Response response = post(PostPtcDuties.ROUTE.replace("{epoch}", "2"), "[1]");
+    final String responseBody = response.body().string();
+    assertThat(responseBody).isNotEmpty();
+    assertThat(response.code()).isEqualTo(SC_OK);
+
+    final PtcDuties duties = parse(responseBody, PTC_DUTIES_TYPE_DEFINITION);
+
+    assertThat(duties.dependentRoot()).isEqualTo(dependentRoot);
+    assertThat(duties.executionOptimistic()).isFalse();
+    assertThat(duties.duties().getFirst()).isEqualTo(duty);
+  }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_ptc_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_ptc_{epoch}.json
@@ -3,7 +3,7 @@
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "getPtcDuties",
     "summary" : "Get PTC duties",
-    "description" : "Requests the beacon node to provide a set of Payload Timeliness Committee (PTC) duties, which should be performed by validators, for a particular epoch. Duties should only need to be checked once per epoch, however a chain reorganization could occur, resulting in a change of duties. For full safety, you should monitor head events and confirm the dependent root in this response matches:\n\n - event.previous_duty_dependent_root when compute_epoch_at_slot(event.slot) == epoch\n - event.block otherwise\n\nThe dependent_root value is get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1) or the genesis block root in the case of underflow.",
+    "description" : "Requests the beacon node to provide a set of Payload Timeliness Committee (PTC) duties, which should be performed by validators, for a particular epoch. Duties should only need to be checked once per epoch, however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, resulting in a change of duties. For full safety, you should monitor head events and confirm the dependent root in this response matches:\n- event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`\n- event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`\n- event.block otherwise\n\nThe dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` or the genesis block root in the case of underflow.",
     "parameters" : [ {
       "name" : "epoch",
       "required" : true,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPtcDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPtcDuties.java
@@ -62,12 +62,13 @@ public class PostPtcDuties extends RestApiEndpoint {
             .description(
                 "Requests the beacon node to provide a set of Payload Timeliness Committee (PTC) duties, which "
                     + "should be performed by validators, for a particular epoch. Duties should only need to be "
-                    + "checked once per epoch, however a chain reorganization could occur, "
+                    + "checked once per epoch, however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, "
                     + "resulting in a change of duties. For full safety, you should monitor head events and confirm the "
-                    + "dependent root in this response matches:\n\n"
-                    + " - event.previous_duty_dependent_root when compute_epoch_at_slot(event.slot) == epoch\n"
-                    + " - event.block otherwise\n\n"
-                    + "The dependent_root value is get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1) "
+                    + "dependent root in this response matches:\n"
+                    + "- event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`\n"
+                    + "- event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`\n"
+                    + "- event.block otherwise\n\n"
+                    + "The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` "
                     + "or the genesis block root in the case of underflow.")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
             .requestBodyType(BODY_INTEGER_LIST)

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
@@ -131,8 +131,8 @@ public class SwaggerUIBuilder {
     }
     if ("file".equals(url.getProtocol())) {
       try {
-        return Path.of(url.toURI()).toString();
-      } catch (final URISyntaxException e) {
+        return Path.of(url.toURI()).toRealPath().toString();
+      } catch (final URISyntaxException | IOException e) {
         throw new RuntimeException("Failed to resolve swagger-ui directory", e);
       }
     }
@@ -152,7 +152,9 @@ public class SwaggerUIBuilder {
     final String jarFilePath = URI.create(urlStr.substring("jar:".length(), bangIdx)).getPath();
     final String entryPrefix = urlStr.substring(bangIdx + 2);
 
-    final Path tempDir = Files.createTempDirectory("teku-swagger-ui-");
+    // toRealPath() resolves symlinks (e.g. /var -> /private/var on macOS) so that Javalin's
+    // alias detection does not reject files served from this directory.
+    final Path tempDir = Files.createTempDirectory("teku-swagger-ui-").toRealPath();
     // Register cleanup before extraction so the temp dir is removed even if extraction fails
     Runtime.getRuntime().addShutdownHook(new Thread(() -> deleteDirectory(tempDir)));
     try (final JarFile jar = new JarFile(jarFilePath)) {


### PR DESCRIPTION
  - beacon-APIs #592 (PTC duties next-epoch lookahead): description updated with MIN_SEED_LOOKAHEAD qualifier and current_duty_dependent_root bullet — already in both PostPtcDuties.java and the OpenAPI snapshot from the previous session
  - SwaggerUiTest fix: toRealPath() calls resolve the macOS /var → /private/var symlink that was causing Javalin's alias detection to block all static file serving

  fixes #10524

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how Swagger UI static assets are located/served at runtime (now resolving symlinks via `toRealPath()`), which could affect deployments if path resolution behaves differently across environments.
> 
> **Overview**
> Updates the `POST /eth/v1/validator/duties/ptc/{epoch}` documentation to qualify reorg sensitivity ("> MIN_SEED_LOOKAHEAD") and to include next-epoch lookahead semantics via `event.current_duty_dependent_root`, syncing both `PostPtcDuties` metadata and the OpenAPI snapshot.
> 
> Fixes Swagger UI static file serving on macOS by resolving the swagger-ui directory and temp extraction directory via `toRealPath()` to avoid Javalin alias checks rejecting symlinked paths, and adds an integration test covering fetching PTC duties for the next epoch.
> 
> Pins `gradle/actions/setup-gradle` in the composite `prepare` GitHub Action to a specific commit SHA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8670d11105c89bd11a35b817d9a67d737ef31ef7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->