### PR TITLE
Add dormant Gloas forkchoice model and rebuild support (6 of 7)

### DIFF
--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/GloasForkChoiceRebuildData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/GloasForkChoiceRebuildData.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.api;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Gloas-specific fork-choice rebuild data for reconstructing the base/empty/full node variants on
+ * restart.
+ *
+ * <p>{@code payloadParentBlockHash} replays the modified {@code on_block(...)} parent resolution.
+ * {@code payloadBlockHash} identifies the committed/revealed payload. {@code payloadBlockNumber} is
+ * only present when the execution payload has also been persisted and a FULL node can be recreated
+ * during rebuild.
+ */
+public record GloasForkChoiceRebuildData(
+    Bytes32 payloadParentBlockHash,
+    Bytes32 payloadBlockHash,
+    Optional<UInt64> payloadBlockNumber) {}

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
@@ -82,7 +82,9 @@ public class StoredBlockMetadata {
         blockAndState.getExecutionBlockNumber(),
         blockAndState.getExecutionBlockHash(),
         Optional.of(epochs),
-        extractGloasForkChoiceRebuildData(blockAndState.getSignedBeaconBlock()));
+        blockAndState
+            .getSignedBeaconBlock()
+            .flatMap(StoredBlockMetadata::extractGloasForkChoiceRebuildData));
   }
 
   public UInt64 getBlockSlot() {
@@ -149,19 +151,16 @@ public class StoredBlockMetadata {
         gloasForkChoiceRebuildData);
   }
 
-  private static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
-      final Optional<SignedBeaconBlock> maybeBlock) {
+  public static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
+      final SignedBeaconBlock block) {
     // TODO-GLOAS: keep this helper bid-only. The DB rebuild path should enrich
     // payloadBlockNumber from the persisted SignedBlindedExecutionPayloadEnvelope when
     // KvStoreDatabase builds StoredBlockMetadata with synchronous DAO access.
-    return maybeBlock
-        .flatMap(
-            block ->
-                block
-                    .getMessage()
-                    .getBody()
-                    .getOptionalSignedExecutionPayloadBid()
-                    .map(SignedExecutionPayloadBid::getMessage))
+    return block
+        .getMessage()
+        .getBody()
+        .getOptionalSignedExecutionPayloadBid()
+        .map(SignedExecutionPayloadBid::getMessage)
         .map(
             bid ->
                 new GloasForkChoiceRebuildData(

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
@@ -19,7 +19,9 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 
 public class StoredBlockMetadata {
   private final UInt64 blockSlot;
@@ -29,6 +31,7 @@ public class StoredBlockMetadata {
   private final Optional<UInt64> executionBlockNumber;
   private final Optional<Bytes32> executionBlockHash;
   private final Optional<BlockCheckpoints> checkpointEpochs;
+  private final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData;
 
   public StoredBlockMetadata(
       final UInt64 blockSlot,
@@ -38,6 +41,26 @@ public class StoredBlockMetadata {
       final Optional<UInt64> executionBlockNumber,
       final Optional<Bytes32> executionBlockHash,
       final Optional<BlockCheckpoints> checkpointEpochs) {
+    this(
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        stateRoot,
+        executionBlockNumber,
+        executionBlockHash,
+        checkpointEpochs,
+        Optional.empty());
+  }
+
+  public StoredBlockMetadata(
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final Optional<UInt64> executionBlockNumber,
+      final Optional<Bytes32> executionBlockHash,
+      final Optional<BlockCheckpoints> checkpointEpochs,
+      final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData) {
     this.blockSlot = blockSlot;
     this.blockRoot = blockRoot;
     this.parentRoot = parentRoot;
@@ -45,6 +68,7 @@ public class StoredBlockMetadata {
     this.executionBlockNumber = executionBlockNumber;
     this.executionBlockHash = executionBlockHash;
     this.checkpointEpochs = checkpointEpochs;
+    this.gloasForkChoiceRebuildData = gloasForkChoiceRebuildData;
   }
 
   public static StoredBlockMetadata fromBlockAndState(
@@ -57,7 +81,8 @@ public class StoredBlockMetadata {
         blockAndState.getStateRoot(),
         blockAndState.getExecutionBlockNumber(),
         blockAndState.getExecutionBlockHash(),
-        Optional.of(epochs));
+        Optional.of(epochs),
+        extractGloasForkChoiceRebuildData(blockAndState.getSignedBeaconBlock()));
   }
 
   public UInt64 getBlockSlot() {
@@ -88,6 +113,10 @@ public class StoredBlockMetadata {
     return checkpointEpochs;
   }
 
+  public Optional<GloasForkChoiceRebuildData> getGloasForkChoiceRebuildData() {
+    return gloasForkChoiceRebuildData;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -103,7 +132,8 @@ public class StoredBlockMetadata {
         && Objects.equals(stateRoot, that.stateRoot)
         && Objects.equals(executionBlockNumber, that.executionBlockNumber)
         && Objects.equals(executionBlockHash, that.executionBlockHash)
-        && Objects.equals(checkpointEpochs, that.checkpointEpochs);
+        && Objects.equals(checkpointEpochs, that.checkpointEpochs)
+        && Objects.equals(gloasForkChoiceRebuildData, that.gloasForkChoiceRebuildData);
   }
 
   @Override
@@ -115,6 +145,25 @@ public class StoredBlockMetadata {
         stateRoot,
         executionBlockNumber,
         executionBlockHash,
-        checkpointEpochs);
+        checkpointEpochs,
+        gloasForkChoiceRebuildData);
+  }
+
+  private static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
+      final Optional<SignedBeaconBlock> maybeBlock) {
+    // TODO-GLOAS: populate payloadBlockNumber here once SignedExecutionPayloadEnvelope storage is
+    // persisted through the DB layer and available alongside StoredBlockMetadata creation.
+    return maybeBlock
+        .flatMap(
+            block ->
+                block
+                    .getMessage()
+                    .getBody()
+                    .getOptionalSignedExecutionPayloadBid()
+                    .map(SignedExecutionPayloadBid::getMessage))
+        .map(
+            bid ->
+                new GloasForkChoiceRebuildData(
+                    bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
   }
 }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StoredBlockMetadata.java
@@ -151,8 +151,9 @@ public class StoredBlockMetadata {
 
   private static Optional<GloasForkChoiceRebuildData> extractGloasForkChoiceRebuildData(
       final Optional<SignedBeaconBlock> maybeBlock) {
-    // TODO-GLOAS: populate payloadBlockNumber here once SignedExecutionPayloadEnvelope storage is
-    // persisted through the DB layer and available alongside StoredBlockMetadata creation.
+    // TODO-GLOAS: keep this helper bid-only. The DB rebuild path should enrich
+    // payloadBlockNumber from the persisted SignedBlindedExecutionPayloadEnvelope when
+    // KvStoreDatabase builds StoredBlockMetadata with synchronous DAO access.
     return maybeBlock
         .flatMap(
             block ->

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelFactory.java
@@ -17,18 +17,28 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
 
 /** Centralizes the storage-layer milestone split for forkchoice models. */
 public class ForkChoiceModelFactory {
 
   private final ForkChoiceModel phase0Model = ForkChoiceModelPhase0.INSTANCE;
+  private final ForkChoiceModel gloasModel;
 
   public ForkChoiceModelFactory(final Spec spec) {
-    // Branch 04 lands the model seam with only the Phase0 behavior wired.
+    if (spec.isMilestoneSupported(SpecMilestone.GLOAS)) {
+      gloasModel =
+          new ForkChoiceModelGloas(
+              SpecConfigGloas.required(spec.forMilestone(SpecMilestone.GLOAS).getConfig()));
+    } else {
+      gloasModel = phase0Model;
+    }
   }
 
   ForkChoiceModel forSlot(final UInt64 slot) {
+    // Branch 06 keeps the Gloas model dormant while the storage/rebuild pieces land.
     return phase0Model;
   }
 
@@ -50,5 +60,6 @@ public class ForkChoiceModelFactory {
 
   void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
     phase0Model.onPrunedBlocks(blockNodeIndex);
+    gloasModel.onPrunedBlocks(blockNodeIndex);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -188,9 +188,11 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
       return;
     }
+    final Optional<ForkChoiceNode> maybeBaseNodeIdentity =
+        resolveBaseNode(blockNodeIndex, blockRoot);
     final Optional<ProtoNodeData> maybeBaseNode =
-        getNodeData(protoArray, resolveBaseNode(blockNodeIndex, blockRoot));
-    if (maybeBaseNode.isEmpty()) {
+        maybeBaseNodeIdentity.flatMap(protoArray::getNode).map(ProtoNode::getBlockData);
+    if (maybeBaseNodeIdentity.isEmpty() || maybeBaseNode.isEmpty()) {
       return;
     }
 
@@ -201,7 +203,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
         baseNode.getSlot(),
         blockRoot,
         baseNode.getParentRoot(),
-        Optional.of(resolveBaseNode(blockNodeIndex, blockRoot)),
+        maybeBaseNodeIdentity,
         baseNode.getStateRoot(),
         baseNode.getCheckpoints(),
         executionBlockNumber,
@@ -415,19 +417,14 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
-  public Optional<ProtoNodeData> getNodeData(
-      final ProtoArray protoArray, final ForkChoiceNode node) {
-    return protoArray.getNode(node).map(ProtoNode::getBlockData);
-  }
-
-  @Override
-  public Optional<ProtoNodeData> getBlockData(
+  public Optional<ProtoNodeData> getBaseNodeData(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final Bytes32 blockRoot) {
     return blockNodeIndex
         .getBaseNode(blockRoot)
-        .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+        .flatMap(protoArray::getNode)
+        .map(ProtoNode::getBlockData);
   }
 
   @Override
@@ -448,20 +445,22 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
-  public ForkChoiceNode resolveBaseNode(
+  public Optional<ForkChoiceNode> resolveBaseNode(
       final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
-    return blockNodeIndex.getBaseNode(blockRoot).orElse(ForkChoiceNode.createBase(blockRoot));
+    return blockNodeIndex.getBaseNode(blockRoot);
   }
 
   @Override
-  public ForkChoiceNode resolveExecutionNode(
+  public Optional<ProtoNodeData> getExecutionNodeData(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
       final Bytes32 blockRoot) {
     // FULL is the execution-state node selected when the payload has been revealed.
     return blockNodeIndex
         .getFullNode(blockRoot)
-        .orElseGet(() -> resolveBaseNode(blockNodeIndex, blockRoot));
+        .or(() -> resolveBaseNode(blockNodeIndex, blockRoot))
+        .flatMap(protoArray::getNode)
+        .map(ProtoNode::getBlockData);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.storage.api.GloasForkChoiceRebuildData;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+
+/**
+ * Storage-side implementation of the Gloas three-state fork-choice tree.
+ *
+ * <p>This class is the fork-aware model-side implementation of the Python helpers and handlers that
+ * introduce the EMPTY/FULL child nodes:
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-on_block
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-on_execution_payload
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-get_node_children
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-get_parent_payload_status
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_parent_node_full
+ */
+class ForkChoiceModelGloas implements ForkChoiceModel {
+
+  private final UInt64 firstGloasSlot;
+  private final int payloadTimelyThreshold;
+  private final int dataAvailabilityTimelyThreshold;
+  private final PtcVoteTracker ptcVoteTracker;
+
+  ForkChoiceModelGloas(final SpecConfigGloas specConfig) {
+    this(
+        specConfig,
+        specConfig.getPayloadTimelyThreshold(),
+        specConfig.getDataAvailabilityTimelyThreshold(),
+        new PtcVoteTracker());
+  }
+
+  ForkChoiceModelGloas(
+      final SpecConfigGloas specConfig,
+      final int payloadTimelyThreshold,
+      final int dataAvailabilityTimelyThreshold,
+      final PtcVoteTracker ptcVoteTracker) {
+    this.firstGloasSlot = specConfig.getGloasForkEpoch().times(specConfig.getSlotsPerEpoch());
+    this.payloadTimelyThreshold = payloadTimelyThreshold;
+    this.dataAvailabilityTimelyThreshold = dataAvailabilityTimelyThreshold;
+    this.ptcVoteTracker = ptcVoteTracker;
+  }
+
+  @Override
+  public void processBlock(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 blockSlot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Bytes32 stateRoot,
+      final BlockCheckpoints checkpoints,
+      final Optional<UInt64> maybeExecutionBlockNumber,
+      final Optional<Bytes32> maybeExecutionBlockHash,
+      final boolean optimisticallyProcessed) {
+    // Spec mapping: modified on_block(store, signed_block)
+    // The parent choice follows get_parent_payload_status / is_parent_node_full and the node
+    // layout follows get_node_children with a base PENDING node plus an immediate EMPTY child.
+    // In Gloas, maybeExecutionBlockHash does not represent this block's eventual payload block
+    // hash. During block import it carries the bid's parent_block_hash, which is used to resolve
+    // whether the new node builds on the parent's FULL or EMPTY variant. The execution block
+    // number/hash stored on the new base/EMPTY nodes are inherited from the resolved parent, while
+    // this block's own payload block number/hash are only attached later by onExecutionPayload(...)
+    // when the FULL node is created.
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    final Optional<ProtoNode> parentProtoNode =
+        resolveParentNode(
+            protoArray,
+            blockNodeIndex,
+            parentRoot,
+            maybeExecutionBlockHash.orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH));
+    final UInt64 executionBlockNumber =
+        parentProtoNode
+            .map(ProtoNode::getExecutionBlockNumber)
+            .orElse(ProtoNode.NO_EXECUTION_BLOCK_NUMBER);
+    final Bytes32 executionBlockHash =
+        parentProtoNode
+            .map(ProtoNode::getExecutionBlockHash)
+            .orElse(ProtoNode.NO_EXECUTION_BLOCK_HASH);
+
+    // the node is optimistic only if it builds on top of optimistic node.
+    // In gloas we start being optimistic from a FULL block
+    final boolean isParentOptimistic = parentProtoNode.map(ProtoNode::isOptimistic).orElse(false);
+    protoArray.addNode(
+        baseNode,
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        parentProtoNode.map(ProtoNode::getForkChoiceNode),
+        stateRoot,
+        checkpoints,
+        executionBlockNumber,
+        executionBlockHash,
+        isParentOptimistic);
+    blockNodeIndex.putBaseNode(blockRoot, blockSlot, baseNode);
+
+    final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+    protoArray.addNode(
+        emptyNode,
+        blockSlot,
+        blockRoot,
+        parentRoot,
+        Optional.of(baseNode),
+        stateRoot,
+        checkpoints,
+        executionBlockNumber,
+        executionBlockHash,
+        isParentOptimistic);
+    blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+  }
+
+  @VisibleForTesting
+  Optional<ProtoNode> resolveParentNode(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 parentRoot,
+      final Bytes32 childParentBlockHash) {
+    // Spec mapping: get_parent_payload_status(store, block)
+    // FULL wins only when the child bid's parent_block_hash matches the parent's FULL execution
+    // block hash. Otherwise we attach to EMPTY. The only cases where the structural base node is a
+    // valid fallback are the fork boundary where the parent is pre-Gloas and the base-only anchor
+    // node at the root of the protoarray. A completely missing parent is only valid while
+    // rebuilding the very first anchor node into an empty protoarray.
+    final Optional<ForkChoiceNode> fullNode = blockNodeIndex.getFullNode(parentRoot);
+    if (fullNode.isPresent()) {
+      final Optional<ProtoNode> maybeFullNode = protoArray.getNode(fullNode.get());
+      if (maybeFullNode.isPresent()
+          && maybeFullNode.get().getExecutionBlockHash().equals(childParentBlockHash)) {
+        return maybeFullNode;
+      }
+    }
+
+    final Optional<ProtoNode> emptyNode =
+        blockNodeIndex.getEmptyNode(parentRoot).flatMap(protoArray::getNode);
+    if (emptyNode.isPresent()) {
+      return emptyNode;
+    }
+
+    final Optional<ProtoNode> baseNode =
+        blockNodeIndex.getBaseNode(parentRoot).flatMap(protoArray::getNode);
+    if (baseNode.isPresent()
+        && (baseNode.get().getBlockSlot().isLessThan(firstGloasSlot)
+            || baseNode.get().getParentIndex().isEmpty())) {
+      return baseNode;
+    }
+    if (protoArray.getTotalTrackedNodeCount() == 0) {
+      return Optional.empty();
+    }
+
+    throw new IllegalStateException(
+        String.format(
+            "Missing GLOAS parent variants for parent root %s at or after slot %s",
+            parentRoot, firstGloasSlot));
+  }
+
+  @Override
+  public void onExecutionPayload(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final UInt64 executionBlockNumber,
+      final Bytes32 executionBlockHash,
+      final boolean isOptimistic) {
+    // Spec mapping: on_execution_payload(store, signed_execution_payload_envelope)
+    if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
+      return;
+    }
+    final Optional<ProtoNodeData> maybeBaseNode =
+        getNodeData(protoArray, resolveBaseNode(blockNodeIndex, blockRoot));
+    if (maybeBaseNode.isEmpty()) {
+      return;
+    }
+
+    final ForkChoiceNode fullNode = ForkChoiceNode.createFull(blockRoot);
+    final ProtoNodeData baseNode = maybeBaseNode.get();
+    protoArray.addNode(
+        fullNode,
+        baseNode.getSlot(),
+        blockRoot,
+        baseNode.getParentRoot(),
+        Optional.of(resolveBaseNode(blockNodeIndex, blockRoot)),
+        baseNode.getStateRoot(),
+        baseNode.getCheckpoints(),
+        executionBlockNumber,
+        executionBlockHash,
+        isOptimistic);
+    blockNodeIndex.attachFullNode(blockRoot, fullNode);
+  }
+
+  @Override
+  public void rebuildBlockNodesFromMetadata(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final StoredBlockMetadata block,
+      final boolean optimisticallyProcessed) {
+    // Recovery replays the same modified on_block logic as live import so the EMPTY/FULL layout
+    // matches the Gloas store model after restart.
+    final Optional<Bytes32> parentBlockHash =
+        block
+            .getGloasForkChoiceRebuildData()
+            .map(GloasForkChoiceRebuildData::payloadParentBlockHash);
+    final Optional<UInt64> executionBlockNumber =
+        block
+            .getExecutionBlockNumber()
+            .or(
+                () ->
+                    blockNodeIndex
+                        .getBaseNode(block.getParentRoot())
+                        .flatMap(protoArray::getNode)
+                        .map(ProtoNode::getExecutionBlockNumber));
+    processBlock(
+        protoArray,
+        blockNodeIndex,
+        block.getBlockSlot(),
+        block.getBlockRoot(),
+        block.getParentRoot(),
+        block.getStateRoot(),
+        block.getCheckpointEpochs().orElseThrow(),
+        executionBlockNumber,
+        parentBlockHash,
+        optimisticallyProcessed);
+    block
+        .getGloasForkChoiceRebuildData()
+        .flatMap(this::getFullNodeRebuildPayload)
+        .ifPresent(
+            rebuildPayload ->
+                onExecutionPayload(
+                    protoArray,
+                    blockNodeIndex,
+                    block.getBlockRoot(),
+                    rebuildPayload.executionBlockNumber(),
+                    rebuildPayload.executionBlockHash(),
+                    optimisticallyProcessed));
+  }
+
+  @Override
+  public Optional<ForkChoiceNode> resolveVoteNode(
+      final Bytes32 voteRoot,
+      final UInt64 voteSlot,
+      final boolean payloadPresent,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex) {
+    final Optional<ForkChoiceNode> maybeBaseNode = blockNodeIndex.getBaseNode(voteRoot);
+    if (maybeBaseNode.isEmpty()) {
+      return Optional.empty();
+    }
+
+    final Optional<UInt64> blockSlot =
+        protoArray.getNode(maybeBaseNode.get()).map(ProtoNode::getBlockSlot);
+    if (blockSlot.isPresent() && voteSlot.isLessThanOrEqualTo(blockSlot.get())) {
+      return maybeBaseNode;
+    }
+    if (payloadPresent) {
+      return blockNodeIndex.getFullNode(voteRoot).or(() -> maybeBaseNode);
+    }
+    return blockNodeIndex.getEmptyNode(voteRoot).or(() -> maybeBaseNode);
+  }
+
+  @Override
+  public int compareViableChildren(
+      final ProtoNode candidateChild,
+      final ProtoNode currentBestChild,
+      final ProtoNode parent,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    // Spec mapping: the extra Gloas sort key in modified get_head only applies to the EMPTY/FULL
+    // children returned by get_node_children(parent_root).
+    if (!candidateChild.getBlockRoot().equals(parent.getBlockRoot())
+        || !currentBestChild.getBlockRoot().equals(parent.getBlockRoot())) {
+      return 0;
+    }
+
+    final UInt64 candidateEffectiveWeight = effectiveWeight(candidateChild, currentSlot);
+    final UInt64 currentEffectiveWeight = effectiveWeight(currentBestChild, currentSlot);
+    final int weightComparison = candidateEffectiveWeight.compareTo(currentEffectiveWeight);
+    if (weightComparison != 0) {
+      return weightComparison;
+    }
+
+    return Integer.compare(
+        computePayloadStatusTiebreaker(
+            candidateChild, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot),
+        computePayloadStatusTiebreaker(
+            currentBestChild, protoArray, blockNodeIndex, currentSlot, proposerBoostRoot));
+  }
+
+  private UInt64 effectiveWeight(final ProtoNode node, final UInt64 currentSlot) {
+    if (node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING
+        || !node.getBlockSlot().plus(1).equals(currentSlot)) {
+      return node.getWeight();
+    }
+    return UInt64.ZERO;
+  }
+
+  private int computePayloadStatusTiebreaker(
+      final ProtoNode node,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final UInt64 currentSlot,
+      final Optional<Bytes32> proposerBoostRoot) {
+    if (node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING
+        || !node.getBlockSlot().plus(1).equals(currentSlot)) {
+      return node.getPayloadStatus().getValue();
+    }
+    if (node.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY) {
+      return 1;
+    }
+    return shouldExtendPayload(blockNodeIndex, node.getBlockRoot(), protoArray, proposerBoostRoot)
+        ? 2
+        : 0;
+  }
+
+  private boolean shouldExtendPayload(
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final ProtoArray protoArray,
+      final Optional<Bytes32> proposerBoostRoot) {
+    if (isPayloadTimely(blockNodeIndex, blockRoot)
+        && isPayloadDataAvailable(blockNodeIndex, blockRoot)) {
+      return true;
+    }
+    if (proposerBoostRoot.isEmpty()) {
+      return true;
+    }
+    final Optional<ProtoNode> proposerNode =
+        blockNodeIndex.getBaseNode(proposerBoostRoot.get()).flatMap(protoArray::getNode);
+    if (proposerNode.isEmpty()) {
+      return true;
+    }
+    if (!proposerNode.get().getParentRoot().equals(blockRoot)) {
+      return true;
+    }
+    return blockNodeIndex
+        .getFullNode(blockRoot)
+        .flatMap(protoArray::getNode)
+        .map(
+            fullNode ->
+                fullNode.getExecutionBlockHash().equals(proposerNode.get().getExecutionBlockHash()))
+        .orElse(false);
+  }
+
+  private boolean isPayloadTimely(
+      final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
+    if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
+      return false;
+    }
+    return ptcVoteTracker.getPayloadPresentVoteCount(blockRoot) > payloadTimelyThreshold;
+  }
+
+  private boolean isPayloadDataAvailable(
+      final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
+    if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
+      return false;
+    }
+    return ptcVoteTracker.getDataAvailableVoteCount(blockRoot) > dataAvailabilityTimelyThreshold;
+  }
+
+  @Override
+  public void onExecutionPayloadResult(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot,
+      final ExecutionPayloadStatus status,
+      final Optional<Bytes32> latestValidHash,
+      final boolean verifiedInvalidTransition,
+      final HeadSelectionContext headSelectionContext) {
+    if (status.isValid()) {
+      // Only the FULL node needs validation marking — base/EMPTY are already VALID from block
+      // import
+      blockNodeIndex.getFullNode(blockRoot).ifPresent(protoArray::markNodeValid);
+    } else if (status.isInvalid()) {
+      if (verifiedInvalidTransition) {
+        // In Gloas, an invalid execution payload only invalidates the FULL path.
+        // The beacon block (base + EMPTY) remains valid — the builder, not the proposer, is at
+        // fault.
+        blockNodeIndex
+            .getFullNode(blockRoot)
+            .ifPresent(
+                node -> protoArray.markNodeInvalid(node, latestValidHash, headSelectionContext));
+      } else {
+        // Unverified: a child's payload was invalid, pointing at this parent.
+        // The base node is the correct anchor for parent-chain invalidation search.
+        blockNodeIndex
+            .getBaseNode(blockRoot)
+            .ifPresent(
+                node ->
+                    protoArray.markParentChainInvalid(node, latestValidHash, headSelectionContext));
+      }
+    }
+  }
+
+  @Override
+  public Optional<ProtoNodeData> getNodeData(
+      final ProtoArray protoArray, final ForkChoiceNode node) {
+    return protoArray.getNode(node).map(ProtoNode::getBlockData);
+  }
+
+  @Override
+  public Optional<ProtoNodeData> getBlockData(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    return blockNodeIndex
+        .getBaseNode(blockRoot)
+        .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+  }
+
+  @Override
+  public boolean isHeadCandidate(final ProtoNode node) {
+    // Spec mapping: modified get_head(store)
+    // In the Gloas three-state tree the base PENDING node is structural only. Candidate heads are
+    // the EMPTY/FULL children selected from get_node_children(...).
+    return node.getPayloadStatus() != ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
+  }
+
+  @Override
+  public ForkChoiceNode resolveBaseNode(
+      final BlockNodeVariantsIndex blockNodeIndex, final Bytes32 blockRoot) {
+    return blockNodeIndex.getBaseNode(blockRoot).orElse(ForkChoiceNode.createBase(blockRoot));
+  }
+
+  @Override
+  public ForkChoiceNode resolveExecutionNode(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    // FULL is the execution-state node selected when the payload has been revealed.
+    return blockNodeIndex
+        .getFullNode(blockRoot)
+        .orElseGet(() -> resolveBaseNode(blockNodeIndex, blockRoot));
+  }
+
+  @Override
+  public Optional<ForkChoicePayloadStatus> payloadStatus(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    // Compatibility read for block-root-only callers. This mirrors the best-available payload
+    // status without promoting it to a first-class "preferred node" abstraction.
+    if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
+      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+    }
+    if (blockNodeIndex.getEmptyNode(blockRoot).isPresent()) {
+      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+    }
+    return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
+  }
+
+  @Override
+  public void pullUpBlockCheckpoints(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    blockNodeIndex
+        .getVariants(blockRoot)
+        .ifPresent(variants -> variants.allNodes().forEach(protoArray::pullUpCheckpoints));
+  }
+
+  @Override
+  public void onPtcVote(
+      final Bytes32 blockRoot,
+      final UInt64 validatorIndex,
+      final boolean payloadPresent,
+      final boolean blobDataAvailable) {
+    // Spec mapping: on_payload_attestation_message / notify_ptc_messages
+    ptcVoteTracker.recordVote(blockRoot, validatorIndex, payloadPresent, blobDataAvailable);
+  }
+
+  @Override
+  public void onRemovedBlockRoot(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final Bytes32 blockRoot) {
+    blockNodeIndex
+        .getVariants(blockRoot)
+        .ifPresent(variants -> variants.allNodes().forEach(protoArray::removeNode));
+    blockNodeIndex.remove(blockRoot);
+    ptcVoteTracker.remove(blockRoot);
+  }
+
+  @Override
+  public void onPrunedBlocks(final BlockNodeVariantsIndex blockNodeIndex) {
+    ptcVoteTracker.removeIf(root -> !blockNodeIndex.containsBlock(root));
+  }
+
+  private Optional<FullNodeRebuildPayload> getFullNodeRebuildPayload(
+      final GloasForkChoiceRebuildData rebuildData) {
+    return rebuildData
+        .payloadBlockNumber()
+        .map(
+            executionBlockNumber ->
+                new FullNodeRebuildPayload(executionBlockNumber, rebuildData.payloadBlockHash()));
+  }
+
+  private record FullNodeRebuildPayload(UInt64 executionBlockNumber, Bytes32 executionBlockHash) {}
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -455,22 +455,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   @Override
-  public Optional<ForkChoicePayloadStatus> payloadStatus(
-      final ProtoArray protoArray,
-      final BlockNodeVariantsIndex blockNodeIndex,
-      final Bytes32 blockRoot) {
-    // Compatibility read for block-root-only callers. This mirrors the best-available payload
-    // status without promoting it to a first-class "preferred node" abstraction.
-    if (blockNodeIndex.getFullNode(blockRoot).isPresent()) {
-      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
-    }
-    if (blockNodeIndex.getEmptyNode(blockRoot).isPresent()) {
-      return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
-    }
-    return Optional.of(ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING);
-  }
-
-  @Override
   public void pullUpBlockCheckpoints(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -107,7 +107,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     protoArray.addNode(
         baseNode,
         blockSlot,
-        blockRoot,
         parentRoot,
         parentProtoNode.map(ProtoNode::getForkChoiceNode),
         stateRoot,
@@ -121,7 +120,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     protoArray.addNode(
         emptyNode,
         blockSlot,
-        blockRoot,
         parentRoot,
         Optional.of(baseNode),
         stateRoot,
@@ -201,7 +199,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     protoArray.addNode(
         fullNode,
         baseNode.getSlot(),
-        blockRoot,
         baseNode.getParentRoot(),
         maybeBaseNodeIdentity,
         baseNode.getStateRoot(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -436,8 +436,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
       final BlockNodeVariantsIndex blockNodeIndex,
       final ReadOnlyStore store,
       final Bytes32 blockRoot) {
-    return shouldExtendPayload(
-        blockNodeIndex, blockRoot, protoArray, store.getProposerBoostRoot());
+    return shouldExtendPayload(blockNodeIndex, blockRoot, protoArray, store.getProposerBoostRoot());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.storage.api.GloasForkChoiceRebuildData;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
@@ -427,6 +428,16 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     return blockNodeIndex
         .getBaseNode(blockRoot)
         .flatMap(nodeIdentity -> getNodeData(protoArray, nodeIdentity));
+  }
+
+  @Override
+  public boolean shouldExtendPayload(
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final ReadOnlyStore store,
+      final Bytes32 blockRoot) {
+    return shouldExtendPayload(
+        blockNodeIndex, blockRoot, protoArray, store.getProposerBoostRoot());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -97,7 +97,6 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                     .map(SignedBeaconBlock::getSlot)
                     .map(this::getForkChoiceModel))
         .orElse(ForkChoiceModelPhase0.INSTANCE);
-        .orElse(ForkChoiceModelPhase0.INSTANCE);
   }
 
   public static ForkChoiceStrategy initialize(final Spec spec, final ProtoArray protoArray) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -97,6 +97,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
                     .map(SignedBeaconBlock::getSlot)
                     .map(this::getForkChoiceModel))
         .orElse(ForkChoiceModelPhase0.INSTANCE);
+        .orElse(ForkChoiceModelPhase0.INSTANCE);
   }
 
   public static ForkChoiceStrategy initialize(final Spec spec, final ProtoArray protoArray) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/PtcVoteTracker.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/PtcVoteTracker.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Tracks the per-root PTC vote material consumed by the Gloas fork-choice helpers
+ * `is_payload_timely(...)` and `is_payload_data_available(...)`.
+ *
+ * <p>This is a storage-side representation of the state updated by `notify_ptc_messages(...)` and
+ * later queried from `should_extend_payload(...)`:
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-notify_ptc_messages
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_payload_timely
+ * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#new-is_payload_data_available
+ *
+ * <p>Teku stores the information as per-root validator sets because fork choice only needs the
+ * resulting counts, not the spec's exact vector layout.
+ */
+class PtcVoteTracker {
+
+  private record VotesPerValidator(Set<UInt64> payload, Set<UInt64> data) {}
+
+  private final Map<Bytes32, VotesPerValidator> votesByRoot = new ConcurrentHashMap<>();
+
+  void recordVote(
+      final Bytes32 blockRoot,
+      final UInt64 validatorIndex,
+      final boolean payloadPresent,
+      final boolean blobDataAvailable) {
+    votesByRoot.compute(
+        blockRoot,
+        (__, existingVotes) -> {
+          final VotesPerValidator updatedVotes =
+              existingVotes != null
+                  ? existingVotes
+                  : new VotesPerValidator(
+                      ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet());
+          if (payloadPresent) {
+            updatedVotes.payload.add(validatorIndex);
+          } else {
+            updatedVotes.payload.remove(validatorIndex);
+          }
+
+          if (blobDataAvailable) {
+            updatedVotes.data.add(validatorIndex);
+          } else {
+            updatedVotes.data.remove(validatorIndex);
+          }
+          return updatedVotes;
+        });
+  }
+
+  int getPayloadPresentVoteCount(final Bytes32 blockRoot) {
+    final VotesPerValidator votes = votesByRoot.get(blockRoot);
+    return votes != null ? votes.payload.size() : 0;
+  }
+
+  int getDataAvailableVoteCount(final Bytes32 blockRoot) {
+    final VotesPerValidator votes = votesByRoot.get(blockRoot);
+    return votes != null ? votes.data.size() : 0;
+  }
+
+  void remove(final Bytes32 blockRoot) {
+    votesByRoot.remove(blockRoot);
+  }
+
+  void removeIf(final Predicate<Bytes32> shouldRemove) {
+    votesByRoot.keySet().removeIf(shouldRemove);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -60,6 +60,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -69,6 +70,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+import tech.pegasys.teku.storage.api.GloasForkChoiceRebuildData;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
@@ -323,6 +325,18 @@ public class KvStoreDatabase implements Database {
                 dao.getHotBlockCheckpointEpochs(b.getRoot());
             final Optional<ExecutionPayload> executionPayload =
                 b.getMessage().getBody().getOptionalExecutionPayload();
+            // TODO-GLOAS: persist SignedExecutionPayloadEnvelope alongside hot blocks so
+            // GloasForkChoiceRebuildData can include payloadBlockNumber and restart can recreate
+            // FULL nodes exactly from StoredBlockMetadata.
+            final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData =
+                b.getMessage()
+                    .getBody()
+                    .getOptionalSignedExecutionPayloadBid()
+                    .map(SignedExecutionPayloadBid::getMessage)
+                    .map(
+                        bid ->
+                            new GloasForkChoiceRebuildData(
+                                bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
             blockInformation.put(
                 b.getRoot(),
                 new StoredBlockMetadata(
@@ -332,7 +346,8 @@ public class KvStoreDatabase implements Database {
                     b.getStateRoot(),
                     executionPayload.map(ExecutionPayload::getBlockNumber),
                     executionPayload.map(ExecutionPayload::getBlockHash),
-                    checkpointEpochs));
+                    checkpointEpochs,
+                    gloasForkChoiceRebuildData));
           });
     }
     return blockInformation;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -60,7 +60,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -325,19 +324,8 @@ public class KvStoreDatabase implements Database {
                 dao.getHotBlockCheckpointEpochs(b.getRoot());
             final Optional<ExecutionPayload> executionPayload =
                 b.getMessage().getBody().getOptionalExecutionPayload();
-            // TODO-GLOAS: enrich this rebuild data from
-            // dao.getBlindedExecutionPayloadEnvelope(b.getRoot()). The blinded envelope payload
-            // header has the execution block number/hash needed to recreate FULL nodes during
-            // protoarray rebuild; validate it matches the block bid before using it.
             final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData =
-                b.getMessage()
-                    .getBody()
-                    .getOptionalSignedExecutionPayloadBid()
-                    .map(SignedExecutionPayloadBid::getMessage)
-                    .map(
-                        bid ->
-                            new GloasForkChoiceRebuildData(
-                                bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
+                StoredBlockMetadata.extractGloasForkChoiceRebuildData(b);
             blockInformation.put(
                 b.getRoot(),
                 new StoredBlockMetadata(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -325,9 +325,10 @@ public class KvStoreDatabase implements Database {
                 dao.getHotBlockCheckpointEpochs(b.getRoot());
             final Optional<ExecutionPayload> executionPayload =
                 b.getMessage().getBody().getOptionalExecutionPayload();
-            // TODO-GLOAS: persist SignedExecutionPayloadEnvelope alongside hot blocks so
-            // GloasForkChoiceRebuildData can include payloadBlockNumber and restart can recreate
-            // FULL nodes exactly from StoredBlockMetadata.
+            // TODO-GLOAS: enrich this rebuild data from
+            // dao.getBlindedExecutionPayloadEnvelope(b.getRoot()). The blinded envelope payload
+            // header has the execution block number/hash needed to recreate FULL nodes during
+            // protoarray rebuild; validate it matches the block bid before using it.
             final Optional<GloasForkChoiceRebuildData> gloasForkChoiceRebuildData =
                 b.getMessage()
                     .getBody()

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -74,16 +74,7 @@ public class StoreBuilder {
     final UInt64 time = spec.computeTimeAtSlot(slot, genesisTime).max(currentTime);
 
     Map<Bytes32, StoredBlockMetadata> blockInfo = new HashMap<>();
-    blockInfo.put(
-        anchor.getRoot(),
-        new StoredBlockMetadata(
-            slot,
-            anchor.getRoot(),
-            anchor.getParentRoot(),
-            anchor.getState().hashTreeRoot(),
-            anchor.getExecutionBlockNumber(),
-            anchor.getExecutionBlockHash(),
-            Optional.of(spec.calculateBlockCheckpoints(anchor.getState()))));
+    blockInfo.put(anchor.getRoot(), StoredBlockMetadata.fromBlockAndState(spec, anchor));
 
     return new OnDiskStoreData(
         time,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -74,7 +74,19 @@ public class StoreBuilder {
     final UInt64 time = spec.computeTimeAtSlot(slot, genesisTime).max(currentTime);
 
     Map<Bytes32, StoredBlockMetadata> blockInfo = new HashMap<>();
-    blockInfo.put(anchor.getRoot(), StoredBlockMetadata.fromBlockAndState(spec, anchor));
+    blockInfo.put(
+        anchor.getRoot(),
+        new StoredBlockMetadata(
+            slot,
+            anchor.getRoot(),
+            anchor.getParentRoot(),
+            anchor.getState().hashTreeRoot(),
+            anchor.getExecutionBlockNumber(),
+            anchor.getExecutionBlockHash(),
+            Optional.of(spec.calculateBlockCheckpoints(anchor.getState())),
+            anchor
+                .getSignedBeaconBlock()
+                .flatMap(StoredBlockMetadata::extractGloasForkChoiceRebuildData)));
 
     return new OnDiskStoreData(
         time,

--- a/storage/src/test/java/tech/pegasys/teku/storage/api/StoredBlockMetadataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/api/StoredBlockMetadataTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class StoredBlockMetadataTest {
+
+  @Test
+  void fromBlockAndState_shouldCaptureGloasForkChoiceRebuildDataFromSignedBlock() {
+    final Spec spec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final SignedBlockAndState blockAndState =
+        dataStructureUtil.randomSignedBlockAndState(UInt64.ONE);
+    final ExecutionPayloadBid bid =
+        blockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .map(SignedExecutionPayloadBid::getMessage)
+            .orElseThrow();
+
+    final StoredBlockMetadata metadata = StoredBlockMetadata.fromBlockAndState(spec, blockAndState);
+
+    assertThat(metadata.getGloasForkChoiceRebuildData())
+        .contains(
+            new GloasForkChoiceRebuildData(
+                bid.getParentBlockHash(), bid.getBlockHash(), Optional.empty()));
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -872,7 +872,6 @@ public class ProtoArrayScoreCalculatorTest {
     protoArray.addNode(
         baseNode,
         blockSlot,
-        blockRoot,
         Bytes32.ZERO,
         Optional.empty(),
         Bytes32.ZERO,
@@ -887,7 +886,6 @@ public class ProtoArrayScoreCalculatorTest {
       protoArray.addNode(
           emptyNode,
           blockSlot,
-          blockRoot,
           Bytes32.ZERO,
           Optional.of(baseNode),
           Bytes32.ZERO,
@@ -903,7 +901,6 @@ public class ProtoArrayScoreCalculatorTest {
       protoArray.addNode(
           fullNode,
           blockSlot,
-          blockRoot,
           Bytes32.ZERO,
           Optional.of(baseNode),
           Bytes32.ZERO,

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculatorTest.java
@@ -36,7 +36,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
@@ -45,6 +48,9 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 public class ProtoArrayScoreCalculatorTest {
   private static final Spec SPEC = TestSpecFactory.createMinimalPhase0();
   private static final Checkpoint GENESIS_CHECKPOINT = new Checkpoint(ZERO, Bytes32.ZERO);
+  private static final BlockCheckpoints GENESIS_BLOCK_CHECKPOINTS =
+      new BlockCheckpoints(
+          GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
 
   private final Object2IntMap<Bytes32> indices = new Object2IntOpenHashMap<>();
   private List<UInt64> oldBalances = new ArrayList<>();
@@ -54,6 +60,10 @@ public class ProtoArrayScoreCalculatorTest {
   private UInt64 oldProposerBoostAmount = ZERO;
   private UInt64 newProposerBoostAmount = ZERO;
   private final VoteUpdater store = createStoreToManipulateVotes();
+  private final ForkChoiceModelGloas gloasModel =
+      new ForkChoiceModelGloas(
+          SpecConfigGloas.required(
+              TestSpecFactory.createMinimalGloas().forMilestone(SpecMilestone.GLOAS).getConfig()));
 
   private Optional<Integer> getIndex(final Bytes32 root) {
     final int index = indices.getOrDefault(root, -1);
@@ -86,6 +96,34 @@ public class ProtoArrayScoreCalculatorTest {
         createProtoArray(),
         blockNodeIndex,
         ForkChoiceModelPhase0.INSTANCE);
+  }
+
+  private LongList computeDeltas(
+      final VoteUpdater store,
+      final int protoArraySize,
+      final Function<ForkChoiceNode, Optional<Integer>> getIndexByNode,
+      final Optional<ForkChoiceNode> previousProposerBoostNode,
+      final Optional<ForkChoiceNode> newProposerBoostNode,
+      final List<UInt64> oldBalances,
+      final List<UInt64> newBalances,
+      final UInt64 previousBoostAmount,
+      final UInt64 newBoostAmount,
+      final ProtoArray protoArray,
+      final BlockNodeVariantsIndex blockNodeIndex,
+      final ForkChoiceModel forkChoiceModel) {
+    return ProtoArrayScoreCalculator.computeDeltas(
+        store,
+        protoArraySize,
+        getIndexByNode,
+        previousProposerBoostNode,
+        newProposerBoostNode,
+        oldBalances,
+        newBalances,
+        previousBoostAmount,
+        newBoostAmount,
+        protoArray,
+        blockNodeIndex,
+        forkChoiceModel);
   }
 
   @Test
@@ -550,6 +588,101 @@ public class ProtoArrayScoreCalculatorTest {
   }
 
   @Test
+  void computeDeltas_payloadPresentVoteFallsBackToPendingWhenFullNodeIsMissing() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final ProtoArray protoArray = createProtoArray();
+    final BlockNodeVariantsIndex blockNodeIndex =
+        createBlockNodeVariantsIndex(protoArray, root, true, false, UInt64.ONE);
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+
+    store.putVote(
+        ZERO,
+        new VoteTracker(Bytes32.ZERO, root, false, false, UInt64.valueOf(2), true, ZERO, false));
+
+    final List<Long> deltas =
+        computeDeltas(
+            store,
+            protoArray.getTotalTrackedNodeCount(),
+            protoArray::getNodeIndex,
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            protoArray,
+            blockNodeIndex,
+            gloasModel);
+
+    assertThat(deltas).containsExactly(balance.longValue(), 0L);
+  }
+
+  @Test
+  void computeDeltas_payloadAbsentVoteAtBlockSlotTargetsPendingNode() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final ProtoArray protoArray = createProtoArray();
+    final BlockNodeVariantsIndex blockNodeIndex =
+        createBlockNodeVariantsIndex(protoArray, root, true, false, UInt64.ONE);
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+
+    store.putVote(
+        ZERO, new VoteTracker(Bytes32.ZERO, root, false, false, UInt64.ONE, false, ZERO, false));
+
+    final List<Long> deltas =
+        computeDeltas(
+            store,
+            protoArray.getTotalTrackedNodeCount(),
+            protoArray::getNodeIndex,
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            protoArray,
+            blockNodeIndex,
+            gloasModel);
+
+    assertThat(deltas).containsExactly(balance.longValue(), 0L);
+  }
+
+  @Test
+  void computeDeltas_payloadPresentVoteTargetsFullWhenFullNodeExists() {
+    final UInt64 balance = UInt64.valueOf(42);
+    final Bytes32 root = getHash(1);
+    final ProtoArray protoArray = createProtoArray();
+    final BlockNodeVariantsIndex blockNodeIndex =
+        createBlockNodeVariantsIndex(protoArray, root, true, true, UInt64.ONE);
+    oldBalances = List.of(balance);
+    newBalances = List.of(balance);
+
+    store.putVote(
+        ZERO,
+        new VoteTracker(Bytes32.ZERO, root, false, false, UInt64.valueOf(2), true, ZERO, false));
+
+    final List<Long> deltas =
+        computeDeltas(
+            store,
+            protoArray.getTotalTrackedNodeCount(),
+            protoArray::getNodeIndex,
+            Optional.empty(),
+            Optional.empty(),
+            oldBalances,
+            newBalances,
+            oldProposerBoostAmount,
+            newProposerBoostAmount,
+            protoArray,
+            blockNodeIndex,
+            gloasModel);
+
+    assertThat(deltas).containsExactly(0L, 0L, balance.longValue());
+  }
+
+  @Test
   void computeDeltas_validatorEquivocatesChain() {
     final UInt64 balance = UInt64.valueOf(42);
 
@@ -726,6 +859,62 @@ public class ProtoArrayScoreCalculatorTest {
         .justifiedCheckpoint(GENESIS_CHECKPOINT)
         .finalizedCheckpoint(GENESIS_CHECKPOINT)
         .build();
+  }
+
+  private BlockNodeVariantsIndex createBlockNodeVariantsIndex(
+      final ProtoArray protoArray,
+      final Bytes32 blockRoot,
+      final boolean includeEmptyNode,
+      final boolean includeFullNode,
+      final UInt64 blockSlot) {
+    final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
+    final ForkChoiceNode baseNode = ForkChoiceNode.createBase(blockRoot);
+    protoArray.addNode(
+        baseNode,
+        blockSlot,
+        blockRoot,
+        Bytes32.ZERO,
+        Optional.empty(),
+        Bytes32.ZERO,
+        GENESIS_BLOCK_CHECKPOINTS,
+        ZERO,
+        Bytes32.ZERO,
+        false);
+    blockNodeIndex.putBaseNode(blockRoot, blockSlot, baseNode);
+
+    if (includeEmptyNode) {
+      final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+      protoArray.addNode(
+          emptyNode,
+          blockSlot,
+          blockRoot,
+          Bytes32.ZERO,
+          Optional.of(baseNode),
+          Bytes32.ZERO,
+          GENESIS_BLOCK_CHECKPOINTS,
+          ZERO,
+          Bytes32.ZERO,
+          false);
+      blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+    }
+
+    if (includeFullNode) {
+      final ForkChoiceNode fullNode = ForkChoiceNode.createFull(blockRoot);
+      protoArray.addNode(
+          fullNode,
+          blockSlot,
+          blockRoot,
+          Bytes32.ZERO,
+          Optional.of(baseNode),
+          Bytes32.ZERO,
+          GENESIS_BLOCK_CHECKPOINTS,
+          ZERO,
+          getHash(999),
+          false);
+      blockNodeIndex.attachFullNode(blockRoot, fullNode);
+    }
+
+    return blockNodeIndex;
   }
 
   private void votesShouldBeUpdated(final VoteUpdater store) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -30,13 +30,16 @@ import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.StubVoteUpdater;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ProtoArrayTest {
@@ -46,6 +49,10 @@ class ProtoArrayTest {
       new DataStructureUtil(TestSpecFactory.createMinimalPhase0());
   private final VoteUpdater voteUpdater = new StubVoteUpdater();
   private final StatusLogger statusLog = mock(StatusLogger.class);
+  private final SpecConfigGloas gloasSpecConfig =
+      SpecConfigGloas.required(
+          TestSpecFactory.createMinimalGloas().forMilestone(SpecMilestone.GLOAS).getConfig());
+  private final ForkChoiceModelGloas gloasModel = new ForkChoiceModelGloas(gloasSpecConfig);
 
   private final Bytes32 block1a = dataStructureUtil.randomBytes32();
   private final Bytes32 block1b = dataStructureUtil.randomBytes32();
@@ -564,6 +571,482 @@ class ProtoArrayTest {
     assertHead(block2a);
   }
 
+  private static final UInt64 EXECUTION_BLOCK_NUMBER = UInt64.valueOf(42);
+  private static final Bytes32 EXECUTION_BLOCK_HASH =
+      Bytes32.fromHexString("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+
+  // --- Three-state fork choice (Gloas FULL node) tests ---
+
+  @Test
+  void onExecutionPayload_shouldCreateFullNode() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isFalse();
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isTrue();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final ProtoNode fullNode = protoArray.getNodeByIndex(fullNodeIndex);
+    assertThat(fullNode.getBlockRoot()).isEqualTo(block1a);
+    assertThat(fullNode.getPayloadStatus()).isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+    assertThat(fullNode.getExecutionBlockNumber()).isEqualTo(EXECUTION_BLOCK_NUMBER);
+    assertThat(fullNode.getExecutionBlockHash()).isEqualTo(EXECUTION_BLOCK_HASH);
+    // FULL node parent should be the block node
+    final int blockNodeIndex = protoArray.getIndexByRoot(block1a).orElseThrow();
+    assertThat(fullNode.getParentIndex()).isEqualTo(Optional.of(blockNodeIndex));
+  }
+
+  @Test
+  void onExecutionPayload_shouldBeIdempotent() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    final int totalBefore = protoArray.getTotalTrackedNodeCount();
+
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    assertThat(protoArray.getTotalTrackedNodeCount()).isEqualTo(totalBefore);
+  }
+
+  @Test
+  void onExecutionPayload_shouldDoNothingForUnknownRoot() {
+    final int totalBefore = protoArray.getTotalTrackedNodeCount();
+    protoArray.onExecutionPayload(
+        dataStructureUtil.randomBytes32(), EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    assertThat(protoArray.getTotalTrackedNodeCount()).isEqualTo(totalBefore);
+  }
+
+  @Test
+  void createEmptyNode_shouldCreateEmptyChildNode() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThat(protoArray.getEmptyNodeIndices().containsKey(block1a)).isFalse();
+    protoArray.createEmptyNode(block1a);
+
+    assertThat(protoArray.getEmptyNodeIndices().containsKey(block1a)).isTrue();
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    final ProtoNode emptyNode = protoArray.getNodeByIndex(emptyNodeIndex);
+    assertThat(emptyNode.getBlockRoot()).isEqualTo(block1a);
+    assertThat(emptyNode.getPayloadStatus())
+        .isEqualTo(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+    // EMPTY node parent should be the block (PENDING) node
+    final int blockNodeIndex = protoArray.getIndexByRoot(block1a).orElseThrow();
+    assertThat(emptyNode.getParentIndex()).isEqualTo(Optional.of(blockNodeIndex));
+  }
+
+  @Test
+  void createEmptyNode_shouldBeIdempotent() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    final int totalBefore = protoArray.getTotalTrackedNodeCount();
+
+    protoArray.createEmptyNode(block1a);
+    assertThat(protoArray.getTotalTrackedNodeCount()).isEqualTo(totalBefore);
+  }
+
+  @Test
+  void resolveParentIndex_shouldResolveFull_whenBlockHashMatches() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    // When child's parent_block_hash matches FULL node's execution hash → FULL
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(protoArray.resolveParentIndex(block1a, EXECUTION_BLOCK_HASH))
+        .isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void resolveParentIndex_shouldResolveEmpty_whenBlockHashDoesNotMatch() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    // When child's parent_block_hash does NOT match FULL node's execution hash → EMPTY
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(protoArray.resolveParentIndex(block1a, Bytes32.ZERO))
+        .isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void resolveParentIndex_shouldFallbackToEmpty_whenNoFull() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+
+    // No FULL exists, should resolve to EMPTY regardless of hash
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(protoArray.resolveParentIndex(block1a, EXECUTION_BLOCK_HASH))
+        .isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void resolveParentIndex_shouldThrowWhenPostGloasParentHasNoVariants() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThatThrownBy(() -> protoArray.resolveParentIndex(block1a, Bytes32.ZERO))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Missing GLOAS parent variants");
+  }
+
+  @Test
+  void resolveParentIndex_shouldFallbackToBaseForPreGloasParent() {
+    final SpecConfigGloas delayedGloasSpecConfig =
+        SpecConfigGloas.required(
+            TestSpecFactory.createMinimalWithGloasForkEpoch(UInt64.ONE)
+                .forMilestone(SpecMilestone.GLOAS)
+                .getConfig());
+    final ForkChoiceModelGloas delayedGloasModel = new ForkChoiceModelGloas(delayedGloasSpecConfig);
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+
+    assertThat(
+            delayedGloasModel
+                .resolveParentNode(
+                    protoArray.protoArray(), protoArray.blockNodeIndex(), block1a, Bytes32.ZERO)
+                .map(ProtoNode::getForkChoiceNode))
+        .contains(ForkChoiceNode.createBase(block1a));
+  }
+
+  @Test
+  void threeStateTree_childAttachesToFullParent() {
+    // Build tree: genesis -> block1a (with EMPTY and FULL children)
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    // block2a resolves parent via the Gloas model with matching hash → should attach to
+    // FULL
+    final Optional<Integer> resolvedParent =
+        protoArray.resolveParentIndex(block1a, EXECUTION_BLOCK_HASH);
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(resolvedParent).isEqualTo(Optional.of(fullNodeIndex));
+
+    // Add block2a with resolved parent
+    addValidBlockWithParentIndex(2, block2a, block1a, resolvedParent);
+
+    // block2a's parent should be the FULL node
+    assertThat(protoArray.getProtoNode(block2a).orElseThrow().getParentIndex())
+        .isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void threeStateTree_childAttachesToEmptyWhenNoFull() {
+    // Build tree: genesis -> block1a (with EMPTY child only, no FULL yet)
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.markNodeValid(block1a);
+
+    // block2a resolves parent via the Gloas model with non-matching hash → should attach to
+    // EMPTY
+    final Optional<Integer> resolvedParent = protoArray.resolveParentIndex(block1a, Bytes32.ZERO);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(resolvedParent).isEqualTo(Optional.of(emptyNodeIndex));
+
+    // Add block2a with resolved parent
+    addValidBlockWithParentIndex(2, block2a, block1a, resolvedParent);
+
+    // block2a's parent should be the EMPTY node
+    assertThat(protoArray.getProtoNode(block2a).orElseThrow().getParentIndex())
+        .isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void threeStateTree_fullPathChildAndEmptyPathChild_shouldCompeteByWeight() {
+    // Build tree: genesis -> block1a (with EMPTY and FULL children)
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+
+    // block2a attaches to FULL path
+    addValidBlockWithParentIndex(2, block2a, block1a, Optional.of(fullNodeIndex));
+
+    // block2b attaches to EMPTY path
+    addValidBlockWithParentIndex(2, block2b, block1a, Optional.of(emptyNodeIndex));
+
+    // Vote for block2a (FULL path child)
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+
+    // Apply deltas with Gloas tiebreaker — currentSlot far from block slot so tiebreaker
+    // defaults to payload status ordering (FULL=2 > EMPTY=1)
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // block2a should be head (FULL path wins via tiebreaker)
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(head.getBlockRoot()).isEqualTo(block2a);
+  }
+
+  @Test
+  void markNodeValid_shouldAlsoMarkFullAndEmptyNodesValid() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isOptimistic()).isTrue();
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
+
+    protoArray.markNodeValid(block1a);
+
+    assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isFullyValidated()).isTrue();
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isFullyValidated()).isTrue();
+  }
+
+  @Test
+  void maybePrune_shouldRemoveFullAndEmptyNodesFromIndices() {
+    addValidBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    addValidBlock(2, block2a, block1a);
+    addValidBlock(3, block3a, block2a);
+
+    // Finalize at block2a
+    final Checkpoint finalized = new Checkpoint(UInt64.ONE, block2a);
+    protoArray.applyScoreChanges(
+        computeDeltas(),
+        UInt64.valueOf(5),
+        finalized,
+        finalized,
+        ForkChoiceModelDefault.INSTANCE,
+        UInt64.valueOf(5),
+        Optional.empty());
+    protoArray.setPruneThreshold(0);
+    protoArray.maybePrune(block2a);
+
+    // block1a's FULL and EMPTY nodes should have been removed from indices
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isFalse();
+    assertThat(protoArray.getEmptyNodeIndices().containsKey(block1a)).isFalse();
+    assertThat(protoArray.contains(block1a)).isFalse();
+  }
+
+  // --- Gloas head-selection policy tests ---
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenNotPreviousSlot() {
+    // Block at slot 5, currentSlot = 100 → not previous slot → tiebreaker uses raw payload
+    // status: FULL(2) > EMPTY(1)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // FULL should be bestChild of block1a (PENDING node)
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenShouldExtendPayload_noBoost() {
+    // Block at slot 5, currentSlot = 6 → previous slot → should_extend_payload
+    // No proposer boost → should_extend_payload returns true → FULL wins (score 2)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(6), Optional.empty());
+
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenBoostOnChildBuiltOnFull() {
+    // Block at slot 5, currentSlot = 6 → previous slot → should_extend_payload evaluated.
+    // Proposer boost on block2a (child of block1a). block2a was built on FULL(block1a)
+    // (matching execution hash) → is_parent_node_full = true → should_extend = true → FULL wins.
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    // block2a builds on FULL(block1a) — execution hash matches parent's FULL
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(
+        6, block2a, block1a, Optional.of(fullNodeIndex), EXECUTION_BLOCK_HASH);
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(6), Optional.of(block2a));
+
+    // FULL wins: is_parent_node_full(block1a) = true → should_extend_payload = true
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenPayloadTimelyAndDataAvailable() {
+    // Block at slot 5, currentSlot = 6, proposer boost on a child of block1a.
+    // PTC payload and data-availability votes exceed threshold
+    // → should_extend_payload = true → FULL keeps score 2.
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+
+    // threshold = 5, ptcVoteCount = 6 → timely (6 > 5)
+    applyScoreChanges(
+        createGloasModel(5, 5, block1a, 6, 6), UInt64.valueOf(6), Optional.of(block2a));
+
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_emptyWinsOverFull_whenPayloadTimelyButDataUnavailable() {
+    // Block at slot 5, currentSlot = 6, proposer boost on a child of block1a built on EMPTY.
+    // PTC payload votes exceed threshold but data-availability votes do not
+    // → should_extend_payload = false
+    // → EMPTY wins (score 1) over FULL (score 0).
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+
+    applyScoreChanges(
+        createGloasModel(5, 5, block1a, 6, 0), UInt64.valueOf(6), Optional.of(block2a));
+
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(emptyNodeIndex));
+  }
+
+  @Test
+  void tiebreaker_fullWinsOverEmpty_whenPayloadNotTimely_butBoostOnChildWithFullParent() {
+    // Block at slot 5, currentSlot = 6, proposer boost on block2a (child building on FULL).
+    // PTC votes ≤ threshold → is_payload_timely = false.
+    // But is_parent_node_full = true (block2a's execution hash matches parent's FULL hash)
+    // → should_extend_payload = true → FULL keeps score 2.
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    addValidBlockWithParentIndex(
+        6, block2a, block1a, Optional.of(fullNodeIndex), EXECUTION_BLOCK_HASH);
+
+    // threshold = 5, ptcVoteCount = 3 → NOT timely (3 ≤ 5)
+    applyScoreChanges(
+        createGloasModel(5, 5, block1a, 3, 0), UInt64.valueOf(6), Optional.of(block2a));
+
+    // FULL still wins because is_parent_node_full(block1a) = true
+    final ProtoNode block1aNode = protoArray.getProtoNode(block1a).orElseThrow();
+    assertThat(block1aNode.getBestChildIndex()).isEqualTo(Optional.of(fullNodeIndex));
+  }
+
+  @Test
+  void emptyPathWinsOverFullPath_whenEmptyHasMoreWeight_notPreviousSlot() {
+    // Block at slot 5, currentSlot = 100 → not previous slot → effectiveWeight = node.getWeight()
+    // EMPTY path has more attestation weight than FULL path → EMPTY wins by weight,
+    // overriding tiebreaker (which would favor FULL)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+
+    // block2a attaches to EMPTY path, block2b attaches to FULL path
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+    addValidBlockWithParentIndex(6, block2b, block1a, Optional.of(fullNodeIndex));
+
+    // Vote for block2a (EMPTY path child) — gives EMPTY path more weight
+    // Need two votes so the balance list covers validator 0
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+    voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+
+    applyScoreChanges(gloasModel, UInt64.valueOf(100), Optional.empty());
+
+    // EMPTY path wins by weight, even though tiebreaker would favor FULL
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(head.getBlockRoot()).isEqualTo(block2a);
+  }
+
+  @Test
+  void tiebreakerDecides_whenBothZeroWeight_atPreviousSlot() {
+    // Block at slot 5, currentSlot = 6 → previous slot → effectiveWeight = 0 for both
+    // EMPTY and FULL siblings. Both have descendant votes, but effective weight is 0 for both
+    // at current_slot-1, so tiebreaker decides (FULL wins via should_extend_payload)
+    addValidBlock(5, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+    protoArray.markNodeValid(block1a);
+
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+
+    // block2a on EMPTY path, block2b on FULL path — both get votes
+    addValidBlockWithParentIndex(6, block2a, block1a, Optional.of(emptyNodeIndex));
+    addValidBlockWithParentIndex(6, block2b, block1a, Optional.of(fullNodeIndex));
+
+    // Vote for EMPTY path child (more votes) — validators 0 and 1
+    voteUpdater.putVote(UInt64.ZERO, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+    voteUpdater.putVote(UInt64.ONE, new VoteTracker(Bytes32.ZERO, block2a, false, false));
+    // Vote for FULL path child (less votes) — validator 2
+    voteUpdater.putVote(UInt64.valueOf(2), new VoteTracker(Bytes32.ZERO, block2b, false, false));
+    // Dummy vote to ensure balance list covers all validators above
+    voteUpdater.putVote(UInt64.valueOf(3), new VoteTracker(Bytes32.ZERO, block2b, false, false));
+
+    // currentSlot = 6 = block slot + 1 → effective weight is 0 for both EMPTY and FULL
+    // No proposer boost → should_extend_payload = true → FULL wins tiebreaker
+    applyScoreChanges(gloasModel, UInt64.valueOf(6), Optional.empty());
+
+    // Even though EMPTY path has more votes, at previous slot both have effectiveWeight 0,
+    // so tiebreaker decides → FULL wins
+    final ProtoNode head =
+        protoArray.findOptimisticHead(UInt64.valueOf(5), GENESIS_CHECKPOINT, GENESIS_CHECKPOINT);
+    assertThat(head.getBlockRoot()).isEqualTo(block2b);
+  }
+
+  @Test
+  void gloas_onExecutionPayloadResult_invalid_shouldOnlyInvalidateFullNode() {
+    // Set up a Gloas block with base + EMPTY + FULL nodes (FULL stays optimistic)
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
+    protoArray.createEmptyNode(block1a);
+    protoArray.onExecutionPayload(block1a, EXECUTION_BLOCK_NUMBER, EXECUTION_BLOCK_HASH);
+
+    // Verify FULL node exists and is optimistic
+    assertThat(protoArray.getFullNodeIndices().containsKey(block1a)).isTrue();
+    final int fullNodeIndex = protoArray.getFullNodeIndices().getInt(block1a);
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isOptimistic()).isTrue();
+
+    // Mark payload as INVALID via the Gloas model (verified transition)
+    gloasModel.onExecutionPayloadResult(
+        protoArray.protoArray(),
+        protoArray.blockNodeIndex(),
+        block1a,
+        ExecutionPayloadStatus.INVALID,
+        Optional.empty(),
+        true,
+        new HeadSelectionContext(
+            gloasModel, protoArray.blockNodeIndex(), UInt64.ZERO, Optional.empty()));
+
+    // FULL node should be invalid
+    assertThat(protoArray.getNodeByIndex(fullNodeIndex).isInvalid()).isTrue();
+
+    // Base + EMPTY nodes should remain in the tree (not invalidated)
+    assertThat(protoArray.contains(block1a)).isTrue();
+    assertThat(protoArray.getProtoNode(block1a).orElseThrow().isOptimistic()).isTrue();
+    final int emptyNodeIndex = protoArray.getEmptyNodeIndices().getInt(block1a);
+    assertThat(protoArray.getNodeByIndex(emptyNodeIndex).isOptimistic()).isTrue();
+  }
+
   private void assertHead(final Bytes32 expectedBlockHash) {
     final ProtoNode node = protoArray.getProtoNode(expectedBlockHash).orElseThrow();
     assertThat(
@@ -593,6 +1076,26 @@ class ProtoArrayTest {
         proposerBoostRoot);
   }
 
+  private ForkChoiceModelGloas createGloasModel(
+      final int payloadTimelyThreshold,
+      final int dataAvailabilityTimelyThreshold,
+      final Bytes32 blockRoot,
+      final int payloadPresentVoteCount,
+      final int dataAvailableVoteCount) {
+    final PtcVoteTracker ptcVoteTracker = new PtcVoteTracker();
+    for (int validatorIndex = 0;
+        validatorIndex < Math.max(payloadPresentVoteCount, dataAvailableVoteCount);
+        validatorIndex++) {
+      ptcVoteTracker.recordVote(
+          blockRoot,
+          UInt64.valueOf(validatorIndex),
+          validatorIndex < payloadPresentVoteCount,
+          validatorIndex < dataAvailableVoteCount);
+    }
+    return new ForkChoiceModelGloas(
+        gloasSpecConfig, payloadTimelyThreshold, dataAvailabilityTimelyThreshold, ptcVoteTracker);
+  }
+
   private void addValidBlock(final long slot, final Bytes32 blockRoot, final Bytes32 parentRoot) {
     addValidBlock(slot, blockRoot, parentRoot, getExecutionBlockHash(blockRoot));
   }
@@ -603,6 +1106,35 @@ class ProtoArrayTest {
       final Bytes32 parentRoot,
       final Bytes32 executionBlockHash) {
     addOptimisticBlock(slot, blockRoot, parentRoot, executionBlockHash);
+    protoArray.markNodeValid(blockRoot);
+  }
+
+  private void addValidBlockWithParentIndex(
+      final long slot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Optional<Integer> resolvedParentIndex) {
+    addValidBlockWithParentIndex(
+        slot, blockRoot, parentRoot, resolvedParentIndex, getExecutionBlockHash(blockRoot));
+  }
+
+  private void addValidBlockWithParentIndex(
+      final long slot,
+      final Bytes32 blockRoot,
+      final Bytes32 parentRoot,
+      final Optional<Integer> resolvedParentIndex,
+      final Bytes32 executionBlockHash) {
+    protoArray.onBlock(
+        UInt64.valueOf(slot),
+        blockRoot,
+        parentRoot,
+        resolvedParentIndex,
+        dataStructureUtil.randomBytes32(),
+        new BlockCheckpoints(
+            GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT, GENESIS_CHECKPOINT),
+        ZERO,
+        executionBlockHash,
+        true);
     protoArray.markNodeValid(blockRoot);
   }
 
@@ -651,7 +1183,7 @@ class ProtoArrayTest {
         ForkChoiceModelPhase0.INSTANCE);
   }
 
-  private static class TestProtoArrayFacade {
+  private class TestProtoArrayFacade {
     private final ProtoArray protoArray;
     private final BlockNodeVariantsIndex blockNodeIndex = new BlockNodeVariantsIndex();
     private HeadSelectionContext lastHeadSelectionContext =
@@ -680,6 +1212,32 @@ class ProtoArrayTest {
 
     private Optional<Integer> getIndexByRoot(final Bytes32 blockRoot) {
       return protoArray.getNodeIndex(ForkChoiceNode.createBase(blockRoot));
+    }
+
+    private Object2IntMap<Bytes32> getEmptyNodeIndices() {
+      return getProjectionIndices(ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY);
+    }
+
+    private Object2IntMap<Bytes32> getFullNodeIndices() {
+      return getProjectionIndices(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL);
+    }
+
+    private Object2IntMap<Bytes32> getProjectionIndices(
+        final ForkChoicePayloadStatus payloadStatus) {
+      final Object2IntMap<Bytes32> indices = new Object2IntOpenHashMap<>();
+      blockNodeIndex
+          .variants()
+          .forEach(
+              variants ->
+                  variants
+                      .getNode(payloadStatus)
+                      .flatMap(protoArray::getNodeIndex)
+                      .ifPresent(index -> indices.put(variants.baseNode().blockRoot(), index)));
+      return indices;
+    }
+
+    private ProtoNode getNodeByIndex(final int index) {
+      return protoArray.getNodeByIndex(index);
     }
 
     private int getTotalTrackedNodeCount() {
@@ -750,6 +1308,15 @@ class ProtoArrayTest {
       protoArray.setInitialCanonicalBlockRoot(blockRoot, lastHeadSelectionContext);
     }
 
+    private void setPruneThreshold(final int pruneThreshold) {
+      protoArray.setPruneThreshold(pruneThreshold);
+    }
+
+    private void maybePrune(final Bytes32 finalizedRoot) {
+      protoArray.maybePrune(ForkChoiceNode.createBase(finalizedRoot));
+      pruneRemovedProjections();
+    }
+
     private void updateParentBestChildAndDescendantForBlockVariants(final Bytes32 blockRoot) {
       blockNodeIndex
           .getVariants(blockRoot)
@@ -809,6 +1376,48 @@ class ProtoArrayTest {
           optimisticallyProcessed);
       blockNodeIndex.putBaseNode(blockRoot, blockSlot, ForkChoiceNode.createBase(blockRoot));
       updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    }
+
+    private void createEmptyNode(final Bytes32 blockRoot) {
+      if (blockNodeIndex.getEmptyNode(blockRoot).isPresent()) {
+        return;
+      }
+      final Optional<ProtoNode> maybeBaseNode = getProtoNode(blockRoot);
+      if (maybeBaseNode.isEmpty()) {
+        return;
+      }
+
+      final ProtoNodeData baseNode = maybeBaseNode.get().getBlockData();
+      final ForkChoiceNode emptyNode = ForkChoiceNode.createEmpty(blockRoot);
+      protoArray.addNode(
+          emptyNode,
+          baseNode.getSlot(),
+          blockRoot,
+          baseNode.getParentRoot(),
+          Optional.of(ForkChoiceNode.createBase(blockRoot)),
+          baseNode.getStateRoot(),
+          baseNode.getCheckpoints(),
+          baseNode.getExecutionBlockNumber(),
+          baseNode.getExecutionBlockHash(),
+          baseNode.isOptimistic());
+      blockNodeIndex.attachEmptyNode(blockRoot, emptyNode);
+      updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    }
+
+    private void onExecutionPayload(
+        final Bytes32 blockRoot,
+        final UInt64 executionBlockNumber,
+        final Bytes32 executionBlockHash) {
+      gloasModel.onExecutionPayload(
+          protoArray, blockNodeIndex, blockRoot, executionBlockNumber, executionBlockHash, true);
+      updateParentBestChildAndDescendantForBlockVariants(blockRoot);
+    }
+
+    private Optional<Integer> resolveParentIndex(
+        final Bytes32 parentRoot, final Bytes32 childParentBlockHash) {
+      return gloasModel
+          .resolveParentNode(protoArray, blockNodeIndex, parentRoot, childParentBlockHash)
+          .flatMap(node -> protoArray.getNodeIndex(node.getForkChoiceNode()));
     }
 
     private void pruneRemovedProjections() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -816,7 +816,7 @@ class ProtoArrayTest {
         UInt64.valueOf(5),
         finalized,
         finalized,
-        ForkChoiceModelDefault.INSTANCE,
+        ForkChoiceModelPhase0.INSTANCE,
         UInt64.valueOf(5),
         Optional.empty());
     protoArray.setPruneThreshold(0);

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +37,8 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.StubVoteUpdater;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -1396,7 +1396,6 @@ class ProtoArrayTest {
       protoArray.addNode(
           emptyNode,
           baseNode.getSlot(),
-          blockRoot,
           baseNode.getParentRoot(),
           Optional.of(ForkChoiceNode.createBase(blockRoot)),
           baseNode.getStateRoot(),

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/PtcVoteTrackerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/PtcVoteTrackerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.protoarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class PtcVoteTrackerTest {
+
+  private static final Bytes32 ROOT_1 = Bytes32.fromHexStringLenient("0x01");
+  private static final Bytes32 ROOT_2 = Bytes32.fromHexStringLenient("0x02");
+
+  private final PtcVoteTracker tracker = new PtcVoteTracker();
+
+  @Test
+  void recordVote_incrementsPayloadAndDataCounts() {
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+
+    tracker.recordVote(ROOT_1, ZERO, true, false);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+
+    tracker.recordVote(ROOT_1, ONE, true, true);
+    tracker.recordVote(ROOT_1, UInt64.valueOf(2), true, true);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(3);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(2);
+  }
+
+  @Test
+  void recordVote_tracksUniqueValidatorsPerBlock() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ONE, true, false);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(2);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
+  }
+
+  @Test
+  void recordVote_removesValidatorWhenPayloadOrDataBecomesAbsent() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ONE, true, true);
+    tracker.recordVote(ROOT_1, ZERO, false, false);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
+  }
+
+  @Test
+  void recordVote_tracksDifferentRootsSeparately() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_1, ONE, true, false);
+    tracker.recordVote(ROOT_2, ZERO, true, true);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isEqualTo(2);
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_2)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_2)).isEqualTo(1);
+  }
+
+  @Test
+  void remove_clearsTrackedVotesForRoot() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+
+    tracker.remove(ROOT_1);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+  }
+
+  @Test
+  void removeIf_prunesMatchingRoots() {
+    tracker.recordVote(ROOT_1, ZERO, true, true);
+    tracker.recordVote(ROOT_2, ONE, true, true);
+
+    tracker.removeIf(ROOT_1::equals);
+
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_1)).isZero();
+    assertThat(tracker.getPayloadPresentVoteCount(ROOT_2)).isEqualTo(1);
+    assertThat(tracker.getDataAvailableVoteCount(ROOT_2)).isEqualTo(1);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.storage.api.OnDiskStoreData;
+import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+
+class StoreBuilderTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
+
+  @Test
+  void forkChoiceStoreBuilder_shouldUseAnchorStateSlotAndRootWhenAnchorBlockPrecedesState()
+      throws Exception {
+    chainBuilder.generateGenesis();
+    final UInt64 anchorStateSlot = spec.computeStartSlotAtEpoch(UInt64.ONE);
+    final SignedBlockAndState anchorBlock =
+        chainBuilder.generateBlockAtSlot(anchorStateSlot.minus(1));
+    final BeaconState anchorState = spec.processSlots(anchorBlock.getState(), anchorStateSlot);
+    final Checkpoint checkpoint =
+        new Checkpoint(spec.computeEpochAtSlot(anchorStateSlot), anchorBlock.getRoot());
+    final AnchorPoint anchor =
+        AnchorPoint.create(spec, checkpoint, anchorState, Optional.of(anchorBlock.getBlock()));
+
+    final OnDiskStoreData storeData =
+        StoreBuilder.forkChoiceStoreBuilder(spec, anchor, UInt64.ZERO);
+    final StoredBlockMetadata metadata = storeData.blockInformation().get(anchor.getRoot());
+
+    assertThat(metadata.getBlockSlot()).isEqualTo(anchorState.getSlot());
+    assertThat(metadata.getStateRoot()).isEqualTo(anchorState.hashTreeRoot());
+  }
+}


### PR DESCRIPTION
related #10556

a followup PR will complete the rebuild support and will close the issue

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Gloas fork-choice model implementation and persists extra per-block rebuild metadata, which touches fork-choice/restart behavior even though model selection is still hardwired to Phase0.
> 
> **Overview**
> Introduces Gloas-specific storage metadata (`GloasForkChoiceRebuildData`) and extends `StoredBlockMetadata`/hot block loading (`KvStoreDatabase`, `StoreBuilder`) to capture payload-bid hashes needed to reconstruct Gloas fork-choice node variants after restart.
> 
> Adds a new (currently *dormant*) `ForkChoiceModelGloas` implementing the three-state base/EMPTY/FULL node layout, payload reveal handling, vote routing, head tiebreaking, and PTC vote tracking (`PtcVoteTracker`), plus updates `ForkChoiceModelFactory` to instantiate the model and prune its state.
> 
> Expands test coverage for metadata extraction, PTC vote tracking, vote delta routing, and protoarray behaviors around EMPTY/FULL nodes and Gloas head-selection rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608d5296baef17988f324b6926ea70255338d712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->