### PR TITLE
EIP-8045 - Exclude slashed validators from duties

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
@@ -76,6 +77,21 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
     this.configGloas = config;
     this.miscHelpersGloas = miscHelpers;
     this.schemaDefinitions = schemaDefinitions;
+  }
+
+  /**
+   * get_beacon_proposer_indices
+   *
+   * <p>Return the proposer indices for the given {@code epoch}, excluding slashed validators.
+   */
+  @Override
+  public List<Integer> getBeaconProposerIndices(final BeaconState state, final UInt64 epoch) {
+    final IntList activeIndices = getActiveValidatorIndices(state, epoch);
+    final SszList<Validator> validators = state.getValidators();
+    final IntList indices =
+        IntList.of(activeIndices.intStream().filter(i -> !validators.get(i).isSlashed()).toArray());
+    final Bytes32 seed = getSeed(state, epoch, Domain.BEACON_PROPOSER);
+    return miscHelpers.computeProposerIndices(state, epoch, seed, indices);
   }
 
   public UInt64 getPendingBalanceToWithdrawForBuilder(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -145,6 +145,11 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
         nextIndex = computeShuffledIndex(nextIndex, total, seed);
       }
       final int candidateIndex = indices.getInt(nextIndex);
+      // [EIP-8045] Skip slashed validators
+      if (state.getValidators().get(candidateIndex).isSlashed()) {
+        i++;
+        continue;
+      }
       if (computeBalanceWeightedAcceptance(effectiveBalances.get(nextIndex), seed, i)) {
         selected.add(candidateIndex);
       }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -169,6 +170,48 @@ public class BeaconStateAccessorsFuluTest {
 
     // Slashed validator should still appear in the proposer list in Fulu
     assertThat(proposersAfter).isEqualTo(proposersBefore);
+  }
+
+  @Test
+  void processProposerLookahead_shouldIncludeSlashedValidatorsInLookahead() {
+    storageSystem.chainUpdater().initializeGenesis();
+    final BeaconState genesisState = storageSystem.getChainHead().getState();
+
+    final int slotsPerEpoch = specConfigFulu.getSlotsPerEpoch();
+    final int minSeedLookahead = specConfigFulu.getMinSeedLookahead();
+
+    // The epoch that processProposerLookahead will compute proposers for
+    final UInt64 targetEpoch =
+        stateAccessorsFulu.getCurrentEpoch(genesisState).plus(minSeedLookahead).plus(1);
+
+    // Find which validators would be selected as proposers for the target epoch
+    final List<Integer> expectedProposers =
+        stateAccessorsFulu.getBeaconProposerIndices(genesisState, targetEpoch);
+    final int slashedIndex = expectedProposers.getFirst();
+
+    // Slash that validator and run processProposerLookahead
+    final BeaconState stateAfterProcessing =
+        genesisState.updated(
+            mutableState -> {
+              final Validator validator = mutableState.getValidators().get(slashedIndex);
+              mutableState.getValidators().set(slashedIndex, validator.withSlashed(true));
+
+              final EpochProcessor epochProcessor = spec.getGenesisSpec().getEpochProcessor();
+              epochProcessor.processProposerLookahead(mutableState);
+            });
+
+    // Extract the last epoch of the proposer lookahead (the newly computed entries)
+    final BeaconStateFulu stateFulu = BeaconStateFulu.required(stateAfterProcessing);
+    final List<Integer> newLookaheadProposers =
+        stateFulu.getProposerLookahead().stream()
+            .skip(stateFulu.getProposerLookahead().size() - slotsPerEpoch)
+            .map(SszUInt64::get)
+            .map(UInt64::intValue)
+            .toList();
+
+    // Fulu does NOT exclude slashed validators — the proposer list should be unchanged
+    assertThat(newLookaheadProposers).isEqualTo(expectedProposers);
+    assertThat(newLookaheadProposers).contains(slashedIndex);
   }
 
   private List<Integer> getProposerLookaheadFromState(final BeaconStateFulu beaconStateFulu) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BeaconStateAccessorsFuluTest.java
@@ -30,6 +30,8 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
@@ -137,6 +139,36 @@ public class BeaconStateAccessorsFuluTest {
                     blockAndState.getState(), UInt64.valueOf(slot)))
         .hasMessageContaining(
             "get_beacon_proposer_index is only used for requesting a slot in the current epoch (or next epoch in FULU)");
+  }
+
+  @Test
+  void getBeaconProposerIndices_shouldIncludeSlashedValidators() {
+    storageSystem.chainUpdater().initializeGenesis();
+    final BeaconState genesisState = storageSystem.getChainHead().getState();
+    final UInt64 epoch = UInt64.ZERO;
+
+    // Get proposer indices before slashing
+    final List<Integer> proposersBefore =
+        stateAccessorsFulu.getBeaconProposerIndices(genesisState, epoch);
+    assertThat(proposersBefore).isNotEmpty();
+
+    // Pick a validator that is selected as proposer
+    final int slashedIndex = proposersBefore.getFirst();
+
+    // Slash that validator
+    final BeaconState stateWithSlashedValidator =
+        genesisState.updated(
+            mutableState -> {
+              final Validator validator = mutableState.getValidators().get(slashedIndex);
+              mutableState.getValidators().set(slashedIndex, validator.withSlashed(true));
+            });
+
+    // Get proposer indices after slashing — Fulu does NOT exclude slashed validators
+    final List<Integer> proposersAfter =
+        stateAccessorsFulu.getBeaconProposerIndices(stateWithSlashedValidator, epoch);
+
+    // Slashed validator should still appear in the proposer list in Fulu
+    assertThat(proposersAfter).isEqualTo(proposersBefore);
   }
 
   private List<Integer> getProposerLookaheadFromState(final BeaconStateFulu beaconStateFulu) {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -169,7 +169,9 @@ public class BeaconStateAccessorsGloasTest {
   public void getNextSyncCommitteeIndices_shouldExcludeSlashedValidators() {
     storageSystem.chainUpdater().initializeGenesis();
     final BeaconState genesisState = storageSystem.getChainHead().getState();
-    final int slashedIndex = 0;
+    // chosen based on simulation that helped figure index 1 was present in the selected sync
+    // committee for the next epoch
+    final int slashedIndex = 1;
     final BeaconState state =
         genesisState.updated(
             mutableState -> {
@@ -178,7 +180,7 @@ public class BeaconStateAccessorsGloasTest {
             });
 
     final IntList syncCommitteeIndices = beaconStateAccessors.getNextSyncCommitteeIndices(state);
-
+    System.out.println(syncCommitteeIndices);
     assertThat(syncCommitteeIndices.size()).isGreaterThan(0);
     assertThat(syncCommitteeIndices.contains(slashedIndex)).isFalse();
   }
@@ -187,7 +189,7 @@ public class BeaconStateAccessorsGloasTest {
   public void getNextSyncCommitteeIndices_shouldExcludeMultipleSlashedValidators() {
     storageSystem.chainUpdater().initializeGenesis();
     final BeaconState genesisState = storageSystem.getChainHead().getState();
-    final int[] slashedIndices = {0, 1, 2};
+    final int[] slashedIndices = {2, 3, 4};
     final BeaconState state =
         genesisState.updated(
             mutableState -> {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -20,14 +20,17 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
 import tech.pegasys.teku.storage.storageSystem.StorageSystem;
@@ -115,5 +118,48 @@ public class BeaconStateAccessorsGloasTest {
     // Slashed validator should not appear in the proposer list
     assertThat(proposersAfter).doesNotContain(slashedIndex);
     assertThat(proposersAfter).hasSameSizeAs(proposersBefore);
+  }
+
+  @Test
+  void processProposerLookahead_shouldExcludeSlashedValidatorsFromLookahead() {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(16, spec);
+    storageSystem.chainUpdater().initializeGenesis();
+    final BeaconState genesisState = storageSystem.getChainHead().getState();
+
+    final int slotsPerEpoch = spec.getGenesisSpecConfig().getSlotsPerEpoch();
+    final int minSeedLookahead = spec.getGenesisSpecConfig().getMinSeedLookahead();
+
+    // The epoch that processProposerLookahead will compute proposers for
+    final UInt64 targetEpoch =
+        beaconStateAccessors.getCurrentEpoch(genesisState).plus(minSeedLookahead).plus(1);
+
+    // Find which validators would be selected as proposers for the target epoch
+    final List<Integer> expectedProposers =
+        beaconStateAccessors.getBeaconProposerIndices(genesisState, targetEpoch);
+    final int slashedIndex = expectedProposers.getFirst();
+
+    // Slash that validator and run processProposerLookahead
+    final BeaconState stateAfterProcessing =
+        genesisState.updated(
+            mutableState -> {
+              final Validator validator = mutableState.getValidators().get(slashedIndex);
+              mutableState.getValidators().set(slashedIndex, validator.withSlashed(true));
+
+              final EpochProcessor epochProcessor = spec.getGenesisSpec().getEpochProcessor();
+              epochProcessor.processProposerLookahead(mutableState);
+            });
+
+    // Extract the last epoch of the proposer lookahead (the newly computed entries)
+    final BeaconStateFulu stateFulu = BeaconStateFulu.required(stateAfterProcessing);
+    final List<Integer> newLookaheadProposers =
+        stateFulu.getProposerLookahead().stream()
+            .skip(stateFulu.getProposerLookahead().size() - slotsPerEpoch)
+            .map(SszUInt64::get)
+            .map(UInt64::intValue)
+            .toList();
+
+    // Slashed validator should NOT appear in the newly computed proposer lookahead
+    assertThat(newLookaheadProposers).doesNotContain(slashedIndex);
+    assertThat(newLookaheadProposers).hasSize(slotsPerEpoch);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -41,6 +42,7 @@ public class BeaconStateAccessorsGloasTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final BeaconStateAccessorsGloas beaconStateAccessors =
       BeaconStateAccessorsGloas.required(spec.getGenesisSpec().beaconStateAccessors());
+  private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(16, spec);
 
   @Test
   void getBuilderIndex_shouldReturnBuilderIndex() {
@@ -161,5 +163,45 @@ public class BeaconStateAccessorsGloasTest {
     // Slashed validator should NOT appear in the newly computed proposer lookahead
     assertThat(newLookaheadProposers).doesNotContain(slashedIndex);
     assertThat(newLookaheadProposers).hasSize(slotsPerEpoch);
+  }
+
+  @Test
+  public void getNextSyncCommitteeIndices_shouldExcludeSlashedValidators() {
+    storageSystem.chainUpdater().initializeGenesis();
+    final BeaconState genesisState = storageSystem.getChainHead().getState();
+    final int slashedIndex = 0;
+    final BeaconState state =
+        genesisState.updated(
+            mutableState -> {
+              final Validator validator = mutableState.getValidators().get(slashedIndex);
+              mutableState.getValidators().set(slashedIndex, validator.withSlashed(true));
+            });
+
+    final IntList syncCommitteeIndices = beaconStateAccessors.getNextSyncCommitteeIndices(state);
+
+    assertThat(syncCommitteeIndices.size()).isGreaterThan(0);
+    assertThat(syncCommitteeIndices.contains(slashedIndex)).isFalse();
+  }
+
+  @Test
+  public void getNextSyncCommitteeIndices_shouldExcludeMultipleSlashedValidators() {
+    storageSystem.chainUpdater().initializeGenesis();
+    final BeaconState genesisState = storageSystem.getChainHead().getState();
+    final int[] slashedIndices = {0, 1, 2};
+    final BeaconState state =
+        genesisState.updated(
+            mutableState -> {
+              for (int idx : slashedIndices) {
+                final Validator validator = mutableState.getValidators().get(idx);
+                mutableState.getValidators().set(idx, validator.withSlashed(true));
+              }
+            });
+
+    final IntList syncCommitteeIndices = beaconStateAccessors.getNextSyncCommitteeIndices(state);
+
+    assertThat(syncCommitteeIndices.size()).isGreaterThan(0);
+    for (int slashedIdx : slashedIndices) {
+      assertThat(syncCommitteeIndices.contains(slashedIdx)).isFalse();
+    }
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -180,7 +180,6 @@ public class BeaconStateAccessorsGloasTest {
             });
 
     final IntList syncCommitteeIndices = beaconStateAccessors.getNextSyncCommitteeIndices(state);
-    System.out.println(syncCommitteeIndices);
     assertThat(syncCommitteeIndices.size()).isGreaterThan(0);
     assertThat(syncCommitteeIndices.contains(slashedIndex)).isFalse();
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -22,11 +23,14 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public class BeaconStateAccessorsGloasTest {
 
@@ -79,5 +83,37 @@ public class BeaconStateAccessorsGloasTest {
     final Optional<BLSPublicKey> index =
         beaconStateAccessors.getBuilderPubKey(state, UInt64.valueOf(999));
     assertThat(index).isEmpty();
+  }
+
+  @Test
+  void getBeaconProposerIndices_shouldExcludeSlashedValidators() {
+    final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(16, spec);
+    storageSystem.chainUpdater().initializeGenesis();
+    final BeaconState genesisState = storageSystem.getChainHead().getState();
+    final UInt64 epoch = UInt64.ZERO;
+
+    // Get proposer indices before slashing
+    final List<Integer> proposersBefore =
+        beaconStateAccessors.getBeaconProposerIndices(genesisState, epoch);
+    assertThat(proposersBefore).isNotEmpty();
+
+    // Pick a validator that is selected as proposer
+    final int slashedIndex = proposersBefore.getFirst();
+
+    // Slash that validator
+    final BeaconState stateWithSlashedValidator =
+        genesisState.updated(
+            mutableState -> {
+              final Validator validator = mutableState.getValidators().get(slashedIndex);
+              mutableState.getValidators().set(slashedIndex, validator.withSlashed(true));
+            });
+
+    // Get proposer indices after slashing
+    final List<Integer> proposersAfter =
+        beaconStateAccessors.getBeaconProposerIndices(stateWithSlashedValidator, epoch);
+
+    // Slashed validator should not appear in the proposer list
+    assertThat(proposersAfter).doesNotContain(slashedIndex);
+    assertThat(proposersAfter).hasSameSizeAs(proposersBefore);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
@@ -15,14 +15,21 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class MiscHelpersGloasTest {
 
   private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private final MiscHelpersGloas miscHelpers =
       MiscHelpersGloas.required(spec.getGenesisSpec().miscHelpers());
@@ -37,5 +44,61 @@ public class MiscHelpersGloasTest {
     assertThat(predicates.isBuilderIndex(validatorIndex)).isTrue();
     assertThat(miscHelpers.convertValidatorIndexToBuilderIndex(validatorIndex))
         .isEqualTo(builderIndex);
+  }
+
+  @Test
+  public void computeBalanceWeightedSelection_shouldExcludeSlashedValidators() {
+    final BeaconState baseState = dataStructureUtil.randomBeaconState();
+    final int slashedIndex = 0;
+    // Slash validator at index 0
+    final BeaconState state =
+        baseState.updated(
+            mutableState -> {
+              final Validator validator = mutableState.getValidators().get(slashedIndex);
+              mutableState.getValidators().set(slashedIndex, validator.withSlashed(true));
+            });
+
+    final IntList indices = new IntArrayList();
+    for (int i = 0; i < Math.min(10, state.getValidators().size()); i++) {
+      indices.add(i);
+    }
+    final Bytes32 seed = dataStructureUtil.randomBytes32();
+
+    final IntList selected =
+        miscHelpers.computeBalanceWeightedSelection(state, indices, seed, 5, true);
+
+    assertThat(selected.size()).isEqualTo(5);
+    assertThat(selected.contains(slashedIndex)).isFalse();
+  }
+
+  @Test
+  public void computeBalanceWeightedSelection_shouldExcludeMultipleSlashedValidators() {
+    final BeaconState baseState = dataStructureUtil.randomBeaconState();
+    final int slashedIndex0 = 0;
+    final int slashedIndex1 = 1;
+    final int slashedIndex2 = 2;
+    // Slash validators at indices 0, 1, 2
+    final BeaconState state =
+        baseState.updated(
+            mutableState -> {
+              for (int idx : new int[] {slashedIndex0, slashedIndex1, slashedIndex2}) {
+                final Validator validator = mutableState.getValidators().get(idx);
+                mutableState.getValidators().set(idx, validator.withSlashed(true));
+              }
+            });
+
+    final IntList indices = new IntArrayList();
+    for (int i = 0; i < Math.min(10, state.getValidators().size()); i++) {
+      indices.add(i);
+    }
+    final Bytes32 seed = dataStructureUtil.randomBytes32();
+
+    final IntList selected =
+        miscHelpers.computeBalanceWeightedSelection(state, indices, seed, 5, true);
+
+    assertThat(selected.size()).isEqualTo(5);
+    assertThat(selected.contains(slashedIndex0)).isFalse();
+    assertThat(selected.contains(slashedIndex1)).isFalse();
+    assertThat(selected.contains(slashedIndex2)).isFalse();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
EIP-8045 implementation to exclude slashed validator from being selected for proposals 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #10526 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters duty selection (proposer and sync committee) for the Gloas fork by filtering slashed validators, which can change consensus-critical behavior and requires careful spec/test alignment.
> 
> **Overview**
> Implements EIP-8045 behavior for the Gloas fork by **excluding slashed validators from duty selection**. `BeaconStateAccessorsGloas.getBeaconProposerIndices` now filters slashed validators out of the active set before computing per-slot proposers, and `MiscHelpersGloas.computeBalanceWeightedSelection` skips slashed candidates during balance-weighted sampling (impacting proposer, sync committee, and other balance-weighted selections).
> 
> Adds/updates tests to assert the new Gloas behavior (proposer indices, proposer lookahead, and next sync committee exclude slashed validators) while explicitly asserting that Fulu behavior remains unchanged and still includes slashed validators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f1f3cf27b88867d0fc9efba1f2395f807710df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->