### PR TITLE
docs: fix README user documentation domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the [Changelog](https://github.com/Consensys/teku/releases) for details of t
 ## Useful links
 
 * [Ethereum Beacon Chain specification](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md)
-* [Teku user documentation](https://docs.teku.consensys.net/)
+* [Teku user documentation](https://docs.teku.consensys.io/)
 * [Teku REST API reference documentation](https://consensys.github.io/teku/)
 * [Teku issues](https://github.com/Consensys/teku/issues)
 * [Contribution guidelines](CONTRIBUTING.md)
@@ -23,7 +23,7 @@ See the [Changelog](https://github.com/Consensys/teku/releases) for details of t
 
 ## Teku users
 
-See our [user documentation](https://docs.teku.consensys.net/).
+See our [user documentation](https://docs.teku.consensys.io/).
 
 Raise a [documentation issue](https://github.com/Consensys/doc.teku/issues) or get in touch in
 the #teku channel on [Discord](https://discord.gg/7hPv2T6) if you've got questions or feedback.


### PR DESCRIPTION
## Summary
- update the README user documentation links from `docs.teku.consensys.net` to the currently reachable `docs.teku.consensys.io` domain
- keep the change scoped to the two README references to the user docs site

## Testing
- verified both domains manually with `curl`; `.io` responds while `.net` currently fails
- not run otherwise (README link change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating README links, with no runtime or build impact.
> 
> **Overview**
> Updates the README’s Teku user documentation links from `docs.teku.consensys.net` to the reachable `docs.teku.consensys.io` domain to prevent broken links for users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 016ace897386241658c0a0d21ed93c420d3c1d6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->