### PR TITLE
Fix DataColumn blockRoot optimistic metadata

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/datacolumnselector/DataColumnSidecarSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/datacolumnselector/DataColumnSidecarSelectorFactory.java
@@ -174,7 +174,11 @@ public class DataColumnSidecarSelectorFactory
     final Bytes32 blockRoot = slotAndBlockRoot.getBlockRoot();
     final Optional<ChainHead> maybeChainHead = client.getChainHead();
     final boolean isFinalized = client.isFinalized(slot);
-    final boolean isOptimistic = client.isOptimisticBlock(blockRoot);
+    final boolean isBlockOptimistic = client.isOptimisticBlock(blockRoot);
+    final boolean isOptimistic =
+        maybeChainHead
+            .map(chainHead -> chainHead.isOptimistic() || isBlockOptimistic)
+            .orElse(isBlockOptimistic);
     final boolean isCanonical =
         maybeChainHead
             .map(chainHead -> client.isCanonicalBlock(slot, blockRoot, chainHead.getRoot()))

--- a/data/provider/src/test/java/tech/pegasys/teku/api/datacolumnselector/DataColumnSidecarSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/datacolumnselector/DataColumnSidecarSelectorFactoryTest.java
@@ -203,6 +203,34 @@ public class DataColumnSidecarSelectorFactoryTest {
   }
 
   @TestTemplate
+  public void blockRootSelector_shouldMarkDataColumnSidecarsOptimisticWhenChainHeadIsOptimistic()
+      throws ExecutionException, InterruptedException {
+    specContext.assumeFuluActive();
+    final ChainHead chainHead = mock(ChainHead.class);
+
+    when(chainHead.isOptimistic()).thenReturn(true);
+    when(chainHead.getRoot()).thenReturn(dataStructureUtil.randomBytes32());
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.getFinalizedSlotByBlockRoot(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(client.getBlockByBlockRoot(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+    when(client.getDataColumnSidecars(block.getSlot(), indices))
+        .thenReturn(SafeFuture.completedFuture(dataColumnSidecars));
+    when(client.isFinalized(block.getSlot())).thenReturn(false);
+    when(client.isOptimisticBlock(block.getRoot())).thenReturn(false);
+
+    final Optional<DataColumnSidecarsAndMetaData> result =
+        dataColumnSidecarSelectorFactory
+            .blockRootSelector(block.getRoot())
+            .getDataColumnSidecars(indices)
+            .get();
+
+    assertThat(result).isNotEmpty();
+    assertThat(result.get().isExecutionOptimistic()).isTrue();
+  }
+
+  @TestTemplate
   public void slotSelector_shouldGetDataColumnSidecarsFromFinalizedSlot()
       throws ExecutionException, InterruptedException {
     specContext.assumeFuluActive();


### PR DESCRIPTION
## PR Description

Fix `DataColumnSidecarSelectorFactory` so `blockRoot` responses are marked execution optimistic when the chain head is optimistic, matching the existing `Blob`, `Block`, and `State` selector behavior.
Add a regression test for the `blockRoot` path where the block itself is not optimistic but the chain head is.

## Fixed Issue(s)

N/A

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small metadata logic change limited to `DataColumnSidecarSelectorFactory` plus a focused regression test; low risk aside from changing the `execution_optimistic` flag returned by the API in some cases.
> 
> **Overview**
> `DataColumnSidecarSelectorFactory` now sets `execution_optimistic` for `blockRoot` queries when *either* the selected block is optimistic *or* the current chain head is optimistic (previously it only considered the block). 
> 
> Adds a regression test covering the case where `client.isOptimisticBlock(blockRoot)` is false but `chainHead.isOptimistic()` is true, asserting the returned metadata is optimistic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c0f9480e014c59d33fdee3022b35946b3515a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->