### PR TITLE
QUIC transport: ENR-based peer discovery, preferred QUIC dialing, and optional TCP disable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1228,6 +1228,9 @@ distributions {
 				into "licenses"
 				exclude "**/dependencies-without-allowed-license.json"
 				exclude "**/project-licenses-for-check-license-task.json"
+				// fixes 'file name is too long ( > 100 bytes)' Gradle issues
+				exclude "**/netty-tcnative-boringssl-static-*.jar/META-INF/*.txt"
+				exclude "**/netty-codec-native-quic-*.jar/META-INF/*.txt"
 			}
 			from("libs") { into "native" }
 			from("build/teku.autocomplete.sh")

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -37,7 +37,7 @@ dependencyManagement {
 			entry 'javalin-rendering-thymeleaf'
 		}
 
-		dependency 'io.libp2p:jvm-libp2p:1.2.2-RELEASE'
+		dependency 'io.libp2p:jvm-libp2p:develop'
 		dependency 'tech.pegasys:jblst:0.3.15'
 		dependency 'io.consensys.protocols:jc-kzg-4844:2.1.6'
 		dependency 'io.github.crate-crypto:java-eth-kzg:0.10.0'

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SubnetScorerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SubnetScorerTest.java
@@ -214,6 +214,7 @@ class SubnetScorerTest {
           DEFAULT_NODE_RECORD_CONVERTER.convertPublicKeyToNodeId(pubKey),
           new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
           Optional.empty(),
+          Optional.empty(),
           attSubnets,
           syncSubnets,
           Optional.empty(),

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
@@ -338,6 +338,7 @@ class Eth2PeerSelectionStrategyTest {
         peerId,
         peerId,
         new InetSocketAddress(InetAddress.getLoopbackAddress(), peerId.trimLeadingZeros().toInt()),
+        Optional.empty(),
         ENR_FORK_ID,
         SCHEMA_DEFINITIONS.getAttnetsENRFieldSchema().ofBits(attnets),
         SCHEMA_DEFINITIONS.getSyncnetsENRFieldSchema().getDefault(),

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryPeer.java
@@ -26,6 +26,7 @@ public class DiscoveryPeer {
   private final Bytes publicKey;
   private final Bytes nodeId;
   private final InetSocketAddress nodeAddress;
+  private final Optional<InetSocketAddress> quicAddress;
   private final Optional<EnrForkId> enrForkId;
   private final SszBitvector persistentAttestationSubnets;
   private final SszBitvector syncCommitteeSubnets;
@@ -36,6 +37,7 @@ public class DiscoveryPeer {
       final Bytes publicKey,
       final Bytes nodeId,
       final InetSocketAddress nodeAddress,
+      final Optional<InetSocketAddress> quicAddress,
       final Optional<EnrForkId> enrForkId,
       final SszBitvector persistentAttestationSubnets,
       final SszBitvector syncCommitteeSubnets,
@@ -44,6 +46,7 @@ public class DiscoveryPeer {
     this.publicKey = publicKey;
     this.nodeId = nodeId;
     this.nodeAddress = nodeAddress;
+    this.quicAddress = quicAddress;
     this.enrForkId = enrForkId;
     this.persistentAttestationSubnets = persistentAttestationSubnets;
     this.syncCommitteeSubnets = syncCommitteeSubnets;
@@ -61,6 +64,10 @@ public class DiscoveryPeer {
 
   public InetSocketAddress getNodeAddress() {
     return nodeAddress;
+  }
+
+  public Optional<InetSocketAddress> getQuicAddress() {
+    return quicAddress;
   }
 
   public Optional<EnrForkId> getEnrForkId() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -317,6 +317,7 @@ public class DiscV5Service extends Service implements DiscoveryService {
                           nodeRecord.getNodeId(),
                           updAddress,
                           Optional.empty(),
+                          Optional.empty(),
                           currentSchemaDefinitionsSupplier.getAttnetsENRFieldSchema().getDefault(),
                           currentSchemaDefinitionsSupplier.getSyncnetsENRFieldSchema().getDefault(),
                           Optional.empty(),

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -122,30 +122,48 @@ public class DiscV5Service extends Service implements DiscoveryService {
         discoConfig.getBootnodes().stream().map(NodeRecordFactory.DEFAULT::fromEnr).toList();
     final NodeRecordBuilder nodeRecordBuilder =
         new NodeRecordBuilder().signer(localNodeSigner).seq(seqNo);
-    final List<String> advertisedIps = p2pConfig.getAdvertisedIps();
-    Preconditions.checkState(
-        advertisedIps.size() == 1 || advertisedIps.size() == 2,
-        "The configured advertised IPs must be either 1 or 2");
-    if (advertisedIps.size() == 1) {
-      nodeRecordBuilder.address(
-          advertisedIps.get(0), discoConfig.getAdvertisedUdpPort(), p2pConfig.getAdvertisedPort());
-    } else {
-      // IPv4 and IPv6 (dual-stack)
-      advertisedIps.forEach(
-          advertisedIp -> {
-            final IPVersion ipVersion = IPVersionResolver.resolve(advertisedIp);
-            final int advertisedUdpPort =
-                switch (ipVersion) {
-                  case IP_V4 -> discoConfig.getAdvertisedUdpPort();
-                  case IP_V6 -> discoConfig.getAdvertisedUdpPortIpv6();
-                };
-            final int advertisedTcpPort =
-                switch (ipVersion) {
-                  case IP_V4 -> p2pConfig.getAdvertisedPort();
-                  case IP_V6 -> p2pConfig.getAdvertisedPortIpv6();
-                };
-            nodeRecordBuilder.address(advertisedIp, advertisedUdpPort, advertisedTcpPort);
-          });
+    if (p2pConfig.hasUserExplicitlySetAdvertisedIps()) {
+      final List<String> advertisedIps = p2pConfig.getAdvertisedIps();
+      Preconditions.checkState(
+          advertisedIps.size() == 1 || advertisedIps.size() == 2,
+          "The configured advertised IPs must be either 1 or 2");
+      if (advertisedIps.size() == 1) {
+        nodeRecordBuilder.address(
+            advertisedIps.get(0),
+            discoConfig.getAdvertisedUdpPort(),
+            p2pConfig.getAdvertisedPort(),
+            p2pConfig.isQuicEnabled()
+                ? Optional.of(p2pConfig.getAdvertisedQuicPort())
+                : Optional.empty());
+      } else {
+        // IPv4 and IPv6 (dual-stack)
+        advertisedIps.forEach(
+            advertisedIp -> {
+              final IPVersion ipVersion = IPVersionResolver.resolve(advertisedIp);
+              final int advertisedUdpPort =
+                  switch (ipVersion) {
+                    case IP_V4 -> discoConfig.getAdvertisedUdpPort();
+                    case IP_V6 -> discoConfig.getAdvertisedUdpPortIpv6();
+                  };
+              final int advertisedTcpPort =
+                  switch (ipVersion) {
+                    case IP_V4 -> p2pConfig.getAdvertisedPort();
+                    case IP_V6 -> p2pConfig.getAdvertisedPortIpv6();
+                  };
+              Optional<Integer> advertisedQuicPort = Optional.empty();
+              if (p2pConfig.isQuicEnabled()) {
+                advertisedQuicPort =
+                    Optional.of(
+                        switch (ipVersion) {
+                          case IP_V4 -> p2pConfig.getAdvertisedQuicPort();
+                          case IP_V6 -> p2pConfig.getAdvertisedQuicPortIpv6();
+                        });
+              }
+
+              nodeRecordBuilder.address(
+                  advertisedIp, advertisedUdpPort, advertisedTcpPort, advertisedQuicPort);
+            });
+      }
     }
     final NodeRecord localNodeRecord = nodeRecordBuilder.build();
     this.discoverySystem =
@@ -174,8 +192,12 @@ public class DiscV5Service extends Service implements DiscoveryService {
     } else {
       return (oldRecord, newAddress) -> {
         final int newTcpPort;
+        Optional<Integer> newQuicPort = Optional.empty();
         if (p2pConfig.getNetworkInterfaces().size() == 1) {
           newTcpPort = p2pConfig.getAdvertisedPort();
+          if (p2pConfig.isQuicEnabled()) {
+            newQuicPort = Optional.of(p2pConfig.getAdvertisedQuicPort());
+          }
         } else {
           // IPv4 and IPv6 (dual-stack)
           newTcpPort =
@@ -183,10 +205,18 @@ public class DiscV5Service extends Service implements DiscoveryService {
                 case IP_V4 -> p2pConfig.getAdvertisedPort();
                 case IP_V6 -> p2pConfig.getAdvertisedPortIpv6();
               };
+          if (p2pConfig.isQuicEnabled()) {
+            newQuicPort =
+                Optional.of(
+                    switch (IPVersionResolver.resolve(newAddress)) {
+                      case IP_V4 -> p2pConfig.getAdvertisedQuicPort();
+                      case IP_V6 -> p2pConfig.getAdvertisedQuicPortIpv6();
+                    });
+          }
         }
         return Optional.of(
             oldRecord.withNewAddress(
-                newAddress, Optional.of(newTcpPort), Optional.empty(), localNodeSigner));
+                newAddress, Optional.of(newTcpPort), newQuicPort, localNodeSigner));
       };
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
@@ -50,20 +50,25 @@ public class NodeRecordConverter {
       final boolean supportsIpv6,
       final SchemaDefinitions schemaDefinitions) {
     final Optional<InetSocketAddress> tcpAddress;
+    final Optional<InetSocketAddress> quicAddress;
     if (supportsIpv6) {
       // prefer IPv6 address
       tcpAddress = nodeRecord.getTcp6Address().or(nodeRecord::getTcpAddress);
+      quicAddress = nodeRecord.getQuic6Address().or(nodeRecord::getQuicAddress);
     } else {
       tcpAddress = nodeRecord.getTcpAddress();
+      quicAddress = nodeRecord.getQuicAddress();
     }
     return tcpAddress.map(
-        address -> socketAddressToDiscoveryPeer(schemaDefinitions, nodeRecord, address));
+        address ->
+            socketAddressToDiscoveryPeer(schemaDefinitions, nodeRecord, address, quicAddress));
   }
 
   private static DiscoveryPeer socketAddressToDiscoveryPeer(
       final SchemaDefinitions schemaDefinitions,
       final NodeRecord nodeRecord,
-      final InetSocketAddress address) {
+      final InetSocketAddress address,
+      final Optional<InetSocketAddress> quicAddress) {
 
     final Optional<EnrForkId> enrForkId =
         parseField(nodeRecord, ETH2_ENR_FIELD, EnrForkId.SSZ_SCHEMA::sszDeserialize);
@@ -95,6 +100,7 @@ public class NodeRecordConverter {
         ((Bytes) nodeRecord.get(EnrField.PKEY_SECP256K1)),
         nodeRecord.getNodeId(),
         address,
+        quicAddress,
         enrForkId,
         persistentAttestationSubnets,
         syncCommitteeSubnets,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -166,7 +166,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
       return SafeFuture.COMPLETE;
     }
-    LOG.debug("JvmLibP2PNetwork.stop()");
+    LOG.debug("Stopping libp2p network...");
     return SafeFuture.of(host.stop());
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -31,12 +31,14 @@ import io.libp2p.etc.types.ByteArrayExtKt;
 import io.libp2p.protocol.Identify;
 import io.libp2p.protocol.Ping;
 import io.libp2p.security.noise.NoiseXXSecureChannel;
+import io.libp2p.transport.quic.QuicTransport;
 import io.libp2p.transport.tcp.TcpTransport;
 import io.netty.handler.logging.LogLevel;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.io.IPVersionResolver;
@@ -113,23 +115,45 @@ public class LibP2PNetworkBuilder {
         advertisedIps.size() == 1 || advertisedIps.size() == 2,
         "The configured advertised IPs must be either 1 or 2");
     if (advertisedIps.size() == 1) {
-      advertisedAddresses =
-          Collections.singletonList(
-              MultiaddrUtil.fromInetSocketAddress(
-                  new InetSocketAddress(advertisedIps.get(0), config.getAdvertisedPort()), nodeId));
+      final Multiaddr advertisedAddr =
+          MultiaddrUtil.fromInetSocketAddress(
+              new InetSocketAddress(advertisedIps.getFirst(), config.getAdvertisedPort()), nodeId);
+      if (config.isQuicEnabled()) {
+        final Multiaddr advertisedQuicAddr =
+            MultiaddrUtil.fromInetSocketAddressAsQuic(
+                new InetSocketAddress(advertisedIps.getFirst(), config.getAdvertisedQuicPort()),
+                nodeId);
+        advertisedAddresses = List.of(advertisedAddr, advertisedQuicAddr);
+      } else {
+        advertisedAddresses = Collections.singletonList(advertisedAddr);
+      }
     } else {
       // IPv4 and IPv6 (dual-stack)
       advertisedAddresses =
           advertisedIps.stream()
-              .map(
+              .flatMap(
                   advertisedIp -> {
                     final int advertisedPort =
                         switch (IPVersionResolver.resolve(advertisedIp)) {
                           case IP_V4 -> config.getAdvertisedPort();
                           case IP_V6 -> config.getAdvertisedPortIpv6();
                         };
-                    return MultiaddrUtil.fromInetSocketAddress(
-                        new InetSocketAddress(advertisedIp, advertisedPort), nodeId);
+                    final Multiaddr advertisedAddr =
+                        MultiaddrUtil.fromInetSocketAddress(
+                            new InetSocketAddress(advertisedIp, advertisedPort), nodeId);
+                    if (config.isQuicEnabled()) {
+                      final int advertisedQuicPort =
+                          switch (IPVersionResolver.resolve(advertisedIp)) {
+                            case IP_V4 -> config.getAdvertisedQuicPort();
+                            case IP_V6 -> config.getAdvertisedQuicPortIpv6();
+                          };
+                      final Multiaddr advertisedQuicAddr =
+                          MultiaddrUtil.fromInetSocketAddressAsQuic(
+                              new InetSocketAddress(advertisedIp, advertisedQuicPort), nodeId);
+                      return Stream.of(advertisedAddr, advertisedQuicAddr);
+                    } else {
+                      return Stream.of(advertisedAddr);
+                    }
                   })
               .toList();
     }
@@ -138,8 +162,16 @@ public class LibP2PNetworkBuilder {
 
     final List<Integer> listenPorts =
         advertisedAddresses.size() == 2
-            ? List.of(config.getListenPort(), config.getListenPortIpv6())
-            : List.of(config.getListenPort());
+            ? config.isQuicEnabled()
+                ? List.of(
+                    config.getListenPort(),
+                    config.getListenPortIpv6(),
+                    config.getListenQuicPort(),
+                    config.getListenQuicPortIpv6())
+                : List.of(config.getListenPort(), config.getListenPortIpv6())
+            : config.isQuicEnabled()
+                ? List.of(config.getListenPort(), config.getListenQuicPort())
+                : List.of(config.getListenPort());
 
     return new LibP2PNetwork(
         host.getPrivKey(),
@@ -187,13 +219,20 @@ public class LibP2PNetworkBuilder {
     if (networkInterfaces.size() == 1) {
       final Multiaddr addr =
           MultiaddrUtil.fromInetSocketAddress(
-              new InetSocketAddress(networkInterfaces.get(0), config.getListenPort()));
-      listenAddrs = new String[] {addr.toString()};
+              new InetSocketAddress(networkInterfaces.getFirst(), config.getListenPort()));
+      if (config.isQuicEnabled()) {
+        final Multiaddr quicAddr =
+            MultiaddrUtil.fromInetSocketAddressAsQuic(
+                new InetSocketAddress(networkInterfaces.getFirst(), config.getListenQuicPort()));
+        listenAddrs = new String[] {addr.toString(), quicAddr.toString()};
+      } else {
+        listenAddrs = new String[] {addr.toString()};
+      }
     } else {
       // IPv4 and IPv6 (dual-stack)
       listenAddrs =
           networkInterfaces.stream()
-              .map(
+              .flatMap(
                   networkInterface -> {
                     final int listenPort =
                         switch (IPVersionResolver.resolve(networkInterface)) {
@@ -203,7 +242,19 @@ public class LibP2PNetworkBuilder {
                     final Multiaddr addr =
                         MultiaddrUtil.fromInetSocketAddress(
                             new InetSocketAddress(networkInterface, listenPort));
-                    return addr.toString();
+                    if (config.isQuicEnabled()) {
+                      final int listenQuicPort =
+                          switch (IPVersionResolver.resolve(networkInterface)) {
+                            case IP_V4 -> config.getListenQuicPort();
+                            case IP_V6 -> config.getListenQuicPortIpv6();
+                          };
+                      final Multiaddr quicAddr =
+                          MultiaddrUtil.fromInetSocketAddressAsQuic(
+                              new InetSocketAddress(networkInterface, listenQuicPort));
+                      return Stream.of(addr.toString(), quicAddr.toString());
+                    } else {
+                      return Stream.of(addr.toString());
+                    }
                   })
               .toArray(String[]::new);
     }
@@ -213,6 +264,9 @@ public class LibP2PNetworkBuilder {
         b -> {
           b.getIdentity().setFactory(() -> privKey);
           b.getTransports().add(TcpTransport::new);
+          if (config.isQuicEnabled()) {
+            b.getSecureTransports().add(QuicTransport::ECDSA);
+          }
           b.getSecureChannels().add(NoiseXXSecureChannel::new);
 
           // Yamux must take precedence during negotiation

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -263,7 +263,9 @@ public class LibP2PNetworkBuilder {
         hostBuilderDefaults,
         b -> {
           b.getIdentity().setFactory(() -> privKey);
-          b.getTransports().add(TcpTransport::new);
+          if (config.isTcpEnabled()) {
+            b.getTransports().add(TcpTransport::new);
+          }
           if (config.isQuicEnabled()) {
             b.getSecureTransports().add(QuicTransport::ECDSA);
           }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -19,6 +19,7 @@ import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
 import io.libp2p.core.crypto.PubKey;
+import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.protocol.Identify;
 import io.libp2p.protocol.IdentifyController;
 import java.util.List;
@@ -151,6 +152,7 @@ public class LibP2PPeer implements Peer {
 
   private void internalDisconnectImmediately(
       final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
+    final Multiaddr peerAddress = connection.remoteAddress();
     disconnectReason = reason;
     disconnectLocallyInitiated = locallyInitiated;
     SafeFuture.of(connection.close())
@@ -160,7 +162,7 @@ public class LibP2PPeer implements Peer {
                     "Disconnected forcibly {} because {} from {}",
                     locallyInitiated ? "locally" : "remotely",
                     reason,
-                    connection.remoteAddress()),
+                    peerAddress),
             error -> LOG.warn("Failed to disconnect from peer {}", getId(), error));
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
@@ -38,6 +38,16 @@ public class MultiaddrUtil {
     return fromInetSocketAddress(address, "tcp");
   }
 
+  static Multiaddr fromInetSocketAddressAsQuic(final InetSocketAddress address) {
+    final String addrString =
+        String.format(
+            "/%s/%s/udp/%d/quic-v1",
+            protocol(address.getAddress()),
+            address.getAddress().getHostAddress(),
+            address.getPort());
+    return Multiaddr.fromString(addrString);
+  }
+
   static Multiaddr fromInetSocketAddress(final InetSocketAddress address, final String protocol) {
     final String addrString =
         String.format(
@@ -52,6 +62,11 @@ public class MultiaddrUtil {
   public static Multiaddr fromInetSocketAddress(
       final InetSocketAddress address, final NodeId nodeId) {
     return addPeerId(fromInetSocketAddress(address, "tcp"), nodeId);
+  }
+
+  public static Multiaddr fromInetSocketAddressAsQuic(
+      final InetSocketAddress address, final NodeId nodeId) {
+    return addPeerId(fromInetSocketAddressAsQuic(address), nodeId);
   }
 
   private static Multiaddr addPeerId(final Multiaddr addr, final NodeId nodeId) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
@@ -27,7 +27,10 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 public class MultiaddrUtil {
 
   public static Multiaddr fromDiscoveryPeer(final DiscoveryPeer peer) {
-    return fromInetSocketAddress(peer.getNodeAddress(), getNodeId(peer));
+    final NodeId nodeId = getNodeId(peer);
+    return peer.getQuicAddress()
+        .map(quicAddr -> fromInetSocketAddressAsQuic(quicAddr, nodeId))
+        .orElseGet(() -> fromInetSocketAddress(peer.getNodeAddress(), nodeId));
   }
 
   public static Multiaddr fromDiscoveryPeerAsUdp(final DiscoveryPeer peer) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
@@ -121,7 +121,7 @@ public class LibP2PGossipNetworkBuilder {
         new TTLSeenCache<>(
             new FastIdSeenCache<>(msg -> Bytes.wrap(msg.messageSha256())),
             gossipParams.getSeenTTL(),
-            builder.getCurrentTimeSuppluer());
+            builder.getCurrentTimeSupplier());
 
     builder.setParams(gossipParams);
     builder.setScoreParams(scoreParams);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -53,6 +53,7 @@ public class NetworkConfig {
   public static final boolean DEFAULT_YAMUX_ENABLED = false;
   public static final boolean DEFAULT_STRICT_CONFIG_LOADING_ENABLED = false;
   public static final boolean DEFAULT_QUIC_ENABLED = false;
+  public static final boolean DEFAULT_TCP_ENABLED = true;
 
   private final GossipConfig gossipConfig;
   private final WireLogsConfig wireLogsConfig;
@@ -71,6 +72,7 @@ public class NetworkConfig {
   private final OptionalInt advertisedQuicPortIpv6;
   private final boolean yamuxEnabled;
   private final boolean quicEnabled;
+  private final boolean tcpEnabled;
 
   private NetworkConfig(
       final boolean isEnabled,
@@ -88,7 +90,8 @@ public class NetworkConfig {
       final OptionalInt advertisedQuicPort,
       final OptionalInt advertisedQuicPortIpv6,
       final boolean yamuxEnabled,
-      final boolean quicEnabled) {
+      final boolean quicEnabled,
+      final boolean tcpEnabled) {
     this.privateKeySource = privateKeySource;
     this.networkInterfaces = networkInterfaces;
     this.advertisedIps = advertisedIps;
@@ -105,6 +108,7 @@ public class NetworkConfig {
     this.gossipConfig = gossipConfig;
     this.wireLogsConfig = wireLogsConfig;
     this.quicEnabled = quicEnabled;
+    this.tcpEnabled = tcpEnabled;
   }
 
   public static Builder builder() {
@@ -171,6 +175,10 @@ public class NetworkConfig {
 
   public boolean isQuicEnabled() {
     return quicEnabled;
+  }
+
+  public boolean isTcpEnabled() {
+    return tcpEnabled;
   }
 
   public GossipConfig getGossipConfig() {
@@ -264,6 +272,7 @@ public class NetworkConfig {
     private OptionalInt advertisedQuicPortIpv6 = OptionalInt.empty();
     private boolean yamuxEnabled = DEFAULT_YAMUX_ENABLED;
     private boolean quicEnabled = DEFAULT_QUIC_ENABLED;
+    private boolean tcpEnabled = DEFAULT_TCP_ENABLED;
 
     private Builder() {}
 
@@ -294,7 +303,8 @@ public class NetworkConfig {
           advertisedQuicPort,
           advertisedQuicPortIpv6,
           yamuxEnabled,
-          quicEnabled);
+          quicEnabled,
+          tcpEnabled);
     }
 
     private Optional<PrivateKeySource> createFileKeySource() {
@@ -440,6 +450,11 @@ public class NetworkConfig {
 
     public Builder quicEnabled(final Boolean quicEnabled) {
       this.quicEnabled = quicEnabled;
+      return this;
+    }
+
+    public Builder tcpEnabled(final boolean tcpEnabled) {
+      this.tcpEnabled = tcpEnabled;
       return this;
     }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -47,9 +47,12 @@ public class NetworkConfig {
 
   public static final List<String> DEFAULT_P2P_INTERFACE = List.of("0.0.0.0");
   public static final int DEFAULT_P2P_PORT = 9000;
+  public static final int DEFAULT_P2P_QUIC_PORT = 9100;
   public static final int DEFAULT_P2P_PORT_IPV6 = 9090;
+  public static final int DEFAULT_P2P_QUIC_PORT_IPV6 = 9190;
   public static final boolean DEFAULT_YAMUX_ENABLED = false;
   public static final boolean DEFAULT_STRICT_CONFIG_LOADING_ENABLED = false;
+  public static final boolean DEFAULT_QUIC_ENABLED = false;
 
   private final GossipConfig gossipConfig;
   private final WireLogsConfig wireLogsConfig;
@@ -60,9 +63,14 @@ public class NetworkConfig {
   private final Optional<List<String>> advertisedIps;
   private final int listenPort;
   private final int listenPortIpv6;
+  private final int listenQuicPort;
+  private final int listenQuicPortIpv6;
   private final OptionalInt advertisedPort;
   private final OptionalInt advertisedPortIpv6;
+  private final OptionalInt advertisedQuicPort;
+  private final OptionalInt advertisedQuicPortIpv6;
   private final boolean yamuxEnabled;
+  private final boolean quicEnabled;
 
   private NetworkConfig(
       final boolean isEnabled,
@@ -73,20 +81,30 @@ public class NetworkConfig {
       final Optional<List<String>> advertisedIps,
       final int listenPort,
       final int listenPortIpv6,
+      final int listenQuicPort,
+      final int listenQuicPortIpv6,
       final OptionalInt advertisedPort,
       final OptionalInt advertisedPortIpv6,
-      final boolean yamuxEnabled) {
+      final OptionalInt advertisedQuicPort,
+      final OptionalInt advertisedQuicPortIpv6,
+      final boolean yamuxEnabled,
+      final boolean quicEnabled) {
     this.privateKeySource = privateKeySource;
     this.networkInterfaces = networkInterfaces;
     this.advertisedIps = advertisedIps;
     this.isEnabled = isEnabled;
     this.listenPort = listenPort;
     this.listenPortIpv6 = listenPortIpv6;
+    this.listenQuicPort = listenQuicPort;
+    this.listenQuicPortIpv6 = listenQuicPortIpv6;
     this.advertisedPort = advertisedPort;
     this.advertisedPortIpv6 = advertisedPortIpv6;
+    this.advertisedQuicPort = advertisedQuicPort;
+    this.advertisedQuicPortIpv6 = advertisedQuicPortIpv6;
     this.yamuxEnabled = yamuxEnabled;
     this.gossipConfig = gossipConfig;
     this.wireLogsConfig = wireLogsConfig;
+    this.quicEnabled = quicEnabled;
   }
 
   public static Builder builder() {
@@ -123,6 +141,14 @@ public class NetworkConfig {
     return listenPortIpv6;
   }
 
+  public int getListenQuicPort() {
+    return listenQuicPort;
+  }
+
+  public int getListenQuicPortIpv6() {
+    return listenQuicPortIpv6;
+  }
+
   public int getAdvertisedPort() {
     return advertisedPort.orElse(listenPort);
   }
@@ -131,8 +157,20 @@ public class NetworkConfig {
     return advertisedPortIpv6.orElse(listenPortIpv6);
   }
 
+  public int getAdvertisedQuicPort() {
+    return advertisedQuicPort.orElse(listenQuicPort);
+  }
+
+  public int getAdvertisedQuicPortIpv6() {
+    return advertisedQuicPortIpv6.orElse(listenQuicPortIpv6);
+  }
+
   public boolean isYamuxEnabled() {
     return yamuxEnabled;
+  }
+
+  public boolean isQuicEnabled() {
+    return quicEnabled;
   }
 
   public GossipConfig getGossipConfig() {
@@ -218,9 +256,14 @@ public class NetworkConfig {
     private Optional<List<String>> advertisedIps = Optional.empty();
     private int listenPort = DEFAULT_P2P_PORT;
     private int listenPortIpv6 = DEFAULT_P2P_PORT_IPV6;
+    private int listenQuicPort = DEFAULT_P2P_QUIC_PORT;
+    private int listenQuicPortIpv6 = DEFAULT_P2P_QUIC_PORT_IPV6;
     private OptionalInt advertisedPort = OptionalInt.empty();
     private OptionalInt advertisedPortIpv6 = OptionalInt.empty();
+    private OptionalInt advertisedQuicPort = OptionalInt.empty();
+    private OptionalInt advertisedQuicPortIpv6 = OptionalInt.empty();
     private boolean yamuxEnabled = DEFAULT_YAMUX_ENABLED;
+    private boolean quicEnabled = DEFAULT_QUIC_ENABLED;
 
     private Builder() {}
 
@@ -244,9 +287,14 @@ public class NetworkConfig {
           advertisedIps,
           listenPort,
           listenPortIpv6,
+          listenQuicPort,
+          listenQuicPortIpv6,
           advertisedPort,
           advertisedPortIpv6,
-          yamuxEnabled);
+          advertisedQuicPort,
+          advertisedQuicPortIpv6,
+          yamuxEnabled,
+          quicEnabled);
     }
 
     private Optional<PrivateKeySource> createFileKeySource() {
@@ -344,6 +392,18 @@ public class NetworkConfig {
       return this;
     }
 
+    public Builder listenQuicPort(final int listenQuicPort) {
+      validatePort(listenQuicPort, "--Xp2p-quic-port");
+      this.listenQuicPort = listenQuicPort;
+      return this;
+    }
+
+    public Builder listenQuicPortIpv6(final int listenQuicPortIpv6) {
+      validatePort(listenQuicPortIpv6, "--Xp2p-quic-port-ipv6");
+      this.listenQuicPortIpv6 = listenQuicPortIpv6;
+      return this;
+    }
+
     public Builder advertisedPort(final OptionalInt advertisedPort) {
       checkNotNull(advertisedPort);
       advertisedPort.ifPresent(port -> validatePort(port, "--p2p-advertised-port"));
@@ -358,8 +418,28 @@ public class NetworkConfig {
       return this;
     }
 
+    public Builder advertisedQuicPort(final OptionalInt advertisedQuicPort) {
+      checkNotNull(advertisedQuicPort);
+      advertisedQuicPort.ifPresent(port -> validatePort(port, "--Xp2p-advertised-quic-port"));
+      this.advertisedQuicPort = advertisedQuicPort;
+      return this;
+    }
+
+    public Builder advertisedQuicPortIpv6(final OptionalInt advertisedQuicPortIpv6) {
+      checkNotNull(advertisedQuicPortIpv6);
+      advertisedQuicPortIpv6.ifPresent(
+          port -> validatePort(port, "--Xp2p-advertised-quic-port-ipv6"));
+      this.advertisedQuicPortIpv6 = advertisedQuicPortIpv6;
+      return this;
+    }
+
     public Builder yamuxEnabled(final boolean yamuxEnabled) {
       this.yamuxEnabled = yamuxEnabled;
+      return this;
+    }
+
+    public Builder quicEnabled(final Boolean quicEnabled) {
+      this.quicEnabled = quicEnabled;
       return this;
     }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManagerTest.java
@@ -582,6 +582,7 @@ class ConnectionManagerTest {
         peerId,
         Bytes32.ZERO,
         new InetSocketAddress(InetAddress.getLoopbackAddress(), peerId.trimLeadingZeros().toInt()),
+        Optional.empty(),
         ENR_FORK_ID,
         SCHEMA_DEFINITIONS_SUPPLIER.getAttnetsENRFieldSchema().ofBits(subnetIds),
         SCHEMA_DEFINITIONS_SUPPLIER.getSyncnetsENRFieldSchema().getDefault(),

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
@@ -366,6 +366,7 @@ class DiscoveryNetworkTest {
         BLSPublicKey.empty().toSSZBytes(),
         Bytes32.ZERO,
         InetSocketAddress.createUnresolved("yo", 9999),
+        Optional.empty(),
         maybeForkId,
         SszBitvectorSchema.create(spec.getNetworkingConfig().getAttestationSubnetCount())
             .getDefault(),

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
@@ -82,6 +82,7 @@ class NodeRecordConverterTest {
             nodeId,
             new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
             Optional.empty(),
+            Optional.empty(),
             ATTNETS,
             SYNCNETS,
             Optional.empty(),
@@ -125,6 +126,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 30303),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -161,6 +163,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("129.24.31.22", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -191,6 +194,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -213,6 +217,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("127.0.0.1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -236,6 +241,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 persistentSubnets,
                 SYNCNETS,
@@ -259,6 +265,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATT_SUBNET_SCHEMA.getDefault(),
                 SYNCNETS,
@@ -282,6 +289,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 syncnets,
@@ -307,6 +315,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -330,6 +339,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 Optional.of(enrForkId),
                 ATTNETS,
                 SYNCNETS,
@@ -353,6 +363,7 @@ class NodeRecordConverterTest {
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
                 Optional.empty(),
+                Optional.empty(),
                 ATTNETS,
                 SYNCNETS,
                 Optional.empty(),
@@ -373,6 +384,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("127.0.0.1", 1234),
+                Optional.empty(),
                 Optional.empty(),
                 ATTNETS,
                 SYNCNETS,
@@ -395,10 +407,47 @@ class NodeRecordConverterTest {
                 NODE_ID,
                 new InetSocketAddress("127.0.0.1", 1234),
                 Optional.empty(),
+                Optional.empty(),
                 ATTNETS,
                 SYNCNETS,
                 Optional.empty(),
                 Optional.of(nfd)));
+  }
+
+  @Test
+  public void shouldExtractQuicAddressFromEnr() {
+    final Optional<DiscoveryPeer> result =
+        convertNodeRecordWithFields(
+            false,
+            new EnrField(EnrField.IP_V4, Bytes.wrap(new byte[] {127, 0, 0, 1})),
+            new EnrField(EnrField.TCP, 9000),
+            new EnrField(EnrField.QUIC, 9100));
+    assertThat(result).isPresent();
+    assertThat(result.get().getQuicAddress()).contains(new InetSocketAddress("127.0.0.1", 9100));
+    assertThat(result.get().getNodeAddress()).isEqualTo(new InetSocketAddress("127.0.0.1", 9000));
+  }
+
+  @Test
+  public void shouldExtractQuicV6AddressFromEnrWhenIpv6Supported() {
+    final Optional<DiscoveryPeer> result =
+        convertNodeRecordWithFields(
+            true,
+            new EnrField(EnrField.IP_V6, IPV6_LOCALHOST),
+            new EnrField(EnrField.TCP_V6, 9000),
+            new EnrField(EnrField.QUIC_V6, 9100));
+    assertThat(result).isPresent();
+    assertThat(result.get().getQuicAddress()).contains(new InetSocketAddress("::1", 9100));
+  }
+
+  @Test
+  public void shouldHaveEmptyQuicAddressWhenNotAdvertised() {
+    final Optional<DiscoveryPeer> result =
+        convertNodeRecordWithFields(
+            false,
+            new EnrField(EnrField.IP_V4, Bytes.wrap(new byte[] {127, 0, 0, 1})),
+            new EnrField(EnrField.TCP, 9000));
+    assertThat(result).isPresent();
+    assertThat(result.get().getQuicAddress()).isEmpty();
   }
 
   private Optional<DiscoveryPeer> convertNodeRecordWithFields(

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
@@ -82,6 +82,7 @@ class MultiaddrUtilTest {
             PUB_KEY,
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(ipAddress), port),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,
@@ -103,6 +104,7 @@ class MultiaddrUtilTest {
             PUB_KEY,
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(ipAddress), port),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,
@@ -124,6 +126,7 @@ class MultiaddrUtilTest {
                 "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,
@@ -136,6 +139,53 @@ class MultiaddrUtilTest {
   }
 
   @Test
+  public void fromDiscoveryPeer_shouldPreferQuicWhenQuicAddressIsPresent() throws Exception {
+    final byte[] ipAddress = {127, 0, 0, 1};
+    final int tcpPort = 9000;
+    final int quicPort = 9100;
+    final DiscoveryPeer peer =
+        new DiscoveryPeer(
+            Bytes.fromHexString(
+                "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
+            Bytes32.ZERO,
+            new InetSocketAddress(InetAddress.getByAddress(ipAddress), tcpPort),
+            Optional.of(new InetSocketAddress(InetAddress.getByAddress(ipAddress), quicPort)),
+            ENR_FORK_ID,
+            PERSISTENT_ATTESTATION_SUBNETS,
+            SYNC_COMMITTEE_SUBNETS,
+            Optional.empty(),
+            Optional.empty());
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    assertThat(result)
+        .isEqualTo(
+            Multiaddr.fromString(
+                "/ip4/127.0.0.1/udp/9100/quic-v1/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF"));
+  }
+
+  @Test
+  public void fromDiscoveryPeer_shouldFallBackToTcpWhenNoQuicAddress() throws Exception {
+    final byte[] ipAddress = {127, 0, 0, 1};
+    final int tcpPort = 9000;
+    final DiscoveryPeer peer =
+        new DiscoveryPeer(
+            Bytes.fromHexString(
+                "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
+            Bytes32.ZERO,
+            new InetSocketAddress(InetAddress.getByAddress(ipAddress), tcpPort),
+            Optional.empty(),
+            ENR_FORK_ID,
+            PERSISTENT_ATTESTATION_SUBNETS,
+            SYNC_COMMITTEE_SUBNETS,
+            Optional.empty(),
+            Optional.empty());
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    assertThat(result)
+        .isEqualTo(
+            Multiaddr.fromString(
+                "/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF"));
+  }
+
+  @Test
   public void fromDiscoveryPeerAsUdp_shouldConvertDiscoveryPeer() throws Exception {
     final DiscoveryPeer peer =
         new DiscoveryPeer(
@@ -143,6 +193,7 @@ class MultiaddrUtilTest {
                 "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.libp2p.core.Connection;
-import io.libp2p.core.transport.Transport;
 import io.libp2p.mux.mplex.MplexFlag;
 import io.libp2p.mux.mplex.MplexFrame;
 import io.libp2p.mux.mplex.MplexId;
@@ -26,6 +25,7 @@ import io.libp2p.mux.yamux.YamuxFrame;
 import io.libp2p.mux.yamux.YamuxId;
 import io.libp2p.mux.yamux.YamuxType;
 import io.libp2p.transport.implementation.ConnectionOverNetty;
+import io.libp2p.transport.implementation.NettyTransport;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -53,7 +53,7 @@ public class MuxFirewallTest {
   private final ByteBuf data1K = Unpooled.buffer().writeBytes(new byte[1024]);
   private final EmbeddedChannel channel = new EmbeddedChannel();
   private final Connection connectionOverNetty =
-      new ConnectionOverNetty(channel, mock(Transport.class), true);
+      new ConnectionOverNetty(channel, mock(NettyTransport.class), true);
   private final List<String> passedMessages = new ArrayList<>();
 
   @BeforeEach

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -97,6 +97,33 @@ public class P2POptions {
   private Integer p2pUdpPortIpv6;
 
   @Option(
+      names = {"--Xp2p-quic-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Enables QUIC transport",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean p2pQuicEnabled = NetworkConfig.DEFAULT_QUIC_ENABLED;
+
+  @Option(
+      names = {"--Xp2p-quic-port"},
+      paramLabel = "<INTEGER>",
+      description = "P2P QUIC port",
+      hidden = true,
+      arity = "1")
+  private Integer p2pQuicPort = NetworkConfig.DEFAULT_P2P_QUIC_PORT;
+
+  @Option(
+      names = {"--Xp2p-quic-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          "P2P IPv6 QUIC port. This port is only used when listening over both IPv4 and IPv6.",
+      hidden = true,
+      arity = "1")
+  private int p2pQuicPortIpv6 = NetworkConfig.DEFAULT_P2P_QUIC_PORT_IPV6;
+
+  @Option(
       names = {"--p2p-discovery-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -165,6 +192,26 @@ public class P2POptions {
               The default is the port specified in --p2p-advertised-port-ipv6.""",
       arity = "1")
   private Integer p2pAdvertisedUdpPortIpv6;
+
+  @Option(
+      names = {"--Xp2p-advertised-quic-port"},
+      paramLabel = "<INTEGER>",
+      description =
+          "P2P advertised QUIC port. The default is the port specified in --p2p-quic-port",
+      hidden = true,
+      arity = "1")
+  private Integer p2pAdvertisedQuicPort;
+
+  @Option(
+      names = {"--Xp2p-advertised-quic-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          """
+                      P2P advertised IPv6 QUIC port. This port is only used when advertising both IPv4 and IPv6 addresses.
+                      The default is the port specified in --p2p-quic-port-ipv6.""",
+      hidden = true,
+      arity = "1")
+  private Integer p2pAdvertisedQuicPortIpv6;
 
   @Option(
       names = {"--p2p-private-key-file"},
@@ -773,6 +820,12 @@ public class P2POptions {
               if (p2pAdvertisedPortIpv6 != null) {
                 n.advertisedPortIpv6(OptionalInt.of(p2pAdvertisedPortIpv6));
               }
+              if (p2pAdvertisedQuicPort != null) {
+                n.advertisedQuicPort(OptionalInt.of(p2pAdvertisedQuicPort));
+              }
+              if (p2pAdvertisedQuicPortIpv6 != null) {
+                n.advertisedQuicPortIpv6(OptionalInt.of(p2pAdvertisedQuicPortIpv6));
+              }
               if (!p2pDirectPeers.isEmpty()) {
                 n.directPeers(
                     p2pDirectPeers.stream()
@@ -784,8 +837,11 @@ public class P2POptions {
                   .isEnabled(p2pEnabled)
                   .listenPort(p2pPort)
                   .listenPortIpv6(p2pPortIpv6)
+                  .listenQuicPort(p2pQuicPort)
+                  .listenQuicPortIpv6(p2pQuicPortIpv6)
                   .advertisedIps(Optional.ofNullable(p2pAdvertisedIps))
-                  .yamuxEnabled(yamuxEnabled);
+                  .yamuxEnabled(yamuxEnabled)
+                  .quicEnabled(p2pQuicEnabled);
             })
         .sync(
             s ->

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -107,6 +107,16 @@ public class P2POptions {
   private boolean p2pQuicEnabled = NetworkConfig.DEFAULT_QUIC_ENABLED;
 
   @Option(
+      names = {"--Xp2p-tcp-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Enables TCP transport",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean p2pTcpEnabled = NetworkConfig.DEFAULT_TCP_ENABLED;
+
+  @Option(
       names = {"--Xp2p-quic-port"},
       paramLabel = "<INTEGER>",
       description = "P2P QUIC port",
@@ -841,7 +851,8 @@ public class P2POptions {
                   .listenQuicPortIpv6(p2pQuicPortIpv6)
                   .advertisedIps(Optional.ofNullable(p2pAdvertisedIps))
                   .yamuxEnabled(yamuxEnabled)
-                  .quicEnabled(p2pQuicEnabled);
+                  .quicEnabled(p2pQuicEnabled)
+                  .tcpEnabled(p2pTcpEnabled);
             })
         .sync(
             s ->


### PR DESCRIPTION
## PR Description

Builds on the initial QUIC transport integration to wire up ENR-based QUIC address discovery and route outbound connections over QUIC when the remote peer advertises a QUIC port. Also adds the ability to disable TCP independently of QUIC for testing QUIC-only configurations.

**Changes**

  - DiscoveryPeer carries QUIC address — adds an Optional<InetSocketAddress> quicAddress field alongside the existing TCP address. NodeRecordConverter reads the quic/quic6 ENR fields and populates it when present.
  - Prefer QUIC when dialing — MultiaddrUtil.fromDiscoveryPeer now emits a /udp/<port>/quic-v1 multiaddr when the peer advertises a QUIC address, falling back to the TCP multiaddr otherwise. This means Teku will prefer
  QUIC connections to peers that support them, without any further configuration.
  - Optional TCP disable (--Xp2p-tcp-enabled) — NetworkConfig gains a tcpEnabled flag (default true). LibP2PNetworkBuilder conditionally registers TcpTransport based on this flag. Exposed via the hidden CLI option
  --Xp2p-tcp-enabled=false for QUIC-only testing.
  - getCurrentTimeSupplier typo fix — corrects the call site in LibP2PGossipNetworkBuilder from the old misspelled getCurrentTimeSuppluer() to getCurrentTimeSupplier(), matching the updated jvm-libp2p API.
  - Tests — updated all DiscoveryPeer constructor call sites for the new parameter; added tests for QUIC address extraction from ENR, QUIC multiaddr preference, and TCP fallback in NodeRecordConverterTest and
  MultiaddrUtilTest.

## Fixed Issue(s)
N/A

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
