### PR TITLE
Add payload attestations to blocks

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -50,7 +50,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
@@ -94,8 +93,6 @@ public class BlockOperationSelectorFactory {
   private final OperationPool<SignedVoluntaryExit> voluntaryExitPool;
   private final OperationPool<SignedBlsToExecutionChange> blsToExecutionChangePool;
   private final SyncCommitteeContributionPool contributionPool;
-
-  @SuppressWarnings("unused")
   private final PayloadAttestationPool payloadAttestationPool;
 
   private final DepositProvider depositProvider;
@@ -253,11 +250,8 @@ public class BlockOperationSelectorFactory {
 
       // Post-Gloas: Payload Attestations
       if (bodyBuilder.supportsPayloadAttestations()) {
-        // TODO-GLOAS: disable packing of payload attestations for devnet-0
         bodyBuilder.payloadAttestations(
-            BeaconBlockBodySchemaGloas.required(schemaDefinitions.getBeaconBlockBodySchema())
-                .getPayloadAttestationsSchema()
-                .of());
+            payloadAttestationPool.getPayloadAttestationsForBlock(blockSlotState, parentRoot));
       }
 
       return SafeFuture.allOfFailFast(setExecutionDataComplete, setExecutionPayloadBidComplete)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We disabled it for devnet-0 temporarily

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes block body construction for post-Gloas blocks by sourcing payload attestations from the pool, which can affect produced block contents and fork-specific validity. Risk is limited in scope but touches consensus-critical block assembly logic.
> 
> **Overview**
> Populates post-Gloas blocks with real `payloadAttestations` by fetching them from `PayloadAttestationPool` (using `blockSlotState` and `parentRoot`) instead of always inserting an empty list.
> 
> Cleans up related dead code by removing the Gloas schema-based empty construction and an `@SuppressWarnings("unused")` tied to the previously-unused pool dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddad2f639eafe9751677a4bddfd392ea7599d57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->