### PR TITLE
fix ci permissions (and make windowsBuild not blocking)

### DIFF
--- a/.github/workflows/check-specrefs.yml
+++ b/.github/workflows/check-specrefs.yml
@@ -1,6 +1,9 @@
 name: Check Spec References
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   check-specrefs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,6 +583,10 @@ jobs:
   publishDockerJDK21:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-docker.yml
     with:
       assemble_run_id: ${{ github.run_id }}
@@ -593,6 +597,10 @@ jobs:
   publishDockerJDK25:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-docker.yml
     with:
       assemble_run_id: ${{ github.run_id }}
@@ -604,6 +612,9 @@ jobs:
   publishRelease:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     needs: [assemble, unitTests, integrationTests, propertyTests, acceptanceTests, referenceTests]
+    permissions:
+      actions: read
+      contents: write
     uses: ./.github/workflows/publish-release.yml
     with:
       assemble_run_id: ${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           ./gradlew checkMavenCoordinateCollisions checkModuleDependencies
 
   windowsBuild:
+    continue-on-error: true
     needs: [spotless, moduleChecks ]
     runs-on: windows-2022
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,9 @@ jobs:
   ## Tests 
   unitTests:
     needs: assemble
+    permissions:
+      actions: read
+      contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
     secrets: inherit  
     with:
@@ -289,6 +292,9 @@ jobs:
 
   integrationTests:
     needs: assemble
+    permissions:
+      actions: read
+      contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
     secrets: inherit
     with:
@@ -328,6 +334,9 @@ jobs:
 
   propertyTests:
     needs: assemble
+    permissions:
+      actions: read
+      contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
     secrets: inherit
     with:
@@ -367,6 +376,9 @@ jobs:
 
   acceptanceTests:
     needs: assemble
+    permissions:
+      actions: read
+      contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
-      contents: write 
+      actions: read
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -254,7 +255,6 @@ jobs:
       actions: read
       contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
-    secrets: inherit  
     with:
       assemble_output_run_id: ${{ github.run_id }}
       stage_name: Unit Tests
@@ -296,7 +296,6 @@ jobs:
       actions: read
       contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
-    secrets: inherit
     with:
       assemble_output_run_id: ${{ github.run_id }}
       stage_name: Integration Tests
@@ -338,7 +337,6 @@ jobs:
       actions: read
       contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
-    secrets: inherit
     with:
       assemble_output_run_id: ${{ github.run_id }}
       stage_name: Property Tests
@@ -380,7 +378,6 @@ jobs:
       actions: read
       contents: read
     uses: ./.github/workflows/matrix-tests-template.yml
-    secrets: inherit
     with:
       assemble_output_run_id: ${{ github.run_id }}
       stage_name: Acceptance Tests

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   CLAAssistant:
+    if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     steps:
       # v2.6.1

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,6 +8,9 @@ name: Codespell
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,9 @@
 name: "Validate Gradle Wrapper"
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -27,8 +27,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-      id-token: write  
     environment: publish
+    outputs:
+      image_digest: ${{ steps.dockerBuildPush.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -116,12 +117,29 @@ jobs:
             BUILD_DATE=${{ steps.jdkDetails.outputs.build_date }}
           push: true
           tags: ${{ steps.jdkDetails.outputs.dockertags }}
+
+  signAndAttest:
+    runs-on: ubuntu-24.04
+    needs: publishDocker
+    permissions:
+      id-token: write
+    environment: publish
+    steps:
+      # v4.0.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        with:
+          username: ${{ secrets.DOCKER_USER_RW }}
+          password: ${{ secrets.DOCKER_PASSWORD_RW }}
+
       # v4
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22
       - name: Sign image with keyless cosign
+        env:
+          IMAGE_DIGEST: ${{ needs.publishDocker.outputs.image_digest }}
         run: |
-          IMAGE=docker.io/consensys/teku@${{ steps.dockerBuildPush.outputs.digest }}
+          IMAGE=docker.io/consensys/teku@$IMAGE_DIGEST
           echo "Signing $IMAGE"
           cosign sign --yes $IMAGE
       - name: Generate provenance file
@@ -159,7 +177,9 @@ jobs:
           sed -i "s/__BUILD_STARTED_ON__/$BUILD_STARTED_ON/" provenance.json
           sed -i "s/__BUILD_FINISHED_ON__/$BUILD_FINISHED_ON/" provenance.json
       - name: Attest cosign provenance 
+        env:
+          IMAGE_DIGEST: ${{ needs.publishDocker.outputs.image_digest }}
         run: |
-          IMAGE=docker.io/consensys/teku@${{ steps.dockerBuildPush.outputs.digest }}
+          IMAGE=docker.io/consensys/teku@$IMAGE_DIGEST
           echo "Attesting provenance for $IMAGE"
           cosign attest --yes --predicate provenance.json --type slsaprovenance $IMAGE

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -25,6 +25,7 @@ jobs:
   publishDocker:
     runs-on: ubuntu-24.04
     permissions:
+      actions: read
       contents: read
       id-token: write  
     environment: publish

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,6 +15,7 @@ jobs:
   publishRelease:
     runs-on: ubuntu-24.04
     permissions:
+      actions: read
       contents: write  
     environment: publish
     steps:

--- a/.github/workflows/test-path-check.yml
+++ b/.github/workflows/test-path-check.yml
@@ -1,6 +1,9 @@
 name: "Test Path Check"
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: "Check"


### PR DESCRIPTION
## PR Description

Harden GitHub Actions permissions and reusable workflow calls under restricted repo defaults.

- Add explicit `actions: read` / caller permissions where reusable workflows and artifact downloads require them (`ci.yml`, `publish-release.yml`)
- Remove unnecessary `secrets: inherit` from matrix test workflow calls
- Split Docker publishing from signing/attestation so `id-token: write` is limited to the signing job (`publish-docker.yml`)
- Add explicit `contents: read` defaults to simple read-only workflows
- Restrict the CLA workflow job to PR-related events/comments only

No intended CI behavior change beyond permission scoping, workflow validation fixes, and reduced token/secret exposure.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow permission and job-structure changes can break CI/publish/signing if any job implicitly relied on broader tokens or inherited secrets, though intent is no functional behavior change beyond scoping.
> 
> **Overview**
> Tightens GitHub Actions permission scoping across workflows by adding explicit default `contents: read`, setting caller permissions for reusable workflow jobs (tests, Docker publish, release, API spec), and dropping unnecessary `secrets: inherit` from matrix test workflow calls.
> 
> Refactors Docker publishing so the build/push job runs without `id-token: write` and exports an `image_digest` output, while a separate `signAndAttest` job (OIDC-only) signs and attests the pushed image using that digest.
> 
> Also makes Windows CI non-blocking (`continue-on-error: true`) and limits the CLA assistant job to PR-related events/comments to avoid running on unrelated issue comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e76693b67efc08d07a6e37420f91e202e6a061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->