### PR TITLE
Gloas changes for v1.7.0-alpha.5

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconStateGloas.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconStateGloas.json
@@ -1,7 +1,7 @@
 {
   "title" : "BeaconStateGloas",
   "type" : "object",
-  "required" : [ "genesis_time", "genesis_validators_root", "slot", "fork", "latest_block_header", "block_roots", "state_roots", "historical_roots", "eth1_data", "eth1_data_votes", "eth1_deposit_index", "validators", "balances", "randao_mixes", "slashings", "previous_epoch_participation", "current_epoch_participation", "justification_bits", "previous_justified_checkpoint", "current_justified_checkpoint", "finalized_checkpoint", "inactivity_scores", "current_sync_committee", "next_sync_committee", "latest_execution_payload_bid", "next_withdrawal_index", "next_withdrawal_validator_index", "historical_summaries", "deposit_requests_start_index", "deposit_balance_to_consume", "exit_balance_to_consume", "earliest_exit_epoch", "consolidation_balance_to_consume", "earliest_consolidation_epoch", "pending_deposits", "pending_partial_withdrawals", "pending_consolidations", "proposer_lookahead", "builders", "next_withdrawal_builder_index", "execution_payload_availability", "builder_pending_payments", "builder_pending_withdrawals", "latest_block_hash", "payload_expected_withdrawals", "ptc_window" ],
+  "required" : [ "genesis_time", "genesis_validators_root", "slot", "fork", "latest_block_header", "block_roots", "state_roots", "historical_roots", "eth1_data", "eth1_data_votes", "eth1_deposit_index", "validators", "balances", "randao_mixes", "slashings", "previous_epoch_participation", "current_epoch_participation", "justification_bits", "previous_justified_checkpoint", "current_justified_checkpoint", "finalized_checkpoint", "inactivity_scores", "current_sync_committee", "next_sync_committee", "latest_block_hash", "next_withdrawal_index", "next_withdrawal_validator_index", "historical_summaries", "deposit_requests_start_index", "deposit_balance_to_consume", "exit_balance_to_consume", "earliest_exit_epoch", "consolidation_balance_to_consume", "earliest_consolidation_epoch", "pending_deposits", "pending_partial_withdrawals", "pending_consolidations", "proposer_lookahead", "builders", "next_withdrawal_builder_index", "execution_payload_availability", "builder_pending_payments", "builder_pending_withdrawals", "latest_execution_payload_bid", "payload_expected_withdrawals", "ptc_window" ],
   "properties" : {
     "genesis_time" : {
       "type" : "string",
@@ -150,8 +150,11 @@
     "next_sync_committee" : {
       "$ref" : "#/components/schemas/SyncCommittee"
     },
-    "latest_execution_payload_bid" : {
-      "$ref" : "#/components/schemas/ExecutionPayloadBid"
+    "latest_block_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
     },
     "next_withdrawal_index" : {
       "type" : "string",
@@ -264,11 +267,8 @@
         "$ref" : "#/components/schemas/BuilderPendingWithdrawal"
       }
     },
-    "latest_block_hash" : {
-      "type" : "string",
-      "description" : "Bytes32 hexadecimal",
-      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-      "format" : "byte"
+    "latest_execution_payload_bid" : {
+      "$ref" : "#/components/schemas/ExecutionPayloadBid"
     },
     "payload_expected_withdrawals" : {
       "type" : "array",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadEnvelope.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadEnvelope.json
@@ -4,7 +4,7 @@
   "required" : [ "payload", "execution_requests", "builder_index", "beacon_block_root", "slot" ],
   "properties" : {
     "payload" : {
-      "$ref" : "#/components/schemas/ExecutionPayloadDeneb"
+      "$ref" : "#/components/schemas/ExecutionPayloadGloas"
     },
     "execution_requests" : {
       "$ref" : "#/components/schemas/ExecutionRequestsElectra"

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadEnvelope.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadEnvelope.json
@@ -1,7 +1,7 @@
 {
   "title" : "ExecutionPayloadEnvelope",
   "type" : "object",
-  "required" : [ "payload", "execution_requests", "builder_index", "beacon_block_root", "slot" ],
+  "required" : [ "payload", "execution_requests", "builder_index", "beacon_block_root" ],
   "properties" : {
     "payload" : {
       "$ref" : "#/components/schemas/ExecutionPayloadGloas"
@@ -20,12 +20,6 @@
       "description" : "Bytes32 hexadecimal",
       "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
       "format" : "byte"
-    },
-    "slot" : {
-      "type" : "string",
-      "description" : "unsigned 64 bit integer",
-      "example" : "1",
-      "format" : "uint64"
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadGloas.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadGloas.json
@@ -1,0 +1,124 @@
+{
+  "title" : "ExecutionPayloadGloas",
+  "type" : "object",
+  "required" : [ "parent_hash", "fee_recipient", "state_root", "receipts_root", "logs_bloom", "prev_randao", "block_number", "gas_limit", "gas_used", "timestamp", "extra_data", "base_fee_per_gas", "block_hash", "transactions", "withdrawals", "blob_gas_used", "excess_blob_gas", "block_access_list", "slot_number" ],
+  "properties" : {
+    "parent_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "fee_recipient" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "receipts_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "logs_bloom" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "prev_randao" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "block_number" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_limit" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_used" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "timestamp" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "extra_data" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ encoded byte list",
+      "format" : "bytes"
+    },
+    "base_fee_per_gas" : {
+      "type" : "string",
+      "description" : "unsigned 256 bit integer",
+      "example" : "1",
+      "format" : "uint256"
+    },
+    "block_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "transactions" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "pattern" : "^0x[a-fA-F0-9]{2,}$",
+        "description" : "SSZ encoded byte list",
+        "format" : "bytes"
+      }
+    },
+    "withdrawals" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Withdrawal"
+      }
+    },
+    "blob_gas_used" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "excess_blob_gas" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "block_access_list" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ encoded byte list",
+      "format" : "bytes"
+    },
+    "slot_number" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
@@ -5,69 +5,76 @@
   "data": {
     "message": {
       "payload": {
-        "parent_hash": "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef",
-        "fee_recipient": "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d",
-        "state_root": "0x103ac9406cdc59b89027eb1c9e97f607dd5fdccfa8fb2da4eaeea9d25032add9",
-        "receipts_root": "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a938e7f946cf74fbbb9416428f",
-        "logs_bloom": "0x8200a6402ca295554fb9562193cc71d60272d63beeaf2201fdf53e846e77f919f9baec48b037438512f21e75157c9bae6a09b5c486a1490ce72c45ff9ade728dd88b8abf34dfacbd855264120cea4f17f8b11544cfb01b897ccda2c8b1bfcd2da844e16ea30f6dd1f321317193169b19208914dd57e37159006682033def101b66e3cf524f654aae3a6b2375c63f9af207ac8cff51d623788b6de2360edc1bd5032db8ff6a6a69b14a5bc2d6471ebcbd08facc61128fbdff880a52b8b7135e46e317ad398eefbee7a9efb0e5bb311c8b33a7321295dbee96362910de0ed74ac75f06142a36f444acf2f417c44b1d4b84c99e9369f842560a2ae28684b0befa4f",
-        "prev_randao": "0x499db7404cbff78670f0209f1932346fef68d985cb55a8d27472742bdf54d379",
-        "block_number": "4661716390776343276",
-        "gas_limit": "4600574485989226763",
-        "gas_used": "4598922002772542634",
-        "timestamp": "4603879456717562315",
-        "extra_data": "0x0c65de3f6bad3d7be19d0de5aff82b13d6d8b49f26588dba111e361d6f545486",
-        "base_fee_per_gas": "48416477019128246725380374409950726173176617399493993885769417069594850945339",
-        "block_hash": "0x7e2bbb3f2a737918a12f79e9a52da7e1fceaae0b6c0c82172425cbce8d99a0c6",
+        "parent_hash": "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464",
+        "fee_recipient": "0x367cbd40ac7318427aadb97345a91fa2e965daf3",
+        "state_root": "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
+        "receipts_root": "0x103ac9406cdc59b89027eb1c9e97f607dd5fdccfa8fb2da4eaeea9d25032add9",
+        "logs_bloom": "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a938e7f946cf74fbbb9416428f619b26eab6d66297cbd9dbc84db437c8d36f9b30556f5f8062bbc80a0e3f35fb2f4921ae3f8361dacf697513c2f8aac786dccb24a7ca3eef9743ab9071ee3663dca121493e717c27ee277bf5d484a83c2da75b4bea86c1d15a2b29352abad715b00fa1c4b94733e496720ced4c31ce785ec3e407136f39dcb857d7d9ff590deeb512704b2f0a58ee953d5a85894a9e9ab9528d1fc87daf2064b515ee861e4dd23bb5714c0fb38a36a1da1698fbee3aae5de1b51de39f6e3d3309e338abb70e275410a1b83e9e9d43d051e6a4a9bdbe6d6fb282c4f2463428a0502a0e2e4b71fb",
+        "prev_randao": "0x8200a6402ca295554fb9562193cc71d60272d63beeaf2201fdf53e846e77f919",
+        "block_number": "4663368873993027404",
+        "gas_limit": "4661716390776343276",
+        "gas_used": "4600574485989226763",
+        "timestamp": "4598922002772542634",
+        "extra_data": "0xf943e43fcb615e36ec5aa6b9db6f1746d0d5b50d708f6400e39cf25495f39cfb",
+        "base_fee_per_gas": "5607739634047123094894921697827507956212874690624863559868619143368523666566",
+        "block_hash": "0x6b0ac13f8a279ad3abec11bed1a49214f6e7af79b643595df6a38706b338e93b",
         "transactions": [
-          "0xb88ea93f0a5617"
+          "0x58e9c63feadbba",
+          "0xcbafa33faaa1f6",
+          "0xa56daf3f6a0a38",
+          "0x17348c3f2ad073",
+          "0xf1f1973fea38b5",
+          "0x00963040ab8a07b7",
+          "0xda533c406bf3482d",
+          "0x4d1a19402bb984ca"
         ],
         "withdrawals": [
           {
-            "index": "4589007099177470570",
-            "validator_index": "2268866",
-            "address": "0x17348c3f2ad0733f4b47b34442744b4a2e03a79b",
-            "amount": "4584049649527418186"
+            "index": "4613794356017667083",
+            "validator_index": "2923980",
+            "address": "0x603b1340cb04640f42436c5e3e2973dd9ebdbd7d",
+            "amount": "4615446843529318507"
+          },
+          {
+            "index": "4605531939934246443",
+            "validator_index": "2731606",
+            "address": "0xbfe0f53feb7ec0670c92703760d5d9debdccb857",
+            "amount": "4547695001580498185"
           }
         ],
-        "blob_gas_used": "4582397162015766762",
-        "excess_blob_gas": "4627014230341074699"
+        "blob_gas_used": "4546042514068846761",
+        "excess_blob_gas": "4550999968013866441",
+        "block_access_list": "0x6f87223f6921271789fcf5512313bdb59e3995dff16ea6ffca43a625bb6f40dd",
+        "slot_number": "1"
       },
       "execution_requests": {
         "deposits": [
           {
-            "pubkey": "0x957b584f85a85a770a334e18e8af755406089824d3558487983161a8cb61b6503b02e939f75407c3b8bbbbd9d4e9ad15",
-            "withdrawal_credentials": "0x0100000000000000000000003af91e408b6da58558bd9d0797174a4392b7bf59",
-            "amount": "4618751809962686763",
-            "signature": "0xadd071eb32731713b9040770807acb7033344aafc6df54ebf8a790187ddc947e2bb06a9547eb7c3876533720f36e54761018488a3857bb1d87175f7905620088fd81593465b7139e794f75bba0daaef713a9b7bec99656073c1396866d35f9b0",
-            "index": "4622056780691022315"
-          },
-          {
-            "pubkey": "0xb8b37b9a8444d8405693cf5decca1fac4ce06a5646b785702a27592b853689c5545b8c2d9054ee0e4e67ed45092981e4",
-            "withdrawal_credentials": "0x010000000000000000000000603b1340cb04640f42436c5e3e2973dd9ebdbd7d",
-            "amount": "4615446843529318507",
-            "signature": "0xb2213ef588828a7c18cdc781d0ed2516fd3e11de625f191aae7ae4be8b1ad2cc217728c65a500aedea276d345f09fd3212b009568a6549f5f40ead6d7ec4d0f3f329c00a1b4bca59068ee0555c94aec91bebc18365ca0b2d6692557b4b0c4267",
-            "index": "4605531939934246443"
+            "pubkey": "0x953a8de3dcd4d3de3c66b228c393694124651a7a3068fa0fd70ec051e42b8f53eb753d04e6101ab4374b65a79d71400f",
+            "withdrawal_credentials": "0x010000000000000000000000bb0b0b3fe94fa42a5e0893ff71360feab7459127",
+            "amount": "4534475127257090569",
+            "signature": "0x8f5c34de9e22ceaa7e8d165fc0553b32f02188539e89e2cc91e2eb9077645986550d872ee3403204ae5d554eae3cac12124e18d2324bccc814775316aaef352abc0450812b3ca9fde96ecafa911b3b8bfddca8db4027f08e29c22a9c370ad933",
+            "index": "4537780097985426121"
           }
         ],
         "withdrawals": [
           {
-            "source_address": "0x82a81c3f096d065c7e3f5d7df79bd182a53c9471",
-            "validator_pubkey": "0x922b5a6e6f8f6e9d69b523e4516a54a5bd20f0b44ef34d102fca67bcf98e0785cccc29e4b275900ec8aebaa50f3e024c",
-            "amount": "4550999968013866441"
+            "source_address": "0x7a56d03e29445ddbf2a59bb1b68edcecf66387db",
+            "validator_pubkey": "0x831a41d8cf9fcf8faa0a3a47fa7937a0548f3a36a032e10340ba8a265c68660888ac87e51e8d4c8205d53765cf2e7c3b",
+            "amount": "4529517677607038185"
           }
         ],
         "consolidations": [
           {
-            "source_address": "0xe24dff3e29e762b4488e615619483884c44b8f4b",
-            "source_pubkey": "0x953a8de3dcd4d3de3c66b228c393694124651a7a3068fa0fd70ec051e42b8f53eb753d04e6101ab4374b65a79d71400f",
-            "target_pubkey": "0xa3a76501f1755df6cddb593cf2b7d6180426e55dfdb83e167be72f9d4596645edd7f861a34b482606e238f8530d4ddc1"
+            "source_address": "0x2a55863fca1b5384408a1a7015fd5f173406a62d",
+            "source_pubkey": "0x90b2ffa8992560bca2080afa9b3adc904ce9085a8c2cc897282f20378bdf3cdc0a74100f226ea698e07d4afe50d8ff54",
+            "target_pubkey": "0xaed83e77fbc39e3b1115994cf6cffb5e12c8a60d6e5a511b8f4176f74660db30cc9acedb53d3288806420f903ab69157"
           }
         ]
       },
-      "builder_index": "2882381",
-      "beacon_block_root": "0x2ed2e73ea915e0c71d9afe03676b8ab8dd578b9311463e45934f49f843386a48",
-      "slot": "1"
+      "builder_index": "537496",
+      "beacon_block_root": "0x77d96e3f4a4ad0971596b71d6420b24b4d12a275af3d948b77b438faa484f0d1"
     },
-    "signature": "0x958ab38cce5390fd750e87806f32ed8993a175bc3ccdab7ce2a40c23ac6117b603d5ae98d44a9780cca1f32d28bf5176058ef667b17fd95f13e047cd9cdebbf19f5270ec5a154e2ce2283da513c9ad05c26f10b0a65755eab4b1ed6f42175027"
+    "signature": "0x8c2c3b368bc00b3853e6df352e816dd910016db953ac77cc1565e3c22f1c0b24c59f24ea9e8ca406aa95b23368d163e80baa6de3f8f7ac19ee78c976d2ae5a21c86fa1762cc959bc734379055cb7aa1de36eae00541936b8c2ee908c770d41ff"
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -56,7 +56,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    *
    * <p>May be overridden by the ENV_MILESTONE environment variable.
    */
-  private static final String MILESTONE = "gloas";
+  private static final String MILESTONE = "";
 
   /**
    * Filter tests to run only those where the display name contains this string.

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -56,7 +56,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    *
    * <p>May be overridden by the ENV_MILESTONE environment variable.
    */
-  private static final String MILESTONE = "";
+  private static final String MILESTONE = "gloas";
 
   /**
    * Filter tests to run only those where the display name contains this string.

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.Sy
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
@@ -37,9 +36,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerificationException;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
@@ -128,17 +125,6 @@ public class DefaultOperationProcessor implements OperationProcessor {
   }
 
   @Override
-  public void verifyExecutionPayloadEnvelope(
-      final BeaconState state,
-      final SignedExecutionPayloadEnvelope signedEnvelope,
-      final Optional<? extends OptimisticExecutionPayloadExecutor> payloadExecutor)
-      throws ExecutionPayloadVerificationException {
-    spec.getExecutionPayloadVerifier(state.getSlot())
-        .verifyExecutionPayloadEnvelope(
-            signedEnvelope, state, BLSSignatureVerifier.SIMPLE, payloadExecutor);
-  }
-
-  @Override
   public void processBlsToExecutionChange(
       final MutableBeaconState state, final SignedBlsToExecutionChange blsToExecutionChange)
       throws BlockProcessingException {
@@ -180,6 +166,18 @@ public class DefaultOperationProcessor implements OperationProcessor {
       final MutableBeaconState state, final List<ConsolidationRequest> consolidationRequests) {
     spec.getExecutionRequestsProcessor(state.getSlot())
         .processConsolidationRequests(state, consolidationRequests);
+  }
+
+  @Override
+  public void processParentExecutionPayload(
+      final MutableBeaconState state, final BeaconBlock beaconBlock)
+      throws BlockProcessingException {
+    final Supplier<ValidatorExitContext> validatorExitContextSupplier =
+        spec.atSlot(state.getSlot())
+            .beaconStateMutators()
+            .createValidatorExitContextSupplier(state);
+    spec.getBlockProcessor(state.getSlot())
+        .processParentExecutionPayload(state, beaconBlock, validatorExitContextSupplier);
   }
 
   @Override

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
@@ -31,9 +30,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerificationException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
 
@@ -65,13 +62,6 @@ public interface OperationProcessor {
       Optional<? extends OptimisticExecutionPayloadExecutor> payloadExecutor)
       throws BlockProcessingException;
 
-  // >= Gloas
-  void verifyExecutionPayloadEnvelope(
-      BeaconState state,
-      SignedExecutionPayloadEnvelope signedEnvelope,
-      Optional<? extends OptimisticExecutionPayloadExecutor> payloadExecutor)
-      throws ExecutionPayloadVerificationException;
-
   void processBlsToExecutionChange(
       MutableBeaconState state, SignedBlsToExecutionChange blsToExecutionChange)
       throws BlockProcessingException;
@@ -87,6 +77,9 @@ public interface OperationProcessor {
 
   void processConsolidationRequests(
       MutableBeaconState state, List<ConsolidationRequest> consolidationRequest);
+
+  void processParentExecutionPayload(MutableBeaconState state, BeaconBlock beaconBlock)
+      throws BlockProcessingException;
 
   void processExecutionPayloadBid(MutableBeaconState state, BeaconBlock beaconBlock)
       throws BlockProcessingException;

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
@@ -56,7 +55,6 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerificationException;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.TotalBalances;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
@@ -95,6 +93,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     DEPOSIT_REQUEST,
     WITHDRAWAL_REQUEST,
     CONSOLIDATION_REQUEST,
+    PARENT_EXECUTION_PAYLOAD,
     EXECUTION_PAYLOAD_BID,
     PAYLOAD_ATTESTATION
   }
@@ -148,6 +147,9 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
               "operations/consolidation_request",
               new OperationsTestExecutor<>(
                   "consolidation_request.ssz_snappy", Operation.CONSOLIDATION_REQUEST))
+          .put(
+              "operations/parent_execution_payload",
+              new OperationsTestExecutor<>("block.ssz_snappy", Operation.PARENT_EXECUTION_PAYLOAD))
           .put(
               "operations/execution_payload_bid",
               new OperationsTestExecutor<>("block.ssz_snappy", Operation.EXECUTION_PAYLOAD_BID))
@@ -274,8 +276,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       final OperationProcessor processor,
       final BeaconState preState) {
     assertThatThrownBy(() -> applyOperation(testDefinition, processor, preState))
-        .isInstanceOfAny(
-            BlockProcessingException.class, ExecutionPayloadVerificationException.class);
+        .isInstanceOf(BlockProcessingException.class);
   }
 
   private BeaconState applyOperation(
@@ -346,36 +347,27 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
 
         final SchemaDefinitions schemaDefinitions =
             testDefinition.getSpec().getGenesisSchemaDefinitions();
-
-        if (schemaDefinitions.toVersionGloas().isPresent()) {
-          final SignedExecutionPayloadEnvelope signedEnvelope =
-              loadSsz(
-                  testDefinition,
-                  "signed_envelope.ssz_snappy",
-                  SchemaDefinitionsGloas.required(schemaDefinitions)
-                      .getSignedExecutionPayloadEnvelopeSchema());
-          processor.verifyExecutionPayloadEnvelope(
-              state,
-              signedEnvelope,
-              Optional.of(
-                  (latestExecutionPayloadHeader, payloadToExecute) ->
-                      executionMeta.executionValid));
-        } else {
-          final BeaconBlockBody beaconBlockBody =
-              loadSsz(testDefinition, dataFileName, schemaDefinitions.getBeaconBlockBodySchema());
-          processor.processExecutionPayload(
-              state,
-              beaconBlockBody,
-              Optional.of(
-                  (latestExecutionPayloadHeader, payloadToExecute) ->
-                      executionMeta.executionValid));
-        }
+        final BeaconBlockBody beaconBlockBody =
+            loadSsz(testDefinition, dataFileName, schemaDefinitions.getBeaconBlockBodySchema());
+        processor.processExecutionPayload(
+            state,
+            beaconBlockBody,
+            Optional.of(
+                (latestExecutionPayloadHeader, payloadToExecute) -> executionMeta.executionValid));
       }
       case BLS_TO_EXECUTION_CHANGE -> processBlsToExecutionChange(testDefinition, state, processor);
       case WITHDRAWAL -> processWithdrawal(testDefinition, state, processor);
       case DEPOSIT_REQUEST -> processDepositRequest(testDefinition, state, processor);
       case WITHDRAWAL_REQUEST -> processWithdrawalRequest(testDefinition, state, processor);
       case CONSOLIDATION_REQUEST -> processConsolidations(testDefinition, state, processor);
+      case PARENT_EXECUTION_PAYLOAD -> {
+        final BeaconBlock beaconBlock =
+            loadSsz(
+                testDefinition,
+                dataFileName,
+                testDefinition.getSpec().getGenesisSchemaDefinitions().getBeaconBlockSchema());
+        processor.processParentExecutionPayload(state, beaconBlock);
+      }
       case EXECUTION_PAYLOAD_BID -> {
         final BeaconBlock beaconBlock =
             loadSsz(
@@ -541,6 +533,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
           DEPOSIT_REQUEST,
           WITHDRAWAL_REQUEST,
           CONSOLIDATION_REQUEST,
+          PARENT_EXECUTION_PAYLOAD,
           EXECUTION_PAYLOAD_BID,
           PAYLOAD_ATTESTATION -> {}
     }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -61,11 +61,6 @@ public class ReferenceTestFinder {
               if (!testsPath.toFile().exists()) {
                 return Stream.empty();
               }
-              // TODO-GLOAS: temporarily don't run Gloas reference tests until we merge all
-              // v1.7.0-alpha.5 changes
-              if (fork.equals(TestFork.GLOAS)) {
-                return Stream.empty();
-              }
               return Stream.of(
                       new BlsTestFinder(),
                       new KzgTestFinder(),

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SszTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SszTestFinder.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.ethtests.finder;
 import static tech.pegasys.teku.ethtests.finder.ReferenceTestFinder.unchecked;
 
 import com.google.errorprone.annotations.MustBeClosed;
+import tech.pegasys.teku.ethtests.TestFork;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,6 +47,13 @@ public class SszTestFinder implements TestFinder {
   private static Stream<TestDefinition> findSszStaticTests(
       final String fork, final String config, final Path phase0Tests, final Path testCategoryDir)
       throws IOException {
+    // TODO-GLOAS: we extend ExecutionPayloadHeader internally in Teku in order to blind execution
+    // payload envelopes, these tests will be deprecated in the future version of the
+    // consensus-specs
+    if (fork.equals(TestFork.GLOAS)
+        && testCategoryDir.getFileName().toString().contains("ExecutionPayloadHeader")) {
+      return Stream.empty();
+    }
     final String testType = phase0Tests.relativize(testCategoryDir).toString();
     return Files.walk(testCategoryDir)
         .filter(path -> path.resolve("serialized.ssz_snappy").toFile().exists())

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SszTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SszTestFinder.java
@@ -16,12 +16,11 @@ package tech.pegasys.teku.ethtests.finder;
 import static tech.pegasys.teku.ethtests.finder.ReferenceTestFinder.unchecked;
 
 import com.google.errorprone.annotations.MustBeClosed;
-import tech.pegasys.teku.ethtests.TestFork;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import tech.pegasys.teku.ethtests.TestFork;
 
 @SuppressWarnings("MustBeClosedChecker")
 public class SszTestFinder implements TestFinder {

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProvider.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.dataproviders.lookup;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -209,8 +211,7 @@ public class UnblindingExecutionPayloadProvider implements ExecutionPayloadProvi
                 .withdrawals(() -> toWithdrawals(body, slot))
                 .blobGasUsed(() -> getBlobGasUsed(header))
                 .excessBlobGas(() -> getExcessBlobGas(header))
-                .blockAccessList(
-                    () -> body.blockAccessList() != null ? body.blockAccessList() : Bytes.EMPTY)
+                .blockAccessList(() -> firstNonNull(body.blockAccessList(), Bytes.EMPTY))
                 .slotNumber(() -> slot));
   }
 

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/lookup/UnblindingExecutionPayloadProviderTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBody;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -238,6 +239,9 @@ class UnblindingExecutionPayloadProviderTest {
                     new ExecutionPayloadBody.EncodedWithdrawal(
                         w.getIndex(), w.getValidatorIndex(), w.getAddress(), w.getAmount()))
             .toList();
-    return new ExecutionPayloadBody(transactions, withdrawals, Bytes.EMPTY);
+    return new ExecutionPayloadBody(
+        transactions,
+        withdrawals,
+        ExecutionPayloadGloas.required(executionPayload).getBlockAccessList().getBytes());
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5.java
@@ -23,7 +23,6 @@ import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
@@ -54,7 +53,6 @@ public class EngineNewPayloadV5 extends AbstractEngineJsonRpcMethod<PayloadStatu
         params.getRequiredListParameter(1, VersionedHash.class);
     final Bytes32 parentBeaconBlockRoot = params.getRequiredParameter(2, Bytes32.class);
     final List<Bytes> executionRequests = params.getRequiredListParameter(3, Bytes.class);
-    final UInt64 slot = params.getRequiredParameter(4, UInt64.class);
 
     LOG.trace(
         "Calling {}(executionPayload={}, blobVersionedHashes={}, parentBeaconBlockRoot={}, executionRequests={})",
@@ -65,7 +63,7 @@ public class EngineNewPayloadV5 extends AbstractEngineJsonRpcMethod<PayloadStatu
         executionRequests);
 
     final ExecutionPayloadV4 executionPayloadV4 =
-        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload, slot);
+        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload);
     return executionEngineClient
         .newPayloadV5(
             executionPayloadV4, blobVersionedHashes, parentBeaconBlockRoot, executionRequests)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV4.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBuilder;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadGloas;
 
 public class ExecutionPayloadV4 extends ExecutionPayloadV3 {
   @JsonSerialize(using = BytesSerializer.class)
@@ -83,6 +84,7 @@ public class ExecutionPayloadV4 extends ExecutionPayloadV3 {
         withdrawals,
         blobGasUsed,
         excessBlobGas);
+    checkNotNull(blockAccessList, "blockAccessList");
     checkNotNull(slotNumber, "slotNumber");
     this.blockAccessList = blockAccessList;
     this.slotNumber = slotNumber;
@@ -98,7 +100,7 @@ public class ExecutionPayloadV4 extends ExecutionPayloadV3 {
   }
 
   public static ExecutionPayloadV4 fromInternalExecutionPayload(
-      final ExecutionPayload executionPayload, final UInt64 slot) {
+      final ExecutionPayload executionPayload) {
     return new ExecutionPayloadV4(
         executionPayload.getParentHash(),
         executionPayload.getFeeRecipient(),
@@ -117,9 +119,8 @@ public class ExecutionPayloadV4 extends ExecutionPayloadV3 {
         getWithdrawals(ExecutionPayloadCapella.required(executionPayload).getWithdrawals()),
         ExecutionPayloadDeneb.required(executionPayload).getBlobGasUsed(),
         ExecutionPayloadDeneb.required(executionPayload).getExcessBlobGas(),
-        // TODO-GLOAS: populate blockAccessList (not required for devnet-0)
-        null,
-        slot);
+        ExecutionPayloadGloas.required(executionPayload).getBlockAccessList().getBytes(),
+        ExecutionPayloadGloas.required(executionPayload).getSlotNumber());
   }
 
   @Override

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6Test.java
@@ -137,7 +137,7 @@ class EngineGetPayloadV6Test {
     when(executionEngineClient.getPayloadV6(eq(executionPayloadContext.getPayloadId())))
         .thenReturn(
             dummySuccessfulResponse(
-                executionPayloadFulu, blockValue, blobsBundle, encodedExecutionRequests, slot));
+                executionPayloadFulu, blockValue, blobsBundle, encodedExecutionRequests));
 
     final JsonRpcRequestParams params =
         new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
@@ -157,12 +157,11 @@ class EngineGetPayloadV6Test {
       final ExecutionPayload executionPayload,
       final UInt256 blockValue,
       final BlobsBundle blobsBundle,
-      final List<Bytes> encodedExecutionRequests,
-      final UInt64 slot) {
+      final List<Bytes> encodedExecutionRequests) {
     return SafeFuture.completedFuture(
         Response.fromPayloadReceivedAsJson(
             new GetPayloadV6Response(
-                ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload, slot),
+                ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload),
                 blockValue,
                 BlobsBundleV2.fromInternalBlobsBundle(blobsBundle),
                 false,

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV5Test.java
@@ -151,7 +151,7 @@ class EngineNewPayloadV5Test {
     final List<Bytes> executionRequests = dataStructureUtil.randomEncodedExecutionRequests();
 
     final ExecutionPayloadV4 executionPayloadV4 =
-        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload, slot);
+        ExecutionPayloadV4.fromInternalExecutionPayload(executionPayload);
     assertThat(executionPayloadV4).isExactlyInstanceOf(ExecutionPayloadV4.class);
 
     jsonRpcMethod = new EngineNewPayloadV5(executionEngineClient);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -117,8 +117,7 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
             .add(executionPayload)
             .addOptional(newPayloadRequest.getVersionedHashes())
             .addOptional(newPayloadRequest.getParentBeaconBlockRoot())
-            .addOptional(newPayloadRequest.getExecutionRequests())
-            .add(slot);
+            .addOptional(newPayloadRequest.getExecutionRequests());
 
     return engineMethodsResolver
         .getMethod(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -30,12 +30,14 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadBodiesByHashV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV5;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV6;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineJsonRpcMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV2;
@@ -130,8 +132,8 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
     final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV5(executionEngineClient));
-    methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV5(executionEngineClient, spec));
-    methods.put(ENGINE_FORK_CHOICE_UPDATED, new EngineForkChoiceUpdatedV3(executionEngineClient));
+    methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV6(executionEngineClient, spec));
+    methods.put(ENGINE_FORK_CHOICE_UPDATED, new EngineForkChoiceUpdatedV4(executionEngineClient));
     methods.put(
         ENGINE_GET_PAYLOAD_BODIES_BY_HASH,
         new EngineGetPayloadBodiesByHashV2(executionEngineClient));

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
@@ -32,8 +32,8 @@ import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
-import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV5Response;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV6Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV4;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -71,20 +71,20 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayloadContext context = randomContext();
     final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
-    final GetPayloadV5Response responseData =
-        new GetPayloadV5Response(
+    final GetPayloadV6Response responseData =
+        new GetPayloadV6Response(
             ExecutionPayloadV4.fromInternalExecutionPayload(
                 dataStructureUtil.randomExecutionPayload(slot)),
             UInt256.MAX_VALUE,
             BlobsBundleV2.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
             true,
             dataStructureUtil.randomEncodedExecutionRequests());
-    final SafeFuture<Response<GetPayloadV5Response>> dummyResponse =
+    final SafeFuture<Response<GetPayloadV6Response>> dummyResponse =
         SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(responseData));
-    when(executionEngineClient.getPayloadV5(context.getPayloadId())).thenReturn(dummyResponse);
+    when(executionEngineClient.getPayloadV6(context.getPayloadId())).thenReturn(dummyResponse);
 
     final SafeFuture<GetPayloadResponse> future = handler.engineGetPayload(context, slot);
-    verify(executionEngineClient).getPayloadV5(context.getPayloadId());
+    verify(executionEngineClient).getPayloadV6(context.getPayloadId());
     final SchemaDefinitionsFulu schemaDefinitionGloas =
         SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
     final ExecutionPayloadSchema<?> executionPayloadSchema =
@@ -145,9 +145,8 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             Optional.empty(),
             Optional.of(List.of()),
             dataStructureUtil.randomBytes32());
-    final PayloadAttributesV3 payloadAttributes =
-        PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(Optional.of(attributes))
-            .orElseThrow();
+    final PayloadAttributesV4 payloadAttributes =
+        PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(attributes);
     final ForkChoiceUpdatedResult responseData =
         new ForkChoiceUpdatedResult(
             new PayloadStatusV1(
@@ -155,13 +154,13 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             dataStructureUtil.randomBytes8());
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
         SafeFuture.completedFuture(Response.fromPayloadReceivedAsJson(responseData));
-    when(executionEngineClient.forkChoiceUpdatedV3(
+    when(executionEngineClient.forkChoiceUpdatedV4(
             forkChoiceStateV1, Optional.of(payloadAttributes)))
         .thenReturn(dummyResponse);
     final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
         handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
     verify(executionEngineClient)
-        .forkChoiceUpdatedV3(forkChoiceStateV1, Optional.of(payloadAttributes));
+        .forkChoiceUpdatedV4(forkChoiceStateV1, Optional.of(payloadAttributes));
     assertThat(future).isCompletedWithValue(responseData.asInternalExecutionPayload());
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
@@ -74,7 +74,7 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final GetPayloadV5Response responseData =
         new GetPayloadV5Response(
             ExecutionPayloadV4.fromInternalExecutionPayload(
-                dataStructureUtil.randomExecutionPayload(slot), slot),
+                dataStructureUtil.randomExecutionPayload(slot)),
             UInt256.MAX_VALUE,
             BlobsBundleV2.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
             true,
@@ -107,8 +107,7 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final NewPayloadRequest newPayloadRequest =
         new NewPayloadRequest(
             payload, versionedHashes, parentBeaconBlockRoot, encodedExecutionRequests);
-    final ExecutionPayloadV4 payloadV4 =
-        ExecutionPayloadV4.fromInternalExecutionPayload(payload, slot);
+    final ExecutionPayloadV4 payloadV4 = ExecutionPayloadV4.fromInternalExecutionPayload(payload);
     final PayloadStatusV1 responseData =
         new PayloadStatusV1(
             ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null);

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -34,12 +34,14 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadBodiesByHashV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV4;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV5;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV6;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineJsonRpcMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV2;
@@ -272,8 +274,8 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
   private static Stream<Arguments> gloasMethods() {
     return Stream.of(
         arguments(ENGINE_NEW_PAYLOAD, EngineNewPayloadV5.class),
-        arguments(ENGINE_GET_PAYLOAD, EngineGetPayloadV5.class),
-        arguments(ENGINE_FORK_CHOICE_UPDATED, EngineForkChoiceUpdatedV3.class),
+        arguments(ENGINE_GET_PAYLOAD, EngineGetPayloadV6.class),
+        arguments(ENGINE_FORK_CHOICE_UPDATED, EngineForkChoiceUpdatedV4.class),
         arguments(ENGINE_GET_PAYLOAD_BODIES_BY_HASH, EngineGetPayloadBodiesByHashV2.class));
   }
 
@@ -295,19 +297,21 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
 
     assertThat(capabilities)
         .containsExactlyInAnyOrder(
-            "engine_newPayloadV1",
-            "engine_getPayloadV1",
-            "engine_forkchoiceUpdatedV1",
-            "engine_newPayloadV2",
-            "engine_getPayloadV2",
-            "engine_forkchoiceUpdatedV2",
-            "engine_newPayloadV3",
             "engine_getPayloadV3",
-            "engine_forkchoiceUpdatedV3",
-            "engine_newPayloadV4",
-            "engine_getPayloadV4",
             "engine_newPayloadV5",
+            "engine_getPayloadV4",
+            "engine_getPayloadV1",
+            "engine_newPayloadV3",
+            "engine_getPayloadV2",
+            "engine_newPayloadV4",
             "engine_getPayloadV5",
-            "engine_getPayloadBodiesByHashV2");
+            "engine_getPayloadV6",
+            "engine_newPayloadV1",
+            "engine_newPayloadV2",
+            "engine_getPayloadBodiesByHashV2",
+            "engine_forkchoiceUpdatedV1",
+            "engine_forkchoiceUpdatedV2",
+            "engine_forkchoiceUpdatedV3",
+            "engine_forkchoiceUpdatedV4");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BlindedExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BlindedExecutionPayloadEnvelope.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.datastructures.epbs.versions.gloas;
 import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container5;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -25,31 +25,29 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadHeaderGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class BlindedExecutionPayloadEnvelope
-    extends Container5<
+    extends Container4<
         BlindedExecutionPayloadEnvelope,
         ExecutionPayloadHeader,
         ExecutionRequests,
         SszUInt64,
-        SszBytes32,
-        SszUInt64> {
+        SszBytes32> {
 
   BlindedExecutionPayloadEnvelope(
       final BlindedExecutionPayloadEnvelopeSchema schema,
       final ExecutionPayloadHeader payloadHeader,
       final ExecutionRequests executionRequests,
       final UInt64 builderIndex,
-      final Bytes32 beaconBlockRoot,
-      final UInt64 slot) {
+      final Bytes32 beaconBlockRoot) {
     super(
         schema,
         payloadHeader,
         executionRequests,
         SszUInt64.of(builderIndex),
-        SszBytes32.of(beaconBlockRoot),
-        SszUInt64.of(slot));
+        SszBytes32.of(beaconBlockRoot));
   }
 
   BlindedExecutionPayloadEnvelope(
@@ -74,7 +72,7 @@ public class BlindedExecutionPayloadEnvelope
   }
 
   public UInt64 getSlot() {
-    return getField4().get();
+    return ExecutionPayloadHeaderGloas.required(getPayloadHeader()).getSlotNumber();
   }
 
   public SlotAndBlockRoot getSlotAndBlockRoot() {
@@ -94,12 +92,7 @@ public class BlindedExecutionPayloadEnvelope
     final ExecutionPayloadEnvelope executionPayloadEnvelope =
         schemaDefinitions
             .getExecutionPayloadEnvelopeSchema()
-            .create(
-                payload,
-                getExecutionRequests(),
-                getBuilderIndex(),
-                getBeaconBlockRoot(),
-                getSlot());
+            .create(payload, getExecutionRequests(), getBuilderIndex(), getBeaconBlockRoot());
     checkState(
         executionPayloadEnvelope.hashTreeRoot().equals(hashTreeRoot()),
         "unblinded execution payload envelope root does not match original envelope root");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BlindedExecutionPayloadEnvelopeSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/BlindedExecutionPayloadEnvelopeSchema.java
@@ -17,7 +17,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYL
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQUESTS_SCHEMA;
 
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema5;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
@@ -29,13 +29,12 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class BlindedExecutionPayloadEnvelopeSchema
-    extends ContainerSchema5<
+    extends ContainerSchema4<
         BlindedExecutionPayloadEnvelope,
         ExecutionPayloadHeader,
         ExecutionRequests,
         SszUInt64,
-        SszBytes32,
-        SszUInt64> {
+        SszBytes32> {
 
   public BlindedExecutionPayloadEnvelopeSchema(final SchemaRegistry schemaRegistry) {
     super(
@@ -46,18 +45,16 @@ public class BlindedExecutionPayloadEnvelopeSchema
                 ExecutionPayloadHeader.class, schemaRegistry.get(EXECUTION_PAYLOAD_HEADER_SCHEMA))),
         namedSchema("execution_requests", schemaRegistry.get(EXECUTION_REQUESTS_SCHEMA)),
         namedSchema("builder_index", SszPrimitiveSchemas.UINT64_SCHEMA),
-        namedSchema("beacon_block_root", SszPrimitiveSchemas.BYTES32_SCHEMA),
-        namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA));
+        namedSchema("beacon_block_root", SszPrimitiveSchemas.BYTES32_SCHEMA));
   }
 
   public BlindedExecutionPayloadEnvelope create(
       final ExecutionPayloadHeader payloadHeader,
       final ExecutionRequests executionRequests,
       final UInt64 builderIndex,
-      final Bytes32 beaconBlockRoot,
-      final UInt64 slot) {
+      final Bytes32 beaconBlockRoot) {
     return new BlindedExecutionPayloadEnvelope(
-        this, payloadHeader, executionRequests, builderIndex, beaconBlockRoot, slot);
+        this, payloadHeader, executionRequests, builderIndex, beaconBlockRoot);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelope.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelope.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.datastructures.epbs.versions.gloas;
 import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container5;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -25,31 +25,25 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class ExecutionPayloadEnvelope
-    extends Container5<
-        ExecutionPayloadEnvelope,
-        ExecutionPayload,
-        ExecutionRequests,
-        SszUInt64,
-        SszBytes32,
-        SszUInt64> {
+    extends Container4<
+        ExecutionPayloadEnvelope, ExecutionPayload, ExecutionRequests, SszUInt64, SszBytes32> {
 
   ExecutionPayloadEnvelope(
       final ExecutionPayloadEnvelopeSchema schema,
       final ExecutionPayload payload,
       final ExecutionRequests executionRequests,
       final UInt64 builderIndex,
-      final Bytes32 beaconBlockRoot,
-      final UInt64 slot) {
+      final Bytes32 beaconBlockRoot) {
     super(
         schema,
         payload,
         executionRequests,
         SszUInt64.of(builderIndex),
-        SszBytes32.of(beaconBlockRoot),
-        SszUInt64.of(slot));
+        SszBytes32.of(beaconBlockRoot));
   }
 
   ExecutionPayloadEnvelope(final ExecutionPayloadEnvelopeSchema type, final TreeNode backingNode) {
@@ -73,7 +67,7 @@ public class ExecutionPayloadEnvelope
   }
 
   public UInt64 getSlot() {
-    return getField4().get();
+    return ExecutionPayloadGloas.required(getPayload()).getSlotNumber();
   }
 
   public SlotAndBlockRoot getSlotAndBlockRoot() {
@@ -99,8 +93,7 @@ public class ExecutionPayloadEnvelope
                     .createFromExecutionPayload(getPayload()),
                 getExecutionRequests(),
                 getBuilderIndex(),
-                getBeaconBlockRoot(),
-                getSlot());
+                getBeaconBlockRoot());
     checkState(
         blinded.hashTreeRoot().equals(hashTreeRoot()),
         "Blinded root does not match the unblinded root");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelopeInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelopeInvariants.java
@@ -14,50 +14,101 @@
 package tech.pegasys.teku.spec.datastructures.epbs.versions.gloas;
 
 import static tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas.BYTES32_SCHEMA;
+import static tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas.UINT256_SCHEMA;
 import static tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas.UINT64_SCHEMA;
 
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszType;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-/** Utility functions to extract data from the ssz bytes of Gloas execution payload envelopes. */
+/** Utility functions to extract data from the ssz bytes of execution payload envelopes. */
 public class ExecutionPayloadEnvelopeInvariants {
 
   private static final int BYTES_PER_LENGTH_OFFSET = 4;
+  private static final int BYTES_PER_LOGS_BLOOM = 256;
 
   private static final int EXECUTION_PAYLOAD_ENVELOPE_OFFSET_IN_SIGNED_ENVELOPE =
       BYTES_PER_LENGTH_OFFSET + SszSignatureSchema.INSTANCE.getSszFixedPartSize();
 
-  private static final int SLOT_OFFSET_IN_EXECUTION_PAYLOAD_ENVELOPE =
+  // Fixed part of ExecutionPayloadEnvelope:
+  // payload_offset(4) + execution_requests_offset(4) + builder_index(8) + beacon_block_root(32)
+  private static final int EXECUTION_PAYLOAD_ENVELOPE_FIXED_PART_SIZE =
       BYTES_PER_LENGTH_OFFSET
           + BYTES_PER_LENGTH_OFFSET
+          + UINT64_SCHEMA.getSszFixedPartSize()
+          + BYTES32_SCHEMA.getSszFixedPartSize();
+
+  // Common fixed-part prefix shared by both ExecutionPayload and ExecutionPayloadHeader
+  // up through block_hash (fields 0-12):
+  // parent_hash(32) + fee_recipient(20) + state_root(32) + receipts_root(32) +
+  // logs_bloom(256) + prev_randao(32) + block_number(8) + gas_limit(8) + gas_used(8) +
+  // timestamp(8) + extra_data_offset(4) + base_fee_per_gas(32) + block_hash(32)
+  private static final int COMMON_PAYLOAD_PREFIX_FIXED_SIZE =
+      BYTES32_SCHEMA.getSszFixedPartSize()
+          + Bytes20.SIZE
+          + BYTES32_SCHEMA.getSszFixedPartSize()
+          + BYTES32_SCHEMA.getSszFixedPartSize()
+          + BYTES_PER_LOGS_BLOOM
+          + BYTES32_SCHEMA.getSszFixedPartSize()
+          + UINT64_SCHEMA.getSszFixedPartSize()
+          + UINT64_SCHEMA.getSszFixedPartSize()
+          + UINT64_SCHEMA.getSszFixedPartSize()
+          + UINT64_SCHEMA.getSszFixedPartSize()
+          + BYTES_PER_LENGTH_OFFSET
+          + UINT256_SCHEMA.getSszFixedPartSize()
+          + BYTES32_SCHEMA.getSszFixedPartSize();
+
+  // SLOT_NUMBER offset in ExecutionPayload fixed part:
+  // after common prefix + transactions_offset(4) + withdrawals_offset(4) +
+  // blob_gas_used(8) + excess_blob_gas(8) + block_access_list_offset(4)
+  private static final int SLOT_NUMBER_OFFSET_IN_EXECUTION_PAYLOAD =
+      COMMON_PAYLOAD_PREFIX_FIXED_SIZE
+          + BYTES_PER_LENGTH_OFFSET
+          + BYTES_PER_LENGTH_OFFSET
+          + UINT64_SCHEMA.getSszFixedPartSize()
+          + UINT64_SCHEMA.getSszFixedPartSize()
+          + BYTES_PER_LENGTH_OFFSET;
+
+  // SLOT_NUMBER offset in ExecutionPayloadHeader fixed part:
+  // after common prefix + transactions_root(32) + withdrawals_root(32) +
+  // blob_gas_used(8) + excess_blob_gas(8) + block_access_list_root(32)
+  // (header uses fixed Bytes32 roots instead of variable lists)
+  private static final int SLOT_NUMBER_OFFSET_IN_EXECUTION_PAYLOAD_HEADER =
+      COMMON_PAYLOAD_PREFIX_FIXED_SIZE
+          + BYTES32_SCHEMA.getSszFixedPartSize()
+          + BYTES32_SCHEMA.getSszFixedPartSize()
+          + UINT64_SCHEMA.getSszFixedPartSize()
           + UINT64_SCHEMA.getSszFixedPartSize()
           + BYTES32_SCHEMA.getSszFixedPartSize();
 
   private ExecutionPayloadEnvelopeInvariants() {}
 
   public static UInt64 extractSignedExecutionPayloadEnvelopeSlot(final Bytes bytes) {
-    return extractSlotFromSignedExecutionPayloadEnvelope(
-        bytes, SLOT_OFFSET_IN_EXECUTION_PAYLOAD_ENVELOPE);
+    return extractSlotFromSignedPayloadEnvelope(bytes, SLOT_NUMBER_OFFSET_IN_EXECUTION_PAYLOAD);
   }
 
-  // Delegates to non-blinded extraction because both containers share identical SSZ fixed-part
   public static UInt64 extractSignedBlindedExecutionPayloadEnvelopeSlot(final Bytes bytes) {
-    return extractSignedExecutionPayloadEnvelopeSlot(bytes);
+    return extractSlotFromSignedPayloadEnvelope(
+        bytes, SLOT_NUMBER_OFFSET_IN_EXECUTION_PAYLOAD_HEADER);
   }
 
-  private static UInt64 extractSlotFromSignedExecutionPayloadEnvelope(
-      final Bytes bytes, final int slotOffsetInExecutionPayloadEnvelope) {
-    final int executionPayloadEnvelopeDataOffset =
+  private static UInt64 extractSlotFromSignedPayloadEnvelope(
+      final Bytes bytes, final int slotOffsetInPayload) {
+    final int envelopeDataOffset =
         SszType.sszBytesToLength(bytes.slice(0, BYTES_PER_LENGTH_OFFSET));
-    if (executionPayloadEnvelopeDataOffset
-        != EXECUTION_PAYLOAD_ENVELOPE_OFFSET_IN_SIGNED_ENVELOPE) {
+    if (envelopeDataOffset != EXECUTION_PAYLOAD_ENVELOPE_OFFSET_IN_SIGNED_ENVELOPE) {
       throw new IllegalArgumentException("Unexpected signed execution payload envelope format");
+    }
+    final int payloadDataOffset =
+        SszType.sszBytesToLength(bytes.slice(envelopeDataOffset, BYTES_PER_LENGTH_OFFSET));
+    if (payloadDataOffset != EXECUTION_PAYLOAD_ENVELOPE_FIXED_PART_SIZE) {
+      throw new IllegalArgumentException("Unexpected execution payload envelope format");
     }
     final Bytes slotData =
         bytes.slice(
-            executionPayloadEnvelopeDataOffset + slotOffsetInExecutionPayloadEnvelope,
+            envelopeDataOffset + payloadDataOffset + slotOffsetInPayload,
             UINT64_SCHEMA.getSszFixedPartSize());
     return UINT64_SCHEMA.sszDeserialize(slotData).get();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelopeSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadEnvelopeSchema.java
@@ -17,7 +17,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_PAYL
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.EXECUTION_REQUESTS_SCHEMA;
 
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema5;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
@@ -29,13 +29,8 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class ExecutionPayloadEnvelopeSchema
-    extends ContainerSchema5<
-        ExecutionPayloadEnvelope,
-        ExecutionPayload,
-        ExecutionRequests,
-        SszUInt64,
-        SszBytes32,
-        SszUInt64> {
+    extends ContainerSchema4<
+        ExecutionPayloadEnvelope, ExecutionPayload, ExecutionRequests, SszUInt64, SszBytes32> {
 
   public ExecutionPayloadEnvelopeSchema(final SchemaRegistry schemaRegistry) {
     super(
@@ -45,18 +40,16 @@ public class ExecutionPayloadEnvelopeSchema
             SszSchema.as(ExecutionPayload.class, schemaRegistry.get(EXECUTION_PAYLOAD_SCHEMA))),
         namedSchema("execution_requests", schemaRegistry.get(EXECUTION_REQUESTS_SCHEMA)),
         namedSchema("builder_index", SszPrimitiveSchemas.UINT64_SCHEMA),
-        namedSchema("beacon_block_root", SszPrimitiveSchemas.BYTES32_SCHEMA),
-        namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA));
+        namedSchema("beacon_block_root", SszPrimitiveSchemas.BYTES32_SCHEMA));
   }
 
   public ExecutionPayloadEnvelope create(
       final ExecutionPayload payload,
       final ExecutionRequests executionRequests,
       final UInt64 builderIndex,
-      final Bytes32 beaconBlockRoot,
-      final UInt64 slot) {
+      final Bytes32 beaconBlockRoot) {
     return new ExecutionPayloadEnvelope(
-        this, payload, executionRequests, builderIndex, beaconBlockRoot, slot);
+        this, payload, executionRequests, builderIndex, beaconBlockRoot);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.Execut
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadGloas;
 
 public interface ExecutionPayload extends ExecutionPayloadSummary, SszContainer, BuilderPayload {
 
@@ -52,6 +53,10 @@ public interface ExecutionPayload extends ExecutionPayloadSummary, SszContainer,
   }
 
   default Optional<ExecutionPayloadDeneb> toVersionDeneb() {
+    return Optional.empty();
+  }
+
+  default Optional<ExecutionPayloadGloas> toVersionGloas() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadFields.java
@@ -37,6 +37,9 @@ public enum ExecutionPayloadFields implements SszFieldName {
   BLOB_GAS_USED,
   EXCESS_BLOB_GAS,
   // Gloas
+  BLOCK_ACCESS_LIST,
+  BLOCK_ACCESS_LIST_ROOT,
+  SLOT_NUMBER,
   PARENT_BLOCK_HASH,
   PARENT_BLOCK_ROOT,
   BUILDER_INDEX,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadHeaderBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadHeaderCapella;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadHeaderDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadHeaderGloas;
 
 public interface ExecutionPayloadHeader extends ExecutionPayloadSummary, SszContainer {
 
@@ -35,6 +36,10 @@ public interface ExecutionPayloadHeader extends ExecutionPayloadSummary, SszCont
   }
 
   default Optional<ExecutionPayloadHeaderDeneb> toVersionDeneb() {
+    return Optional.empty();
+  }
+
+  default Optional<ExecutionPayloadHeaderGloas> toVersionGloas() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderBuilder.java
@@ -55,5 +55,9 @@ public interface ExecutionPayloadHeaderBuilder {
 
   ExecutionPayloadHeaderBuilder excessBlobGas(Supplier<UInt64> excessBlobGasSupplier);
 
+  ExecutionPayloadHeaderBuilder blockAccessListRoot(Supplier<Bytes32> blockAccessListRootSupplier);
+
+  ExecutionPayloadHeaderBuilder slotNumber(Supplier<UInt64> slotNumberSupplier);
+
   ExecutionPayloadHeader build();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSchema.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadSchemaDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadSchemaGloas;
 
 public interface ExecutionPayloadSchema<T extends ExecutionPayload>
     extends SszContainerSchema<T>, BuilderPayloadSchema<T> {
@@ -52,5 +53,9 @@ public interface ExecutionPayloadSchema<T extends ExecutionPayload>
 
   default ExecutionPayloadSchemaDeneb toVersionDenebRequired() {
     throw new UnsupportedOperationException("Not a Deneb schema");
+  }
+
+  default ExecutionPayloadSchemaGloas toVersionGloasRequired() {
+    throw new UnsupportedOperationException("Not a Gloas schema");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBuilderBellatrix.java
@@ -152,6 +152,17 @@ public class ExecutionPayloadHeaderBuilderBellatrix implements ExecutionPayloadH
     return this;
   }
 
+  @Override
+  public ExecutionPayloadHeaderBuilder blockAccessListRoot(
+      final Supplier<Bytes32> blockAccessListRootSupplier) {
+    return this;
+  }
+
+  @Override
+  public ExecutionPayloadHeaderBuilder slotNumber(final Supplier<UInt64> slotNumberSupplier) {
+    return this;
+  }
+
   protected void validateSchema() {
     checkNotNull(schema, "schema must be specified");
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadBuilderGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadBuilderGloas.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBuilder;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadBuilderDeneb;
+
+public class ExecutionPayloadBuilderGloas extends ExecutionPayloadBuilderDeneb {
+  private ExecutionPayloadSchemaGloas schema;
+
+  protected Bytes blockAccessList;
+  protected UInt64 slotNumber;
+
+  public ExecutionPayloadBuilderGloas schema(final ExecutionPayloadSchemaGloas schema) {
+    this.schema = schema;
+    return this;
+  }
+
+  @Override
+  public ExecutionPayloadBuilder blockAccessList(final Supplier<Bytes> blockAccessListSupplier) {
+    this.blockAccessList = blockAccessListSupplier.get();
+    return this;
+  }
+
+  @Override
+  public ExecutionPayloadBuilderGloas slotNumber(final Supplier<UInt64> slotNumberSupplier) {
+    this.slotNumber = slotNumberSupplier.get();
+    return this;
+  }
+
+  @Override
+  protected void validateSchema() {
+    checkNotNull(schema, "schema must be specified");
+  }
+
+  @Override
+  protected void validate() {
+    super.validate();
+    checkNotNull(blockAccessList, "blockAccessList must be specified");
+    checkNotNull(slotNumber, "slotNumber must be specified");
+  }
+
+  @Override
+  public ExecutionPayload build() {
+    validate();
+    return new ExecutionPayloadGloasImpl(
+        schema,
+        SszBytes32.of(parentHash),
+        SszByteVector.fromBytes(feeRecipient.getWrappedBytes()),
+        SszBytes32.of(stateRoot),
+        SszBytes32.of(receiptsRoot),
+        SszByteVector.fromBytes(logsBloom),
+        SszBytes32.of(prevRandao),
+        SszUInt64.of(blockNumber),
+        SszUInt64.of(gasLimit),
+        SszUInt64.of(gasUsed),
+        SszUInt64.of(timestamp),
+        schema.getExtraDataSchema().fromBytes(extraData),
+        SszUInt256.of(baseFeePerGas),
+        SszBytes32.of(blockHash),
+        transactions.stream()
+            .map(schema.getTransactionSchema()::fromBytes)
+            .collect(schema.getTransactionsSchema().collector()),
+        schema.getWithdrawalsSchema().createFromElements(withdrawals),
+        SszUInt64.of(blobGasUsed),
+        SszUInt64.of(excessBlobGas),
+        schema.getBlockAccessListSchema().fromBytes(blockAccessList),
+        SszUInt64.of(slotNumber));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadGloas.java
@@ -11,31 +11,32 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.execution.versions.deneb;
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
 
-public interface ExecutionPayloadDeneb extends ExecutionPayloadCapella {
+public interface ExecutionPayloadGloas extends ExecutionPayloadDeneb {
 
-  static ExecutionPayloadDeneb required(final ExecutionPayload payload) {
+  static ExecutionPayloadGloas required(final ExecutionPayload payload) {
     return payload
-        .toVersionDeneb()
+        .toVersionGloas()
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
-                    "Expected Deneb execution payload but got "
+                    "Expected Gloas execution payload but got "
                         + payload.getClass().getSimpleName()));
   }
 
-  UInt64 getBlobGasUsed();
+  SszByteList getBlockAccessList();
 
-  UInt64 getExcessBlobGas();
+  UInt64 getSlotNumber();
 
   @Override
-  default Optional<ExecutionPayloadDeneb> toVersionDeneb() {
+  default Optional<ExecutionPayloadGloas> toVersionGloas() {
     return Optional.of(this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadGloasImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadGloasImpl.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container19;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema19;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.Transaction;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+
+public class ExecutionPayloadGloasImpl
+    extends Container19<
+        ExecutionPayloadGloasImpl,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszByteList,
+        SszUInt256,
+        SszBytes32,
+        SszList<Transaction>,
+        SszList<Withdrawal>,
+        SszUInt64,
+        SszUInt64,
+        SszByteList,
+        SszUInt64>
+    implements ExecutionPayloadGloas {
+
+  public ExecutionPayloadGloasImpl(
+      final ContainerSchema19<
+              ExecutionPayloadGloasImpl,
+              SszBytes32,
+              SszByteVector,
+              SszBytes32,
+              SszBytes32,
+              SszByteVector,
+              SszBytes32,
+              SszUInt64,
+              SszUInt64,
+              SszUInt64,
+              SszUInt64,
+              SszByteList,
+              SszUInt256,
+              SszBytes32,
+              SszList<Transaction>,
+              SszList<Withdrawal>,
+              SszUInt64,
+              SszUInt64,
+              SszByteList,
+              SszUInt64>
+          schema,
+      final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  public ExecutionPayloadGloasImpl(
+      final ExecutionPayloadSchemaGloas schema,
+      final SszBytes32 parentHash,
+      final SszByteVector feeRecipient,
+      final SszBytes32 stateRoot,
+      final SszBytes32 receiptsRoot,
+      final SszByteVector logsBloom,
+      final SszBytes32 prevRandao,
+      final SszUInt64 blockNumber,
+      final SszUInt64 gasLimit,
+      final SszUInt64 gasUsed,
+      final SszUInt64 timestamp,
+      final SszByteList extraData,
+      final SszUInt256 baseFeePerGas,
+      final SszBytes32 blockHash,
+      final SszList<Transaction> transactions,
+      final SszList<Withdrawal> withdrawals,
+      final SszUInt64 blobGasUsed,
+      final SszUInt64 excessBlobGas,
+      final SszByteList blockAccessList,
+      final SszUInt64 slotNumber) {
+    super(
+        schema,
+        parentHash,
+        feeRecipient,
+        stateRoot,
+        receiptsRoot,
+        logsBloom,
+        prevRandao,
+        blockNumber,
+        gasLimit,
+        gasUsed,
+        timestamp,
+        extraData,
+        baseFeePerGas,
+        blockHash,
+        transactions,
+        withdrawals,
+        blobGasUsed,
+        excessBlobGas,
+        blockAccessList,
+        slotNumber);
+  }
+
+  @Override
+  public boolean isDefaultPayload() {
+    return super.isDefault();
+  }
+
+  @Override
+  public Optional<Bytes32> getOptionalWithdrawalsRoot() {
+    return Optional.of(getWithdrawals().hashTreeRoot());
+  }
+
+  @Override
+  public ExecutionPayloadSchemaGloas getSchema() {
+    return (ExecutionPayloadSchemaGloas) super.getSchema();
+  }
+
+  @Override
+  public Bytes32 getParentHash() {
+    return getField0().get();
+  }
+
+  @Override
+  public Bytes20 getFeeRecipient() {
+    return Bytes20.leftPad(getField1().getBytes());
+  }
+
+  @Override
+  public Bytes32 getStateRoot() {
+    return getField2().get();
+  }
+
+  @Override
+  public Bytes32 getReceiptsRoot() {
+    return getField3().get();
+  }
+
+  @Override
+  public Bytes getLogsBloom() {
+    return getField4().getBytes();
+  }
+
+  @Override
+  public Bytes32 getPrevRandao() {
+    return getField5().get();
+  }
+
+  @Override
+  public UInt64 getBlockNumber() {
+    return getField6().get();
+  }
+
+  @Override
+  public UInt64 getGasLimit() {
+    return getField7().get();
+  }
+
+  @Override
+  public UInt64 getGasUsed() {
+    return getField8().get();
+  }
+
+  @Override
+  public UInt64 getTimestamp() {
+    return getField9().get();
+  }
+
+  @Override
+  public Bytes getExtraData() {
+    return getField10().getBytes();
+  }
+
+  @Override
+  public UInt256 getBaseFeePerGas() {
+    return getField11().get();
+  }
+
+  @Override
+  public Bytes32 getBlockHash() {
+    return getField12().get();
+  }
+
+  @Override
+  public SszList<Transaction> getTransactions() {
+    return getField13();
+  }
+
+  @Override
+  public SszList<Withdrawal> getWithdrawals() {
+    return getField14();
+  }
+
+  @Override
+  public UInt64 getBlobGasUsed() {
+    return getField15().get();
+  }
+
+  @Override
+  public UInt64 getExcessBlobGas() {
+    return getField16().get();
+  }
+
+  @Override
+  public SszByteList getBlockAccessList() {
+    return getField17();
+  }
+
+  @Override
+  public UInt64 getSlotNumber() {
+    return getField18().get();
+  }
+
+  @Override
+  public List<TreeNode> getUnblindedTreeNodes() {
+    return List.of(
+        getTransactions().getBackingNode(),
+        getWithdrawals().getBackingNode(),
+        getBlockAccessList().getBackingNode());
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderBuilderGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderBuilderGloas.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderBuilder;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadHeaderBuilderDeneb;
+
+public class ExecutionPayloadHeaderBuilderGloas extends ExecutionPayloadHeaderBuilderDeneb {
+  private ExecutionPayloadHeaderSchemaGloas schema;
+
+  protected Bytes32 blockAccessListRoot;
+  protected UInt64 slotNumber;
+
+  public ExecutionPayloadHeaderBuilderGloas schema(final ExecutionPayloadHeaderSchemaGloas schema) {
+    this.schema = schema;
+    return this;
+  }
+
+  @Override
+  public ExecutionPayloadHeaderBuilder blockAccessListRoot(
+      final Supplier<Bytes32> blockAccessListRootSupplier) {
+    this.blockAccessListRoot = blockAccessListRootSupplier.get();
+    return this;
+  }
+
+  @Override
+  public ExecutionPayloadHeaderBuilderGloas slotNumber(final Supplier<UInt64> slotNumberSupplier) {
+    this.slotNumber = slotNumberSupplier.get();
+    return this;
+  }
+
+  @Override
+  protected void validateSchema() {
+    checkNotNull(schema, "schema must be specified");
+  }
+
+  @Override
+  protected void validate() {
+    super.validate();
+    checkNotNull(blockAccessListRoot, "blockAccessListRoot must be specified");
+    checkNotNull(slotNumber, "slotNumber must be specified");
+  }
+
+  @Override
+  public ExecutionPayloadHeader build() {
+    validate();
+    return new ExecutionPayloadHeaderGloasImpl(
+        schema,
+        SszBytes32.of(parentHash),
+        SszByteVector.fromBytes(feeRecipient.getWrappedBytes()),
+        SszBytes32.of(stateRoot),
+        SszBytes32.of(receiptsRoot),
+        SszByteVector.fromBytes(logsBloom),
+        SszBytes32.of(prevRandao),
+        SszUInt64.of(blockNumber),
+        SszUInt64.of(gasLimit),
+        SszUInt64.of(gasUsed),
+        SszUInt64.of(timestamp),
+        schema.getExtraDataSchema().fromBytes(extraData),
+        SszUInt256.of(baseFeePerGas),
+        SszBytes32.of(blockHash),
+        SszBytes32.of(transactionsRoot),
+        SszBytes32.of(withdrawalsRoot),
+        SszUInt64.of(blobGasUsed),
+        SszUInt64.of(excessBlobGas),
+        SszBytes32.of(blockAccessListRoot),
+        SszUInt64.of(slotNumber));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderGloas.java
@@ -11,31 +11,32 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.execution.versions.deneb;
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
 
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadHeaderDeneb;
 
-public interface ExecutionPayloadDeneb extends ExecutionPayloadCapella {
+public interface ExecutionPayloadHeaderGloas extends ExecutionPayloadHeaderDeneb {
 
-  static ExecutionPayloadDeneb required(final ExecutionPayload payload) {
-    return payload
-        .toVersionDeneb()
+  static ExecutionPayloadHeaderGloas required(final ExecutionPayloadHeader executionPayloadHeader) {
+    return executionPayloadHeader
+        .toVersionGloas()
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
-                    "Expected Deneb execution payload but got "
-                        + payload.getClass().getSimpleName()));
+                    "Expected Gloas execution payload header but got "
+                        + executionPayloadHeader.getClass().getSimpleName()));
   }
 
-  UInt64 getBlobGasUsed();
+  Bytes32 getBlockAccessListRoot();
 
-  UInt64 getExcessBlobGas();
+  UInt64 getSlotNumber();
 
   @Override
-  default Optional<ExecutionPayloadDeneb> toVersionDeneb() {
+  default Optional<ExecutionPayloadHeaderGloas> toVersionGloas() {
     return Optional.of(this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderGloasImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderGloasImpl.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container19;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema19;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ExecutionPayloadHeaderGloasImpl
+    extends Container19<
+        ExecutionPayloadHeaderGloasImpl,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszByteList,
+        SszUInt256,
+        SszBytes32,
+        SszBytes32,
+        SszBytes32,
+        SszUInt64,
+        SszUInt64,
+        SszBytes32,
+        SszUInt64>
+    implements ExecutionPayloadHeaderGloas {
+
+  protected ExecutionPayloadHeaderGloasImpl(
+      final ContainerSchema19<
+              ExecutionPayloadHeaderGloasImpl,
+              SszBytes32,
+              SszByteVector,
+              SszBytes32,
+              SszBytes32,
+              SszByteVector,
+              SszBytes32,
+              SszUInt64,
+              SszUInt64,
+              SszUInt64,
+              SszUInt64,
+              SszByteList,
+              SszUInt256,
+              SszBytes32,
+              SszBytes32,
+              SszBytes32,
+              SszUInt64,
+              SszUInt64,
+              SszBytes32,
+              SszUInt64>
+          schema,
+      final TreeNode backingTree) {
+    super(schema, backingTree);
+  }
+
+  public ExecutionPayloadHeaderGloasImpl(
+      final ExecutionPayloadHeaderSchemaGloas schema,
+      final SszBytes32 parentHash,
+      final SszByteVector feeRecipient,
+      final SszBytes32 stateRoot,
+      final SszBytes32 receiptsRoot,
+      final SszByteVector logsBloom,
+      final SszBytes32 prevRandao,
+      final SszUInt64 blockNumber,
+      final SszUInt64 gasLimit,
+      final SszUInt64 gasUsed,
+      final SszUInt64 timestamp,
+      final SszByteList extraData,
+      final SszUInt256 baseFeePerGas,
+      final SszBytes32 blockHash,
+      final SszBytes32 transactionsRoot,
+      final SszBytes32 withdrawalsRoot,
+      final SszUInt64 blobGasUsed,
+      final SszUInt64 excessBlobGas,
+      final SszBytes32 blockAccessListRoot,
+      final SszUInt64 slotNumber) {
+    super(
+        schema,
+        parentHash,
+        feeRecipient,
+        stateRoot,
+        receiptsRoot,
+        logsBloom,
+        prevRandao,
+        blockNumber,
+        gasLimit,
+        gasUsed,
+        timestamp,
+        extraData,
+        baseFeePerGas,
+        blockHash,
+        transactionsRoot,
+        withdrawalsRoot,
+        blobGasUsed,
+        excessBlobGas,
+        blockAccessListRoot,
+        slotNumber);
+  }
+
+  @Override
+  public boolean isDefaultPayload() {
+    return isHeaderOfDefaultPayload();
+  }
+
+  @Override
+  public ExecutionPayloadHeaderSchemaGloas getSchema() {
+    return (ExecutionPayloadHeaderSchemaGloas) super.getSchema();
+  }
+
+  @Override
+  public boolean isHeaderOfDefaultPayload() {
+    return equals(getSchema().getHeaderOfDefaultPayload());
+  }
+
+  @Override
+  public Bytes32 getParentHash() {
+    return getField0().get();
+  }
+
+  @Override
+  public Bytes20 getFeeRecipient() {
+    return Bytes20.leftPad(getField1().getBytes());
+  }
+
+  @Override
+  public Bytes32 getStateRoot() {
+    return getField2().get();
+  }
+
+  @Override
+  public Bytes32 getReceiptsRoot() {
+    return getField3().get();
+  }
+
+  @Override
+  public Bytes getLogsBloom() {
+    return getField4().getBytes();
+  }
+
+  @Override
+  public Bytes32 getPrevRandao() {
+    return getField5().get();
+  }
+
+  @Override
+  public UInt64 getBlockNumber() {
+    return getField6().get();
+  }
+
+  @Override
+  public UInt64 getGasLimit() {
+    return getField7().get();
+  }
+
+  @Override
+  public UInt64 getGasUsed() {
+    return getField8().get();
+  }
+
+  @Override
+  public UInt64 getTimestamp() {
+    return getField9().get();
+  }
+
+  @Override
+  public Bytes getExtraData() {
+    return getField10().getBytes();
+  }
+
+  @Override
+  public UInt256 getBaseFeePerGas() {
+    return getField11().get();
+  }
+
+  @Override
+  public Bytes32 getBlockHash() {
+    return getField12().get();
+  }
+
+  @Override
+  public Bytes32 getTransactionsRoot() {
+    return getField13().get();
+  }
+
+  @Override
+  public Bytes32 getWithdrawalsRoot() {
+    return getField14().get();
+  }
+
+  @Override
+  public UInt64 getBlobGasUsed() {
+    return getField15().get();
+  }
+
+  @Override
+  public UInt64 getExcessBlobGas() {
+    return getField16().get();
+  }
+
+  @Override
+  public Bytes32 getBlockAccessListRoot() {
+    return getField17().get();
+  }
+
+  @Override
+  public UInt64 getSlotNumber() {
+    return getField18().get();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderSchemaGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadHeaderSchemaGloas.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
+
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BASE_FEE_PER_GAS;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOB_GAS_USED;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_ACCESS_LIST_ROOT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_HASH;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_NUMBER;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.EXCESS_BLOB_GAS;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.EXTRA_DATA;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.FEE_RECIPIENT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.GAS_LIMIT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.GAS_USED;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.LOGS_BLOOM;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.PARENT_HASH;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.PREV_RANDAO;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.RECEIPTS_ROOT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.SLOT_NUMBER;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.STATE_ROOT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.TIMESTAMP;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.TRANSACTIONS_ROOT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.WITHDRAWALS_ROOT;
+
+import it.unimi.dsi.fastutil.longs.LongList;
+import java.util.function.Consumer;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema19;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderBuilder;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
+
+public class ExecutionPayloadHeaderSchemaGloas
+    extends ContainerSchema19<
+        ExecutionPayloadHeaderGloasImpl,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszByteList,
+        SszUInt256,
+        SszBytes32,
+        SszBytes32,
+        SszBytes32,
+        SszUInt64,
+        SszUInt64,
+        SszBytes32,
+        SszUInt64>
+    implements ExecutionPayloadHeaderSchema<ExecutionPayloadHeaderGloasImpl> {
+
+  private final ExecutionPayloadHeaderGloasImpl defaultExecutionPayloadHeader;
+  private final ExecutionPayloadHeaderGloasImpl executionPayloadHeaderOfDefaultPayload;
+
+  public ExecutionPayloadHeaderSchemaGloas(final SpecConfigGloas specConfig) {
+    super(
+        "ExecutionPayloadHeaderGloas",
+        namedSchema(PARENT_HASH, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(FEE_RECIPIENT, SszByteVectorSchema.create(Bytes20.SIZE)),
+        namedSchema(STATE_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(RECEIPTS_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(LOGS_BLOOM, SszByteVectorSchema.create(specConfig.getBytesPerLogsBloom())),
+        namedSchema(PREV_RANDAO, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(BLOCK_NUMBER, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(GAS_LIMIT, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(GAS_USED, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(TIMESTAMP, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(EXTRA_DATA, SszByteListSchema.create(specConfig.getMaxExtraDataBytes())),
+        namedSchema(BASE_FEE_PER_GAS, SszPrimitiveSchemas.UINT256_SCHEMA),
+        namedSchema(BLOCK_HASH, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(TRANSACTIONS_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(WITHDRAWALS_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(BLOB_GAS_USED, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(EXCESS_BLOB_GAS, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(BLOCK_ACCESS_LIST_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(SLOT_NUMBER, SszPrimitiveSchemas.UINT64_SCHEMA));
+
+    final ExecutionPayloadGloasImpl defaultExecutionPayload =
+        new ExecutionPayloadSchemaGloas(specConfig).getDefault();
+
+    this.executionPayloadHeaderOfDefaultPayload =
+        createFromExecutionPayload(defaultExecutionPayload);
+
+    this.defaultExecutionPayloadHeader = createFromBackingNode(getDefaultTree());
+  }
+
+  public SszByteListSchema<?> getExtraDataSchema() {
+    return (SszByteListSchema<?>) getChildSchema(getFieldIndex(EXTRA_DATA));
+  }
+
+  @Override
+  public LongList getBlindedNodeGeneralizedIndices() {
+    return LongList.of(
+        getChildGeneralizedIndex(getFieldIndex(TRANSACTIONS_ROOT)),
+        getChildGeneralizedIndex(getFieldIndex(WITHDRAWALS_ROOT)),
+        getChildGeneralizedIndex(getFieldIndex(BLOCK_ACCESS_LIST_ROOT)));
+  }
+
+  @Override
+  public ExecutionPayloadHeader createExecutionPayloadHeader(
+      final Consumer<ExecutionPayloadHeaderBuilder> builderConsumer) {
+    final ExecutionPayloadHeaderBuilderGloas builder =
+        new ExecutionPayloadHeaderBuilderGloas().schema(this);
+    builderConsumer.accept(builder);
+    return builder.build();
+  }
+
+  @Override
+  public ExecutionPayloadHeaderGloasImpl getDefault() {
+    return defaultExecutionPayloadHeader;
+  }
+
+  @Override
+  public ExecutionPayloadHeaderGloas getHeaderOfDefaultPayload() {
+    return executionPayloadHeaderOfDefaultPayload;
+  }
+
+  @Override
+  public ExecutionPayloadHeaderGloasImpl createFromBackingNode(final TreeNode node) {
+    return new ExecutionPayloadHeaderGloasImpl(this, node);
+  }
+
+  @Override
+  public ExecutionPayloadHeaderGloasImpl createFromExecutionPayload(
+      final ExecutionPayload payload) {
+    final ExecutionPayloadGloas executionPayload = ExecutionPayloadGloas.required(payload);
+    return new ExecutionPayloadHeaderGloasImpl(
+        this,
+        SszBytes32.of(executionPayload.getParentHash()),
+        SszByteVector.fromBytes(executionPayload.getFeeRecipient().getWrappedBytes()),
+        SszBytes32.of(executionPayload.getStateRoot()),
+        SszBytes32.of(executionPayload.getReceiptsRoot()),
+        SszByteVector.fromBytes(executionPayload.getLogsBloom()),
+        SszBytes32.of(executionPayload.getPrevRandao()),
+        SszUInt64.of(executionPayload.getBlockNumber()),
+        SszUInt64.of(executionPayload.getGasLimit()),
+        SszUInt64.of(executionPayload.getGasUsed()),
+        SszUInt64.of(executionPayload.getTimestamp()),
+        getExtraDataSchema().fromBytes(executionPayload.getExtraData()),
+        SszUInt256.of(executionPayload.getBaseFeePerGas()),
+        SszBytes32.of(executionPayload.getBlockHash()),
+        SszBytes32.of(executionPayload.getTransactions().hashTreeRoot()),
+        SszBytes32.of(executionPayload.getWithdrawals().hashTreeRoot()),
+        SszUInt64.of(executionPayload.getBlobGasUsed()),
+        SszUInt64.of(executionPayload.getExcessBlobGas()),
+        SszBytes32.of(executionPayload.getBlockAccessList().hashTreeRoot()),
+        SszUInt64.of(executionPayload.getSlotNumber()));
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution.versions.gloas;
+
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BASE_FEE_PER_GAS;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOB_GAS_USED;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_ACCESS_LIST;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_HASH;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.BLOCK_NUMBER;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.EXCESS_BLOB_GAS;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.EXTRA_DATA;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.FEE_RECIPIENT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.GAS_LIMIT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.GAS_USED;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.LOGS_BLOOM;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.PARENT_HASH;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.PREV_RANDAO;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.RECEIPTS_ROOT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.SLOT_NUMBER;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.STATE_ROOT;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.TIMESTAMP;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.TRANSACTIONS;
+import static tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadFields.WITHDRAWALS;
+
+import it.unimi.dsi.fastutil.longs.LongList;
+import java.util.function.Consumer;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema19;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBuilder;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.Transaction;
+import tech.pegasys.teku.spec.datastructures.execution.TransactionSchema;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
+
+public class ExecutionPayloadSchemaGloas
+    extends ContainerSchema19<
+        ExecutionPayloadGloasImpl,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszBytes32,
+        SszByteVector,
+        SszBytes32,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszUInt64,
+        SszByteList,
+        SszUInt256,
+        SszBytes32,
+        SszList<Transaction>,
+        SszList<Withdrawal>,
+        SszUInt64,
+        SszUInt64,
+        SszByteList,
+        SszUInt64>
+    implements ExecutionPayloadSchema<ExecutionPayloadGloasImpl> {
+
+  private final ExecutionPayloadGloasImpl defaultExecutionPayload;
+
+  public ExecutionPayloadSchemaGloas(final SpecConfigGloas specConfig) {
+    super(
+        "ExecutionPayloadGloas",
+        namedSchema(PARENT_HASH, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(FEE_RECIPIENT, SszByteVectorSchema.create(Bytes20.SIZE)),
+        namedSchema(STATE_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(RECEIPTS_ROOT, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(LOGS_BLOOM, SszByteVectorSchema.create(specConfig.getBytesPerLogsBloom())),
+        namedSchema(PREV_RANDAO, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(BLOCK_NUMBER, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(GAS_LIMIT, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(GAS_USED, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(TIMESTAMP, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(EXTRA_DATA, SszByteListSchema.create(specConfig.getMaxExtraDataBytes())),
+        namedSchema(BASE_FEE_PER_GAS, SszPrimitiveSchemas.UINT256_SCHEMA),
+        namedSchema(BLOCK_HASH, SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(
+            TRANSACTIONS,
+            SszListSchema.create(
+                new TransactionSchema(specConfig), specConfig.getMaxTransactionsPerPayload())),
+        namedSchema(
+            WITHDRAWALS,
+            SszListSchema.create(Withdrawal.SSZ_SCHEMA, specConfig.getMaxWithdrawalsPerPayload())),
+        namedSchema(BLOB_GAS_USED, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(EXCESS_BLOB_GAS, SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema(
+            BLOCK_ACCESS_LIST, SszByteListSchema.create(specConfig.getMaxBytesPerTransaction())),
+        namedSchema(SLOT_NUMBER, SszPrimitiveSchemas.UINT64_SCHEMA));
+    this.defaultExecutionPayload = createFromBackingNode(getDefaultTree());
+  }
+
+  @Override
+  public ExecutionPayloadGloasImpl getDefault() {
+    return defaultExecutionPayload;
+  }
+
+  @Override
+  public TransactionSchema getTransactionSchema() {
+    return (TransactionSchema) getTransactionsSchema().getElementSchema();
+  }
+
+  @Override
+  public SszListSchema<Withdrawal, ? extends SszList<Withdrawal>> getWithdrawalsSchemaRequired() {
+    return getWithdrawalsSchema();
+  }
+
+  @Override
+  public WithdrawalSchema getWithdrawalSchemaRequired() {
+    return getWithdrawalSchema();
+  }
+
+  public WithdrawalSchema getWithdrawalSchema() {
+    return (WithdrawalSchema) getWithdrawalsSchema().getElementSchema();
+  }
+
+  @Override
+  public LongList getBlindedNodeGeneralizedIndices() {
+    return LongList.of(
+        getChildGeneralizedIndex(getFieldIndex(TRANSACTIONS)),
+        getChildGeneralizedIndex(getFieldIndex(WITHDRAWALS)),
+        getChildGeneralizedIndex(getFieldIndex(BLOCK_ACCESS_LIST)));
+  }
+
+  @Override
+  public ExecutionPayload createExecutionPayload(
+      final Consumer<ExecutionPayloadBuilder> builderConsumer) {
+    final ExecutionPayloadBuilderGloas builder = new ExecutionPayloadBuilderGloas().schema(this);
+    builderConsumer.accept(builder);
+    return builder.build();
+  }
+
+  @Override
+  public ExecutionPayloadGloasImpl createFromBackingNode(final TreeNode node) {
+    return new ExecutionPayloadGloasImpl(this, node);
+  }
+
+  public SszByteListSchema<?> getExtraDataSchema() {
+    return (SszByteListSchema<?>) getChildSchema(getFieldIndex(EXTRA_DATA));
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszListSchema<Transaction, ?> getTransactionsSchema() {
+    return (SszListSchema<Transaction, ?>) getChildSchema(getFieldIndex(TRANSACTIONS));
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszListSchema<Withdrawal, ?> getWithdrawalsSchema() {
+    return (SszListSchema<Withdrawal, ?>) getChildSchema(getFieldIndex(WITHDRAWALS));
+  }
+
+  public SszByteListSchema<?> getBlockAccessListSchema() {
+    return (SszByteListSchema<?>) getChildSchema(getFieldIndex(BLOCK_ACCESS_LIST));
+  }
+
+  @Override
+  public ExecutionPayloadSchemaGloas toVersionGloasRequired() {
+    return this;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/GenesisStateBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/GenesisStateBuilder.java
@@ -165,6 +165,9 @@ public class GenesisStateBuilder {
               // Deneb
               b.blobGasUsed(() -> UInt64.ZERO);
               b.excessBlobGas(() -> UInt64.ZERO);
+              // Gloas
+              b.blockAccessListRoot(() -> Bytes32.ZERO);
+              b.slotNumber(() -> UInt64.ZERO);
             });
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloas.java
@@ -73,14 +73,14 @@ public interface BeaconStateGloas extends BeaconStateFulu {
   static void describeCustomGloasFields(
       final MoreObjects.ToStringHelper stringBuilder, final BeaconStateGloas state) {
     BeaconStateFulu.describeCustomFuluFields(stringBuilder, state);
-    stringBuilder.add("latest_execution_payload_bid", state.getLatestExecutionPayloadBid());
+    stringBuilder.add("latest_block_hash", state.getLatestBlockHash());
     addItems(stringBuilder, "builders", state.getBuilders());
     stringBuilder.add("next_withdrawal_builder_index", state.getNextWithdrawalBuilderIndex());
     addItems(
         stringBuilder, "execution_payload_availability", state.getExecutionPayloadAvailability());
     addItems(stringBuilder, "builder_pending_payments", state.getBuilderPendingPayments());
     addItems(stringBuilder, "builder_pending_withdrawals", state.getBuilderPendingWithdrawals());
-    stringBuilder.add("latest_block_hash", state.getLatestBlockHash());
+    stringBuilder.add("latest_execution_payload_bid", state.getLatestExecutionPayloadBid());
     stringBuilder.add("payload_expected_withdrawals", state.getPayloadExpectedWithdrawals());
     stringBuilder.add("ptc_window", state.getPtcWindow());
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateSchemaGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateSchemaGloas.java
@@ -59,7 +59,7 @@ public class BeaconStateSchemaGloas
   public static final int EXECUTION_PAYLOAD_AVAILABILITY_FIELD_INDEX = 40;
   public static final int BUILDER_PENDING_PAYMENTS_FIELD_INDEX = 41;
   public static final int BUILDER_PENDING_WITHDRAWALS_FIELD_INDEX = 42;
-  public static final int LATEST_BLOCK_HASH_FIELD_INDEX = 43;
+  public static final int LATEST_EXECUTION_PAYLOAD_BID_FIELD_INDEX = 43;
   public static final int PAYLOAD_EXPECTED_WITHDRAWALS_FIELD_INDEX = 44;
   public static final int PTC_WINDOW_INDEX = 45;
 
@@ -96,9 +96,9 @@ public class BeaconStateSchemaGloas
                 BeaconStateFields.BUILDER_PENDING_WITHDRAWALS,
                 () -> schemaRegistry.get(BUILDER_PENDING_WITHDRAWALS_SCHEMA)),
             new SszField(
-                LATEST_BLOCK_HASH_FIELD_INDEX,
-                BeaconStateFields.LATEST_BLOCK_HASH,
-                () -> SszPrimitiveSchemas.BYTES32_SCHEMA),
+                LATEST_EXECUTION_PAYLOAD_BID_FIELD_INDEX,
+                BeaconStateFields.LATEST_EXECUTION_PAYLOAD_BID,
+                () -> schemaRegistry.get(EXECUTION_PAYLOAD_BID_SCHEMA)),
             new SszField(
                 PAYLOAD_EXPECTED_WITHDRAWALS_FIELD_INDEX,
                 BeaconStateFields.PAYLOAD_EXPECTED_WITHDRAWALS,
@@ -113,12 +113,12 @@ public class BeaconStateSchemaGloas
                 .map(
                     field -> {
                       // replacing the old `latest_execution_payload_header` with the new
-                      // `latest_execution_payload_bid`
+                      // `latest_block_hash`
                       if (field.getIndex() == LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX) {
                         return new SszField(
                             LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX,
-                            BeaconStateFields.LATEST_EXECUTION_PAYLOAD_BID,
-                            () -> schemaRegistry.get(EXECUTION_PAYLOAD_BID_SCHEMA));
+                            BeaconStateFields.LATEST_BLOCK_HASH,
+                            () -> SszPrimitiveSchemas.BYTES32_SCHEMA);
                       } else {
                         return field;
                       }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -302,7 +302,9 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                         .transactions(transactions)
                         .withdrawals(() -> payloadAttributes.getWithdrawals().orElse(List.of()))
                         .blobGasUsed(() -> UInt64.ZERO)
-                        .excessBlobGas(() -> UInt64.ZERO));
+                        .excessBlobGas(() -> UInt64.ZERO)
+                        .blockAccessList(() -> Bytes32.ZERO)
+                        .slotNumber(() -> slot));
 
     // we assume all blocks are produced locally
     lastValidBlock =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ExecutionPayloadProposalUtil.java
@@ -49,7 +49,6 @@ public class ExecutionPayloadProposalUtil {
                     executionPayloadProposalData.executionPayload,
                     executionPayloadProposalData.executionRequests,
                     builderIndex,
-                    blockAndState.getRoot(),
-                    proposalSlot));
+                    blockAndState.getRoot()));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -92,25 +92,7 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
               // New in Gloas
               final Bytes32 latestBlockHash =
                   preStateFulu.getLatestExecutionPayloadHeaderRequired().getBlockHash();
-              state.setLatestExecutionPayloadBid(
-                  schemaDefinitions
-                      .getExecutionPayloadBidSchema()
-                      .create(
-                          Bytes32.ZERO,
-                          Bytes32.ZERO,
-                          latestBlockHash,
-                          Bytes32.ZERO,
-                          Bytes20.ZERO,
-                          UInt64.ZERO,
-                          UInt64.ZERO,
-                          UInt64.ZERO,
-                          UInt64.ZERO,
-                          UInt64.ZERO,
-                          schemaDefinitions.getBlobKzgCommitmentsSchema().of(),
-                          schemaDefinitions
-                              .getExecutionRequestsSchema()
-                              .getDefault()
-                              .hashTreeRoot()));
+              state.setLatestBlockHash(latestBlockHash);
 
               state.setNextWithdrawalIndex(preStateFulu.getNextWithdrawalIndex());
               state.setNextWithdrawalValidatorIndex(preStateFulu.getNextWithdrawalValidatorIndex());
@@ -148,7 +130,25 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                       .createFromElements(builderPendingPayments));
               state.setBuilderPendingWithdrawals(
                   schemaDefinitions.getBuilderPendingWithdrawalsSchema().of());
-              state.setLatestBlockHash(latestBlockHash);
+              state.setLatestExecutionPayloadBid(
+                  schemaDefinitions
+                      .getExecutionPayloadBidSchema()
+                      .create(
+                          Bytes32.ZERO,
+                          Bytes32.ZERO,
+                          latestBlockHash,
+                          Bytes32.ZERO,
+                          Bytes20.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          UInt64.ZERO,
+                          schemaDefinitions.getBlobKzgCommitmentsSchema().of(),
+                          schemaDefinitions
+                              .getExecutionRequestsSchema()
+                              .getDefault()
+                              .hashTreeRoot()));
               state.setPayloadExpectedWithdrawals(
                   schemaDefinitions
                       .getExecutionPayloadSchema()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/forktransition/HezeStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/forktransition/HezeStateUpgrade.java
@@ -60,7 +60,7 @@ public class HezeStateUpgrade implements StateUpgrade<BeaconStateGloas> {
               state.setCurrentSyncCommittee(preStateGloas.getCurrentSyncCommittee());
               state.setNextSyncCommittee(preStateGloas.getNextSyncCommittee());
 
-              state.setLatestExecutionPayloadBid(preStateGloas.getLatestExecutionPayloadBid());
+              state.setLatestBlockHash(preStateGloas.getLatestBlockHash());
               state.setNextWithdrawalIndex(preStateGloas.getNextWithdrawalIndex());
               state.setNextWithdrawalValidatorIndex(
                   preStateGloas.getNextWithdrawalValidatorIndex());
@@ -82,7 +82,7 @@ public class HezeStateUpgrade implements StateUpgrade<BeaconStateGloas> {
                   preStateGloas.getExecutionPayloadAvailability());
               state.setBuilderPendingPayments(preStateGloas.getBuilderPendingPayments());
               state.setBuilderPendingWithdrawals(preStateGloas.getBuilderPendingWithdrawals());
-              state.setLatestBlockHash(preStateGloas.getLatestBlockHash());
+              state.setLatestExecutionPayloadBid(preStateGloas.getLatestExecutionPayloadBid());
               state.setPayloadExpectedWithdrawals(preStateGloas.getPayloadExpectedWithdrawals());
               state.setPtcWindow(preStateGloas.getPtcWindow());
             });

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBuilderBellatrix;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBidSchema;
@@ -42,7 +41,7 @@ import tech.pegasys.teku.spec.schemas.registry.SchemaRegistry;
 
 public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   private final ExecutionPayloadSchema<?> executionPayloadSchema;
-  private final BlindedBeaconBlockBodySchemaBellatrix<?> blindedBeaconBlockBodySchema;
+  private final BeaconBlockBodySchema<?> blindedBeaconBlockBodySchema;
   private final BeaconBlockSchema blindedBeaconBlockSchema;
   private final SignedBeaconBlockSchema signedBlindedBeaconBlockSchema;
   private final ExecutionPayloadHeaderSchema<?> executionPayloadHeaderSchema;
@@ -53,9 +52,9 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     super(schemaRegistry);
     this.executionPayloadSchema = schemaRegistry.get(EXECUTION_PAYLOAD_SCHEMA);
     this.executionPayloadHeaderSchema = schemaRegistry.get(EXECUTION_PAYLOAD_HEADER_SCHEMA);
-    this.blindedBeaconBlockBodySchema = schemaRegistry.get(BLINDED_BEACON_BLOCK_BODY_SCHEMA);
-    this.blindedBeaconBlockSchema = schemaRegistry.get(BLINDED_BEACON_BLOCK_SCHEMA);
-    this.signedBlindedBeaconBlockSchema = schemaRegistry.get(SIGNED_BLINDED_BEACON_BLOCK_SCHEMA);
+    this.blindedBeaconBlockBodySchema = createBlindedBeaconBlockBodySchema(schemaRegistry);
+    this.blindedBeaconBlockSchema = createBlindedBeaconBlockSchema(schemaRegistry);
+    this.signedBlindedBeaconBlockSchema = createSignedBlindedBeaconBlockSchema(schemaRegistry);
     this.builderBidSchema = schemaRegistry.get(BUILDER_BID_SCHEMA);
     this.signedBuilderBidSchema = schemaRegistry.get(SIGNED_BUILDER_BID_SCHEMA);
   }
@@ -67,6 +66,20 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
         SchemaDefinitionsBellatrix.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsBellatrix) schemaDefinitions;
+  }
+
+  protected BeaconBlockBodySchema<?> createBlindedBeaconBlockBodySchema(
+      final SchemaRegistry schemaRegistry) {
+    return schemaRegistry.get(BLINDED_BEACON_BLOCK_BODY_SCHEMA);
+  }
+
+  protected BeaconBlockSchema createBlindedBeaconBlockSchema(final SchemaRegistry schemaRegistry) {
+    return schemaRegistry.get(BLINDED_BEACON_BLOCK_SCHEMA);
+  }
+
+  protected SignedBeaconBlockSchema createSignedBlindedBeaconBlockSchema(
+      final SchemaRegistry schemaRegistry) {
+    return schemaRegistry.get(SIGNED_BLINDED_BEACON_BLOCK_SCHEMA);
   }
 
   @Override
@@ -98,7 +111,7 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   public BeaconBlockBodyBuilder createBeaconBlockBodyBuilder() {
     return new BeaconBlockBodyBuilderBellatrix(
         getBeaconBlockBodySchema().toVersionBellatrix().orElseThrow(),
-        blindedBeaconBlockBodySchema);
+        getBlindedBeaconBlockBodySchema().toBlindedVersionBellatrix().orElseThrow());
   }
 
   public ExecutionPayloadSchema<?> getExecutionPayloadSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsGloas.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.spec.schemas;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_BODY_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BEACON_BLOCK_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BLINDED_EXECUTION_PAYLOAD_ENVELOPE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BUILDER_PENDING_PAYMENTS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.BUILDER_PENDING_PAYMENT_SCHEMA;
@@ -29,6 +31,7 @@ import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PAYLOAD_ATTEST
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PAYLOAD_ATTESTATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PROPOSER_PREFERENCES_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.PTC_WINDOW_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BEACON_BLOCK_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_BLINDED_EXECUTION_PAYLOAD_ENVELOPE_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_EXECUTION_PAYLOAD_BID_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.registry.SchemaTypes.SIGNED_EXECUTION_PAYLOAD_ENVELOPE_SCHEMA;
@@ -129,18 +132,20 @@ public class SchemaDefinitionsGloas extends SchemaDefinitionsFulu {
   }
 
   @Override
-  public BeaconBlockSchema getBlindedBeaconBlockSchema() {
-    return getBeaconBlockSchema();
+  protected BeaconBlockBodySchema<?> createBlindedBeaconBlockBodySchema(
+      final SchemaRegistry schemaRegistry) {
+    return schemaRegistry.get(BEACON_BLOCK_BODY_SCHEMA);
   }
 
   @Override
-  public BeaconBlockBodySchema<?> getBlindedBeaconBlockBodySchema() {
-    return getBeaconBlockBodySchema();
+  protected BeaconBlockSchema createBlindedBeaconBlockSchema(final SchemaRegistry schemaRegistry) {
+    return schemaRegistry.get(BEACON_BLOCK_SCHEMA);
   }
 
   @Override
-  public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
-    return getSignedBeaconBlockSchema();
+  protected SignedBeaconBlockSchema createSignedBlindedBeaconBlockSchema(
+      final SchemaRegistry schemaRegistry) {
+    return schemaRegistry.get(SIGNED_BEACON_BLOCK_SCHEMA);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/registry/SchemaRegistryBuilder.java
@@ -174,6 +174,8 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Consolid
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequestSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequestSchema;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadHeaderSchemaGloas;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadSchemaGloas;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionListSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.SignedInclusionListSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
@@ -477,6 +479,7 @@ public class SchemaRegistryBuilder {
             BELLATRIX,
             (registry, specConfig, schemaName) ->
                 new BeaconBlockSchema(registry.get(BLINDED_BEACON_BLOCK_BODY_SCHEMA), schemaName))
+        .until(FULU)
         .build();
   }
 
@@ -486,6 +489,7 @@ public class SchemaRegistryBuilder {
             BELLATRIX,
             (registry, specConfig, schemaName) ->
                 new SignedBeaconBlockSchema(registry.get(BLINDED_BEACON_BLOCK_SCHEMA), schemaName))
+        .until(FULU)
         .build();
   }
 
@@ -539,6 +543,7 @@ public class SchemaRegistryBuilder {
             (registry, specConfig, schemaName) ->
                 BlindedBeaconBlockBodySchemaElectraImpl.create(
                     SpecConfigElectra.required(specConfig), schemaName, registry))
+        .until(FULU)
         .build();
   }
 
@@ -594,6 +599,10 @@ public class SchemaRegistryBuilder {
             DENEB,
             (registry, specConfig, schemaName) ->
                 new ExecutionPayloadHeaderSchemaDeneb(SpecConfigDeneb.required(specConfig)))
+        .withCreator(
+            GLOAS,
+            (registry, specConfig, schemaName) ->
+                new ExecutionPayloadHeaderSchemaGloas(SpecConfigGloas.required(specConfig)))
         .build();
   }
 
@@ -611,6 +620,10 @@ public class SchemaRegistryBuilder {
             DENEB,
             (registry, specConfig, schemaName) ->
                 new ExecutionPayloadSchemaDeneb(SpecConfigDeneb.required(specConfig)))
+        .withCreator(
+            GLOAS,
+            (registry, specConfig, schemaName) ->
+                new ExecutionPayloadSchemaGloas(SpecConfigGloas.required(specConfig)))
         .build();
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -246,7 +246,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "hpmBOIyDi4XnQSV7Hn970MEKkO+ZLWeu3I6S0PIRkLrXqVDa8KceV7g+doSt//UKC1r1yUy9EGSECGWmsn1g6Dy7KGzbIfyWpJaUtWJLsEv991OWgSBhlgLIlk4LTA33"));
+                "g+USsUINry4KnjTkdMyPUsnHyGcxIfrh+3F2i1uTNYqo51GtqSDTMAR4r4J4lHl3BeYi9PXY6t6BAHUK3BdA8IufCC80XJygahbLQiTJwBje7Pc4W8XLOzQUuBRclzeT"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadEnvelope(envelope, fork);
     asyncRunner.executeQueuedActions();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -246,7 +246,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "g+USsUINry4KnjTkdMyPUsnHyGcxIfrh+3F2i1uTNYqo51GtqSDTMAR4r4J4lHl3BeYi9PXY6t6BAHUK3BdA8IufCC80XJygahbLQiTJwBje7Pc4W8XLOzQUuBRclzeT"));
+                "pK9IGfSg1frZ2CvTmXs3U/7Nmxnegt4NUvBgODImOl2D/MHsLhBLZ8uX+0weWPSrF6qiTH/PBa2VJlBJ4ao9/puaEUlSurXC2W+itEI71GzUokLM+48Onsmzxi8fbe1O"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadEnvelope(envelope, fork);
     asyncRunner.executeQueuedActions();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/interop/MergedGenesisTestBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/interop/MergedGenesisTestBuilder.java
@@ -81,6 +81,10 @@ public class MergedGenesisTestBuilder {
                             .orElseThrow())
                 // New in Deneb
                 .blobGasUsed(() -> UInt64.ZERO)
-                .excessBlobGas(() -> UInt64.ZERO));
+                .excessBlobGas(() -> UInt64.ZERO)
+                // New in Gloas
+                .blockAccessListRoot(
+                    () -> Bytes32.wrap(header.getBalHash().orElseThrow().getBytes()))
+                .slotNumber(() -> UInt64.valueOf(header.getSlotNumber())));
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -512,7 +512,9 @@ public class BlockProposalTestUtil {
                 .transactions(transactions.orElse(Collections.emptyList()))
                 .withdrawals(List::of)
                 .blobGasUsed(() -> UInt64.ZERO)
-                .excessBlobGas(() -> UInt64.ZERO));
+                .excessBlobGas(() -> UInt64.ZERO)
+                .blockAccessList(() -> Bytes32.ZERO)
+                .slotNumber(() -> newSlot));
   }
 
   private SignedExecutionPayloadBid createSignedExecutionPayloadBid(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ExecutionPayloadProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ExecutionPayloadProposalTestUtil.java
@@ -47,8 +47,7 @@ public class ExecutionPayloadProposalTestUtil {
                 executionPayloadProposalData.executionPayload(),
                 executionPayloadProposalData.executionRequests(),
                 BUILDER_INDEX_SELF_BUILD,
-                blockAndState.getRoot(),
-                newSlot);
+                blockAndState.getRoot());
     // Sign execution payload and set signature
     return signer
         .signExecutionPayloadEnvelope(executionPayload, blockAndState.getState().getForkInfo())

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -700,7 +700,9 @@ public final class DataStructureUtil {
                     .transactionsRoot(randomBytes32())
                     .withdrawalsRoot(() -> withdrawalsRoot)
                     .blobGasUsed(this::randomUInt64)
-                    .excessBlobGas(this::randomUInt64));
+                    .excessBlobGas(this::randomUInt64)
+                    .blockAccessListRoot(this::randomBytes32)
+                    .slotNumber(this::randomSlot));
   }
 
   public ExecutionPayloadHeader randomExecutionPayloadHeader(final SpecVersion specVersion) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -252,6 +252,7 @@ public final class DataStructureUtil {
 
   private static final int MAX_EP_RANDOM_TRANSACTIONS = 10;
   private static final int MAX_EP_RANDOM_TRANSACTIONS_SIZE = 32;
+  private static final int MAX_EP_BLOCK_ACCESS_LIST_SIZE = 32;
 
   private static final int MAX_EP_RANDOM_WITHDRAWALS = 4;
   private static final int MAX_EP_RANDOM_DEPOSIT_REQUESTS = 4;
@@ -800,8 +801,7 @@ public final class DataStructureUtil {
                       .withdrawals(this::randomExecutionPayloadWithdrawals)
                       .blobGasUsed(this::randomUInt64)
                       .excessBlobGas(this::randomUInt64)
-                      .blockAccessList(
-                          () -> randomBytes(specConfigBellatrix.getMaxBytesPerTransaction()))
+                      .blockAccessList(() -> randomBytes(MAX_EP_BLOCK_ACCESS_LIST_SIZE))
                       .slotNumber(() -> slot);
               builderModifier.accept(executionPayloadBuilder);
             });

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -797,7 +797,10 @@ public final class DataStructureUtil {
                       .transactions(randomExecutionPayloadTransactions())
                       .withdrawals(this::randomExecutionPayloadWithdrawals)
                       .blobGasUsed(this::randomUInt64)
-                      .excessBlobGas(this::randomUInt64);
+                      .excessBlobGas(this::randomUInt64)
+                      .blockAccessList(
+                          () -> randomBytes(specConfigBellatrix.getMaxBytesPerTransaction()))
+                      .slotNumber(() -> slot);
               builderModifier.accept(executionPayloadBuilder);
             });
   }
@@ -3353,25 +3356,23 @@ public final class DataStructureUtil {
     return getGloasSchemaDefinitions()
         .getExecutionPayloadEnvelopeSchema()
         .create(
-            randomExecutionPayload(),
+            randomExecutionPayload(block.getSlot()),
             randomExecutionRequests(),
             BeaconBlockBodyGloas.required(block.getMessage().getBody())
                 .getSignedExecutionPayloadBid()
                 .getMessage()
                 .getBuilderIndex(),
-            block.getRoot(),
-            block.getSlot());
+            block.getRoot());
   }
 
   public ExecutionPayloadEnvelope randomExecutionPayloadEnvelope(final UInt64 slot) {
     return getGloasSchemaDefinitions()
         .getExecutionPayloadEnvelopeSchema()
         .create(
-            randomExecutionPayload(),
+            randomExecutionPayload(slot),
             randomExecutionRequests(),
             randomBuilderIndex(),
-            randomBytes32(),
-            slot);
+            randomBytes32());
   }
 
   public SignedExecutionPayloadEnvelope randomSignedExecutionPayloadEnvelope(final long slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -130,7 +130,9 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
     final Bytes32 parentRoot = state.getLatestBlockHeader().getRoot();
     final boolean shouldExtendPayload =
         ForkChoiceUtilGloas.required(specVersion.getForkChoiceUtil())
-            .shouldExtendPayload(recentChainData.getStore(), parentRoot);
+                .shouldExtendPayload(recentChainData.getStore(), parentRoot)
+            // handle Gloas fork boundary edge case
+            || state.getLatestExecutionPayloadBid().getParentBlockHash().equals(Bytes32.ZERO);
     final Bytes32 parentBlockHash =
         shouldExtendPayload
             ? state.getLatestExecutionPayloadBid().getBlockHash()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
 import tech.pegasys.teku.spec.signatures.SigningRootUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -94,8 +94,6 @@ public class ProposerPreferencesGossipValidator {
     return getState()
         .thenApply(
             state -> {
-              final BeaconStateGloas gloasState = BeaconStateGloas.required(state);
-
               /*
                * [REJECT] preferences.validator_index is present at the correct slot in the
                * next epoch's portion of state.proposer_lookahead -- i.e.
@@ -104,7 +102,7 @@ public class ProposerPreferencesGossipValidator {
               final int slotsPerEpoch = spec.atSlot(proposalSlot).getConfig().getSlotsPerEpoch();
               final int lookaheadIndex = slotsPerEpoch + proposalSlot.mod(slotsPerEpoch).intValue();
               final UInt64 expectedValidatorIndex =
-                  gloasState.getProposerLookahead().getElement(lookaheadIndex);
+                  BeaconStateFulu.required(state).getProposerLookahead().getElement(lookaheadIndex);
               if (!expectedValidatorIndex.equals(proposerPreferences.getValidatorIndex())) {
                 LOG.trace(
                     "Proposer preferences validator index {} does not match expected proposer {} for slot {}",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implements remaining parts of https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.5 specifically for Gloas

## Fixed Issue(s)
fixes #10571 
fixes #10572 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches consensus-critical SSZ containers and execution-engine RPC method selection/serialization for the Gloas fork; mistakes could break block processing, signing roots, or EL/CL interoperability.
> 
> **Overview**
> Implements remaining Gloas v1.7.0-alpha.5 spec updates by introducing `ExecutionPayloadGloas`/`ExecutionPayloadHeaderGloas` (adds `block_access_list` and `slot_number`) and updating SSZ schemas/builders/serialization so the slot is derived from the payload/header rather than carried in `ExecutionPayloadEnvelope`/`BlindedExecutionPayloadEnvelope`.
> 
> Updates execution-layer JSON-RPC wiring for Gloas to use newer engine endpoints (`engine_getPayloadV6`, `engine_forkchoiceUpdatedV4`) and adjusts `ExecutionPayloadV4`/`engine_newPayloadV5` payload encoding to populate the new Gloas fields (and drop the extra slot param). Reference/REST tests and fixtures are updated accordingly, including re-enabling Gloas reference tests with a narrow SSZ-static exclusion and adding a new `parent_execution_payload` operation test path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 969d12b93c2965e79a37ad10b292616db24cb306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->