### PR TITLE
build: skip CI checks on docs-only changes

### DIFF
--- a/.github/workflows/check-specrefs.yml
+++ b/.github/workflows/check-specrefs.yml
@@ -1,5 +1,13 @@
 name: Check Spec References
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'specrefs/**'
+      - 'build.gradle'
+  pull_request:
+    paths:
+      - 'specrefs/**'
+      - 'build.gradle'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,31 @@ on:
       - master
     tags:
       - '*'
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE*'
+      - 'NOTICE*'
+      - 'CHANGELOG*'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.codespell/**'
+      - 'specrefs/**'
+      - 'mlc_config.json'
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE*'
+      - 'NOTICE*'
+      - 'CHANGELOG*'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.codespell/**'
+      - 'specrefs/**'
+      - 'mlc_config.json'
   workflow_dispatch:
     inputs:
       include_hash_in_docker:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,31 @@ name: "CodeQL"
 on:
   push:
     branches: [ master, "*-integration", "release-*" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE*'
+      - 'NOTICE*'
+      - 'CHANGELOG*'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.codespell/**'
+      - 'specrefs/**'
+      - 'mlc_config.json'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE*'
+      - 'NOTICE*'
+      - 'CHANGELOG*'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.codespell/**'
+      - 'specrefs/**'
+      - 'mlc_config.json'
   schedule:
     - cron: '39 22 * * 5'
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,15 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'gradle/wrapper/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+  pull_request:
+    paths:
+      - 'gradle/wrapper/**'
+      - 'gradlew'
+      - 'gradlew.bat'
 
 permissions:
   contents: read

--- a/.github/workflows/test-path-check.yml
+++ b/.github/workflows/test-path-check.yml
@@ -1,5 +1,13 @@
 name: "Test Path Check"
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**/*.java'
+      - 'scripts/testcheck.sh'
+  pull_request:
+    paths:
+      - '**/*.java'
+      - 'scripts/testcheck.sh'
 
 permissions:
   contents: read

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
-*         @consensys/protocol-centaur 
 
 .github/workflows/  @consensys/protocol-centaur @consensys/protocol-galileo


### PR DESCRIPTION
## Summary

- Add `paths-ignore` to `ci.yml` and `codeql.yml` so the full pipeline (26+ jobs, multi-shard tests, Docker builds) and security analysis are skipped when only non-code files change (READMEs, changelogs, license files, `.gitignore`, codespell config, spec refs, `mlc_config.json`)
- Narrow `check-specrefs.yml` to only trigger on `specrefs/**` or `build.gradle` changes
- Narrow `gradle-wrapper-validation.yml` to only trigger on `gradle/wrapper/**`, `gradlew`, or `gradlew.bat` changes
- Narrow `test-path-check.yml` to only trigger on `**/*.java` or `scripts/testcheck.sh` changes

`codespell.yml` and `cla.yml` are intentionally left unchanged — spell checking and CLA verification should still run on every PR regardless of content.

IMPORTANT: I am also bundling a change to CODEOWNERS as discussed with @joshuafernandes, removing the main owner from the document. Branch enforcement will be handled by rulesets.

## Test plan

- [ ] Open a PR changing only a `.md` file — `ci`, `codeql`, `check-specrefs`, `gradle-wrapper-validation`, and `test-path-check` should not appear in checks; `codespell` and `cla` should still run
- [ ] Open a PR changing a `.java` file — `ci`, `codeql`, and `test-path-check` should run; `check-specrefs` and `gradle-wrapper-validation` should not
- [ ] Open a PR changing `gradle/wrapper/gradle-wrapper.jar` — `gradle-wrapper-validation` should run, and `ci` should run (wrapper changes affect builds)
- [ ] Open a PR changing `specrefs/.ethspecify.yml` — `check-specrefs` should run; `ci` should not (specrefs are in its `paths-ignore`)
- [ ] Manually trigger `ci` via `workflow_dispatch` — should always run regardless of paths


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes workflow trigger filters and CODEOWNERS, which can unintentionally suppress required CI/security checks or alter review enforcement if path patterns are incorrect.
> 
> **Overview**
> Updates GitHub Actions triggers to reduce unnecessary runs: `ci.yml` and `codeql.yml` now use `paths-ignore` to skip execution when only documentation/metadata files (e.g., `*.md`, license/changelog files, `.gitignore`, `specrefs/**`, `mlc_config.json`) change.
> 
> Tightens targeted workflows by adding path-scoped triggers: `check-specrefs.yml` runs only for `specrefs/**` or `build.gradle` changes, `gradle-wrapper-validation.yml` only for wrapper/launcher changes, and `test-path-check.yml` only for Java or `scripts/testcheck.sh` changes.
> 
> Removes the repo-wide `*` owner entry from `CODEOWNERS`, leaving explicit ownership for `.github/workflows/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c99e858fdc63e6acdbc7f18fb66ad53e78634a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->