### PR TITLE
build: Update custom renderer coordinates for license reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,11 +126,11 @@ jobs:
           echo "run_id=${{ github.run_id }}" >> $GITHUB_OUTPUT
           echo "build_date=$(date --rfc-3339=date)" >> $GITHUB_OUTPUT
           echo "vcs_ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Determine Teku version
         id: projectDetails
         uses: ./.github/actions/get-project-version
-      - name: Prepare
-        uses: ./.github/actions/prepare
       - name: Assemble
         shell: bash      
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import groovy.json.JsonSlurper
-import tech.pegasys.internal.license.reporter.GroupedLicenseHtmlRenderer
+import io.consensys.protocols.license.reporter.GroupedLicenseHtmlRenderer
 import tech.pegasys.teku.depcheck.DepCheckPlugin
 
 import java.text.SimpleDateFormat
@@ -10,20 +10,16 @@ import static tech.pegasys.teku.repackage.Repackage.repackage
 buildscript {
 	repositories {
 		mavenCentral()
-		maven {
-			url = "https://artifacts.consensys.net/public/maven/maven/"
-			content { includeGroupByRegex('tech\\.pegasys\\..*')}
-		}
 	}
 	dependencies {
-		classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.1.1'
+		classpath 'io.consensys.protocols:license-reporter:1.2.0'
 	}
 }
 
 plugins {
 	id 'com.diffplug.spotless' version '7.2.1'
 	id 'com.github.ben-manes.versions' version '0.53.0'
-	id 'com.github.jk1.dependency-license-report' version '3.1.1'
+	id 'com.github.jk1.dependency-license-report' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'net.ltgt.errorprone' version '4.3.0' apply false
 	id 'de.undercouch.download' version '5.6.0'
@@ -606,7 +602,7 @@ if (project.hasProperty('enableLicenseReport')) {
 licenseReport {
 	projects = project.subprojects
 	configurations = ['runtimeClasspath']
-	outputDir = "${buildDir}/reports/licenses"
+	outputDir = layout.buildDirectory.dir("reports/licenses").get().asFile.absolutePath
 	// These jars don't have machine readable license information
 	excludes = [
 		'org.junit:junit-bom',


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update custom renderer coordinates for license reporter plugin.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/CI-only changes but they modify license reporting dependencies and Gradle output paths, which could break `licenseCheck`/distribution packaging if the new artifact or directory resolution differs.
> 
> **Overview**
> Updates the build’s license reporting setup by switching the custom `GroupedLicenseHtmlRenderer` to the new `io.consensys.protocols:license-reporter` coordinates (bumping to `1.2.0`) and upgrading the `com.github.jk1.dependency-license-report` plugin to `3.1.2`.
> 
> Adjusts the license report output directory to use Gradle’s `layout.buildDirectory` API, and makes a small CI workflow tweak by moving the `Prepare` step earlier in the `assemble` job (before version determination).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7f56581b253f312a90be7e243238aaa2e540d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->