### PR TITLE
Stabilize forkchoice state during block production

### DIFF
--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -49,7 +49,6 @@ import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -125,12 +124,7 @@ public class HistoricalBatchFetcherTest {
     final StorageQueryChannel historicalChainData = mock(StorageQueryChannel.class);
     final RecentChainData recentChainData = storageSystem.recentChainData();
     chainDataClient =
-        new CombinedChainDataClient(
-            recentChainData,
-            historicalChainData,
-            spec,
-            LateBlockReorgPreparationHandler.NOOP,
-            false);
+        new CombinedChainDataClient(recentChainData, historicalChainData, spec, false);
 
     peer = RespondingEth2Peer.create(spec, chainBuilder);
     fetcher =

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -15,28 +15,19 @@ package tech.pegasys.teku.validator.coordinator;
 
 import java.util.List;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler.BlockProductionContext;
 
 public interface BlockFactory {
 
   SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
-      BeaconState blockSlotState,
-      UInt64 proposalSlot,
-      BLSSignature randaoReveal,
-      Optional<Bytes32> optionalGraffiti,
-      Optional<UInt64> requestedBuilderBoostFactor,
-      BlockProductionPerformance blockProductionPerformance);
+      BlockProductionContext blockProductionContext);
 
   SafeFuture<Optional<SignedBeaconBlock>> unblindSignedBlockIfBlinded(
       SignedBeaconBlock maybeBlindedBlock, BlockPublishingPerformance blockPublishingPerformance);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -14,12 +14,7 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import java.util.List;
-import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -27,8 +22,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler.BlockProductionContext;
 
 public class BlockFactoryDeneb extends BlockFactoryPhase0 {
 
@@ -38,19 +33,8 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
 
   @Override
   public SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
-      final BeaconState blockSlotState,
-      final UInt64 proposalSlot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti,
-      final Optional<UInt64> requestedBuilderBoostFactor,
-      final BlockProductionPerformance blockProductionPerformance) {
-    return super.createUnsignedBlock(
-            blockSlotState,
-            proposalSlot,
-            randaoReveal,
-            optionalGraffiti,
-            requestedBuilderBoostFactor,
-            blockProductionPerformance)
+      final BlockProductionContext blockProductionContext) {
+    return super.createUnsignedBlock(blockProductionContext)
         .thenCompose(
             blockContainerAndMetaData -> {
               final BeaconBlock block = blockContainerAndMetaData.blockContainer().getBlock();

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -19,9 +19,6 @@ import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -35,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.SlotCaches;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler.BlockProductionContext;
 
 public class BlockFactoryPhase0 implements BlockFactory {
 
@@ -49,36 +47,22 @@ public class BlockFactoryPhase0 implements BlockFactory {
 
   @Override
   public SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
-      final BeaconState blockSlotState,
-      final UInt64 proposalSlot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti,
-      final Optional<UInt64> requestedBuilderBoostFactor,
-      final BlockProductionPerformance blockProductionPerformance) {
+      final BlockProductionContext blockProductionContext) {
+    final BeaconState blockSlotState = blockProductionContext.blockSlotState();
+    final UInt64 proposalSlot = blockProductionContext.proposalSlot();
     checkArgument(
         blockSlotState.getSlot().equals(proposalSlot),
         "Block slot state for slot %s but should be for slot %s",
         blockSlotState.getSlot(),
         proposalSlot);
 
-    // Process empty slots up to the one before the new block slot
-    final UInt64 slotBeforeBlock = proposalSlot.minus(UInt64.ONE);
-
-    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slotBeforeBlock);
-
     return spec.createNewUnsignedBlock(
             proposalSlot,
             spec.getBeaconProposerIndex(blockSlotState, proposalSlot),
             blockSlotState,
-            parentRoot,
-            operationSelector.createSelector(
-                parentRoot,
-                blockSlotState,
-                randaoReveal,
-                optionalGraffiti,
-                requestedBuilderBoostFactor,
-                blockProductionPerformance),
-            blockProductionPerformance)
+            blockProductionContext.parentRoot(),
+            operationSelector.createSelector(blockProductionContext),
+            blockProductionContext.blockProductionPerformance())
         .thenApply(this::blockAndStateToBlockContainerAndMetaData);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -28,8 +28,6 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
@@ -86,6 +84,7 @@ import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler.BlockProductionContext;
 
 public class BlockOperationSelectorFactory {
   private final Spec spec;
@@ -144,15 +143,13 @@ public class BlockOperationSelectorFactory {
   }
 
   public Function<BeaconBlockBodyBuilder, SafeFuture<Void>> createSelector(
-      final Bytes32 parentRoot,
-      final BeaconState blockSlotState,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti,
-      final Optional<UInt64> requestedBuilderBoostFactor,
-      final BlockProductionPerformance blockProductionPerformance) {
+      final BlockProductionContext blockProductionContext) {
+
+    final BeaconState blockSlotState = blockProductionContext.blockSlotState();
+    final Bytes32 parentRoot = blockProductionContext.parentRoot();
 
     return bodyBuilder -> {
-      blockProductionPerformance.beaconBlockBodyPreparationStarted();
+      blockProductionContext.blockProductionPerformance().beaconBlockBodyPreparationStarted();
 
       final SchemaDefinitions schemaDefinitions =
           spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions();
@@ -172,10 +169,8 @@ public class BlockOperationSelectorFactory {
                         setExecutionData(
                             executionPayloadContext,
                             bodyBuilder,
-                            requestedBuilderBoostFactor,
                             SchemaDefinitionsBellatrix.required(schemaDefinitions),
-                            blockSlotState,
-                            blockProductionPerformance));
+                            blockProductionContext));
       } else {
         setExecutionDataComplete = COMPLETE;
       }
@@ -193,8 +188,7 @@ public class BlockOperationSelectorFactory {
                             parentRoot,
                             executionPayloadContext,
                             bodyBuilder,
-                            blockSlotState,
-                            blockProductionPerformance));
+                            blockProductionContext));
 
       } else {
         setExecutionPayloadBidComplete = COMPLETE;
@@ -205,7 +199,7 @@ public class BlockOperationSelectorFactory {
       final SszList<Attestation> attestations =
           attestationPool.getAttestationsForBlock(
               blockSlotState, new AttestationForkChecker(spec, blockSlotState));
-      blockProductionPerformance.getAttestationsForBlock();
+      blockProductionContext.blockProductionPerformance().getAttestationsForBlock();
 
       // Collect slashings to include
       final Set<UInt64> exitedValidators = new HashSet<>();
@@ -230,7 +224,7 @@ public class BlockOperationSelectorFactory {
           bodyBuilder.supportsParentExecutionRequests()
               ? Optional.of(
                   executionPayloadManager.getParentExecutionRequestsForBlock(
-                      blockSlotState.getSlot(), parentRoot))
+                      blockSlotState.getSlot(), parentRoot, blockProductionContext.payloadStatus()))
               : Optional.empty();
       final Set<UInt64> validatorsWithParentWithdrawalRequests = new HashSet<>();
       parentExecutionRequests.ifPresent(
@@ -255,9 +249,9 @@ public class BlockOperationSelectorFactory {
               exit -> exitedValidators.add(exit.getMessage().getValidatorIndex()));
 
       bodyBuilder
-          .randaoReveal(randaoReveal)
+          .randaoReveal(blockProductionContext.randaoReveal())
           .eth1Data(eth1Data)
-          .graffiti(graffitiBuilder.buildGraffiti(optionalGraffiti))
+          .graffiti(graffitiBuilder.buildGraffiti(blockProductionContext.graffiti()))
           .attestations(attestations)
           .proposerSlashings(proposerSlashings)
           .attesterSlashings(attesterSlashings)
@@ -283,10 +277,12 @@ public class BlockOperationSelectorFactory {
         bodyBuilder.payloadAttestations(
             payloadAttestationPool.getPayloadAttestationsForBlock(blockSlotState, parentRoot));
       }
+
       parentExecutionRequests.ifPresent(bodyBuilder::parentExecutionRequests);
 
       return SafeFuture.allOfFailFast(setExecutionDataComplete, setExecutionPayloadBidComplete)
-          .thenPeek(__ -> blockProductionPerformance.beaconBlockBodyPrepared());
+          .thenPeek(
+              __ -> blockProductionContext.blockProductionPerformance().beaconBlockBodyPrepared());
     };
   }
 
@@ -319,10 +315,9 @@ public class BlockOperationSelectorFactory {
   private SafeFuture<Void> setExecutionData(
       final Optional<ExecutionPayloadContext> executionPayloadContext,
       final BeaconBlockBodyBuilder bodyBuilder,
-      final Optional<UInt64> requestedBuilderBoostFactor,
       final SchemaDefinitionsBellatrix schemaDefinitions,
-      final BeaconState blockSlotState,
-      final BlockProductionPerformance blockProductionPerformance) {
+      final BlockProductionContext blockProductionContext) {
+    final BeaconState blockSlotState = blockProductionContext.blockSlotState();
 
     if (spec.isMergeTransitionComplete(blockSlotState) && executionPayloadContext.isEmpty()) {
       throw new IllegalStateException(
@@ -348,8 +343,8 @@ public class BlockOperationSelectorFactory {
             executionPayloadContext.orElseThrow(),
             blockSlotState,
             shouldTryBuilderFlow,
-            requestedBuilderBoostFactor,
-            blockProductionPerformance);
+            blockProductionContext.requestedBuilderBoostFactor(),
+            blockProductionContext.blockProductionPerformance());
 
     return SafeFuture.allOf(
         cacheExecutionPayloadValue(executionPayloadResult, blockSlotState),
@@ -494,8 +489,8 @@ public class BlockOperationSelectorFactory {
       final Bytes32 parentRoot,
       final Optional<ExecutionPayloadContext> executionPayloadContext,
       final BeaconBlockBodyBuilder bodyBuilder,
-      final BeaconState blockSlotState,
-      final BlockProductionPerformance blockProductionPerformance) {
+      final BlockProductionContext blockProductionContext) {
+    final BeaconState blockSlotState = blockProductionContext.blockSlotState();
     checkState(
         executionPayloadContext.isPresent(),
         "ExecutionPayloadContext is not provided for production of block at slot %s",
@@ -507,14 +502,14 @@ public class BlockOperationSelectorFactory {
             // builder flow (mev-boost) is not used in Gloas
             false,
             Optional.empty(),
-            blockProductionPerformance);
+            blockProductionContext.blockProductionPerformance());
     final SafeFuture<Void> setExecutionPayloadBid =
         executionPayloadBidManager
             .getBidForBlock(
                 parentRoot,
                 blockSlotState,
                 executionPayloadResult.getPayloadResponseFutureFromLocalFlowRequired(),
-                blockProductionPerformance)
+                blockProductionContext.blockProductionPerformance())
             .thenAccept(
                 signedBid -> {
                   checkState(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -21,9 +21,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -34,7 +31,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler.BlockProductionContext;
 
 public class MilestoneBasedBlockFactory implements BlockFactory {
   private static final Logger LOG = LogManager.getLogger();
@@ -76,22 +73,12 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
 
   @Override
   public SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
-      final BeaconState blockSlotState,
-      final UInt64 proposalSlot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti,
-      final Optional<UInt64> requestedBuilderBoostFactor,
-      final BlockProductionPerformance blockProductionPerformance) {
+      final BlockProductionContext blockProductionContext) {
+    final UInt64 proposalSlot = blockProductionContext.proposalSlot();
     final SpecMilestone milestone = getMilestone(proposalSlot);
     return registeredFactories
         .get(milestone)
-        .createUnsignedBlock(
-            blockSlotState,
-            proposalSlot,
-            randaoReveal,
-            optionalGraffiti,
-            requestedBuilderBoostFactor,
-            blockProductionPerformance)
+        .createUnsignedBlock(blockProductionContext)
         .whenException(
             error -> {
               LOG.debug("Error creating unsigned block for slot {}: {}", proposalSlot, error);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -120,6 +120,7 @@ import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPo
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
@@ -145,7 +146,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
 
   private final Map<UInt64, SafeFuture<Optional<BlockContainerAndMetaData>>>
       blockProductionBySlotCache = new ConcurrentHashMap<>();
-  private final Map<UInt64, SafeFuture<BlockProductionPreparationContext>>
+  private final Map<UInt64, BlockProductionPreparationContext>
       blockProductionPreparationContextBySlotCache = new ConcurrentHashMap<>();
 
   private final BlockProductionAndPublishingPerformanceFactory
@@ -455,7 +456,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
             });
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored")
   public void onBlockProductionPreparationDue(final UInt64 slot) {
     if (isSyncActive()) {
       return;
@@ -463,24 +463,27 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     prepareBlockProductionInternal(slot);
   }
 
-  private SafeFuture<BlockProductionPreparationContext> prepareBlockProductionInternal(
-      final UInt64 slot) {
+  private BlockProductionPreparationContext prepareBlockProductionInternal(final UInt64 slot) {
     return blockProductionPreparationContextBySlotCache.computeIfAbsent(
         slot,
         __ -> {
           LOG.info("Preparing block production for slot {}", slot);
           final BlockProductionPerformance productionPerformance =
               blockProductionAndPublishingPerformanceFactory.createForProduction(slot);
-          return forkChoiceTrigger
-              .prepareForBlockProduction(slot, productionPerformance)
-              .thenApply(
-                  chainHead ->
-                      new BlockProductionPreparationContext(
-                          combinedChainDataClient
-                              .getStateForBlockProduction(chainHead, slot)
-                              .thenPeek(___ -> productionPerformance.getState()),
-                          chainHead.getPayloadStatus(),
-                          productionPerformance));
+          final SafeFuture<ChainHead> maybeChainHead =
+              forkChoiceTrigger.prepareForBlockProduction(slot, productionPerformance);
+
+          final SafeFuture<BeaconState> stateFuture =
+              maybeChainHead
+                  .thenCompose(
+                      chainHead ->
+                          combinedChainDataClient.getStateForBlockProduction(chainHead, slot))
+                  .thenPeek(___ -> productionPerformance.getState());
+
+          return new BlockProductionPreparationContext(
+              stateFuture,
+              maybeChainHead.thenApply(ChainHead::getPayloadStatus),
+              productionPerformance);
         });
   }
 
@@ -495,26 +498,21 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
       return NodeSyncingException.failedFuture();
     }
 
-    return prepareBlockProductionInternal(slot)
-        .thenCompose(
-            blockProductionPreparationContext -> {
-              final BlockProductionPerformance blockProductionPerformance =
-                  blockProductionPreparationContext.blockProductionPerformance;
+    final BlockProductionPreparationContext blockProductionPreparationContext =
+        prepareBlockProductionInternal(slot);
 
-              blockProductionPerformance.validatorBlockRequested();
+    blockProductionPreparationContext.blockProductionPerformance.validatorBlockRequested();
 
-              return blockProductionPreparationContext
-                  .toBlockProductionContext(
-                      spec, slot, randaoReveal, graffiti, requestedBuilderBoostFactor)
-                  .thenCompose(this::createBlock)
-                  .thenPeek(
-                      maybeBlock ->
-                          maybeBlock.ifPresent(
-                              block ->
-                                  performanceTracker.saveProducedBlock(
-                                      block.blockContainer().getBlock().getSlotAndBlockRoot())))
-                  .alwaysRun(blockProductionPerformance::complete);
-            });
+    return blockProductionPreparationContext
+        .toBlockProductionContext(spec, slot, randaoReveal, graffiti, requestedBuilderBoostFactor)
+        .thenCompose(this::createBlock)
+        .thenPeek(
+            maybeBlock ->
+                maybeBlock.ifPresent(
+                    block ->
+                        performanceTracker.saveProducedBlock(
+                            block.blockContainer().getBlock().getSlotAndBlockRoot())))
+        .alwaysRun(blockProductionPreparationContext.blockProductionPerformance::complete);
   }
 
   private SafeFuture<Optional<BlockContainerAndMetaData>> createBlock(
@@ -1214,7 +1212,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
 
   private record BlockProductionPreparationContext(
       SafeFuture<BeaconState> stateFuture,
-      ForkChoicePayloadStatus payloadStatus,
+      SafeFuture<ForkChoicePayloadStatus> payloadStatusFuture,
       BlockProductionPerformance blockProductionPerformance) {
 
     SafeFuture<BlockProductionContext> toBlockProductionContext(
@@ -1223,8 +1221,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
         final BLSSignature randaoReveal,
         final Optional<Bytes32> graffiti,
         final Optional<UInt64> requestedBuilderBoostFactor) {
-      return stateFuture.thenApply(
-          state ->
+      return stateFuture.thenCombine(
+          payloadStatusFuture,
+          (state, payloadStatus) ->
               BlockProductionContext.create(
                   spec,
                   proposalSlot,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -476,10 +476,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
               .thenApply(
                   chainHead ->
                       new BlockProductionPreparationContext(
-                          combinedChainDataClient.getStateForBlockProduction(chainHead, slot),
+                          combinedChainDataClient
+                              .getStateForBlockProduction(chainHead, slot)
+                              .thenPeek(___ -> productionPerformance.getState()),
                           chainHead.getPayloadStatus(),
-                          productionPerformance))
-              .thenPeek(___ -> productionPerformance.getState());
+                          productionPerformance));
         });
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.stream.Collectors.toMap;
 import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessageOrSimpleName;
 import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getRootCauseMessage;
@@ -89,6 +90,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -143,7 +145,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
 
   private final Map<UInt64, SafeFuture<Optional<BlockContainerAndMetaData>>>
       blockProductionBySlotCache = new ConcurrentHashMap<>();
-  private final Map<UInt64, BlockProductionPreparationContext>
+  private final Map<UInt64, SafeFuture<BlockProductionPreparationContext>>
       blockProductionPreparationContextBySlotCache = new ConcurrentHashMap<>();
 
   private final BlockProductionAndPublishingPerformanceFactory
@@ -453,6 +455,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
             });
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void onBlockProductionPreparationDue(final UInt64 slot) {
     if (isSyncActive()) {
       return;
@@ -460,25 +463,23 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     prepareBlockProductionInternal(slot);
   }
 
-  private BlockProductionPreparationContext prepareBlockProductionInternal(final UInt64 slot) {
+  private SafeFuture<BlockProductionPreparationContext> prepareBlockProductionInternal(
+      final UInt64 slot) {
     return blockProductionPreparationContextBySlotCache.computeIfAbsent(
         slot,
         __ -> {
           LOG.info("Preparing block production for slot {}", slot);
           final BlockProductionPerformance productionPerformance =
               blockProductionAndPublishingPerformanceFactory.createForProduction(slot);
-          final SafeFuture<Optional<BeaconState>> state =
-              forkChoiceTrigger
-                  .prepareForBlockProduction(slot, productionPerformance)
-                  .thenCompose(
-                      ___ ->
-                          combinedChainDataClient.getStateForBlockProduction(
-                              slot,
-                              forkChoiceTrigger.isForkChoiceOverrideLateBlockEnabled(),
-                              productionPerformance::lateBlockReorgPreparationCompleted))
-                  .thenPeek(___ -> productionPerformance.getState());
-
-          return new BlockProductionPreparationContext(state, productionPerformance);
+          return forkChoiceTrigger
+              .prepareForBlockProduction(slot, productionPerformance)
+              .thenApply(
+                  chainHead ->
+                      new BlockProductionPreparationContext(
+                          combinedChainDataClient.getStateForBlockProduction(chainHead, slot),
+                          chainHead.getPayloadStatus(),
+                          productionPerformance))
+              .thenPeek(___ -> productionPerformance.getState());
         });
   }
 
@@ -493,61 +494,41 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
       return NodeSyncingException.failedFuture();
     }
 
-    final BlockProductionPreparationContext blockProductionContext =
-        prepareBlockProductionInternal(slot);
-    final BlockProductionPerformance blockProductionPerformance =
-        blockProductionContext.blockProductionPerformance;
-
-    blockProductionPerformance.validatorBlockRequested();
-
-    return blockProductionContext
-        .stateFuture
+    return prepareBlockProductionInternal(slot)
         .thenCompose(
-            blockSlotState ->
-                createBlock(
-                    slot,
-                    randaoReveal,
-                    graffiti,
-                    requestedBuilderBoostFactor,
-                    blockSlotState,
-                    blockProductionPerformance))
-        .thenPeek(
-            maybeBlock ->
-                maybeBlock.ifPresent(
-                    block ->
-                        performanceTracker.saveProducedBlock(
-                            block.blockContainer().getBlock().getSlotAndBlockRoot())))
-        .alwaysRun(blockProductionPerformance::complete);
+            blockProductionPreparationContext -> {
+              final BlockProductionPerformance blockProductionPerformance =
+                  blockProductionPreparationContext.blockProductionPerformance;
+
+              blockProductionPerformance.validatorBlockRequested();
+
+              return blockProductionPreparationContext
+                  .toBlockProductionContext(
+                      spec, slot, randaoReveal, graffiti, requestedBuilderBoostFactor)
+                  .thenCompose(this::createBlock)
+                  .thenPeek(
+                      maybeBlock ->
+                          maybeBlock.ifPresent(
+                              block ->
+                                  performanceTracker.saveProducedBlock(
+                                      block.blockContainer().getBlock().getSlotAndBlockRoot())))
+                  .alwaysRun(blockProductionPerformance::complete);
+            });
   }
 
   private SafeFuture<Optional<BlockContainerAndMetaData>> createBlock(
-      final UInt64 slot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> graffiti,
-      final Optional<UInt64> requestedBuilderBoostFactor,
-      final Optional<BeaconState> maybeBlockSlotState,
-      final BlockProductionPerformance blockProductionPerformance) {
-    if (maybeBlockSlotState.isEmpty()) {
-      return SafeFuture.completedFuture(Optional.empty());
-    }
-    final BeaconState blockSlotState = maybeBlockSlotState.get();
-    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slot.decrement());
-    LOG.debug("parent block {}:({})", parentRoot, slot);
-    if (combinedChainDataClient.isOptimisticBlock(parentRoot)) {
+      final BlockProductionContext blockProductionContext) {
+    LOG.debug(
+        "parent block {}:({})",
+        blockProductionContext.parentRoot(),
+        blockProductionContext.proposalSlot());
+    if (combinedChainDataClient.isOptimisticBlock(blockProductionContext.parentRoot())) {
       LOG.warn(
           "Unable to produce block at slot {} because parent has optimistically validated payload",
-          slot);
+          blockProductionContext.proposalSlot());
       throw new NodeSyncingException();
     }
-    return blockFactory
-        .createUnsignedBlock(
-            blockSlotState,
-            slot,
-            randaoReveal,
-            graffiti,
-            requestedBuilderBoostFactor,
-            blockProductionPerformance)
-        .thenApply(Optional::of);
+    return blockFactory.createUnsignedBlock(blockProductionContext).thenApply(Optional::of);
   }
 
   @Override
@@ -1231,6 +1212,64 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   }
 
   private record BlockProductionPreparationContext(
-      SafeFuture<Optional<BeaconState>> stateFuture,
-      BlockProductionPerformance blockProductionPerformance) {}
+      SafeFuture<BeaconState> stateFuture,
+      ForkChoicePayloadStatus payloadStatus,
+      BlockProductionPerformance blockProductionPerformance) {
+
+    SafeFuture<BlockProductionContext> toBlockProductionContext(
+        final Spec spec,
+        final UInt64 proposalSlot,
+        final BLSSignature randaoReveal,
+        final Optional<Bytes32> graffiti,
+        final Optional<UInt64> requestedBuilderBoostFactor) {
+      return stateFuture.thenApply(
+          state ->
+              BlockProductionContext.create(
+                  spec,
+                  proposalSlot,
+                  state,
+                  randaoReveal,
+                  graffiti,
+                  requestedBuilderBoostFactor,
+                  payloadStatus,
+                  blockProductionPerformance));
+    }
+  }
+
+  public record BlockProductionContext(
+      UInt64 proposalSlot,
+      BeaconState blockSlotState,
+      Bytes32 parentRoot,
+      BLSSignature randaoReveal,
+      Optional<Bytes32> graffiti,
+      Optional<UInt64> requestedBuilderBoostFactor,
+      ForkChoicePayloadStatus payloadStatus,
+      BlockProductionPerformance blockProductionPerformance) {
+
+    public static BlockProductionContext create(
+        final Spec spec,
+        final UInt64 proposalSlot,
+        final BeaconState blockSlotState,
+        final BLSSignature randaoReveal,
+        final Optional<Bytes32> graffiti,
+        final Optional<UInt64> requestedBuilderBoostFactor,
+        final ForkChoicePayloadStatus payloadStatus,
+        final BlockProductionPerformance blockProductionPerformance) {
+      checkArgument(
+          blockSlotState.getSlot().equals(proposalSlot),
+          "Block slot state for slot %s but should be for slot %s",
+          blockSlotState.getSlot(),
+          proposalSlot);
+      final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, proposalSlot.decrement());
+      return new BlockProductionContext(
+          proposalSlot,
+          blockSlotState,
+          parentRoot,
+          randaoReveal,
+          graffiti,
+          requestedBuilderBoostFactor,
+          payloadStatus,
+          blockProductionPerformance);
+    }
+  }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -25,6 +25,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 import static tech.pegasys.teku.spec.constants.EthConstants.GWEI_TO_WEI;
+import static tech.pegasys.teku.validator.coordinator.BlockProductionTestUtil.blockProductionContext;
 
 import java.util.Collections;
 import java.util.List;
@@ -209,7 +210,7 @@ public abstract class AbstractBlockFactoryTest {
     when(blsToExecutionChangePool.getItemsForBlock(any())).thenReturn(blsToExecutionChanges);
     when(payloadAttestationPool.getPayloadAttestationsForBlock(any(), any()))
         .thenReturn(payloadAttestations);
-    when(executionPayloadManager.getParentExecutionRequestsForBlock(any(), any()))
+    when(executionPayloadManager.getParentExecutionRequestsForBlock(any(), any(), any()))
         .thenAnswer(__ -> dataStructureUtil.emptyExecutionRequests());
     when(eth1DataCache.getEth1Vote(any())).thenReturn(ETH1_DATA);
     if (blinded) {
@@ -256,12 +257,14 @@ public abstract class AbstractBlockFactoryTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         safeJoin(
             blockFactory.createUnsignedBlock(
-                blockSlotState,
-                newSlot,
-                randaoReveal,
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP));
+                blockProductionContext(
+                    spec,
+                    newSlot,
+                    blockSlotState,
+                    randaoReveal,
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP)));
 
     final BeaconBlock block = blockContainerAndMetaData.blockContainer().getBlock();
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryBellatrixTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.validator.coordinator.BlockOperationSelectorFactoryTest.CapturingBeaconBlockBodyBuilder;
+import static tech.pegasys.teku.validator.coordinator.BlockProductionTestUtil.blockProductionContext;
 
 import java.util.Comparator;
 import java.util.Optional;
@@ -205,12 +206,13 @@ class BlockOperationSelectorFactoryBellatrixTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
     assertThat(bodyBuilder.executionPayload).isEqualTo(defaultExecutionPayload);
   }
@@ -231,12 +233,13 @@ class BlockOperationSelectorFactoryBellatrixTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryDenebTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.validator.coordinator.BlockOperationSelectorFactoryTest.CapturingBeaconBlockBodyBuilder;
+import static tech.pegasys.teku.validator.coordinator.BlockProductionTestUtil.blockProductionContext;
 
 import java.util.Comparator;
 import java.util.List;
@@ -236,12 +237,13 @@ class BlockOperationSelectorFactoryDenebTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryFuluTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.validator.coordinator.BlockOperationSelectorFactoryTest.CapturingBeaconBlockBodyBuilder;
+import static tech.pegasys.teku.validator.coordinator.BlockProductionTestUtil.blockProductionContext;
 
 import java.util.Comparator;
 import java.util.List;
@@ -233,12 +234,13 @@ class BlockOperationSelectorFactoryFuluTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
+import static tech.pegasys.teku.validator.coordinator.BlockProductionTestUtil.blockProductionContext;
 
 import java.util.Comparator;
 import java.util.List;
@@ -240,12 +241,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(bodyBuilder.proposerSlashings).isEmpty();
@@ -280,12 +282,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                randaoReveal,
-                Optional.of(defaultGraffiti),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    randaoReveal,
+                    Optional.of(defaultGraffiti),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
     assertThat(bodyBuilder.voluntaryExits).isEmpty();
   }
@@ -321,18 +324,19 @@ class BlockOperationSelectorFactoryTest {
 
     final CapturingBeaconBlockBodyBuilder gloasBodyBuilder =
         new CapturingBeaconBlockBodyBuilder(false, false, true);
-    when(executionPayloadManager.getParentExecutionRequestsForBlock(any(), any()))
+    when(executionPayloadManager.getParentExecutionRequestsForBlock(any(), any(), any()))
         .thenReturn(parentReqs);
 
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                randaoReveal,
-                Optional.of(defaultGraffiti),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    randaoReveal,
+                    Optional.of(defaultGraffiti),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(gloasBodyBuilder));
 
     assertThat(gloasBodyBuilder.voluntaryExits).isEmpty();
@@ -367,12 +371,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                randaoReveal,
-                Optional.of(defaultGraffiti),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    randaoReveal,
+                    Optional.of(defaultGraffiti),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(bodyBuilder.randaoReveal).isEqualTo(randaoReveal);
@@ -454,12 +459,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                randaoReveal,
-                Optional.of(defaultGraffiti),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    randaoReveal,
+                    Optional.of(defaultGraffiti),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(bodyBuilder.randaoReveal).isEqualTo(randaoReveal);
@@ -491,12 +497,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())
@@ -529,12 +536,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())
@@ -559,12 +567,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())
@@ -589,12 +598,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())
@@ -620,12 +630,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())
@@ -661,12 +672,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(BeaconStateCache.getSlotCaches(blockSlotState).getBlockExecutionValue())
@@ -713,12 +725,13 @@ class BlockOperationSelectorFactoryTest {
     assertThatSafeFuture(
             factory
                 .createSelector(
-                    parentRoot,
-                    blockSlotState,
-                    dataStructureUtil.randomSignature(),
-                    Optional.empty(),
-                    Optional.empty(),
-                    BlockProductionPerformance.NOOP)
+                    blockProductionContext(
+                        parentRoot,
+                        blockSlotState,
+                        dataStructureUtil.randomSignature(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        BlockProductionPerformance.NOOP))
                 .apply(bodyBuilder))
         .isCompletedExceptionallyWith(IllegalStateException.class)
         .hasMessage(
@@ -761,12 +774,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                randaoReveal,
-                Optional.of(defaultGraffiti),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    randaoReveal,
+                    Optional.of(defaultGraffiti),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(bodyBuilder.randaoReveal).isEqualTo(randaoReveal);
@@ -810,12 +824,13 @@ class BlockOperationSelectorFactoryTest {
     safeJoin(
         factory
             .createSelector(
-                parentRoot,
-                blockSlotState,
-                dataStructureUtil.randomSignature(),
-                Optional.empty(),
-                Optional.empty(),
-                BlockProductionPerformance.NOOP)
+                blockProductionContext(
+                    parentRoot,
+                    blockSlotState,
+                    dataStructureUtil.randomSignature(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    BlockProductionPerformance.NOOP))
             .apply(bodyBuilder));
 
     assertThat(bodyBuilder.executionRequests).isEqualTo(executionRequests);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionTestUtil.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockProductionTestUtil.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler.BlockProductionContext;
+
+final class BlockProductionTestUtil {
+
+  private static final ForkChoicePayloadStatus DEFAULT_PAYLOAD_STATUS =
+      ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
+
+  private BlockProductionTestUtil() {}
+
+  static BlockProductionContext blockProductionContext(
+      final Spec spec,
+      final UInt64 proposalSlot,
+      final BeaconState blockSlotState,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final Optional<UInt64> requestedBuilderBoostFactor,
+      final BlockProductionPerformance blockProductionPerformance) {
+    return BlockProductionContext.create(
+        spec,
+        proposalSlot,
+        blockSlotState,
+        randaoReveal,
+        graffiti,
+        requestedBuilderBoostFactor,
+        DEFAULT_PAYLOAD_STATUS,
+        blockProductionPerformance);
+  }
+
+  static BlockProductionContext blockProductionContext(
+      final Bytes32 parentRoot,
+      final BeaconState blockSlotState,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final Optional<UInt64> requestedBuilderBoostFactor,
+      final BlockProductionPerformance blockProductionPerformance) {
+    return new BlockProductionContext(
+        blockSlotState.getSlot(),
+        blockSlotState,
+        parentRoot,
+        randaoReveal,
+        graffiti,
+        requestedBuilderBoostFactor,
+        DEFAULT_PAYLOAD_STATUS,
+        blockProductionPerformance);
+  }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -34,9 +34,11 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING;
 import static tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel.EQUIVOCATION;
 import static tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel.GOSSIP;
 import static tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel.NOT_REQUIRED;
+import static tech.pegasys.teku.validator.coordinator.BlockProductionTestUtil.blockProductionContext;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -124,6 +126,7 @@ import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContribution
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
@@ -141,6 +144,7 @@ class ValidatorApiHandlerTest {
   private static final UInt64 PREVIOUS_EPOCH = EPOCH.minus(ONE);
 
   private final CombinedChainDataClient chainDataClient = mock(CombinedChainDataClient.class);
+  private final ChainHead chainHead = mock(ChainHead.class);
   private final UpdatableStore store = mock(UpdatableStore.class);
   private final SyncStateProvider syncStateProvider = mock(SyncStateProvider.class);
   private final BlockFactory blockFactory = mock(BlockFactory.class);
@@ -229,7 +233,9 @@ class ValidatorApiHandlerTest {
 
     when(chainDataClient.getStore()).thenReturn(store);
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
-    when(forkChoiceTrigger.prepareForBlockProduction(any(), any())).thenReturn(SafeFuture.COMPLETE);
+    when(forkChoiceTrigger.prepareForBlockProduction(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(chainHead));
+    when(chainHead.getPayloadStatus()).thenReturn(PAYLOAD_STATUS_PENDING);
     when(chainDataClient.isOptimisticBlock(any())).thenReturn(false);
     doAnswer(invocation -> SafeFuture.completedFuture(invocation.getArgument(0)))
         .when(blockFactory)
@@ -548,8 +554,8 @@ class ValidatorApiHandlerTest {
   public void createUnsignedBlock_shouldFailWhenParentBlockIsOptimistic() {
     final UInt64 newSlot = UInt64.valueOf(25);
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconState(newSlot);
-    when(chainDataClient.getStateForBlockProduction(eq(newSlot), eq(false), any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
+    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(blockSlotState));
     final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, newSlot.minus(1));
     when(chainDataClient.isOptimisticBlock(parentRoot)).thenReturn(true);
 
@@ -570,15 +576,17 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(newSlot), eq(false), any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
+    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(blockSlotState));
     when(blockFactory.createUnsignedBlock(
-            blockSlotState,
-            newSlot,
-            randaoReveal,
-            Optional.empty(),
-            Optional.of(ONE),
-            BlockProductionPerformance.NOOP))
+            blockProductionContext(
+                spec,
+                newSlot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.of(ONE),
+                BlockProductionPerformance.NOOP)))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
     // even if passing a non-empty requestedBlinded and requestedBuilderBoostFactor isn't a valid
@@ -600,12 +608,14 @@ class ValidatorApiHandlerTest {
     // only produced once
     verify(blockFactory)
         .createUnsignedBlock(
-            blockSlotState,
-            newSlot,
-            randaoReveal,
-            Optional.empty(),
-            Optional.of(ONE),
-            BlockProductionPerformance.NOOP);
+            blockProductionContext(
+                spec,
+                newSlot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.of(ONE),
+                BlockProductionPerformance.NOOP));
 
     verify(performanceTracker).reportBlockProductionAttempt(spec.computeEpochAtSlot(newSlot));
     verify(performanceTracker)
@@ -621,15 +631,17 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(newSlot), eq(false), any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
+    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(blockSlotState));
     when(blockFactory.createUnsignedBlock(
-            blockSlotState,
-            newSlot,
-            randaoReveal,
-            Optional.empty(),
-            Optional.of(ONE),
-            BlockProductionPerformance.NOOP))
+            blockProductionContext(
+                spec,
+                newSlot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.of(ONE),
+                BlockProductionPerformance.NOOP)))
         .thenThrow(new IllegalStateException("oopsy"))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
@@ -650,12 +662,14 @@ class ValidatorApiHandlerTest {
     // attempted to produce twice
     verify(blockFactory, times(2))
         .createUnsignedBlock(
-            blockSlotState,
-            newSlot,
-            randaoReveal,
-            Optional.empty(),
-            Optional.of(ONE),
-            BlockProductionPerformance.NOOP);
+            blockProductionContext(
+                spec,
+                newSlot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.of(ONE),
+                BlockProductionPerformance.NOOP));
   }
 
   @Test
@@ -666,20 +680,22 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(newSlot), eq(false), any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
+    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(blockSlotState));
 
     validatorApiHandler.onBlockProductionPreparationDue(newSlot);
 
-    verify(chainDataClient).getStateForBlockProduction(eq(newSlot), eq(false), any());
+    verify(chainDataClient).getStateForBlockProduction(eq(chainHead), eq(newSlot));
 
     when(blockFactory.createUnsignedBlock(
-            blockSlotState,
-            newSlot,
-            randaoReveal,
-            Optional.empty(),
-            Optional.of(ONE),
-            BlockProductionPerformance.NOOP))
+            blockProductionContext(
+                spec,
+                newSlot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.of(ONE),
+                BlockProductionPerformance.NOOP)))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
     SafeFuture<Optional<BlockContainerAndMetaData>> result =
@@ -688,7 +704,7 @@ class ValidatorApiHandlerTest {
 
     assertThat(result).isCompletedWithValue(Optional.of(blockContainerAndMetaData));
 
-    verify(chainDataClient).getStateForBlockProduction(eq(newSlot), eq(false), any());
+    verify(chainDataClient).getStateForBlockProduction(eq(chainHead), eq(newSlot));
   }
 
   @Test
@@ -1034,15 +1050,17 @@ class ValidatorApiHandlerTest {
     final BlockContainerAndMetaData blockContainerAndMetaData =
         dataStructureUtil.randomBlockContainerAndMetaData(newSlot);
 
-    when(chainDataClient.getStateForBlockProduction(eq(newSlot), eq(false), any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
+    when(chainDataClient.getStateForBlockProduction(eq(chainHead), eq(newSlot)))
+        .thenReturn(SafeFuture.completedFuture(blockSlotState));
     when(blockFactory.createUnsignedBlock(
-            blockSlotState,
-            newSlot,
-            randaoReveal,
-            Optional.empty(),
-            Optional.of(ONE),
-            BlockProductionPerformance.NOOP))
+            blockProductionContext(
+                spec,
+                newSlot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.of(ONE),
+                BlockProductionPerformance.NOOP)))
         .thenReturn(SafeFuture.completedFuture(blockContainerAndMetaData));
 
     assertThat(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -296,7 +296,7 @@ public class EventSubscriptionManager
         .ifPresent(
             payloadAttributes -> {
               final SpecMilestone milestone =
-                  spec.atSlot(payloadAttributes.getProposalSlot()).getMilestone();
+                  spec.atSlot(payloadAttributes.proposalSlot()).getMilestone();
               final PayloadAttributesEvent payloadAttributesEvent =
                   PayloadAttributesEvent.create(
                       milestone,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/PayloadAttributesEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/PayloadAttributesEvent.java
@@ -111,19 +111,19 @@ public class PayloadAttributesEvent extends Event<PayloadAttributesData> {
         new PayloadAttributesData(
             milestone,
             new PayloadAttributesEvent.Data(
-                payloadAttributes.getProposalSlot(),
-                payloadAttributes.getParentBeaconBlockRoot(),
-                forkChoiceState.getHeadExecutionBlockNumber(),
-                forkChoiceState.getHeadExecutionBlockHash(),
-                payloadAttributes.getProposerIndex(),
+                payloadAttributes.proposalSlot(),
+                payloadAttributes.parentBeaconBlock().blockRoot(),
+                forkChoiceState.headExecutionBlockNumber(),
+                forkChoiceState.headExecutionBlockHash(),
+                payloadAttributes.proposerIndex(),
                 // based on PayloadAttributesV<N> as defined by the execution-apis specification
                 new PayloadAttributes(
-                    payloadAttributes.getTimestamp(),
-                    payloadAttributes.getPrevRandao(),
-                    payloadAttributes.getFeeRecipient(),
-                    payloadAttributes.getWithdrawals(),
+                    payloadAttributes.timestamp(),
+                    payloadAttributes.prevRandao(),
+                    payloadAttributes.feeRecipient(),
+                    payloadAttributes.withdrawals(),
                     milestone.isGreaterThanOrEqualTo(SpecMilestone.DENEB)
-                        ? Optional.of(payloadAttributes.getParentBeaconBlockRoot())
+                        ? Optional.of(payloadAttributes.parentBeaconBlock().blockRoot())
                         : Optional.empty())));
     return new PayloadAttributesEvent(data);
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -131,21 +132,21 @@ public class EventSubscriptionManagerTest {
       new PayloadAttributesData(
           SpecMilestone.GLOAS,
           new Data(
-              samplePayloadAttributes.getProposalSlot(),
-              samplePayloadAttributes.getParentBeaconBlockRoot(),
+              samplePayloadAttributes.proposalSlot(),
+              samplePayloadAttributes.parentBeaconBlock().blockRoot(),
               data.randomUInt64(),
               data.randomBytes32(),
-              samplePayloadAttributes.getProposerIndex(),
+              samplePayloadAttributes.proposerIndex(),
               new PayloadAttributes(
-                  samplePayloadAttributes.getTimestamp(),
-                  samplePayloadAttributes.getPrevRandao(),
-                  samplePayloadAttributes.getFeeRecipient(),
-                  samplePayloadAttributes.getWithdrawals(),
-                  Optional.of(samplePayloadAttributes.getParentBeaconBlockRoot()))));
+                  samplePayloadAttributes.timestamp(),
+                  samplePayloadAttributes.prevRandao(),
+                  samplePayloadAttributes.feeRecipient(),
+                  samplePayloadAttributes.withdrawals(),
+                  Optional.of(samplePayloadAttributes.parentBeaconBlock().blockRoot()))));
   final ForkChoiceUpdatedResultNotification forkChoiceUpdatedResultNotification =
       new ForkChoiceUpdatedResultNotification(
           new ForkChoiceState(
-              data.randomBytes32(),
+              ForkChoiceNode.createBase(data.randomBytes32()),
               data.randomSlot(),
               samplePayloadAttributesData.data().parentExecutionBlockNumber(),
               samplePayloadAttributesData.data().parentExecutionBlockHash(),

--- a/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -141,12 +140,7 @@ public class StateSelectorFactoryTest {
     final StorageQueryChannel historicalChainData = mock(StorageQueryChannel.class);
     final RecentChainData recentChainData = mock(RecentChainData.class);
     final CombinedChainDataClient client1 =
-        new CombinedChainDataClient(
-            recentChainData,
-            historicalChainData,
-            spec,
-            LateBlockReorgPreparationHandler.NOOP,
-            false);
+        new CombinedChainDataClient(recentChainData, historicalChainData, spec, false);
     final StateSelectorFactory factory = new StateSelectorFactory(spec, client1);
     when(recentChainData.isPreGenesis()).thenReturn(false);
     when(recentChainData.isPreForkChoice()).thenReturn(true);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ForkChoiceStateV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ForkChoiceStateV1.java
@@ -53,9 +53,9 @@ public class ForkChoiceStateV1 {
   public static ForkChoiceStateV1 fromInternalForkChoiceState(
       final ForkChoiceState forkChoiceState) {
     return new ForkChoiceStateV1(
-        forkChoiceState.getHeadExecutionBlockHash(),
-        forkChoiceState.getSafeExecutionBlockHash(),
-        forkChoiceState.getFinalizedExecutionBlockHash());
+        forkChoiceState.headExecutionBlockHash(),
+        forkChoiceState.safeExecutionBlockHash(),
+        forkChoiceState.finalizedExecutionBlockHash());
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV1.java
@@ -62,9 +62,9 @@ public class PayloadAttributesV1 {
     return payloadBuildingAttributes.map(
         payloadAttributes ->
             new PayloadAttributesV1(
-                payloadAttributes.getTimestamp(),
-                payloadAttributes.getPrevRandao(),
-                payloadAttributes.getFeeRecipient()));
+                payloadAttributes.timestamp(),
+                payloadAttributes.prevRandao(),
+                payloadAttributes.feeRecipient()));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
@@ -44,21 +44,21 @@ public class PayloadAttributesV2 extends PayloadAttributesV1 {
     return payloadBuildingAttributes.map(
         payloadAttributes ->
             new PayloadAttributesV2(
-                payloadAttributes.getTimestamp(),
-                payloadAttributes.getPrevRandao(),
-                payloadAttributes.getFeeRecipient(),
+                payloadAttributes.timestamp(),
+                payloadAttributes.prevRandao(),
+                payloadAttributes.feeRecipient(),
                 getWithdrawals(payloadAttributes)));
   }
 
   public static List<WithdrawalV1> getWithdrawals(
       final PayloadBuildingAttributes payloadAttributes) {
     return payloadAttributes
-        .getWithdrawals()
+        .withdrawals()
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
                     "Withdrawals were expected to be part of the payload attributes for slot "
-                        + payloadAttributes.getProposalSlot()))
+                        + payloadAttributes.proposalSlot()))
         .stream()
         .map(
             withdrawal ->

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
@@ -51,11 +51,11 @@ public class PayloadAttributesV3 extends PayloadAttributesV2 {
     return payloadBuildingAttributes.map(
         payloadAttributes ->
             new PayloadAttributesV3(
-                payloadAttributes.getTimestamp(),
-                payloadAttributes.getPrevRandao(),
-                payloadAttributes.getFeeRecipient(),
+                payloadAttributes.timestamp(),
+                payloadAttributes.prevRandao(),
+                payloadAttributes.feeRecipient(),
                 getWithdrawals(payloadAttributes),
-                payloadAttributes.getParentBeaconBlockRoot()));
+                payloadAttributes.parentBeaconBlock().blockRoot()));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
@@ -46,12 +46,12 @@ public class PayloadAttributesV4 extends PayloadAttributesV3 {
   public static PayloadAttributesV4 fromInternalPayloadBuildingAttributesV4(
       final PayloadBuildingAttributes payloadBuildingAttributes) {
     return new PayloadAttributesV4(
-        payloadBuildingAttributes.getTimestamp(),
-        payloadBuildingAttributes.getPrevRandao(),
-        payloadBuildingAttributes.getFeeRecipient(),
+        payloadBuildingAttributes.timestamp(),
+        payloadBuildingAttributes.prevRandao(),
+        payloadBuildingAttributes.feeRecipient(),
         getWithdrawals(payloadBuildingAttributes),
-        payloadBuildingAttributes.getParentBeaconBlockRoot(),
-        payloadBuildingAttributes.getProposalSlot());
+        payloadBuildingAttributes.parentBeaconBlock().blockRoot(),
+        payloadBuildingAttributes.proposalSlot());
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -96,7 +96,7 @@ public class ExecutionBuilderModule {
       final BeaconState state,
       final SafeFuture<GetPayloadResponse> localGetPayloadResponse) {
     final Optional<SignedValidatorRegistration> validatorRegistration =
-        executionPayloadContext.getPayloadBuildingAttributes().getValidatorRegistration();
+        executionPayloadContext.getPayloadBuildingAttributes().validatorRegistration();
 
     // fallback conditions
     final FallbackReason fallbackReason;
@@ -150,7 +150,7 @@ public class ExecutionBuilderModule {
     final UInt64 slot = state.getSlot();
 
     final Optional<SignedValidatorRegistration> validatorRegistration =
-        executionPayloadContext.getPayloadBuildingAttributes().getValidatorRegistration();
+        executionPayloadContext.getPayloadBuildingAttributes().validatorRegistration();
 
     final BLSPublicKey validatorPublicKey =
         validatorRegistration.orElseThrow().getMessage().getPublicKey();
@@ -358,7 +358,7 @@ public class ExecutionBuilderModule {
   }
 
   private boolean isTransitionNotFinalized(final ExecutionPayloadContext executionPayloadContext) {
-    return executionPayloadContext.getForkChoiceState().getFinalizedExecutionBlockHash().isZero();
+    return executionPayloadContext.getForkChoiceState().finalizedExecutionBlockHash().isZero();
   }
 
   private boolean isCircuitBreakerEngaged(final BeaconState state) {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -86,8 +86,8 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
             () -> {
               final UInt64 slot =
                   payloadBuildingAttributes
-                      .map(PayloadBuildingAttributes::getProposalSlot)
-                      .orElse(forkChoiceState.getHeadBlockSlot());
+                      .map(PayloadBuildingAttributes::proposalSlot)
+                      .orElse(forkChoiceState.headBlockSlot());
               return spec.atSlot(slot).getMilestone();
             },
             ForkChoiceUpdatedResult.class)

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -101,7 +102,7 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.empty(),
-            dataStructureUtil.randomBytes32());
+            ForkChoiceNode.createBase(dataStructureUtil.randomBytes32()));
     final Optional<PayloadAttributesV1> payloadAttributes =
         PayloadAttributesV1.fromInternalPayloadBuildingAttributes(Optional.of(attributes));
     final ForkChoiceUpdatedResult responseData =

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -136,7 +137,7 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.of(List.of()),
-            dataStructureUtil.randomBytes32());
+            ForkChoiceNode.createBase(dataStructureUtil.randomBytes32()));
     final Optional<PayloadAttributesV2> payloadAttributes =
         PayloadAttributesV2.fromInternalPayloadBuildingAttributesV2(Optional.of(attributes));
     // headBlockSlot in ForkChoiceState is still in Bellatrix

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -125,7 +126,7 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.of(List.of()),
-            dataStructureUtil.randomBytes32());
+            ForkChoiceNode.createBase(dataStructureUtil.randomBytes32()));
     final Optional<PayloadAttributesV3> payloadAttributes =
         PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(Optional.of(attributes));
     final ForkChoiceUpdatedResult responseData =

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -142,7 +143,7 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.of(List.of()),
-            dataStructureUtil.randomBytes32());
+            ForkChoiceNode.createBase(dataStructureUtil.randomBytes32()));
     final Optional<PayloadAttributesV3> payloadAttributes =
         PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(Optional.of(attributes));
     final ForkChoiceUpdatedResult responseData =

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModuleTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModuleTest.java
@@ -229,7 +229,7 @@ public class ExecutionBuilderModuleTest {
 
   private BuilderBid prepareBuilderGetHeaderResponse(
       final boolean prepareEmptyResponse, final UInt256 builderBlockValue) {
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
 
     final BuilderBid builderBid =
         dataStructureUtil.randomBuilderBid(builder -> builder.value(builderBlockValue));

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -92,7 +92,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -150,7 +150,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     // we expect result from the builder
@@ -202,7 +202,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -250,7 +250,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -301,7 +301,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     // we expect result from the builder
@@ -355,7 +355,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -402,7 +402,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     // we expect result from the builder
@@ -466,7 +466,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
   private BuilderBid prepareBuilderGetHeaderResponse(
       final ExecutionPayloadContext executionPayloadContext, final boolean prepareEmptyResponse) {
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
 
     final SignedBuilderBid signedBuilderBid = dataStructureUtil.randomSignedBuilderBid();
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -165,7 +165,7 @@ class ExecutionLayerManagerImplTest {
   public void engineGetPayload_shouldReturnGetPayloadResponseViaEngine() {
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -187,7 +187,7 @@ class ExecutionLayerManagerImplTest {
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
     executionLayerManager = createExecutionLayerChannelImpl(false, false);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -220,7 +220,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final BuilderBid builderBid =
@@ -263,7 +263,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final BuilderBid builderBid =
@@ -305,7 +305,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final BuilderBid builderBid =
@@ -349,7 +349,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final BuilderBid builderBid =
@@ -392,7 +392,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final BuilderBid builderBid =
@@ -434,7 +434,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final UInt256 builderValue =
@@ -466,7 +466,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     prepareBuilderGetHeaderResponse(executionPayloadContext, false, builderExecutionPayloadValue);
@@ -491,7 +491,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     prepareBuilderGetHeaderFailure(executionPayloadContext);
@@ -539,7 +539,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     prepareBuilderGetHeaderFailure(executionPayloadContext);
@@ -588,7 +588,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     prepareBuilderGetHeaderResponse(executionPayloadContext, false, builderExecutionPayloadValue);
@@ -617,7 +617,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     prepareBuilderGetHeaderResponse(executionPayloadContext, false, builderExecutionPayloadValue);
@@ -642,7 +642,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -667,7 +667,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     prepareBuilderGetHeaderResponse(executionPayloadContext, true, builderExecutionPayloadValue);
@@ -694,7 +694,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(Bytes32.ZERO, false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconStatePreMerge(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -719,7 +719,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -746,7 +746,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -773,7 +773,7 @@ class ExecutionLayerManagerImplTest {
 
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, false);
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
@@ -915,7 +915,7 @@ class ExecutionLayerManagerImplTest {
       final ExecutionPayloadContext executionPayloadContext,
       final boolean prepareEmptyResponse,
       final UInt256 builderBlockValue) {
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
 
     final BuilderBid builderBid =
         dataStructureUtil.randomBuilderBid(builder -> builder.value(builderBlockValue));
@@ -1005,7 +1005,7 @@ class ExecutionLayerManagerImplTest {
 
   private void prepareBuilderGetHeaderFailure(
       final ExecutionPayloadContext executionPayloadContext) {
-    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().headBlockSlot();
 
     when(builderClient.getHeader(
             slot,

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/FuluExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/FuluExecutionClientHandlerTest.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -143,7 +144,7 @@ public class FuluExecutionClientHandlerTest extends ExecutionHandlerClientTest {
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.of(List.of()),
-            dataStructureUtil.randomBytes32());
+            ForkChoiceNode.createBase(dataStructureUtil.randomBytes32()));
     final Optional<PayloadAttributesV3> payloadAttributes =
         PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(Optional.of(attributes));
     final ForkChoiceUpdatedResult responseData =

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -144,7 +145,7 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.of(List.of()),
-            dataStructureUtil.randomBytes32());
+            ForkChoiceNode.createBase(dataStructureUtil.randomBytes32()));
     final PayloadAttributesV4 payloadAttributes =
         PayloadAttributesV4.fromInternalPayloadBuildingAttributesV4(attributes);
     final ForkChoiceUpdatedResult responseData =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadContext.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadContext.java
@@ -47,11 +47,11 @@ public class ExecutionPayloadContext {
   }
 
   public Bytes32 getParentHash() {
-    return forkChoiceState.getHeadExecutionBlockHash();
+    return forkChoiceState.headExecutionBlockHash();
   }
 
   public boolean isValidatorRegistrationPresent() {
-    return payloadBuildingAttributes.getValidatorRegistration().isPresent();
+    return payloadBuildingAttributes.validatorRegistration().isPresent();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -212,6 +212,8 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
     offlineCheck();
 
+    LOG.info("Fork choice update {} attributes {}", forkChoiceState, payloadBuildingAttributes);
+
     if (!bellatrixActivationDetected) {
       LOG.debug(
           "forkChoiceUpdated received before terminalBlock has been sent. Assuming transition already happened");
@@ -230,17 +232,17 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                   payloadIdToHeadAndAttrsCache.invalidateWithNewValue(
                       payloadId,
                       new HeadAndAttributes(
-                          forkChoiceState.getHeadExecutionBlockHash(), payloadAttributes));
+                          forkChoiceState.headExecutionBlockHash(), payloadAttributes));
                   return payloadId;
                 }));
 
     if (!LOG.isDebugEnabled()) {
       LOG.info(
           "EL Stub FCU head: {}:{}, payload: {}:{}",
-          forkChoiceState.getHeadBlockSlot(),
-          forkChoiceState.getHeadBlockRoot(),
-          forkChoiceState.getHeadExecutionBlockNumber(),
-          forkChoiceState.getHeadExecutionBlockHash());
+          forkChoiceState.headBlockSlot(),
+          forkChoiceState.headBlock(),
+          forkChoiceState.headExecutionBlockNumber(),
+          forkChoiceState.headExecutionBlockHash());
     }
     LOG.debug(
         "forkChoiceUpdated: forkChoiceState: {} payloadBuildingAttributes: {} -> forkChoiceUpdatedResult: {}",
@@ -287,20 +289,20 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                 builder ->
                     builder
                         .parentHash(headAndAttrs.head)
-                        .feeRecipient(payloadAttributes.getFeeRecipient())
+                        .feeRecipient(payloadAttributes.feeRecipient())
                         .stateRoot(Bytes32.ZERO)
                         .receiptsRoot(Bytes32.ZERO)
                         .logsBloom(Bytes.random(256))
-                        .prevRandao(payloadAttributes.getPrevRandao())
+                        .prevRandao(payloadAttributes.prevRandao())
                         .blockNumber(UInt64.valueOf(payloadIdCounter.get()))
                         .gasLimit(UInt64.ONE)
                         .gasUsed(UInt64.ZERO)
-                        .timestamp(payloadAttributes.getTimestamp())
+                        .timestamp(payloadAttributes.timestamp())
                         .extraData(Bytes.EMPTY)
                         .baseFeePerGas(UInt256.ONE)
                         .blockHash(Bytes32.random())
                         .transactions(transactions)
-                        .withdrawals(() -> payloadAttributes.getWithdrawals().orElse(List.of()))
+                        .withdrawals(() -> payloadAttributes.withdrawals().orElse(List.of()))
                         .blobGasUsed(() -> UInt64.ZERO)
                         .excessBlobGas(() -> UInt64.ZERO)
                         .blockAccessList(() -> Bytes32.ZERO)
@@ -312,7 +314,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
             new PowBlock(
                 executionPayload.getBlockHash(),
                 executionPayload.getParentHash(),
-                payloadAttributes.getTimestamp()));
+                payloadAttributes.timestamp()));
 
     headAndAttrs.currentExecutionPayload = Optional.of(executionPayload);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ForkChoiceState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ForkChoiceState.java
@@ -13,106 +13,15 @@
 
 package tech.pegasys.teku.spec.executionlayer;
 
-import com.google.common.base.MoreObjects;
-import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 
-public class ForkChoiceState {
-  private final Bytes32 headBlockRoot;
-  private final UInt64 headBlockSlot;
-
-  private final UInt64 headExecutionBlockNumber;
-  private final Bytes32 headExecutionBlockHash;
-  private final Bytes32 safeExecutionBlockHash;
-  private final Bytes32 finalizedExecutionBlockHash;
-  private final boolean isHeadOptimistic;
-
-  public ForkChoiceState(
-      final Bytes32 headBlockRoot,
-      final UInt64 headBlockSlot,
-      final UInt64 headExecutionBlockNumber,
-      final Bytes32 headExecutionBlockHash,
-      final Bytes32 safeExecutionBlockHash,
-      final Bytes32 finalizedExecutionBlockHash,
-      final boolean isHeadOptimistic) {
-    this.headBlockRoot = headBlockRoot;
-    this.headBlockSlot = headBlockSlot;
-    this.headExecutionBlockNumber = headExecutionBlockNumber;
-    this.headExecutionBlockHash = headExecutionBlockHash;
-    this.safeExecutionBlockHash = safeExecutionBlockHash;
-    this.finalizedExecutionBlockHash = finalizedExecutionBlockHash;
-    this.isHeadOptimistic = isHeadOptimistic;
-  }
-
-  public Bytes32 getHeadBlockRoot() {
-    return headBlockRoot;
-  }
-
-  public UInt64 getHeadBlockSlot() {
-    return headBlockSlot;
-  }
-
-  public UInt64 getHeadExecutionBlockNumber() {
-    return headExecutionBlockNumber;
-  }
-
-  public Bytes32 getHeadExecutionBlockHash() {
-    return headExecutionBlockHash;
-  }
-
-  public Bytes32 getSafeExecutionBlockHash() {
-    return safeExecutionBlockHash;
-  }
-
-  public Bytes32 getFinalizedExecutionBlockHash() {
-    return finalizedExecutionBlockHash;
-  }
-
-  public boolean isHeadOptimistic() {
-    return isHeadOptimistic;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("headBlockRoot", headBlockRoot)
-        .add("headBlockSlot", headBlockSlot)
-        .add("headExecutionBlockNumber", headExecutionBlockNumber)
-        .add("headExecutionBlockHash", headExecutionBlockHash)
-        .add("safeExecutionBlockHash", safeExecutionBlockHash)
-        .add("finalizedExecutionBlockHash", finalizedExecutionBlockHash)
-        .add("isHeadOptimistic", isHeadOptimistic)
-        .toString();
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ForkChoiceState that = (ForkChoiceState) o;
-    return isHeadOptimistic == that.isHeadOptimistic
-        && Objects.equals(headBlockRoot, that.headBlockRoot)
-        && Objects.equals(headBlockSlot, that.headBlockSlot)
-        && Objects.equals(headExecutionBlockNumber, that.headExecutionBlockNumber)
-        && Objects.equals(headExecutionBlockHash, that.headExecutionBlockHash)
-        && Objects.equals(safeExecutionBlockHash, that.safeExecutionBlockHash)
-        && Objects.equals(finalizedExecutionBlockHash, that.finalizedExecutionBlockHash);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        headBlockRoot,
-        headBlockSlot,
-        headExecutionBlockNumber,
-        headExecutionBlockHash,
-        safeExecutionBlockHash,
-        finalizedExecutionBlockHash,
-        isHeadOptimistic);
-  }
-}
+public record ForkChoiceState(
+    ForkChoiceNode headBlock,
+    UInt64 headBlockSlot,
+    UInt64 headExecutionBlockNumber,
+    Bytes32 headExecutionBlockHash,
+    Bytes32 safeExecutionBlockHash,
+    Bytes32 finalizedExecutionBlockHash,
+    boolean isHeadOptimistic) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
@@ -13,9 +13,7 @@
 
 package tech.pegasys.teku.spec.executionlayer;
 
-import com.google.common.base.MoreObjects;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -23,117 +21,20 @@ import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 
-public class PayloadBuildingAttributes {
-
-  private final UInt64 proposerIndex;
-  private final UInt64 proposalSlot;
-  private final UInt64 timestamp;
-  private final Bytes32 prevRandao;
-  private final Eth1Address feeRecipient;
-  private final Optional<SignedValidatorRegistration> validatorRegistration;
-  private final Optional<List<Withdrawal>> withdrawals;
-  private final Bytes32 parentBeaconBlockRoot;
-
-  public PayloadBuildingAttributes(
-      final UInt64 proposerIndex,
-      final UInt64 proposalSlot,
-      final UInt64 timestamp,
-      final Bytes32 prevRandao,
-      final Eth1Address feeRecipient,
-      final Optional<SignedValidatorRegistration> validatorRegistration,
-      final Optional<List<Withdrawal>> withdrawals,
-      final Bytes32 parentBeaconBlockRoot) {
-    this.proposerIndex = proposerIndex;
-    this.proposalSlot = proposalSlot;
-    this.timestamp = timestamp;
-    this.prevRandao = prevRandao;
-    this.feeRecipient = feeRecipient;
-    this.validatorRegistration = validatorRegistration;
-    this.withdrawals = withdrawals;
-    this.parentBeaconBlockRoot = parentBeaconBlockRoot;
-  }
-
-  public UInt64 getProposerIndex() {
-    return proposerIndex;
-  }
-
-  public UInt64 getProposalSlot() {
-    return proposalSlot;
-  }
-
-  public UInt64 getTimestamp() {
-    return timestamp;
-  }
-
-  public Bytes32 getPrevRandao() {
-    return prevRandao;
-  }
-
-  public Eth1Address getFeeRecipient() {
-    return feeRecipient;
-  }
-
-  public Bytes32 getParentBeaconBlockRoot() {
-    return parentBeaconBlockRoot;
-  }
-
-  public Optional<SignedValidatorRegistration> getValidatorRegistration() {
-    return validatorRegistration;
-  }
+public record PayloadBuildingAttributes(
+    UInt64 proposerIndex,
+    UInt64 proposalSlot,
+    UInt64 timestamp,
+    Bytes32 prevRandao,
+    Eth1Address feeRecipient,
+    Optional<SignedValidatorRegistration> validatorRegistration,
+    Optional<List<Withdrawal>> withdrawals,
+    ForkChoiceNode parentBeaconBlock) {
 
   public Optional<BLSPublicKey> getValidatorRegistrationPublicKey() {
     return validatorRegistration.map(
         signedValidatorRegistration -> signedValidatorRegistration.getMessage().getPublicKey());
-  }
-
-  public Optional<List<Withdrawal>> getWithdrawals() {
-    return withdrawals;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final PayloadBuildingAttributes that = (PayloadBuildingAttributes) o;
-    return Objects.equals(proposerIndex, that.proposerIndex)
-        && Objects.equals(proposalSlot, that.proposalSlot)
-        && Objects.equals(timestamp, that.timestamp)
-        && Objects.equals(prevRandao, that.prevRandao)
-        && Objects.equals(feeRecipient, that.feeRecipient)
-        && Objects.equals(validatorRegistration, that.validatorRegistration)
-        && Objects.equals(withdrawals, that.withdrawals)
-        && Objects.equals(parentBeaconBlockRoot, that.parentBeaconBlockRoot);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        proposerIndex,
-        proposalSlot,
-        timestamp,
-        prevRandao,
-        feeRecipient,
-        validatorRegistration,
-        withdrawals,
-        parentBeaconBlockRoot);
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("proposerIndex", proposerIndex)
-        .add("proposalSlot", proposalSlot)
-        .add("timestamp", timestamp)
-        .add("prevRandao", prevRandao)
-        .add("feeRecipient", feeRecipient)
-        .add("validatorRegistration", validatorRegistration)
-        .add("withdrawals", withdrawals)
-        .add("parentBeaconBlockRoot", parentBeaconBlockRoot)
-        .toString();
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -170,6 +170,8 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.electra.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.WithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.fulu.BlobsBundleFulu;
 import tech.pegasys.teku.spec.datastructures.execution.versions.heze.InclusionList;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartDepositGenerator;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
@@ -1998,7 +2000,7 @@ public final class DataStructureUtil {
             ? Optional.of(randomSignedValidatorRegistration())
             : Optional.empty(),
         randomWithdrawalList(),
-        randomBytes32());
+        new ForkChoiceNode(randomBytes32(), ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING));
   }
 
   public ClientVersion randomClientVersion() {
@@ -2051,7 +2053,7 @@ public final class DataStructureUtil {
   public ForkChoiceState randomForkChoiceState(
       final UInt64 headBlockSlot, final Bytes32 finalizedBlockHash, final boolean optimisticHead) {
     return new ForkChoiceState(
-        randomBytes32(),
+        new ForkChoiceNode(randomBytes32(), ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING),
         headBlockSlot,
         randomUInt64(),
         randomBytes32(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadBidManager.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecution
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.validation.ExecutionPayloadBidGossipValidator;
@@ -84,17 +85,20 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
     // only supporting local self-built bids
-    return getLocalSelfBuiltBid(parentRoot, slot, getPayloadResponseFuture).thenApply(Optional::of);
+    return getLocalSelfBuiltBid(
+            state.toVersionGloas().orElseThrow(), slot, getPayloadResponseFuture)
+        .thenApply(Optional::of);
   }
 
   private SafeFuture<SignedExecutionPayloadBid> getLocalSelfBuiltBid(
-      final Bytes32 parentRoot,
+      final BeaconStateGloas state,
       final UInt64 slot,
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture) {
     return getPayloadResponseFuture.thenApply(
         getPayloadResponse -> {
           final SignedExecutionPayloadBid localSelfBuiltSignedBid =
-              createLocalSelfBuiltSignedBid(getPayloadResponse, parentRoot, slot);
+              createLocalSelfBuiltSignedBid(
+                  getPayloadResponse, slot, state.getLatestBlockHeader().getRoot());
           LOG.info(
               "Considering self-built bid (value: {} ETH, EL block: {}) for block at slot {}",
               weiToEth(getPayloadResponse.getExecutionPayloadValue()),
@@ -108,7 +112,7 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
   }
 
   private SignedExecutionPayloadBid createLocalSelfBuiltSignedBid(
-      final GetPayloadResponse getPayloadResponse, final Bytes32 parentRoot, final UInt64 slot) {
+      final GetPayloadResponse getPayloadResponse, final UInt64 slot, final Bytes32 parentRoot) {
     final SpecVersion specVersion = spec.atSlot(slot);
     final SchemaDefinitionsGloas schemaDefinitions =
         SchemaDefinitionsGloas.required(specVersion.getSchemaDefinitions());
@@ -119,6 +123,7 @@ public class DefaultExecutionPayloadBidManager implements ExecutionPayloadBidMan
             .createFromBlobsBundle(getPayloadResponse.getBlobsBundle().orElseThrow());
     final Bytes32 executionRequestsRoot =
         getPayloadResponse.getExecutionRequests().orElseThrow().hashTreeRoot();
+
     final ExecutionPayloadBid bid =
         schemaDefinitions
             .getExecutionPayloadBidSchema()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.Bea
 import tech.pegasys.teku.spec.datastructures.epbs.BlockRootAndBuilderIndex;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -170,10 +171,10 @@ public class DefaultExecutionPayloadManager
 
   @Override
   public ExecutionRequests getParentExecutionRequestsForBlock(
-      final UInt64 slot, final Bytes32 parentRoot) {
+      final UInt64 slot, final Bytes32 parentRoot, final ForkChoicePayloadStatus payloadStatus) {
     final SpecVersion specVersion = spec.atSlot(slot);
     final UpdatableStore store = recentChainData.getStore();
-    if (!store.getForkChoiceStrategy().shouldExtendPayload(store, parentRoot)) {
+    if (!payloadStatus.equals(ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL)) {
       return SchemaDefinitionsGloas.required(specVersion.getSchemaDefinitions())
           .getExecutionRequestsSchema()
           .getDefault();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
@@ -47,7 +48,9 @@ public interface ExecutionPayloadManager {
 
         @Override
         public ExecutionRequests getParentExecutionRequestsForBlock(
-            final UInt64 slot, final Bytes32 parentRoot) {
+            final UInt64 slot,
+            final Bytes32 parentRoot,
+            final ForkChoicePayloadStatus payloadStatus) {
           return null;
         }
       };
@@ -76,7 +79,8 @@ public interface ExecutionPayloadManager {
       SignedExecutionPayloadEnvelope signedExecutionPayload);
 
   /** Retrieves parent execution requests (used in block production) */
-  ExecutionRequests getParentExecutionRequestsForBlock(UInt64 slot, Bytes32 parentRoot);
+  ExecutionRequests getParentExecutionRequestsForBlock(
+      UInt64 slot, Bytes32 parentRoot, ForkChoicePayloadStatus payloadStatus);
 
   default SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.logging.P2PLogger.P2P_LOG;
 import static tech.pegasys.teku.statetransition.forkchoice.StateRootCollector.addParentStateRoots;
 
@@ -49,9 +50,12 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.SlotAndForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -82,6 +86,7 @@ import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AttestationStateSelector;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.protoarray.DeferredVotes;
@@ -107,6 +112,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       Subscribers.create(true);
   private final TickProcessor tickProcessor;
   private final boolean forkChoiceLateBlockReorgEnabled;
+  private final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler;
   private Optional<Boolean> optimisticSyncing = Optional.empty();
 
   private final AtomicReference<UInt64> lastProcessHeadSlot = new AtomicReference<>();
@@ -125,6 +131,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final TickProcessor tickProcessor,
       final MergeTransitionBlockValidator transitionBlockValidator,
       final boolean forkChoiceLateBlockReorgEnabled,
+      final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler,
       final DebugDataDumper debugDataDumper,
       final MetricsSystem metricsSystem,
       final AsyncBLSSignatureVerifier signatureVerifier) {
@@ -138,6 +145,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         new AttestationStateSelector(spec, recentChainData, metricsSystem);
     this.tickProcessor = tickProcessor;
     this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
+    this.lateBlockReorgPreparationHandler = lateBlockReorgPreparationHandler;
     this.lastProcessHeadSlot.set(UInt64.ZERO);
     LOG.debug("forkChoiceLateBlockReorgEnabled is set to {}", forkChoiceLateBlockReorgEnabled);
     this.debugDataDumper = debugDataDumper;
@@ -169,6 +177,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         new TickProcessor(spec, recentChainData),
         transitionBlockValidator,
         false,
+        LateBlockReorgPreparationHandler.NOOP,
         DebugDataDumper.NOOP,
         metricsSystem,
         AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.SIMPLE));
@@ -185,13 +194,11 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                   && forkChoiceUpdatedResult.getPayloadStatus().hasInvalidStatus()) {
                 LOG.error(
                     "Execution engine considers INVALID recently provided terminal block {}",
-                    forkChoiceUpdatedResultNotification
-                        .forkChoiceState()
-                        .getHeadExecutionBlockHash());
+                    forkChoiceUpdatedResultNotification.forkChoiceState().headExecutionBlockHash());
                 return;
               }
               onExecutionPayloadResult(
-                  forkChoiceUpdatedResultNotification.forkChoiceState().getHeadBlockRoot(),
+                  forkChoiceUpdatedResultNotification.forkChoiceState().headBlock().blockRoot(),
                   forkChoiceUpdatedResult.getPayloadStatus());
             })
         .finish(
@@ -205,7 +212,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             });
   }
 
-  public SafeFuture<Boolean> processHead() {
+  public SafeFuture<Optional<ChainHead>> processHead() {
     return processHead(Optional.empty(), false);
   }
 
@@ -362,11 +369,11 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     processHead().join();
   }
 
-  SafeFuture<Boolean> processHead(final UInt64 nodeSlot) {
+  SafeFuture<Optional<ChainHead>> processHead(final UInt64 nodeSlot) {
     return processHead(Optional.of(nodeSlot), false);
   }
 
-  private SafeFuture<Boolean> processHead(
+  private SafeFuture<Optional<ChainHead>> processHead(
       final Optional<UInt64> nodeSlot, final boolean isPreProposal) {
     final Checkpoint retrievedJustifiedCheckpoint =
         recentChainData.getStore().getJustifiedCheckpoint();
@@ -387,27 +394,35 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                             retrievedJustifiedCheckpoint::getRoot,
                             justifiedCheckpoint::getEpoch,
                             justifiedCheckpoint::getRoot);
-                        return false;
+                        return recentChainData.getChainHead();
                       }
                       if (maybeJustifiedCheckpointState.isEmpty()) {
                         LOG.debug(
                             "Retrieved justified checkpoint state for {} was empty, cannot update head given current information.",
                             justifiedCheckpoint::getRoot);
-                        return false;
+                        return recentChainData.getChainHead();
                       }
-                      updateHeadTransaction(
-                          nodeSlot,
-                          maybeJustifiedCheckpointState.orElseThrow(),
-                          finalizedCheckpoint,
-                          justifiedCheckpoint);
+                      final Optional<ChainHead> newHead =
+                          updateHeadTransaction(
+                              nodeSlot,
+                              maybeJustifiedCheckpointState.orElseThrow(),
+                              finalizedCheckpoint,
+                              justifiedCheckpoint);
                       nodeSlot.ifPresent(lastProcessHeadSlot::set);
-                      notifyForkChoiceUpdatedAndOptimisticSyncingChanged(
-                          isPreProposal ? nodeSlot : Optional.empty());
-                      return true;
+
+                      if (isPreProposal) {
+                        checkState(newHead.isPresent(), "We need a chainHead for block production");
+                        // Pre-proposal callers (prepareForBlockProduction) handle the proposer-head
+                        // override and the resulting fcU notification themselves.
+                      } else {
+                        notifyForkChoiceUpdatedAndOptimisticSyncingChanged(
+                            Optional.empty(), Optional.empty());
+                      }
+                      return newHead;
                     }));
   }
 
-  private void updateHeadTransaction(
+  private Optional<ChainHead> updateHeadTransaction(
       final Optional<UInt64> nodeSlot,
       final BeaconState justifiedState,
       final Checkpoint finalizedCheckpoint,
@@ -443,6 +458,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       // successful updateHead call
       transaction.commit();
     }
+
+    return recentChainData.getChainHead();
   }
 
   /**
@@ -722,7 +739,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     updateForkChoiceForImportedBlock(
         block, shouldUpdateProposerBoostRoot, result, forkChoiceStrategy);
     if (forkChoiceUtil.shouldNotifyForkChoiceUpdatedOnBlock()) {
-      notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
+      notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty(), Optional.empty());
     }
     return result;
   }
@@ -774,7 +791,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();
     updateForkChoiceForImportedExecutionPayload(forkChoiceStrategy);
-    notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty());
+    notifyForkChoiceUpdatedAndOptimisticSyncingChanged(Optional.empty(), Optional.empty());
 
     return ExecutionPayloadImportResult.successful(signedEnvelope);
   }
@@ -984,8 +1001,13 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   }
 
   private void notifyForkChoiceUpdatedAndOptimisticSyncingChanged(
-      final Optional<UInt64> proposingSlot) {
-    final ForkChoiceState forkChoiceState = forkChoiceStateProvider.getForkChoiceStateSync();
+      final Optional<UInt64> proposingSlot, final Optional<ChainHead> proposingOnHead) {
+    checkState(
+        proposingSlot.isPresent() == proposingOnHead.isPresent(),
+        "proposing slot and proposingOnHead must be consistent");
+
+    final ForkChoiceState forkChoiceState =
+        forkChoiceStateProvider.getForkChoiceStateSync(proposingOnHead);
 
     forkChoiceNotifier.onForkChoiceUpdated(forkChoiceState, proposingSlot);
     getProposerHeadSelectedCounter.labels("fork_choice").inc();
@@ -1058,7 +1080,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     return lastProcessHeadSlot.get();
   }
 
-  SafeFuture<Void> prepareForBlockProduction(
+  SafeFuture<ChainHead> prepareForBlockProduction(
       final UInt64 slot, final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slotStartTimeMillis =
         spec.computeTimeMillisAtSlot(slot, recentChainData.getGenesisTimeMillis());
@@ -1072,7 +1094,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
           "Block creation requested more than {}ms before the start of slot {}",
           BLOCK_CREATION_TOLERANCE_MS,
           slot);
-      return SafeFuture.COMPLETE;
+      return SafeFuture.completedFuture(recentChainData.getChainHead().orElseThrow());
     }
 
     return SafeFuture.allOf(
@@ -1082,7 +1104,103 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             applyDeferredAttestations(slot)
                 .thenPeek(__ -> blockProductionPerformance.prepareApplyDeferredAttestations()))
         .thenCompose(__ -> processHead(Optional.of(slot), true))
-        .thenRun(blockProductionPerformance::prepareProcessHead);
+        .thenApply(Optional::orElseThrow)
+        .thenCompose(
+            canonicalHead ->
+                applyProposerHeadOverrideAndNotify(canonicalHead, slot, blockProductionPerformance))
+        .thenPeek(__ -> blockProductionPerformance.prepareProcessHead());
+  }
+
+  /**
+   * If late-block-reorg is enabled and {@code get_proposer_head} flips the proposer to the parent
+   * of the canonical head, materialize a {@link ChainHead} for the parent (with the parent's
+   * FULL/EMPTY payload variant) and trigger the late-block reorg preparation handler. The
+   * proposer-head fcU notification fires from the same event-thread tick (notify requires the
+   * fork-choice event thread). Returned future completes after the preparation handler completes,
+   * mirroring the previous behavior of {@code CombinedChainDataClient.getStateForBlockProduction}
+   * which awaited preparation before returning the state.
+   */
+  private SafeFuture<ChainHead> applyProposerHeadOverrideAndNotify(
+      final ChainHead canonicalHead,
+      final UInt64 slot,
+      final BlockProductionPerformance performance) {
+    return forkChoiceExecutor.executeFuture(
+        () -> {
+          final Optional<ChainHead> overriddenHead =
+              resolveProposerHeadOverride(canonicalHead, slot);
+          final ChainHead proposerHead = overriddenHead.orElse(canonicalHead);
+          final SafeFuture<Void> preparation;
+          if (overriddenHead.isPresent()) {
+            // Run preparation in parallel; await it before returning so block-body construction
+            // sees the updated operation pools.
+            preparation =
+                lateBlockReorgPreparationHandler
+                    .onLateBlockReorgPreparation(proposerHead.getSlot(), canonicalHead.getRoot())
+                    .thenPeek(__ -> performance.lateBlockReorgPreparationCompleted());
+          } else {
+            preparation = SafeFuture.COMPLETE;
+          }
+          notifyForkChoiceUpdatedAndOptimisticSyncingChanged(
+              Optional.of(slot), Optional.of(proposerHead));
+          return preparation.thenApply(__ -> proposerHead);
+        });
+  }
+
+  /**
+   * Returns the proposer-head {@link ChainHead} when {@code get_proposer_head} flips the proposer
+   * to the parent of the canonical head, or {@link Optional#empty()} when no override is needed.
+   */
+  private Optional<ChainHead> resolveProposerHeadOverride(
+      final ChainHead canonicalHead, final UInt64 slot) {
+    forkChoiceExecutor.checkOnEventThread();
+    if (!forkChoiceLateBlockReorgEnabled) {
+      return Optional.empty();
+    }
+    final Bytes32 canonicalRoot = canonicalHead.getRoot();
+    final Bytes32 proposerHeadRoot = recentChainData.getProposerHead(canonicalRoot, slot);
+    if (proposerHeadRoot.equals(canonicalRoot)) {
+      return Optional.empty();
+    }
+
+    LOG.debug(
+        "prepareForBlockProduction overriding head {} with proposer head {} for slot {}",
+        canonicalRoot,
+        proposerHeadRoot,
+        slot);
+
+    final ForkChoiceStrategy strategy = getForkChoiceStrategy();
+    final UpdatableStore store = recentChainData.getStore();
+    final ForkChoicePayloadStatus parentPayloadStatus =
+        strategy.shouldExtendPayload(store, proposerHeadRoot)
+            ? ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL
+            : ForkChoicePayloadStatus.PAYLOAD_STATUS_EMPTY;
+    // Phase0/non-Gloas blocks only have a base node; fall back if the variant lookup misses.
+    final Optional<ProtoNodeData> parentBlockData =
+        strategy
+            .getBlockData(proposerHeadRoot, parentPayloadStatus)
+            .or(() -> strategy.getBlockData(proposerHeadRoot));
+
+    if (parentBlockData.isEmpty()) {
+      LOG.warn(
+          "Unable to resolve proposer head {} in fork choice; sticking with canonical head {}",
+          proposerHeadRoot,
+          canonicalRoot);
+      return Optional.empty();
+    }
+
+    final SafeFuture<StateAndBlockSummary> parentStateAndBlock =
+        store
+            .retrieveStateAndBlockSummary(proposerHeadRoot)
+            .thenApply(
+                maybe ->
+                    maybe.orElseThrow(
+                        () ->
+                            new IllegalStateException(
+                                String.format(
+                                    "Unable to load proposer head state for %s while preparing block production at slot %s",
+                                    proposerHeadRoot, slot))));
+
+    return Optional.of(ChainHead.create(parentBlockData.get(), parentStateAndBlock));
   }
 
   private SafeFuture<Void> applyDeferredAttestations(final UInt64 slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,12 +42,16 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
   private final ProposersDataManager proposersDataManager;
   private final Spec spec;
   private final TimeProvider timeProvider;
-  private final boolean forkChoiceLateBlockReorgEnabled;
 
   private final Subscribers<ForkChoiceUpdatedResultSubscriber> forkChoiceUpdatedSubscribers =
       Subscribers.create(true);
 
   private ForkChoiceUpdateData forkChoiceUpdateData = new ForkChoiceUpdateData();
+
+  // Pinned proposing slot for which forkChoiceUpdateData must remain stable. Set when block
+  // production starts (proposingSlot is supplied). Cleared as soon as the produced block is
+  // imported (head advances past it).
+  private Optional<UInt64> lastProposingSlot = Optional.empty();
 
   private boolean inSync = false; // Assume we are not in sync at startup.
 
@@ -56,8 +62,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
       final Spec spec,
       final ExecutionLayerChannel executionLayerChannel,
       final RecentChainData recentChainData,
-      final ProposersDataManager proposersDataManager,
-      final boolean forkChoiceLateBlockReorgEnabled) {
+      final ProposersDataManager proposersDataManager) {
     this.forkChoiceStateProvider = forkChoiceStateProvider;
     this.eventThread = eventThread;
     this.spec = spec;
@@ -65,7 +70,6 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
     this.recentChainData = recentChainData;
     this.proposersDataManager = proposersDataManager;
     this.timeProvider = timeProvider;
-    this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
   }
 
   @Override
@@ -150,9 +154,16 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
         parentBeaconBlockRoot,
         blockSlot);
 
+    checkState(
+        forkChoiceUpdateData
+            .getForkChoiceState()
+            .headBlock()
+            .blockRoot()
+            .equals(parentBeaconBlockRoot));
+
     final Bytes32 parentExecutionHash =
         recentChainData
-            .getExecutionBlockHashForBlockRoot(parentBeaconBlockRoot)
+            .getExecutionBlockHashForBlock(forkChoiceUpdateData.getForkChoiceState().headBlock())
             .orElseThrow(
                 () ->
                     new IllegalStateException(
@@ -165,6 +176,10 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
       // Pre-merge so ok to use default payload
       return SafeFuture.completedFuture(Optional.empty());
     } else {
+      // TODO: with the pinned forkChoiceUpdateData there is no point in trying to refresh.
+      // Now we should have a stable forkChoiceUpdateData which must be compatible with
+      // parentBeaconBlockRoot and slot by blockSlot. So we can just throw here.
+
       // Request a new payload with refreshed forkChoiceState and payloadBuildingAttributes
 
       LOG.warn(
@@ -215,13 +230,40 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
     final Optional<UInt64> localProposingSlot =
         calculatePayloadAttributesSlot(forkChoiceState, proposingSlot);
 
-    if (forkChoiceLateBlockReorgEnabled
-        && localProposingSlot.isPresent()
-        && recentChainData.shouldOverrideForkChoiceUpdate(
-            forkChoiceState.getHeadBlockRoot(), forkChoiceState.getHeadBlockSlot())) {
+    // Reset rule: if our produced block (or a later block) has been imported, clear the pin and
+    // let this fcU through so the EL learns the new head immediately. The fall-through path below
+    // refreshes forkChoiceUpdateData and broadcasts on the same event-thread tick.
+    if (lastProposingSlot.isPresent()
+        && forkChoiceState.headBlockSlot().isGreaterThanOrEqualTo(lastProposingSlot.get())) {
       LOG.debug(
-          "internalForkChoiceUpdated skipped due to late block reorg override producing block at slot {}",
-          localProposingSlot.get());
+          "internalForkChoiceUpdated clearing pin for slot {} (head advanced to slot {})",
+          lastProposingSlot.get(),
+          forkChoiceState.headBlockSlot());
+      lastProposingSlot = Optional.empty();
+    }
+
+    if (proposingSlot.isPresent()) {
+      // Production trigger: refresh forkChoiceUpdateData and (re)set the pin to the proposing slot
+      // regardless of any cached value. ForkChoice has already substituted the proposer head
+      // (incl. late-block reorg) so the broadcast is correct without an override gate here.
+      this.forkChoiceUpdateData = this.forkChoiceUpdateData.withForkChoiceState(forkChoiceState);
+      lastProposingSlot = localProposingSlot;
+      LOG.debug(
+          "internalForkChoiceUpdated forkChoiceUpdateData {} pinned for slot {}",
+          forkChoiceUpdateData,
+          lastProposingSlot);
+      localProposingSlot.ifPresent(this::updatePayloadAttributes);
+      sendForkChoiceUpdated();
+      return;
+    }
+
+    if (localProposingSlot.isPresent()
+        && lastProposingSlot.isPresent()
+        && localProposingSlot.get().equals(lastProposingSlot.get())) {
+      // Pin-hold: a background fcU arrived during the active proposing window. Skip the swap
+      // (which would also wipe payloadBuildingAttributes via withForkChoiceState) so the
+      // proposing-slot state stays stable.
+      LOG.debug("internalForkChoiceUpdated skipped — pinned for slot {}", lastProposingSlot.get());
       return;
     }
 
@@ -260,13 +302,13 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
     final Optional<UInt64> maybeCurrentPayloadAttributesSlot =
         forkChoiceUpdateData
             .getPayloadBuildingAttributes()
-            .map(PayloadBuildingAttributes::getProposalSlot);
+            .map(PayloadBuildingAttributes::proposalSlot);
 
     if (maybeCurrentPayloadAttributesSlot.isPresent()
         // we are still in the same slot as the last proposing slot
         && currentSlot.get().equals(maybeCurrentPayloadAttributesSlot.get())
         // we have not yet imported our own produced block
-        && forkChoiceState.getHeadBlockSlot().isLessThan(maybeCurrentPayloadAttributesSlot.get())) {
+        && forkChoiceState.headBlockSlot().isLessThan(maybeCurrentPayloadAttributesSlot.get())) {
 
       LOG.debug(
           "current payload attributes slot has been chosen for payload attributes calculation: {}",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class ForkChoiceStateProvider {
@@ -29,19 +31,20 @@ public class ForkChoiceStateProvider {
   }
 
   public SafeFuture<ForkChoiceState> getForkChoiceStateAsync() {
-    return forkChoiceExecutor.execute(this::internalGetForkChoiceState);
+    return forkChoiceExecutor.execute(() -> internalGetForkChoiceState(Optional.empty()));
   }
 
-  public ForkChoiceState getForkChoiceStateSync() {
+  public ForkChoiceState getForkChoiceStateSync(final Optional<ChainHead> proposingOnHead) {
     forkChoiceExecutor.checkOnEventThread();
-    return internalGetForkChoiceState();
+    return internalGetForkChoiceState(proposingOnHead);
   }
 
-  private ForkChoiceState internalGetForkChoiceState() {
+  private ForkChoiceState internalGetForkChoiceState(final Optional<ChainHead> proposingOnHead) {
     return recentChainData
         .getUpdatableForkChoiceStrategy()
         .orElseThrow()
         .getForkChoiceState(
+            proposingOnHead,
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
             recentChainData.getFinalizedCheckpoint().orElseThrow());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTrigger.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTrigger.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.ChainHead;
 
 public class ForkChoiceTrigger {
   public static final int WARNING_TIME_MILLIS = 250;
@@ -79,7 +80,7 @@ public class ForkChoiceTrigger {
     }
   }
 
-  public SafeFuture<Void> prepareForBlockProduction(
+  public SafeFuture<ChainHead> prepareForBlockProduction(
       final UInt64 slot, final BlockProductionPerformance blockProductionPerformance) {
     return forkChoice.prepareForBlockProduction(slot, blockProductionPerformance);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -24,6 +24,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
@@ -34,7 +36,13 @@ public class ForkChoiceUpdateData {
   private static final Logger LOG = LogManager.getLogger();
   private static final ForkChoiceState DEFAULT_FORK_CHOICE_STATE =
       new ForkChoiceState(
-          Bytes32.ZERO, UInt64.ZERO, UInt64.ZERO, Bytes32.ZERO, Bytes32.ZERO, Bytes32.ZERO, false);
+          new ForkChoiceNode(Bytes32.ZERO, ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING),
+          UInt64.ZERO,
+          UInt64.ZERO,
+          Bytes32.ZERO,
+          Bytes32.ZERO,
+          Bytes32.ZERO,
+          false);
 
   private final ForkChoiceState forkChoiceState;
   private final Optional<PayloadBuildingAttributes> payloadBuildingAttributes;
@@ -56,11 +64,11 @@ public class ForkChoiceUpdateData {
       final ForkChoiceState forkChoiceState,
       final Optional<PayloadBuildingAttributes> payloadBuildingAttributes,
       final Optional<Bytes32> terminalBlockHash) {
-    if (terminalBlockHash.isPresent() && forkChoiceState.getHeadExecutionBlockHash().isZero()) {
+    if (terminalBlockHash.isPresent() && forkChoiceState.headExecutionBlockHash().isZero()) {
       this.forkChoiceState =
           new ForkChoiceState(
-              forkChoiceState.getHeadBlockRoot(),
-              forkChoiceState.getHeadBlockSlot(),
+              forkChoiceState.headBlock(),
+              forkChoiceState.headBlockSlot(),
               // We don't have data for terminal block number
               UInt64.ZERO,
               terminalBlockHash.get(),
@@ -130,7 +138,7 @@ public class ForkChoiceUpdateData {
     }
 
     final PayloadBuildingAttributes attributes = this.payloadBuildingAttributes.get();
-    if (!attributes.getTimestamp().equals(timestamp)) {
+    if (!attributes.timestamp().equals(timestamp)) {
       LOG.debug("isPayloadIdSuitable - wrong timestamp, returning false");
       // EL building a block with wrong timestamp
       return false;
@@ -141,12 +149,12 @@ public class ForkChoiceUpdateData {
       // pre-merge, must build on top of a detected terminal block
       boolean isSuitable =
           terminalBlockHash.isPresent()
-              && forkChoiceState.getHeadExecutionBlockHash().equals(terminalBlockHash.get());
+              && forkChoiceState.headExecutionBlockHash().equals(terminalBlockHash.get());
       LOG.debug("isPayloadIdSuitable - pre-merge: returning {}", isSuitable);
       return isSuitable;
     } else {
       // post-merge, must build on top of the existing parent
-      boolean isSuitable = forkChoiceState.getHeadExecutionBlockHash().equals(parentExecutionHash);
+      boolean isSuitable = forkChoiceState.headExecutionBlockHash().equals(parentExecutionHash);
       LOG.debug("isPayloadIdSuitable - post-merge: returning {}", isSuitable);
       return isSuitable;
     }
@@ -167,7 +175,7 @@ public class ForkChoiceUpdateData {
     }
     toBeSentAtTime = currentTimestamp.plus(RESEND_AFTER_MILLIS);
 
-    if (forkChoiceState.getHeadExecutionBlockHash().isZero()) {
+    if (forkChoiceState.headExecutionBlockHash().isZero()) {
       LOG.debug("send - getHeadBlockHash is zero - returning empty");
       executionPayloadContext.complete(Optional.empty());
       return Optional.empty();
@@ -215,12 +223,12 @@ public class ForkChoiceUpdateData {
           buildingAttributes ->
               LOG.info(
                   "Calling local execution layer to start block production (block slot: {})",
-                  buildingAttributes.getProposalSlot()));
+                  buildingAttributes.proposalSlot()));
     }
   }
 
   public boolean hasHeadBlockHash() {
-    return !forkChoiceState.getHeadExecutionBlockHash().isZero();
+    return !forkChoiceState.headExecutionBlockHash().isZero();
   }
 
   public boolean hasTerminalBlockHash() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
@@ -209,12 +210,12 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
     }
     final UInt64 epoch = spec.computeEpochAtSlot(blockSlot);
     final ForkChoiceState forkChoiceState = forkChoiceUpdateData.getForkChoiceState();
-    final Bytes32 currentHeadBlockRoot = forkChoiceState.getHeadBlockRoot();
+    final ForkChoiceNode currentHeadBlock = forkChoiceState.headBlock();
     return getStateInEpoch(epoch)
         .thenApplyAsync(
             maybeState ->
                 calculatePayloadBuildingAttributes(
-                    currentHeadBlockRoot, blockSlot, epoch, maybeState, mandatory),
+                    currentHeadBlock, blockSlot, epoch, maybeState, mandatory),
             eventThread);
   }
 
@@ -227,7 +228,7 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
    *     where payloadId hasn't been retrieved from EL for the block slot)
    */
   private Optional<PayloadBuildingAttributes> calculatePayloadBuildingAttributes(
-      final Bytes32 currentHeadBlockRoot,
+      final ForkChoiceNode currentHeadBlock,
       final UInt64 blockSlot,
       final UInt64 epoch,
       final Optional<BeaconState> maybeState,
@@ -263,7 +264,7 @@ public class ProposersDataManager implements SlotEventsChannel, ValidatorIsConne
             feeRecipient,
             validatorRegistration,
             spec.getExpectedWithdrawals(state),
-            currentHeadBlockRoot));
+            currentHeadBlock));
   }
 
   // this function MUST return a fee recipient.

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
@@ -127,8 +128,7 @@ class ForkChoiceNotifierTest {
             spec,
             executionLayerChannel,
             recentChainData,
-            proposersDataManager,
-            false);
+            proposersDataManager);
     notifier.onSyncingStatusChanged(true); // Start in sync to make testing easier
     // store fcu notification
     notifier.subscribeToForkChoiceUpdatedResult(
@@ -171,8 +171,7 @@ class ForkChoiceNotifierTest {
             spec,
             executionLayerChannel,
             recentChainData,
-            proposersDataManager,
-            false);
+            proposersDataManager);
     notifier.onSyncingStatusChanged(true);
     // store fcu notification
     notifier.subscribeToForkChoiceUpdatedResult(
@@ -246,8 +245,7 @@ class ForkChoiceNotifierTest {
             spec,
             executionLayerChannel,
             recentChainData,
-            proposersDataManager,
-            true);
+            proposersDataManager);
     // store fcu notification
     notifier.subscribeToForkChoiceUpdatedResult(
         notification -> forkChoiceUpdatedResultNotification = notification);
@@ -276,8 +274,7 @@ class ForkChoiceNotifierTest {
             spec,
             executionLayerChannel,
             recentChainData,
-            proposersDataManager,
-            true);
+            proposersDataManager);
     // store fcu notification
     notifier.subscribeToForkChoiceUpdatedResult(
         notification -> forkChoiceUpdatedResultNotification = notification);
@@ -389,7 +386,7 @@ class ForkChoiceNotifierTest {
 
     notifyForkChoiceUpdated(
         new ForkChoiceState(
-            Bytes32.ZERO,
+            ForkChoiceNode.createBase(Bytes32.ZERO),
             UInt64.ZERO,
             UInt64.ZERO,
             Bytes32.ZERO,
@@ -518,7 +515,7 @@ class ForkChoiceNotifierTest {
             headState,
             blockSlot,
             false,
-            Optional.of(payloadBuildingAttributesArr.get(1).getFeeRecipient()),
+            Optional.of(payloadBuildingAttributesArr.get(1).feeRecipient()),
             Optional.empty());
 
     // store real payload attributes and return an incomplete future
@@ -717,7 +714,7 @@ class ForkChoiceNotifierTest {
             Optional.empty(),
             Optional.of(createValidatorRegistration(headState, blockSlot)));
 
-    assertThat(payloadBuildingAttributes.getValidatorRegistration()).isNotEmpty();
+    assertThat(payloadBuildingAttributes.validatorRegistration()).isNotEmpty();
 
     final SafeFuture<ForkChoiceUpdatedResult> responseFuture = new SafeFuture<>();
     when(executionLayerChannel.engineForkChoiceUpdated(
@@ -787,7 +784,7 @@ class ForkChoiceNotifierTest {
     // onForkChoiceUpdated before calling onTerminalBlock, so it will initialize ZEROED
     final ForkChoiceState forkChoiceState =
         new ForkChoiceState(
-            Bytes32.ZERO,
+            ForkChoiceNode.createBase(Bytes32.ZERO),
             UInt64.ZERO,
             UInt64.ZERO,
             terminalBlockHash,
@@ -822,8 +819,7 @@ class ForkChoiceNotifierTest {
 
     // send merge onForkChoiceUpdated (with non-finalized block state)
     final ForkChoiceState nonFinalizedForkChoiceState = getCurrentForkChoiceState();
-    assertThat(nonFinalizedForkChoiceState.getFinalizedExecutionBlockHash())
-        .isEqualTo(Bytes32.ZERO);
+    assertThat(nonFinalizedForkChoiceState.finalizedExecutionBlockHash()).isEqualTo(Bytes32.ZERO);
     notifyForkChoiceUpdated(nonFinalizedForkChoiceState);
     verify(executionLayerChannel)
         .engineForkChoiceUpdated(nonFinalizedForkChoiceState, Optional.empty());
@@ -847,8 +843,7 @@ class ForkChoiceNotifierTest {
 
     // send post-merge onForkChoiceUpdated (with finalized block state)
     ForkChoiceState finalizedForkChoiceState = getCurrentForkChoiceState();
-    assertThat(finalizedForkChoiceState.getFinalizedExecutionBlockHash())
-        .isNotEqualTo(Bytes32.ZERO);
+    assertThat(finalizedForkChoiceState.finalizedExecutionBlockHash()).isNotEqualTo(Bytes32.ZERO);
     notifyForkChoiceUpdated(finalizedForkChoiceState);
     verify(executionLayerChannel)
         .engineForkChoiceUpdated(finalizedForkChoiceState, Optional.empty());
@@ -876,8 +871,7 @@ class ForkChoiceNotifierTest {
 
     // send post-merge onForkChoiceUpdated (with finalized block state)
     ForkChoiceState finalizedForkChoiceState = getCurrentForkChoiceState();
-    assertThat(finalizedForkChoiceState.getFinalizedExecutionBlockHash())
-        .isNotEqualTo(Bytes32.ZERO);
+    assertThat(finalizedForkChoiceState.finalizedExecutionBlockHash()).isNotEqualTo(Bytes32.ZERO);
     notifyForkChoiceUpdated(finalizedForkChoiceState);
     verify(executionLayerChannel)
         .engineForkChoiceUpdated(finalizedForkChoiceState, Optional.empty());
@@ -907,8 +901,7 @@ class ForkChoiceNotifierTest {
 
     // send post-merge onForkChoiceUpdated (with finalized block state)
     ForkChoiceState finalizedForkChoiceState = getCurrentForkChoiceState();
-    assertThat(finalizedForkChoiceState.getFinalizedExecutionBlockHash())
-        .isNotEqualTo(Bytes32.ZERO);
+    assertThat(finalizedForkChoiceState.finalizedExecutionBlockHash()).isNotEqualTo(Bytes32.ZERO);
     notifyForkChoiceUpdated(finalizedForkChoiceState);
     verify(executionLayerChannel)
         .engineForkChoiceUpdated(finalizedForkChoiceState, Optional.empty());
@@ -1082,7 +1075,7 @@ class ForkChoiceNotifierTest {
       proposersDataManager.updatePreparedProposers(
           List.of(
               new BeaconPreparableProposer(
-                  proposerIndex, payloadBuildingAttributes.getFeeRecipient())),
+                  proposerIndex, payloadBuildingAttributes.feeRecipient())),
           recentChainData.getHeadSlot());
     }
     validatorRegistration.ifPresent(
@@ -1127,10 +1120,9 @@ class ForkChoiceNotifierTest {
     }
     proposersDataManager.updatePreparedProposers(
         List.of(
+            new BeaconPreparableProposer(proposerIndex1, payloadBuildingAttributes1.feeRecipient()),
             new BeaconPreparableProposer(
-                proposerIndex1, payloadBuildingAttributes1.getFeeRecipient()),
-            new BeaconPreparableProposer(
-                proposerIndex2, payloadBuildingAttributes2.getFeeRecipient())),
+                proposerIndex2, payloadBuildingAttributes2.feeRecipient())),
         recentChainData.getHeadSlot());
     return List.of(payloadBuildingAttributes1, payloadBuildingAttributes2);
   }
@@ -1154,7 +1146,7 @@ class ForkChoiceNotifierTest {
         feeRecipient,
         validatorRegistration,
         dataStructureUtil.randomWithdrawalList(),
-        forkChoiceState.getHeadBlockRoot());
+        forkChoiceState.headBlock());
   }
 
   private ForkChoiceState getCurrentForkChoiceState() {
@@ -1169,7 +1161,7 @@ class ForkChoiceNotifierTest {
         forkChoiceStrategy.executionBlockHash(finalizedRoot).orElseThrow();
 
     return new ForkChoiceState(
-        headBlockRoot,
+        ForkChoiceNode.createBase(headBlockRoot),
         headBlockSlot,
         headExecutionBlockNumber,
         headExecutionHash,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchetTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceRatchetTest.java
@@ -21,15 +21,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.ChainHead;
 
 class ForkChoiceRatchetTest {
 
   private final ForkChoice forkChoice = mock(ForkChoice.class);
-  private final SafeFuture<Boolean> processHeadResult = new SafeFuture<>();
+  private final SafeFuture<Optional<ChainHead>> processHeadResult = new SafeFuture<>();
   private final ForkChoiceRatchet ratchet = new ForkChoiceRatchet(forkChoice);
 
   @BeforeEach
@@ -75,7 +77,7 @@ class ForkChoiceRatchetTest {
     verifyNoMoreInteractions(forkChoice);
     assertThat(result).isNotDone();
 
-    processHeadResult.complete(true);
+    processHeadResult.complete(Optional.empty());
     assertThat(result).isCompleted();
   }
 
@@ -89,7 +91,7 @@ class ForkChoiceRatchetTest {
     verify(forkChoice).processHead(UInt64.ONE);
     assertThat(result).isNotDone();
 
-    processHeadResult.complete(true);
+    processHeadResult.complete(Optional.empty());
     assertThat(result).isCompleted();
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -72,6 +72,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -100,6 +101,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubsc
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator.BroadcastValidationResult;
+import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel.ReorgEvent;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.ChainUpdater;
@@ -173,6 +175,7 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
+            LateBlockReorgPreparationHandler.NOOP,
             debugDataDumper,
             metricsSystem,
             AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.SIMPLE));
@@ -424,6 +427,7 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
+            LateBlockReorgPreparationHandler.NOOP,
             DebugDataDumper.NOOP,
             metricsSystem,
             AsyncBLSSignatureVerifier.wrap(BLSSignatureVerifier.SIMPLE));
@@ -951,8 +955,8 @@ class ForkChoiceTest {
     // EL should have been notified of the invalid head first and after that the valid
     // head
     List<ForkChoiceState> notifiedStates = forkChoiceStateCaptor.getAllValues();
-    assertThat(notifiedStates.get(0).getHeadBlockRoot()).isEqualTo(chainHeadRoot);
-    assertThat(notifiedStates.get(1).getHeadBlockRoot()).isEqualTo(initialHeadRoot);
+    assertThat(notifiedStates.get(0).headBlock().blockRoot()).isEqualTo(chainHeadRoot);
+    assertThat(notifiedStates.get(1).headBlock().blockRoot()).isEqualTo(initialHeadRoot);
   }
 
   @Test
@@ -1033,7 +1037,7 @@ class ForkChoiceTest {
 
     // last notification to EL should be a valid block
     ForkChoiceState lastNotifiedState = forkChoiceStateCaptor.getValue();
-    assertThat(lastNotifiedState.getHeadBlockRoot()).isEqualTo(blockAndState.getRoot());
+    assertThat(lastNotifiedState.headBlock().blockRoot()).isEqualTo(blockAndState.getRoot());
 
     // New head is optimistic because latestValidHash might still point to an optimistic block
     assertHeadIsOptimistic(blockAndState);
@@ -1044,8 +1048,8 @@ class ForkChoiceTest {
   void onForkChoiceUpdatedResult_shouldLogWhenInvalidTerminalBlock(
       final ForkChoiceUpdatedResult result) {
     final ForkChoiceState state = mock(ForkChoiceState.class);
-    when(state.getHeadExecutionBlockHash()).thenReturn(Bytes32.random());
-    when(state.getHeadBlockRoot()).thenReturn(Bytes32.random());
+    when(state.headExecutionBlockHash()).thenReturn(Bytes32.random());
+    when(state.headBlock()).thenReturn(ForkChoiceNode.createBase(Bytes32.random()));
     try (LogCaptor logCaptor = LogCaptor.forClass(ForkChoice.class)) {
       forkChoice.onForkChoiceUpdatedResult(
           new ForkChoiceUpdatedResultNotification(
@@ -1135,7 +1139,7 @@ class ForkChoiceTest {
     verify(forkChoiceNotifier, mode)
         .onForkChoiceUpdated(
             new ForkChoiceState(
-                blockAndState.getRoot(),
+                ForkChoiceNode.createBase(blockAndState.getRoot()),
                 blockAndState.getSlot(),
                 headExecutionBlockNumber,
                 headExecutionHash,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTriggerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTriggerTest.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 import static tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger.DEBUG_TIME_MILLIS;
 import static tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger.WARNING_TIME_MILLIS;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,7 @@ import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
+import tech.pegasys.teku.storage.client.ChainHead;
 
 class ForkChoiceTriggerTest {
 
@@ -46,7 +48,7 @@ class ForkChoiceTriggerTest {
 
   @BeforeEach
   void setUp() {
-    when(forkChoice.processHead(any())).thenReturn(SafeFuture.completedFuture(true));
+    when(forkChoice.processHead(any())).thenReturn(SafeFuture.completedFuture(Optional.empty()));
   }
 
   @Test
@@ -58,7 +60,7 @@ class ForkChoiceTriggerTest {
 
   @Test
   void shouldFailToWaitWithTimeout() {
-    final SafeFuture<Boolean> future = new SafeFuture<>();
+    final SafeFuture<Optional<ChainHead>> future = new SafeFuture<>();
     when(forkChoice.getLastProcessHeadSlot()).thenReturn(UInt64.ZERO);
     when(forkChoice.processHead(UInt64.ONE)).thenReturn(future);
 
@@ -107,7 +109,7 @@ class ForkChoiceTriggerTest {
             forkChoice,
             Eth2NetworkConfiguration.DEFAULT_ATTESTATION_WAIT_TIMEOUT_MILLIS,
             localTime);
-    final SafeFuture<Boolean> processHeadFuture = new SafeFuture<>();
+    final SafeFuture<Optional<ChainHead>> processHeadFuture = new SafeFuture<>();
     when(forkChoice.getLastProcessHeadSlot()).thenReturn(UInt64.ZERO);
     when(localTime.getTimeInMillis())
         .thenReturn(startTimeMillis, startTimeMillis.plus(durationMillis));
@@ -115,7 +117,7 @@ class ForkChoiceTriggerTest {
 
     final CompletableFuture<Void> attestationsDueFuture =
         SafeFuture.runAsync(() -> localTrigger.onAttestationsDueForSlot(UInt64.ONE));
-    processHeadFuture.complete(true);
+    processHeadFuture.complete(Optional.empty());
 
     // Wait for the async operation to complete using proper synchronization
     // instead of polling with Thread.sleep which is flaky on Windows
@@ -131,9 +133,9 @@ class ForkChoiceTriggerTest {
 
   @Test
   void shouldRunForkChoicePriorToBlockProduction() {
-    final SafeFuture<Void> prepareFuture = new SafeFuture<>();
+    final SafeFuture<ChainHead> prepareFuture = new SafeFuture<>();
     when(forkChoice.prepareForBlockProduction(any(), any())).thenReturn(prepareFuture);
-    final SafeFuture<Void> result =
+    final SafeFuture<ChainHead> result =
         trigger.prepareForBlockProduction(UInt64.ONE, BlockProductionPerformance.NOOP);
     assertThatSafeFuture(result).isNotDone();
     verify(forkChoice).prepareForBlockProduction(UInt64.ONE, BlockProductionPerformance.NOOP);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -123,7 +123,6 @@ import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarArchiveRec
 import tech.pegasys.teku.statetransition.datacolumns.log.gossip.DasGossipLogger;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StubStorageQueryChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -238,11 +237,7 @@ public class Eth2P2PNetworkFactory {
             new SubnetSubscriptionService();
         final CombinedChainDataClient combinedChainDataClient =
             new CombinedChainDataClient(
-                recentChainData,
-                historicalChainData,
-                spec,
-                LateBlockReorgPreparationHandler.NOOP,
-                config.isReworkedSidecarSyncEnabled());
+                recentChainData, historicalChainData, spec, config.isReworkedSidecarSyncEnabled());
         final DataColumnSidecarSubnetTopicProvider dataColumnSidecarSubnetTopicProvider =
             new DataColumnSidecarSubnetTopicProvider(
                 combinedChainDataClient.getRecentChainData(), gossipEncoding);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
@@ -121,7 +121,7 @@ public class LibP2PGossipNetworkBuilder {
         new TTLSeenCache<>(
             new FastIdSeenCache<>(msg -> Bytes.wrap(msg.messageSha256())),
             gossipParams.getSeenTTL(),
-            builder.getCurrentTimeSuppluer());
+            builder.getCurrentTimeSupplier());
 
     builder.setParams(gossipParams);
     builder.setScoreParams(scoreParams);

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.libp2p.core.Connection;
-import io.libp2p.core.transport.Transport;
 import io.libp2p.mux.mplex.MplexFlag;
 import io.libp2p.mux.mplex.MplexFrame;
 import io.libp2p.mux.mplex.MplexId;
@@ -26,6 +25,7 @@ import io.libp2p.mux.yamux.YamuxFrame;
 import io.libp2p.mux.yamux.YamuxId;
 import io.libp2p.mux.yamux.YamuxType;
 import io.libp2p.transport.implementation.ConnectionOverNetty;
+import io.libp2p.transport.implementation.NettyTransport;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -53,7 +53,7 @@ public class MuxFirewallTest {
   private final ByteBuf data1K = Unpooled.buffer().writeBytes(new byte[1024]);
   private final EmbeddedChannel channel = new EmbeddedChannel();
   private final Connection connectionOverNetty =
-      new ConnectionOverNetty(channel, mock(Transport.class), true);
+      new ConnectionOverNetty(channel, mock(NettyTransport.class), true);
   private final List<String> passedMessages = new ArrayList<>();
 
   @BeforeEach

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -261,7 +261,6 @@ import tech.pegasys.teku.storage.api.CombinedStorageChannel;
 import tech.pegasys.teku.storage.api.DataColumnSidecarNetworkRetriever;
 import tech.pegasys.teku.storage.api.Eth1DepositStorageChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
@@ -1551,9 +1550,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
             recentChainData,
             storageQueryChannel,
             spec,
-            (slot, blockRoot) ->
-                beaconAsyncRunner.runAsync(
-                    () -> operationsReOrgManager.onLateBlockReorgPreparation(slot, blockRoot)),
             beaconConfig.p2pConfig().isReworkedSidecarSyncEnabled());
   }
 
@@ -1578,6 +1574,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
             new TickProcessor(spec, recentChainData),
             new MergeTransitionBlockValidator(spec, recentChainData),
             beaconConfig.eth2NetworkConfig().isForkChoiceLateBlockReorgEnabled(),
+            (slot, blockRoot) ->
+                beaconAsyncRunner.runAsync(
+                    () -> operationsReOrgManager.onLateBlockReorgPreparation(slot, blockRoot)),
             debugDataDumper,
             metricsSystem,
             signatureVerificationService);
@@ -1966,7 +1965,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
                   recentChainData,
                   throttlingStorageQueryChannel,
                   spec,
-                  LateBlockReorgPreparationHandler.NOOP,
                   beaconConfig.p2pConfig().isReworkedSidecarSyncEnabled()));
     }
 
@@ -2320,8 +2318,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             spec,
             executionLayer,
             recentChainData,
-            proposersDataManager,
-            beaconConfig.eth2NetworkConfig().isForkChoiceLateBlockReorgEnabled());
+            proposersDataManager);
   }
 
   private Optional<Eth1Address> getProposerDefaultFeeRecipient() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -53,7 +53,6 @@ import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.store.UpdatableStore;
 
@@ -71,19 +70,16 @@ public class CombinedChainDataClient {
   private final StorageQueryChannel historicalChainData;
   private final Spec spec;
 
-  private final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler;
   private final boolean isEarliestAvailableDataColumnSlotSupported;
 
   public CombinedChainDataClient(
       final RecentChainData recentChainData,
       final StorageQueryChannel historicalChainData,
       final Spec spec,
-      final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler,
       final boolean isEarliestAvailableDataColumnSlotSupported) {
     this.recentChainData = recentChainData;
     this.historicalChainData = historicalChainData;
     this.spec = spec;
-    this.lateBlockReorgPreparationHandler = lateBlockReorgPreparationHandler;
     this.isEarliestAvailableDataColumnSlotSupported = isEarliestAvailableDataColumnSlotSupported;
   }
 
@@ -301,45 +297,24 @@ public class CombinedChainDataClient {
     return regenerateStateAndSlotExact(slot);
   }
 
-  public SafeFuture<Optional<BeaconState>> getStateForBlockProduction(
-      final UInt64 slot,
-      final boolean isForkChoiceLateBlockReorgEnabled,
-      final Runnable onLateBlockPreparationCompleted) {
-    if (!isForkChoiceLateBlockReorgEnabled) {
-      return getStateAtSlotExact(slot);
-    }
-    final Optional<ChainHead> chainHead = getChainHead();
-    if (chainHead.isEmpty()) {
-      return getStateAtSlotExact(slot);
-    }
-    final Bytes32 headRoot = chainHead.get().getRoot();
-
-    final Bytes32 proposerHeadRoot = recentChainData.getProposerHead(headRoot, slot);
-    if (proposerHeadRoot.equals(headRoot)) {
-      return getStateAtSlotExact(slot);
-    }
-    // otherwise we're looking for the parent slot
-    return getStateByBlockRoot(proposerHeadRoot)
-        .thenCompose(
-            maybeState ->
-                maybeState
-                    .map(
-                        beaconState -> {
-                          // let's run preparation and state generation in parallel
-                          final SafeFuture<Void> preparationCompletion =
-                              lateBlockReorgPreparationHandler
-                                  .onLateBlockReorgPreparation(
-                                      recentChainData
-                                          .getSlotForBlockRoot(proposerHeadRoot)
-                                          .orElseThrow(),
-                                      headRoot)
-                                  .thenPeek(__ -> onLateBlockPreparationCompleted.run());
-                          final Optional<BeaconState> state =
-                              regenerateBeaconState(beaconState, slot);
-
-                          return preparationCompletion.thenApply(__ -> state);
-                        })
-                    .orElseGet(() -> getStateAtSlotExact(slot)));
+  /**
+   * Builds the block-production beacon state from the (already proposer-head-resolved) {@link
+   * ChainHead} returned by {@code ForkChoice.prepareForBlockProduction}. The late-block-reorg
+   * deviation and its preparation handler now live in {@code ForkChoice}, so this method just
+   * advances the supplied chain-head state to the proposing slot.
+   */
+  public SafeFuture<BeaconState> getStateForBlockProduction(
+      final ChainHead chainHead, final UInt64 slot) {
+    return chainHead
+        .getState()
+        .thenApply(
+            state -> {
+              try {
+                return spec.processSlots(state, slot);
+              } catch (SlotProcessingException | EpochProcessingException e) {
+                throw new RuntimeException(e);
+              }
+            });
   }
 
   public SafeFuture<Optional<BeaconState>> getStateAtSlotExact(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -668,6 +668,12 @@ public abstract class RecentChainData
     return getForkChoiceStrategy().flatMap(forkChoice -> forkChoice.executionBlockHash(root));
   }
 
+  public Optional<Bytes32> getExecutionBlockHashForBlock(final ForkChoiceNode block) {
+    return getForkChoiceStrategy()
+        .flatMap(forkChoice -> forkChoice.getNodeData(block))
+        .map(ProtoNodeData::getExecutionBlockHash);
+  }
+
   public Optional<List<BlobSidecar>> getBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.ofNullable(store)
         .flatMap(s -> store.getBlobSidecarsIfAvailable(slotAndBlockRoot));

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -372,11 +372,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
       return false;
     }
-    System.out.println(
-        "ptcVoteTracker.getPayloadPresentVoteCount(blockRoot) > payloadTimelyThreshold "
-            + ptcVoteTracker.getPayloadPresentVoteCount(blockRoot)
-            + " > "
-            + payloadTimelyThreshold);
     return ptcVoteTracker.getPayloadPresentVoteCount(blockRoot) > payloadTimelyThreshold;
   }
 
@@ -385,11 +380,6 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
       return false;
     }
-    System.out.println(
-        "ptcVoteTracker.getDataAvailableVoteCount(blockRoot) > dataAvailabilityTimelyThreshold "
-            + ptcVoteTracker.getDataAvailableVoteCount(blockRoot)
-            + " > "
-            + dataAvailabilityTimelyThreshold);
     return ptcVoteTracker.getDataAvailableVoteCount(blockRoot) > dataAvailabilityTimelyThreshold;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -372,6 +372,11 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
       return false;
     }
+    System.out.println(
+        "ptcVoteTracker.getPayloadPresentVoteCount(blockRoot) > payloadTimelyThreshold "
+            + ptcVoteTracker.getPayloadPresentVoteCount(blockRoot)
+            + " > "
+            + payloadTimelyThreshold);
     return ptcVoteTracker.getPayloadPresentVoteCount(blockRoot) > payloadTimelyThreshold;
   }
 
@@ -380,6 +385,11 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     if (blockNodeIndex.getFullNode(blockRoot).isEmpty()) {
       return false;
     }
+    System.out.println(
+        "ptcVoteTracker.getDataAvailableVoteCount(blockRoot) > dataAvailabilityTimelyThreshold "
+            + ptcVoteTracker.getDataAvailableVoteCount(blockRoot)
+            + " > "
+            + dataAvailabilityTimelyThreshold);
     return ptcVoteTracker.getDataAvailableVoteCount(blockRoot) > dataAvailabilityTimelyThreshold;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 
 public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoiceStrategy {
   private static final Logger LOG = LogManager.getLogger();
@@ -257,14 +258,22 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   public ForkChoiceState getForkChoiceState(
+      final Optional<ChainHead> proposingOnHead,
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint finalizedCheckpoint) {
     protoArrayLock.readLock().lock();
     try {
       final ProtoNode headNode =
-          protoArray.findOptimisticHead(
-              currentEpoch, justifiedCheckpoint, finalizedCheckpoint, headSelectionContext);
+          proposingOnHead
+              .map(head -> protoArray.getNode(head.getForkChoiceNode()).orElseThrow())
+              .orElseGet(
+                  () ->
+                      protoArray.findOptimisticHead(
+                          currentEpoch,
+                          justifiedCheckpoint,
+                          finalizedCheckpoint,
+                          headSelectionContext));
       final UInt64 headExecutionBlockNumber = headNode.getExecutionBlockNumber();
       final Bytes32 headExecutionBlockHash = headNode.getExecutionBlockHash();
       final Bytes32 justifiedExecutionHash =
@@ -276,7 +285,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
               .map(ProtoNodeData::getExecutionBlockHash)
               .orElse(Bytes32.ZERO);
       return new ForkChoiceState(
-          headNode.getBlockRoot(),
+          headNode.getForkChoiceNode(),
           headNode.getBlockSlot(),
           headExecutionBlockNumber,
           headExecutionBlockHash,

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -43,7 +43,6 @@ import tech.pegasys.teku.spec.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.protoarray.ForkChoiceStrategy;
 import tech.pegasys.teku.storage.store.UpdatableStore;
@@ -55,13 +54,9 @@ class CombinedChainDataClientTest {
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final ForkChoiceStrategy forkChoiceStrategy = mock(ForkChoiceStrategy.class);
   private final StorageQueryChannel historicalChainData = mock(StorageQueryChannel.class);
-  private final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler =
-      mock(LateBlockReorgPreparationHandler.class);
-
   private final UpdatableStore store = mock(UpdatableStore.class);
   private final CombinedChainDataClient client =
-      new CombinedChainDataClient(
-          recentChainData, historicalChainData, spec, lateBlockReorgPreparationHandler, false);
+      new CombinedChainDataClient(recentChainData, historicalChainData, spec, false);
   private final ChainHead chainHead = mock(ChainHead.class);
 
   final List<SignedBeaconBlock> nonCanonicalBlocks = new ArrayList<>();
@@ -77,8 +72,6 @@ class CombinedChainDataClientTest {
     when(forkChoiceStrategy.isOptimistic(any())).thenReturn(Optional.of(true));
     when(chainHead.isOptimistic()).thenReturn(false);
     when(chainHead.getSlot()).thenReturn(UInt64.valueOf(8428924L));
-    when(lateBlockReorgPreparationHandler.onLateBlockReorgPreparation(any(), any()))
-        .thenReturn(SafeFuture.COMPLETE);
   }
 
   @Test
@@ -157,126 +150,15 @@ class CombinedChainDataClientTest {
   }
 
   @Test
-  void getStateForBlockProduction_directsToStateAtSlotExact()
+  void getStateForBlockProduction_processesChainHeadState()
       throws ExecutionException, InterruptedException {
-    final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(2));
-    final Optional<Bytes32> recentBlockRoot =
-        Optional.of(spec.getBlockRootAtSlot(state, UInt64.ONE));
-    final SlotAndBlockRoot slotAndBlockRoot =
-        new SlotAndBlockRoot(UInt64.ONE, recentBlockRoot.get());
-    final Runnable onLateBlockReorgPreparationCompleted = mock(Runnable.class);
-    when(recentChainData.getBlockRootInEffectBySlot(UInt64.ONE)).thenReturn(recentBlockRoot);
-    when(recentChainData.getStore()).thenReturn(store);
-    when(store.retrieveBlockState(slotAndBlockRoot))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    final SafeFuture<Optional<BeaconState>> future =
-        client.getStateForBlockProduction(UInt64.ONE, false, onLateBlockReorgPreparationCompleted);
-    assertThat(future.get()).contains(state);
-    verify(onLateBlockReorgPreparationCompleted, never()).run();
-    // getStateAtSlotExact
-    verify(recentChainData).getBlockRootInEffectBySlot(UInt64.ONE);
-    verify(store).retrieveBlockState(slotAndBlockRoot);
-  }
+    final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.ONE);
+    when(chainHead.getState()).thenReturn(SafeFuture.completedFuture(state));
 
-  @Test
-  void getStateForBlockProduction_whenEnabledAndHaveNoChainHead()
-      throws ExecutionException, InterruptedException {
-    final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(2));
-    final Optional<Bytes32> recentBlockRoot =
-        Optional.of(spec.getBlockRootAtSlot(state, UInt64.ONE));
-    final SlotAndBlockRoot slotAndBlockRoot =
-        new SlotAndBlockRoot(UInt64.ONE, recentBlockRoot.get());
-    final Runnable onLateBlockReorgPreparationCompleted = mock(Runnable.class);
-    when(recentChainData.getStore()).thenReturn(store);
+    final SafeFuture<BeaconState> future = client.getStateForBlockProduction(chainHead, UInt64.ONE);
 
-    when(recentChainData.getBestBlockRoot()).thenReturn(Optional.empty());
-    when(recentChainData.getBlockRootInEffectBySlot(UInt64.ONE)).thenReturn(recentBlockRoot);
-    when(store.retrieveBlockState(slotAndBlockRoot))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-
-    final SafeFuture<Optional<BeaconState>> future =
-        client.getStateForBlockProduction(UInt64.ONE, true, onLateBlockReorgPreparationCompleted);
-    assertThat(future.get()).contains(state);
-    verify(onLateBlockReorgPreparationCompleted, never()).run();
-    // getStateAtSlotExact
-    verify(recentChainData).getBlockRootInEffectBySlot(UInt64.ONE);
-    verify(store).retrieveBlockState(slotAndBlockRoot);
-  }
-
-  @Test
-  void getStateForBlockProduction_whenEnabledAndHeadChainMatches()
-      throws ExecutionException, InterruptedException {
-    final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(2));
-
-    final ChainHead chainHead = mock(ChainHead.class);
-    final Bytes32 recentBlockRoot = spec.getBlockRootAtSlot(state, UInt64.ONE);
-    final Runnable onLateBlockReorgPreparationCompleted = mock(Runnable.class);
-
-    when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
-    when(chainHead.getRoot()).thenReturn(recentBlockRoot);
-
-    final SlotAndBlockRoot slotAndBlockRoot = new SlotAndBlockRoot(UInt64.ONE, recentBlockRoot);
-    when(recentChainData.getStore()).thenReturn(store);
-
-    when(recentChainData.getProposerHead(any(), any())).thenReturn(recentBlockRoot);
-    when(recentChainData.getBlockRootInEffectBySlot(UInt64.ONE))
-        .thenReturn(Optional.of(recentBlockRoot));
-    when(store.retrieveBlockState(slotAndBlockRoot))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-
-    final SafeFuture<Optional<BeaconState>> future =
-        client.getStateForBlockProduction(UInt64.ONE, true, onLateBlockReorgPreparationCompleted);
-    assertThat(future.get()).contains(state);
-    verify(onLateBlockReorgPreparationCompleted, never()).run();
-    // getStateAtSlotExact
-    verify(recentChainData).getBlockRootInEffectBySlot(UInt64.ONE);
-    verify(store).retrieveBlockState(slotAndBlockRoot);
-  }
-
-  @Test
-  void getStateForBlockProduction_whenEnabledAndChainHeadDifferent()
-      throws ExecutionException, InterruptedException {
-    final BeaconState state = dataStructureUtil.randomBeaconState(UInt64.valueOf(2));
-    final Bytes32 proposerHead = dataStructureUtil.randomBytes32();
-    final BeaconState proposerState = dataStructureUtil.randomBeaconState(UInt64.ONE);
-    final ChainHead chainHead = mock(ChainHead.class);
-    final Bytes32 recentBlockRoot = spec.getBlockRootAtSlot(state, UInt64.ONE);
-    final SlotAndBlockRoot slotAndBlockRoot = new SlotAndBlockRoot(UInt64.ONE, recentBlockRoot);
-    final Runnable onLateBlockReorgPreparationCompleted = mock(Runnable.class);
-    when(recentChainData.getStore()).thenReturn(store);
-
-    when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
-    when(chainHead.getRoot()).thenReturn(recentBlockRoot);
-    when(recentChainData.getProposerHead(any(), any())).thenReturn(proposerHead);
-    when(recentChainData.getSlotForBlockRoot(proposerHead)).thenReturn(Optional.of(UInt64.ZERO));
-    when(recentChainData.getBlockRootInEffectBySlot(UInt64.ONE))
-        .thenReturn(Optional.of(recentBlockRoot));
-    when(store.retrieveBlockState(proposerHead))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(proposerState)));
-
-    final SafeFuture<Void> lateBlockReorgPreparationFuture = new SafeFuture<>();
-
-    when(lateBlockReorgPreparationHandler.onLateBlockReorgPreparation(UInt64.ZERO, recentBlockRoot))
-        .thenReturn(lateBlockReorgPreparationFuture);
-
-    when(store.retrieveBlockState(slotAndBlockRoot))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-
-    final SafeFuture<Optional<BeaconState>> future =
-        client.getStateForBlockProduction(UInt64.ONE, true, onLateBlockReorgPreparationCompleted);
-
-    // should be pending until late block reorg preparation completes
-    assertThat(future).isNotDone();
-    verify(onLateBlockReorgPreparationCompleted, never()).run();
-    // should retrieve state while waiting
-    verify(store).retrieveBlockState(proposerHead);
-
-    lateBlockReorgPreparationFuture.complete(null);
-    verify(onLateBlockReorgPreparationCompleted).run();
-
-    assertThat(future.get()).contains(proposerState);
-
-    verify(store, never()).retrieveBlockState(slotAndBlockRoot);
+    assertThat(future.get()).isEqualTo(state);
+    verify(chainHead).getState();
   }
 
   @Test
@@ -433,8 +315,7 @@ class CombinedChainDataClientTest {
     verify(historicalChainData).getEarliestDataColumnSidecarSlot();
 
     final CombinedChainDataClient clientWithEarliestAvailableDataColumnSlotSupport =
-        new CombinedChainDataClient(
-            recentChainData, historicalChainData, spec, lateBlockReorgPreparationHandler, true);
+        new CombinedChainDataClient(recentChainData, historicalChainData, spec, true);
 
     clientWithEarliestAvailableDataColumnSlotSupport
         .getEarliestAvailableDataColumnSlotWithFallback();

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -627,12 +627,13 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
 
     final ForkChoiceState forkChoiceState =
         protoArray.getForkChoiceState(
+            Optional.empty(),
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
             recentChainData.getFinalizedCheckpoint().orElseThrow());
 
     // Should have reverted to the justified checkpoint as head
-    assertThat(forkChoiceState.getHeadBlockRoot()).isEqualTo(currentJustified.getRoot());
+    assertThat(forkChoiceState.headBlock().blockRoot()).isEqualTo(currentJustified.getRoot());
     // The current head block itself is fully validated
     assertThat(protoArray.isFullyValidated(currentJustified.getRoot())).isTrue();
     // the head is optimistic because it is not viable

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
-import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.api.StubFinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel;
 import tech.pegasys.teku.storage.archive.BlobSidecarsArchiver;
@@ -122,12 +121,7 @@ public class StorageSystem implements AutoCloseable {
 
     // Create combined client
     final CombinedChainDataClient combinedChainDataClient =
-        new CombinedChainDataClient(
-            recentChainData,
-            chainStorageServer,
-            spec,
-            LateBlockReorgPreparationHandler.NOOP,
-            false);
+        new CombinedChainDataClient(recentChainData, chainStorageServer, spec, false);
 
     final BlobSidecarManager blobSidecarManager = BlobSidecarManager.NOOP;
 


### PR DESCRIPTION

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core validator block-production and execution-request selection, so incorrect context wiring or payload-status handling could cause missed/invalid block contents; changes are mostly structural and covered by updated tests.
> 
> **Overview**
> Validator block production is refactored to **capture a stable forkchoice `ChainHead` during preparation** and derive a new `BlockProductionContext` (slot state, parent root, randao, graffiti, builder boost factor, payload status, performance tracker) that is threaded through `ValidatorApiHandler`, `BlockFactory*`, and `BlockOperationSelectorFactory` instead of passing many individual parameters.
> 
> Parent execution-request selection is updated to include the forkchoice `payloadStatus`, only attempting to extend with parent execution requests when the payload is `FULL`, and `DefaultExecutionPayloadBidManager` now builds self-bids using the parent root from the Gloas state header rather than a separate argument. Execution-layer/forkchoice DTOs (`ForkChoiceState`, `PayloadBuildingAttributes`) are converted to records with updated accessors (including `ForkChoiceNode` for head/parent beacon block), and all impacted REST/event handlers and tests are updated accordingly (plus a small `CombinedChainDataClient` constructor signature update in tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40687f865ee94ac24a877b14957facaeb1155853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->