### PR TITLE
Add forkchoice node identity plumbing with current behavior unchanged (2 of 7)

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetForkChoiceTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetForkChoiceTest.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.api.ForkChoiceData;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -60,7 +61,8 @@ class GetForkChoiceTest extends AbstractMigratedBeaconHandlerTest {
                       new Checkpoint(UInt64.valueOf(11), Bytes32.fromHexString("0x8888")),
                       new Checkpoint(UInt64.valueOf(12), Bytes32.fromHexString("0x9999")),
                       new Checkpoint(UInt64.valueOf(13), Bytes32.fromHexString("0x0000"))),
-                  UInt64.valueOf(409600000000L))));
+                  UInt64.valueOf(409600000000L),
+                  ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING)));
 
   @BeforeEach
   void setup() {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -73,6 +73,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
@@ -127,7 +128,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
                 bestBlock.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
                 ProtoNodeValidationStatus.VALID,
                 spec.calculateBlockCheckpoints(bestBlock.getState()),
-                ZERO));
+                ZERO,
+                ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING));
   }
 
   @Test

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTestPhase0.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTestPhase0.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
@@ -99,7 +100,8 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
                 bestBlock.getExecutionBlockHash().orElse(Bytes32.ZERO),
                 ProtoNodeValidationStatus.VALID,
                 spec.calculateBlockCheckpoints(bestBlock.getState()),
-                ZERO));
+                ZERO,
+                ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING));
   }
 
   @Test

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoiceNode.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoiceNode.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.forkchoice;
+
+import org.apache.tuweni.bytes.Bytes32;
+
+/**
+ * Identifies a node in the fork-choice tree. In the Gloas three-state model, each block produces
+ * multiple nodes (PENDING, EMPTY, FULL), so a block root alone is not sufficient to identify a
+ * node. This record combines the block root with the payload status to form a complete node
+ * identity.
+ *
+ * <p>Spec reference: ForkChoiceNode(block_root, payload_status)
+ */
+public record ForkChoiceNode(Bytes32 blockRoot, ForkChoicePayloadStatus payloadStatus) {
+
+  public static ForkChoiceNode createBase(final Bytes32 blockRoot) {
+    return new ForkChoiceNode(blockRoot, ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
+  }
+
+  public static ForkChoiceNode createEmpty(final Bytes32 blockRoot) {
+    return new ForkChoiceNode(blockRoot, ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+  }
+
+  public static ForkChoiceNode createFull(final Bytes32 blockRoot) {
+    return new ForkChoiceNode(blockRoot, ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ForkChoicePayloadStatus.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.forkchoice;
+
+/**
+ * Possible status of a payload in the fork-choice
+ *
+ * <p>Spec reference:
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md
+ */
+public enum ForkChoicePayloadStatus {
+  PAYLOAD_STATUS_EMPTY(0),
+  PAYLOAD_STATUS_FULL(1),
+  PAYLOAD_STATUS_PENDING(2);
+
+  private final int value;
+
+  ForkChoicePayloadStatus(final int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ProtoNodeData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ProtoNodeData.java
@@ -31,6 +31,7 @@ public class ProtoNodeData implements MinimalBeaconBlockSummary {
   private final ProtoNodeValidationStatus validationStatus;
   private final BlockCheckpoints checkpoints;
   private final UInt64 weight;
+  private final ForkChoicePayloadStatus payloadStatus;
 
   public ProtoNodeData(
       final UInt64 slot,
@@ -41,7 +42,8 @@ public class ProtoNodeData implements MinimalBeaconBlockSummary {
       final Bytes32 executionBlockHash,
       final ProtoNodeValidationStatus validationStatus,
       final BlockCheckpoints checkpoints,
-      final UInt64 weight) {
+      final UInt64 weight,
+      final ForkChoicePayloadStatus payloadStatus) {
     this.slot = slot;
     this.root = root;
     this.parentRoot = parentRoot;
@@ -51,6 +53,7 @@ public class ProtoNodeData implements MinimalBeaconBlockSummary {
     this.validationStatus = validationStatus;
     this.checkpoints = checkpoints;
     this.weight = weight;
+    this.payloadStatus = payloadStatus;
   }
 
   @Override
@@ -97,6 +100,10 @@ public class ProtoNodeData implements MinimalBeaconBlockSummary {
     return weight;
   }
 
+  public ForkChoicePayloadStatus getPayloadStatus() {
+    return payloadStatus;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -114,7 +121,8 @@ public class ProtoNodeData implements MinimalBeaconBlockSummary {
         && Objects.equals(executionBlockHash, that.executionBlockHash)
         && validationStatus == that.validationStatus
         && Objects.equals(checkpoints, that.checkpoints)
-        && Objects.equals(weight, that.weight);
+        && Objects.equals(weight, that.weight)
+        && payloadStatus == that.payloadStatus;
   }
 
   @Override
@@ -128,7 +136,8 @@ public class ProtoNodeData implements MinimalBeaconBlockSummary {
         executionBlockHash,
         validationStatus,
         checkpoints,
-        weight);
+        weight,
+        payloadStatus);
   }
 
   @Override
@@ -143,6 +152,7 @@ public class ProtoNodeData implements MinimalBeaconBlockSummary {
         .add("validationStatus", validationStatus)
         .add("checkpoints", checkpoints)
         .add("weight", weight)
+        .add("payloadStatus", payloadStatus)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -31,10 +31,27 @@ public interface ReadOnlyForkChoiceStrategy {
 
   Optional<Bytes32> getAncestor(Bytes32 blockRoot, UInt64 slot);
 
+  /**
+   * Walks the parent chain from blockRoot to find the ancestor node at the given slot.
+   *
+   * <p>This mirrors the Gloas {@code get_ancestor(...)} helper, which returns a full {@link
+   * ForkChoiceNode} identity.
+   */
+  Optional<ForkChoiceNode> getAncestorNode(Bytes32 blockRoot, UInt64 slot);
+
   Optional<SlotAndBlockRoot> findCommonAncestor(Bytes32 blockRoot1, Bytes32 blockRoot2);
 
   List<Bytes32> getBlockRootsAtSlot(UInt64 slot);
 
+  /**
+   * Returns the current terminal fork-choice heads.
+   *
+   * <p>This is a node-facing API. In pre-Gloas it returns the base block nodes. In the Gloas
+   * three-state tree it may return EMPTY/FULL nodes for the same block root, because those are the
+   * actual candidate heads selected by the modified {@code get_head(...)} spec logic.
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-get_head
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-get_node_children
+   */
   default List<ProtoNodeData> getChainHeads() {
     return getChainHeads(false);
   }
@@ -53,5 +70,29 @@ public interface ReadOnlyForkChoiceStrategy {
 
   Optional<ProtoNodeData> getBlockData(Bytes32 blockRoot);
 
+  default Optional<ProtoNodeData> getNodeData(final ForkChoiceNode node) {
+    return getBlockData(node.blockRoot(), node.payloadStatus());
+  }
+
+  /**
+   * Gets block data for a specific node identity (blockRoot + payloadStatus). In the Gloas
+   * three-state tree, the same blockRoot may have multiple nodes (PENDING, EMPTY, FULL). This
+   * method resolves to the correct node based on the payload status.
+   *
+   * <p>This is the read-side mirror of the Gloas spec helpers that distinguish the canonical block
+   * root from the EMPTY/FULL child returned by `get_node_children(...)` and selected by
+   * `get_head(...)`:
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-get_node_children
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-get_head
+   *
+   * <p>Default: delegates to {@link #getBlockData(Bytes32)}, ignoring payloadStatus.
+   */
+  default Optional<ProtoNodeData> getBlockData(
+      final Bytes32 blockRoot, final ForkChoicePayloadStatus payloadStatus) {
+    return getBlockData(blockRoot);
+  }
+
   Optional<UInt64> getWeight(Bytes32 blockRoot);
+
+  Optional<ForkChoicePayloadStatus> payloadStatus(Bytes32 blockRoot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -95,6 +95,4 @@ public interface ReadOnlyForkChoiceStrategy {
   }
 
   Optional<UInt64> getWeight(Bytes32 blockRoot);
-
-  Optional<ForkChoicePayloadStatus> payloadStatus(Bytes32 blockRoot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -37,7 +37,9 @@ public interface ReadOnlyForkChoiceStrategy {
    * <p>This mirrors the Gloas {@code get_ancestor(...)} helper, which returns a full {@link
    * ForkChoiceNode} identity.
    */
-  Optional<ForkChoiceNode> getAncestorNode(Bytes32 blockRoot, UInt64 slot);
+  default Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
+    return getAncestor(blockRoot, slot).map(ForkChoiceNode::createBase);
+  }
 
   Optional<SlotAndBlockRoot> findCommonAncestor(Bytes32 blockRoot1, Bytes32 blockRoot2);
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -447,11 +447,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     }
 
     @Override
-    public Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
-      return getAncestor(blockRoot, slot).map(ForkChoiceNode::createBase);
-    }
-
-    @Override
     public Optional<SlotAndBlockRoot> findCommonAncestor(
         final Bytes32 blockRoot1, final Bytes32 blockRoot2) {
       throw new UnsupportedOperationException("Not implemented");

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -521,10 +521,5 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     public Optional<UInt64> getWeight(final Bytes32 blockRoot) {
       throw new UnsupportedOperationException("Not implemented");
     }
-
-    @Override
-    public Optional<ForkChoicePayloadStatus> payloadStatus(final Bytes32 blockRoot) {
-      throw new UnsupportedOperationException("Not implemented");
-    }
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -447,6 +447,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     }
 
     @Override
+    public Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
+      return getAncestor(blockRoot, slot).map(ForkChoiceNode::createBase);
+    }
+
+    @Override
     public Optional<SlotAndBlockRoot> findCommonAncestor(
         final Bytes32 blockRoot1, final Bytes32 blockRoot2) {
       throw new UnsupportedOperationException("Not implemented");
@@ -480,7 +485,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
                         executionPayload.map(ExecutionPayload::getBlockHash).orElse(Bytes32.ZERO),
                         ProtoNodeValidationStatus.VALID,
                         blockCheckpoints.get(root),
-                        UInt64.ZERO));
+                        UInt64.ZERO,
+                        ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING));
                 headsByRoot.remove(block.getParentRoot());
               });
       return new ArrayList<>(headsByRoot.values());
@@ -518,6 +524,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
 
     @Override
     public Optional<UInt64> getWeight(final Bytes32 blockRoot) {
+      throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public Optional<ForkChoicePayloadStatus> payloadStatus(final Bytes32 blockRoot) {
       throw new UnsupportedOperationException("Not implemented");
     }
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -156,11 +156,6 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
     return getBlock(blockRoot).map(block -> UInt64.ZERO);
   }
 
-  @Override
-  public Optional<ForkChoicePayloadStatus> payloadStatus(final Bytes32 blockRoot) {
-    return getBlock(blockRoot).map(__ -> ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
-  }
-
   private Optional<SignedBeaconBlock> getBlock(final Bytes32 root) {
     return chainBuilder
         .getBlock(root)

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -27,6 +27,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -78,6 +80,11 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   }
 
   @Override
+  public Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
+    return getAncestor(blockRoot, slot).map(ForkChoiceNode::createBase);
+  }
+
+  @Override
   public Optional<SlotAndBlockRoot> findCommonAncestor(
       final Bytes32 blockRoot1, final Bytes32 blockRoot2) {
     return Optional.empty();
@@ -111,7 +118,8 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
             blockAndState.getState().getFinalizedCheckpoint(),
             blockAndState.getState().getCurrentJustifiedCheckpoint(),
             blockAndState.getState().getFinalizedCheckpoint()),
-        UInt64.ZERO);
+        UInt64.ZERO,
+        ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
   }
 
   @Override
@@ -152,6 +160,11 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   public Optional<UInt64> getWeight(final Bytes32 blockRoot) {
     // We don't track weight so return 0 for all known blocks.
     return getBlock(blockRoot).map(block -> UInt64.ZERO);
+  }
+
+  @Override
+  public Optional<ForkChoicePayloadStatus> payloadStatus(final Bytes32 blockRoot) {
+    return getBlock(blockRoot).map(__ -> ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
   }
 
   private Optional<SignedBeaconBlock> getBlock(final Bytes32 root) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
@@ -77,11 +76,6 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
       return Optional.empty();
     }
     return getBlock(slot).map(SignedBeaconBlock::getRoot);
-  }
-
-  @Override
-  public Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
-    return getAncestor(blockRoot, slot).map(ForkChoiceNode::createBase);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -48,15 +49,7 @@ public class ChainHead implements MinimalBeaconBlockSummary {
     this.stateAndBlockSummaryFuture = stateAndBlockSummaryFuture;
   }
 
-  public static ChainHead create(final ChainHead chainHead) {
-    return new ChainHead(
-        chainHead.blockData,
-        chainHead.executionPayloadBlockHash,
-        chainHead.isOptimistic,
-        chainHead.stateAndBlockSummaryFuture,
-        chainHead.getPayloadStatus());
-  }
-
+  @VisibleForTesting
   public static ChainHead create(final StateAndBlockSummary stateAndBlockSummary) {
     return new ChainHead(
         stateAndBlockSummary.getBlockSummary(),
@@ -66,6 +59,7 @@ public class ChainHead implements MinimalBeaconBlockSummary {
         ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
   }
 
+  @VisibleForTesting
   public static ChainHead create(final SignedBlockAndState blockAndState) {
     return new ChainHead(
         blockAndState.getBlockSummary(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
@@ -22,12 +22,15 @@ import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class ChainHead implements MinimalBeaconBlockSummary {
 
   private final MinimalBeaconBlockSummary blockData;
+  private final ForkChoiceNode forkChoiceNode;
   private final Bytes32 executionPayloadBlockHash;
   private final boolean isOptimistic;
   private final SafeFuture<StateAndBlockSummary> stateAndBlockSummaryFuture;
@@ -36,8 +39,10 @@ public class ChainHead implements MinimalBeaconBlockSummary {
       final MinimalBeaconBlockSummary blockData,
       final Bytes32 executionPayloadBlockHash,
       final boolean isOptimistic,
-      final SafeFuture<StateAndBlockSummary> stateAndBlockSummaryFuture) {
+      final SafeFuture<StateAndBlockSummary> stateAndBlockSummaryFuture,
+      final ForkChoicePayloadStatus payloadStatus) {
     this.blockData = blockData;
+    this.forkChoiceNode = new ForkChoiceNode(blockData.getRoot(), payloadStatus);
     this.executionPayloadBlockHash = executionPayloadBlockHash;
     this.isOptimistic = isOptimistic;
     this.stateAndBlockSummaryFuture = stateAndBlockSummaryFuture;
@@ -48,7 +53,8 @@ public class ChainHead implements MinimalBeaconBlockSummary {
         chainHead.blockData,
         chainHead.executionPayloadBlockHash,
         chainHead.isOptimistic,
-        chainHead.stateAndBlockSummaryFuture);
+        chainHead.stateAndBlockSummaryFuture,
+        chainHead.getPayloadStatus());
   }
 
   public static ChainHead create(final StateAndBlockSummary stateAndBlockSummary) {
@@ -56,7 +62,8 @@ public class ChainHead implements MinimalBeaconBlockSummary {
         stateAndBlockSummary.getBlockSummary(),
         stateAndBlockSummary.getExecutionBlockHash().orElse(Bytes32.ZERO),
         false,
-        SafeFuture.completedFuture(stateAndBlockSummary));
+        SafeFuture.completedFuture(stateAndBlockSummary),
+        ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
   }
 
   public static ChainHead create(final SignedBlockAndState blockAndState) {
@@ -64,7 +71,8 @@ public class ChainHead implements MinimalBeaconBlockSummary {
         blockAndState.getBlockSummary(),
         blockAndState.getExecutionBlockHash().orElse(Bytes32.ZERO),
         false,
-        SafeFuture.completedFuture(blockAndState));
+        SafeFuture.completedFuture(blockAndState),
+        ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
   }
 
   public static ChainHead create(
@@ -74,7 +82,8 @@ public class ChainHead implements MinimalBeaconBlockSummary {
         blockData,
         blockData.getExecutionBlockHash(),
         blockData.isOptimistic(),
-        stateAndBlockSummaryFuture);
+        stateAndBlockSummaryFuture,
+        blockData.getPayloadStatus());
   }
 
   public SafeFuture<BeaconState> getState() {
@@ -117,6 +126,14 @@ public class ChainHead implements MinimalBeaconBlockSummary {
     return executionPayloadBlockHash;
   }
 
+  public ForkChoicePayloadStatus getPayloadStatus() {
+    return forkChoiceNode.payloadStatus();
+  }
+
+  public ForkChoiceNode getForkChoiceNode() {
+    return forkChoiceNode;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -126,11 +143,12 @@ public class ChainHead implements MinimalBeaconBlockSummary {
       return false;
     }
     final ChainHead chainHead = (ChainHead) o;
-    return Objects.equals(blockData, chainHead.blockData);
+    return Objects.equals(blockData, chainHead.blockData)
+        && Objects.equals(forkChoiceNode, chainHead.forkChoiceNode);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(blockData);
+    return Objects.hash(blockData, forkChoiceNode);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -33,6 +33,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -354,6 +356,17 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   @Override
+  public Optional<ForkChoicePayloadStatus> payloadStatus(final Bytes32 blockRoot) {
+    protoArrayLock.readLock().lock();
+    try {
+      return getProtoNode(blockRoot)
+          .map(__ -> ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
+  @Override
   public Optional<Bytes32> getAncestor(final Bytes32 blockRoot, final UInt64 slot) {
     protoArrayLock.readLock().lock();
     try {
@@ -377,6 +390,11 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     } finally {
       protoArrayLock.readLock().unlock();
     }
+  }
+
+  @Override
+  public Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
+    return getAncestor(blockRoot, slot).map(ForkChoiceNode::createBase);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -359,8 +358,9 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   public Optional<ForkChoicePayloadStatus> payloadStatus(final Bytes32 blockRoot) {
     protoArrayLock.readLock().lock();
     try {
-      return getProtoNode(blockRoot)
-          .map(__ -> ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
+      // TODO(gloas): return the payload status stored on the matching proto node once the
+      // three-state forkchoice tree is active. Pre-Gloas there is a single node per block root.
+      return getProtoNode(blockRoot).map(__ -> ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
     } finally {
       protoArrayLock.readLock().unlock();
     }
@@ -390,11 +390,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     } finally {
       protoArrayLock.readLock().unlock();
     }
-  }
-
-  @Override
-  public Optional<ForkChoiceNode> getAncestorNode(final Bytes32 blockRoot, final UInt64 slot) {
-    return getAncestor(blockRoot, slot).map(ForkChoiceNode::createBase);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -349,18 +348,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     protoArrayLock.readLock().lock();
     try {
       return getProtoNode(blockRoot).map(ProtoNode::isOptimistic);
-    } finally {
-      protoArrayLock.readLock().unlock();
-    }
-  }
-
-  @Override
-  public Optional<ForkChoicePayloadStatus> payloadStatus(final Bytes32 blockRoot) {
-    protoArrayLock.readLock().lock();
-    try {
-      // TODO(gloas): return the payload status stored on the matching proto node once the
-      // three-state forkchoice tree is active. Pre-Gloas there is a single node per block root.
-      return getProtoNode(blockRoot).map(__ -> ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
     } finally {
       protoArrayLock.readLock().unlock();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -227,7 +228,8 @@ public class ProtoNode {
         executionBlockHash,
         validationStatus,
         checkpoints,
-        weight);
+        weight,
+        ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -50,6 +51,14 @@ public class ChainHeadTest {
     final ChainHead otherChainHead = ChainHead.create(otherBlock);
 
     assertThat(chainHead).isNotEqualTo(otherChainHead);
+  }
+
+  @Test
+  public void create_shouldDefaultToPendingPayloadStatusForBlockStateSummaries() {
+    final SignedBlockAndState block = dataStructureUtil.randomSignedBlockAndState(UInt64.ONE);
+
+    assertThat(ChainHead.create(block).getPayloadStatus())
+        .isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
   }
 
   @SuppressWarnings("unchecked")

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
@@ -222,6 +223,20 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final ForkChoiceStrategy protoArrayStrategy = getProtoArray(storageSystem);
     assertThat(protoArrayStrategy.getAncestor(head.getRoot(), ancestor.getSlot()))
         .contains(ancestor.getRoot());
+  }
+
+  @Test
+  void getAncestorNode_returnsBaseNodeForKnownAncestor() {
+    final StorageSystem storageSystem = initStorageSystem();
+    storageSystem.chainUpdater().advanceChain(1);
+    final SignedBlockAndState ancestor = storageSystem.chainUpdater().advanceChain(2);
+    storageSystem.chainUpdater().advanceChain(3);
+    final SignedBlockAndState head = storageSystem.chainUpdater().advanceChain(5);
+    final ForkChoiceStrategy strategy = getProtoArray(storageSystem);
+
+    assertThat(strategy.getAncestorNode(head.getRoot(), ancestor.getSlot()))
+        .contains(
+            new ForkChoiceNode(ancestor.getRoot(), ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING));
   }
 
   @Test
@@ -459,6 +474,17 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
                 .orElseThrow()
                 .executionBlockHash(block1.getRoot()))
         .isEqualTo(block1.getExecutionBlockHash());
+  }
+
+  @Test
+  void payloadStatus_shouldDefaultToPendingForKnownBlock() {
+    final StorageSystem storageSystem = initStorageSystem();
+    final SignedBlockAndState block = storageSystem.chainUpdater().addNewBestBlock();
+    final ForkChoiceStrategy strategy = getProtoArray(storageSystem);
+
+    assertThat(strategy.payloadStatus(block.getRoot()))
+        .contains(ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
+    assertThat(strategy.payloadStatus(dataStructureUtil.randomBytes32())).isEmpty();
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -240,7 +241,8 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
                     head.getExecutionBlockHash().orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH),
                     ProtoNodeValidationStatus.VALID,
                     spec.calculateBlockCheckpoints(head.getState()),
-                    ZERO)));
+                    ZERO,
+                    ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING)));
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -477,17 +477,6 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   @Test
-  void payloadStatus_shouldDefaultToPendingForKnownBlock() {
-    final StorageSystem storageSystem = initStorageSystem();
-    final SignedBlockAndState block = storageSystem.chainUpdater().addNewBestBlock();
-    final ForkChoiceStrategy strategy = getProtoArray(storageSystem);
-
-    assertThat(strategy.payloadStatus(block.getRoot()))
-        .contains(ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
-    assertThat(strategy.payloadStatus(dataStructureUtil.randomBytes32())).isEmpty();
-  }
-
-  @Test
   void applyPendingVotes_shouldMarkEquivocation() {
     final StorageSystem storageSystem = initStorageSystem();
     final ForkChoiceStrategy strategy = getProtoArray(storageSystem);

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeValidationStatus;
@@ -424,7 +425,8 @@ class StoreTest extends AbstractStoreTest {
             Bytes32.random(),
             ProtoNodeValidationStatus.VALID,
             headCheckpoint,
-            UInt64.ZERO);
+            UInt64.ZERO,
+            ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
     final ProtoNodeData parentNodeData =
         new ProtoNodeData(
             UInt64.ZERO,
@@ -435,7 +437,8 @@ class StoreTest extends AbstractStoreTest {
             Bytes32.random(),
             ProtoNodeValidationStatus.VALID,
             parentCheckpoint,
-            UInt64.ZERO);
+            UInt64.ZERO,
+            ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
     when(dummyForkChoiceStrategy.getBlockData(root)).thenReturn(Optional.of(protoNodeData));
     when(dummyForkChoiceStrategy.getBlockData(parentRoot)).thenReturn(Optional.of(parentNodeData));
   }
@@ -454,7 +457,8 @@ class StoreTest extends AbstractStoreTest {
             Bytes32.random(),
             ProtoNodeValidationStatus.VALID,
             null,
-            headValue);
+            headValue,
+            ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
     final ProtoNodeData parentNodeData =
         new ProtoNodeData(
             UInt64.ZERO,
@@ -465,7 +469,8 @@ class StoreTest extends AbstractStoreTest {
             Bytes32.random(),
             ProtoNodeValidationStatus.VALID,
             null,
-            parentValue);
+            parentValue,
+            ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
     when(dummyForkChoiceStrategy.getBlockData(root)).thenReturn(Optional.of(protoNodeData));
     when(dummyForkChoiceStrategy.getBlockData(parentRoot)).thenReturn(Optional.of(parentNodeData));
   }


### PR DESCRIPTION
fixes #10552

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core fork-choice/storage data models (`ProtoNodeData`, `ChainHead`, strategy interfaces) and their equality/constructor contracts; behavior is intended to be unchanged but downstream serialization/comparisons could be impacted if any callers weren’t updated.
> 
> **Overview**
> Introduces fork-choice *node identity* plumbing for the Gloas three-state model by adding `ForkChoicePayloadStatus` (EMPTY/FULL/PENDING) and `ForkChoiceNode` (block root + payload status).
> 
> Extends `ProtoNodeData` and `ChainHead` to carry `payloadStatus` (defaulting to `PAYLOAD_STATUS_PENDING` in current implementations), adds `ReadOnlyForkChoiceStrategy` helpers (`getAncestorNode`, `getNodeData`, and a payload-aware `getBlockData` overload), and updates protoarray/store/test fixtures and API/REST tests to pass and assert the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30426196960e44fbf601cfcff1e3a27977fae78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->