### PR TITLE
Make availability checker NOOP for `on_Block` for Gloas

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -803,7 +803,12 @@ public class ForkChoiceUtil {
     return beaconStateAccessors.getBeaconProposerIndex(proposerPreState);
   }
 
-  public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+  public AvailabilityChecker<?> createAvailabilityCheckerOnBlock(final SignedBeaconBlock block) {
+    return AvailabilityChecker.NOOP;
+  }
+
+  public AvailabilityChecker<?> createAvailabilityCheckerOnExecutionPayloadEnvelope(
+      final SignedBeaconBlock block) {
     return AvailabilityChecker.NOOP;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/ForkChoiceUtilDeneb.java
@@ -78,7 +78,7 @@ public class ForkChoiceUtilDeneb extends ForkChoiceUtil {
   }
 
   @Override
-  public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+  public AvailabilityChecker<?> createAvailabilityCheckerOnBlock(final SignedBeaconBlock block) {
     final AvailabilityCheckerFactory<BlobSidecar> factory =
         this.blobSidecarAvailabilityCheckerFactory;
     if (factory == null) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/ForkChoiceUtilFulu.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 
 public class ForkChoiceUtilFulu extends ForkChoiceUtilDeneb {
 
-  private volatile AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory;
+  protected volatile AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory;
 
   public ForkChoiceUtilFulu(
       final SpecConfig specConfig,
@@ -44,7 +44,7 @@ public class ForkChoiceUtilFulu extends ForkChoiceUtilDeneb {
   }
 
   @Override
-  public AvailabilityChecker<?> createAvailabilityChecker(final SignedBeaconBlock block) {
+  public AvailabilityChecker<?> createAvailabilityCheckerOnBlock(final SignedBeaconBlock block) {
     final AvailabilityCheckerFactory<UInt64> factory =
         this.dataColumnSidecarAvailabilityCheckerFactory;
     if (factory == null) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -22,11 +22,14 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.PayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.versions.fulu.util.ForkChoiceUtilFulu;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
@@ -68,6 +71,23 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
   @Override
   public boolean getFullPayloadVoteHint(final UInt64 attestationIndex) {
     return attestationIndex.equals(UInt64.ONE);
+  }
+
+  @Override
+  public AvailabilityChecker<?> createAvailabilityCheckerOnBlock(final SignedBeaconBlock block) {
+    return AvailabilityChecker.NOOP;
+  }
+
+  @Override
+  public AvailabilityChecker<?> createAvailabilityCheckerOnExecutionPayloadEnvelope(
+      final SignedBeaconBlock block) {
+    final AvailabilityCheckerFactory<UInt64> factory =
+        this.dataColumnSidecarAvailabilityCheckerFactory;
+    if (factory == null) {
+      throw new IllegalStateException(
+          "DataColumnSidecarAvailabilityCheckerFactory not initialized");
+    }
+    return factory.createAvailabilityChecker(block);
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -278,7 +278,7 @@ class ForkChoiceUtilTest {
 
   @ParameterizedTest
   @EnumSource(SpecMilestone.class)
-  void createAvailabilityChecker_shouldCreateExpectedCheckerForBlock(
+  void createAvailabilityCheckerOnBlock_shouldCreateExpectedAvailabilityChecker(
       final SpecMilestone milestone) {
     final Spec spec = TestSpecFactory.createMinimal(milestone);
     final ForkChoiceUtil util = spec.getGenesisSpec().getForkChoiceUtil();
@@ -296,7 +296,7 @@ class ForkChoiceUtilTest {
         dataColumnSidecarAvailabilityCheckerFactory,
         KZG.DISABLED);
 
-    final AvailabilityChecker<?> availabilityChecker = util.createAvailabilityChecker(block);
+    final AvailabilityChecker<?> availabilityChecker = util.createAvailabilityCheckerOnBlock(block);
 
     switch (milestone) {
       case PHASE0, ALTAIR, BELLATRIX, CAPELLA ->
@@ -304,6 +304,38 @@ class ForkChoiceUtilTest {
       case DENEB, ELECTRA ->
           verify(blobSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
       case FULU, GLOAS, HEZE ->
+          verify(dataColumnSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
+      default -> throw new IllegalStateException("Unexpected milestone " + milestone);
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(SpecMilestone.class)
+  void createAvailabilityCheckerOnExecutionPayloadEnvelope_shouldCreateExpectedAvailabilityChecker(
+      final SpecMilestone milestone) {
+    final Spec spec = TestSpecFactory.createMinimal(milestone);
+    final ForkChoiceUtil util = spec.getGenesisSpec().getForkChoiceUtil();
+    @SuppressWarnings("unchecked")
+    final AvailabilityCheckerFactory<BlobSidecar> blobSidecarAvailabilityCheckerFactory =
+        mock(AvailabilityCheckerFactory.class);
+    @SuppressWarnings("unchecked")
+    final AvailabilityCheckerFactory<UInt64> dataColumnSidecarAvailabilityCheckerFactory =
+        mock(AvailabilityCheckerFactory.class);
+
+    final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
+
+    spec.reinitializeForTesting(
+        blobSidecarAvailabilityCheckerFactory,
+        dataColumnSidecarAvailabilityCheckerFactory,
+        KZG.DISABLED);
+
+    final AvailabilityChecker<?> availabilityChecker =
+        util.createAvailabilityCheckerOnExecutionPayloadEnvelope(block);
+
+    switch (milestone) {
+      case PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA, FULU ->
+          assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP);
+      case GLOAS, HEZE ->
           verify(dataColumnSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
       default -> throw new IllegalStateException("Unexpected milestone " + milestone);
     }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -299,11 +299,11 @@ class ForkChoiceUtilTest {
     final AvailabilityChecker<?> availabilityChecker = util.createAvailabilityCheckerOnBlock(block);
 
     switch (milestone) {
-      case PHASE0, ALTAIR, BELLATRIX, CAPELLA ->
+      case PHASE0, ALTAIR, BELLATRIX, CAPELLA, GLOAS, HEZE ->
           assertThat(availabilityChecker).isSameAs(AvailabilityChecker.NOOP);
       case DENEB, ELECTRA ->
           verify(blobSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
-      case FULU, GLOAS, HEZE ->
+      case FULU ->
           verify(dataColumnSidecarAvailabilityCheckerFactory).createAvailabilityChecker(block);
       default -> throw new IllegalStateException("Unexpected milestone " + milestone);
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -470,7 +470,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         IndexedAttestationCache.capturing();
 
     final AvailabilityChecker<?> availabilityChecker =
-        forkChoiceUtil.createAvailabilityChecker(block);
+        forkChoiceUtil.createAvailabilityCheckerOnBlock(block);
 
     availabilityChecker.initiateDataAvailabilityCheck();
 
@@ -559,7 +559,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final ForkChoiceUtil forkChoiceUtil = spec.atSlot(signedEnvelope.getSlot()).getForkChoiceUtil();
 
     final AvailabilityChecker<?> availabilityChecker =
-        forkChoiceUtil.createAvailabilityChecker(block);
+        forkChoiceUtil.createAvailabilityCheckerOnExecutionPayloadEnvelope(block);
     availabilityChecker.initiateDataAvailabilityCheck();
     final ForkChoicePayloadExecutorGloas payloadExecutor =
         ForkChoicePayloadExecutorGloas.create(signedEnvelope, executionLayer);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
When we call `on_block` we need NOOP availability checker for Gloas to import block immediately

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-choice block/payload import flow and changes when data-availability checks run for Gloas, which could affect import timing and validation ordering if misapplied.
> 
> **Overview**
> Refactors fork-choice data-availability checks to be *context-specific*, replacing `createAvailabilityChecker` with `createAvailabilityCheckerOnBlock` and `createAvailabilityCheckerOnExecutionPayloadEnvelope`, and updates `ForkChoice` to call the appropriate method for `on_block` vs `on_execution_payload_envelope`.
> 
> Changes Gloas behavior so `on_block` uses a NOOP availability checker (allowing immediate block import), while availability checks for Gloas/Heze are performed when importing execution payload envelopes; Deneb/Fulu behavior remains availability-checked on block import. Tests are updated to cover the new method split and milestone-specific expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3baac7e7ece4e20eb2e9485dd30034ffaf855f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->