### PR TITLE
feat(beaconrestapi): expose peer-scoring fields on /eth/v1/node/peers

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetPeersScore.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetPeersScore.java
@@ -99,13 +99,18 @@ public class GetPeersScore extends RestApiEndpoint {
                     new LastAction(
                         adjustment.reason(),
                         adjustment.delta(),
-                        (int) Math.max(0L, (nowMs - adjustment.atMs()) / 1000L)));
+                        secondsSince(nowMs, adjustment.atMs())));
     return new PeerScore(
         peer.getId().toBase58(), peer.getGossipScore(), reputationScore, lastAction);
   }
 
   private static Optional<Integer> toBoxed(final OptionalInt value) {
     return value.isPresent() ? Optional.of(value.getAsInt()) : Optional.empty();
+  }
+
+  private static int secondsSince(final long nowMs, final long thenMs) {
+    final long ageSeconds = Math.max(0L, (nowMs - thenMs) / 1000L);
+    return (int) Math.min(ageSeconds, Integer.MAX_VALUE);
   }
 
   record PeerScore(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetPeersScore.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetPeersScore.java
@@ -17,12 +17,15 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CACHE_NONE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_TEKU;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_DOUBLE_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_INTEGER_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Header;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Function;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
@@ -31,20 +34,29 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 
 public class GetPeersScore extends RestApiEndpoint {
   public static final String ROUTE = "/teku/v1/nodes/peer_scores";
   private final NetworkDataProvider network;
 
-  private static final SerializableTypeDefinition<Eth2Peer> PEER_TYPE =
-      SerializableTypeDefinition.object(Eth2Peer.class)
-          .withField("peer_id", STRING_TYPE, eth2Peer -> eth2Peer.getId().toBase58())
-          .withField("gossip_score", RAW_DOUBLE_TYPE, Peer::getGossipScore)
+  private static final SerializableTypeDefinition<LastAction> LAST_ACTION_TYPE =
+      SerializableTypeDefinition.object(LastAction.class)
+          .withField("reason", STRING_TYPE, LastAction::reason)
+          .withField("delta", RAW_DOUBLE_TYPE, LastAction::delta)
+          .withField("seconds_ago", RAW_INTEGER_TYPE, LastAction::secondsAgo)
           .build();
 
-  private static final SerializableTypeDefinition<List<Eth2Peer>> RESPONSE_TYPE =
-      SerializableTypeDefinition.<List<Eth2Peer>>object()
+  private static final SerializableTypeDefinition<PeerScore> PEER_TYPE =
+      SerializableTypeDefinition.object(PeerScore.class)
+          .withField("peer_id", STRING_TYPE, PeerScore::peerId)
+          .withField("gossip_score", RAW_DOUBLE_TYPE, PeerScore::gossipScore)
+          .withOptionalField("reputation_score", RAW_INTEGER_TYPE, PeerScore::reputationScore)
+          .withOptionalField("last_action", LAST_ACTION_TYPE, PeerScore::lastAction)
+          .build();
+
+  private static final SerializableTypeDefinition<List<PeerScore>> RESPONSE_TYPE =
+      SerializableTypeDefinition.<List<PeerScore>>object()
           .name("GetPeerScoresResponse")
           .withField("data", listOf(PEER_TYPE), Function.identity())
           .build();
@@ -68,6 +80,39 @@ public class GetPeersScore extends RestApiEndpoint {
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     request.header(Header.CACHE_CONTROL, CACHE_NONE);
-    request.respondOk(network.getPeerScores());
+    final ReputationManager reputationManager = network.getReputationManager();
+    final long nowMs = System.currentTimeMillis();
+    final List<PeerScore> data =
+        network.getPeerScores().stream().map(peer -> toPeerScore(peer, reputationManager, nowMs)).toList();
+    request.respondOk(data);
   }
+
+  private static PeerScore toPeerScore(
+      final Eth2Peer peer, final ReputationManager reputationManager, final long nowMs) {
+    final Optional<Integer> reputationScore =
+        toBoxed(reputationManager.getReputationScore(peer.getId()));
+    final Optional<LastAction> lastAction =
+        reputationManager
+            .getLastAdjustment(peer.getId())
+            .map(
+                adjustment ->
+                    new LastAction(
+                        adjustment.reason(),
+                        adjustment.delta(),
+                        (int) Math.max(0L, (nowMs - adjustment.atMs()) / 1000L)));
+    return new PeerScore(
+        peer.getId().toBase58(), peer.getGossipScore(), reputationScore, lastAction);
+  }
+
+  private static Optional<Integer> toBoxed(final OptionalInt value) {
+    return value.isPresent() ? Optional.of(value.getAsInt()) : Optional.empty();
+  }
+
+  record PeerScore(
+      String peerId,
+      Double gossipScore,
+      Optional<Integer> reputationScore,
+      Optional<LastAction> lastAction) {}
+
+  record LastAction(String reason, double delta, int secondsAgo) {}
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.peer.Eth2PeerWithEnr;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers.PeerView;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
@@ -35,8 +36,8 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 public class GetPeerById extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/node/peers/{peer_id}";
 
-  private static final SerializableTypeDefinition<Eth2PeerWithEnr> PEERS_BY_ID_RESPONSE_TYPE =
-      SerializableTypeDefinition.object(Eth2PeerWithEnr.class)
+  private static final SerializableTypeDefinition<PeerView> PEERS_BY_ID_RESPONSE_TYPE =
+      SerializableTypeDefinition.object(PeerView.class)
           .name("GetPeerResponse")
           .withField("data", PEER_DATA_TYPE, Function.identity())
           .build();
@@ -69,7 +70,7 @@ public class GetPeerById extends RestApiEndpoint {
     if (peer.isEmpty()) {
       request.respondError(SC_NOT_FOUND, "Peer not found");
     } else {
-      request.respondOk(peer.get());
+      request.respondOk(GetPeers.toPeerView(peer.get(), network.getReputationManager()));
     }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
@@ -151,8 +151,14 @@ public class GetPeers extends RestApiEndpoint {
             : Optional.empty();
     final Optional<LastAdjustment> lastAdjustment =
         reputationManager.getLastAdjustment(eth2Peer.getId());
+    // Per beacon-API spec, `disconnect_reason` MUST only be populated when the
+    // peer's `state` is `disconnected` or `disconnecting`. Teku exposes only
+    // `connected`/`disconnected` via `isConnected()`, so suppress for connected peers.
     final Optional<String> disconnectReason =
-        lastAdjustment.flatMap(adj -> PeerScoreReasonMapper.mapDisconnectReason(adj.reason()));
+        eth2Peer.isConnected()
+            ? Optional.empty()
+            : lastAdjustment.flatMap(
+                adj -> PeerScoreReasonMapper.mapDisconnectReason(adj.reason()));
     final Optional<List<String>> downscoreReasons =
         lastAdjustment
             .flatMap(adj -> PeerScoreReasonMapper.mapDownscoreReason(adj.reason()))

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
@@ -15,7 +15,9 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_NODE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_DOUBLE_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_INTEGER_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.string;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 import static tech.pegasys.teku.infrastructure.restapi.endpoints.CacheLength.NO_CACHE;
@@ -23,6 +25,8 @@ import static tech.pegasys.teku.infrastructure.restapi.endpoints.CacheLength.NO_
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Function;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
@@ -34,6 +38,9 @@ import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager.LastAdjustment;
 
 public class GetPeers extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/node/peers";
@@ -44,8 +51,8 @@ public class GetPeers extends RestApiEndpoint {
   private static final DeserializableTypeDefinition<Direction> DIRECTION_TYPE =
       DeserializableTypeDefinition.enumOf(Direction.class);
 
-  static final SerializableTypeDefinition<Eth2PeerWithEnr> PEER_DATA_TYPE =
-      SerializableTypeDefinition.object(Eth2PeerWithEnr.class)
+  static final SerializableTypeDefinition<PeerView> PEER_DATA_TYPE =
+      SerializableTypeDefinition.object(PeerView.class)
           .name("Peer")
           .withField(
               "peer_id",
@@ -53,7 +60,7 @@ public class GetPeers extends RestApiEndpoint {
                   "Cryptographic hash of a peer’s public key. "
                       + "'[Read more](https://docs.libp2p.io/concepts/peer-id/)",
                   "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"),
-              eth2Peer -> eth2Peer.peer().getId().toBase58())
+              view -> view.source().peer().getId().toBase58())
           .withOptionalField(
               "enr",
               string(
@@ -61,25 +68,31 @@ public class GetPeers extends RestApiEndpoint {
                   "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrk"
                       + "Tfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYp"
                       + "Ma2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"),
-              Eth2PeerWithEnr::enr)
+              view -> view.source().enr())
           .withField(
               "last_seen_p2p_address",
               string(
                   "Multiaddr used in last peer connection. "
                       + "[Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)",
                   "/ip4/7.7.7.7/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"),
-              eth2Peer -> eth2Peer.peer().getAddress().toExternalForm())
+              view -> view.source().peer().getAddress().toExternalForm())
           .withField(
               "state",
               STATE_TYPE,
-              eth2Peer -> eth2Peer.peer().isConnected() ? State.connected : State.disconnected)
+              view ->
+                  view.source().peer().isConnected() ? State.connected : State.disconnected)
           .withField(
               "direction",
               DIRECTION_TYPE,
-              eth2Peer ->
-                  eth2Peer.peer().connectionInitiatedLocally()
+              view ->
+                  view.source().peer().connectionInitiatedLocally()
                       ? Direction.outbound
                       : Direction.inbound)
+          .withOptionalField("agent_version", STRING_TYPE, PeerView::agentVersion)
+          .withOptionalField("score", RAW_DOUBLE_TYPE, PeerView::score)
+          .withOptionalField("disconnect_reason", STRING_TYPE, PeerView::disconnectReason)
+          .withOptionalField(
+              "downscore_reasons", listOf(STRING_TYPE), PeerView::downscoreReasons)
           .build();
 
   private static final SerializableTypeDefinition<Integer> PEERS_META_TYPE =
@@ -119,19 +132,51 @@ public class GetPeers extends RestApiEndpoint {
 
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
-    request.respondOk(new PeersData(network.getEth2PeersWithEnr()), NO_CACHE);
+    final ReputationManager reputationManager = network.getReputationManager();
+    final List<PeerView> views =
+        network.getEth2PeersWithEnr().stream()
+            .map(source -> toPeerView(source, reputationManager))
+            .toList();
+    request.respondOk(new PeersData(views), NO_CACHE);
   }
 
+  static PeerView toPeerView(
+      final Eth2PeerWithEnr source, final ReputationManager reputationManager) {
+    final Eth2Peer eth2Peer = source.peer();
+    final Optional<String> agentVersion = eth2Peer.getAgentVersion();
+    final OptionalInt reputationScore = reputationManager.getReputationScore(eth2Peer.getId());
+    final Optional<Double> score =
+        reputationScore.isPresent()
+            ? Optional.of((double) reputationScore.getAsInt())
+            : Optional.empty();
+    final Optional<LastAdjustment> lastAdjustment =
+        reputationManager.getLastAdjustment(eth2Peer.getId());
+    final Optional<String> disconnectReason =
+        lastAdjustment.flatMap(adj -> PeerScoreReasonMapper.mapDisconnectReason(adj.reason()));
+    final Optional<List<String>> downscoreReasons =
+        lastAdjustment
+            .flatMap(adj -> PeerScoreReasonMapper.mapDownscoreReason(adj.reason()))
+            .map(List::of);
+    return new PeerView(source, agentVersion, score, disconnectReason, downscoreReasons);
+  }
+
+  record PeerView(
+      Eth2PeerWithEnr source,
+      Optional<String> agentVersion,
+      Optional<Double> score,
+      Optional<String> disconnectReason,
+      Optional<List<String>> downscoreReasons) {}
+
   static class PeersData {
-    private final List<Eth2PeerWithEnr> peers;
+    private final List<PeerView> peers;
     private final Integer count;
 
-    PeersData(final List<Eth2PeerWithEnr> peers) {
+    PeersData(final List<PeerView> peers) {
       this.peers = peers;
       this.count = peers.size();
     }
 
-    public List<Eth2PeerWithEnr> getPeers() {
+    public List<PeerView> getPeers() {
       return peers;
     }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/PeerScoreReasonMapper.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/PeerScoreReasonMapper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
+
+import java.util.Optional;
+import java.util.Set;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
+
+/**
+ * Maps Teku-internal reason identifiers (from {@link ReputationAdjustment} and {@link
+ * DisconnectReason}) onto the controlled vocabularies proposed for the simplified beacon-API peer
+ * scoring spec.
+ *
+ * <p>Teku's reputation adjustments are coarse (just LARGE/SMALL penalty/reward) and don't carry
+ * structured downscore reasons, so penalty adjustments map to {@code "unknown"}. Disconnect reasons
+ * map to the {@code PeerDisconnectReason} enum where there is a direct equivalent.
+ */
+final class PeerScoreReasonMapper {
+
+  private static final Set<String> REPUTATION_ADJUSTMENT_NAMES =
+      Set.of(
+          ReputationAdjustment.LARGE_PENALTY.name(),
+          ReputationAdjustment.SMALL_PENALTY.name(),
+          ReputationAdjustment.LARGE_REWARD.name(),
+          ReputationAdjustment.SMALL_REWARD.name());
+
+  private PeerScoreReasonMapper() {}
+
+  /**
+   * Map a raw Teku reason string (either a {@link ReputationAdjustment} name or a {@link
+   * DisconnectReason} name) onto the spec's {@code PeerScoreReason} vocabulary. Returns empty if
+   * the value is not a recognised reputation adjustment (e.g. it's a disconnect reason, which has
+   * its own mapping).
+   */
+  static Optional<String> mapDownscoreReason(final String rawReason) {
+    if (rawReason == null) {
+      return Optional.empty();
+    }
+    if (!REPUTATION_ADJUSTMENT_NAMES.contains(rawReason)) {
+      return Optional.empty();
+    }
+    // Teku's reputation adjustments don't carry structured downscore context, so we surface
+    // "unknown" rather than guessing at a more specific code.
+    return Optional.of("unknown");
+  }
+
+  /**
+   * Map a raw Teku reason string onto the spec's {@code PeerDisconnectReason} vocabulary if it
+   * corresponds to a {@link DisconnectReason}, otherwise empty.
+   */
+  static Optional<String> mapDisconnectReason(final String rawReason) {
+    if (rawReason == null) {
+      return Optional.empty();
+    }
+    final DisconnectReason reason;
+    try {
+      reason = DisconnectReason.valueOf(rawReason);
+    } catch (final IllegalArgumentException e) {
+      return Optional.empty();
+    }
+    return Optional.of(mapDisconnectReason(reason));
+  }
+
+  private static String mapDisconnectReason(final DisconnectReason reason) {
+    return switch (reason) {
+      case BAD_SCORE -> "bad_score";
+      case IRRELEVANT_NETWORK, UNABLE_TO_VERIFY_NETWORK -> "irrelevant_network";
+      case TOO_MANY_PEERS -> "too_many_peers";
+      case RATE_LIMITING -> "rate_limited";
+      case SHUTTING_DOWN -> "client_shutdown";
+      case REMOTE_FAULT, UNRESPONSIVE, NO_STATUS_RECEIVED, DUPLICATE_CONNECTION -> "io_error";
+      case BANNED -> "bad_score";
+    };
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetPeersScoreTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/node/GetPeersScoreTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
@@ -25,16 +26,22 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node.GetPeersScore.LastAction;
+import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.node.GetPeersScore.PeerScore;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 
 public class GetPeersScoreTest extends AbstractMigratedBeaconHandlerTest {
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
+  private final ReputationManager reputationManager = mock(ReputationManager.class);
   private final MockNodeId peerId = new MockNodeId(123456);
   private final Eth2Peer peer = mock(Eth2Peer.class);
 
@@ -44,6 +51,9 @@ public class GetPeersScoreTest extends AbstractMigratedBeaconHandlerTest {
 
     when(peer.getId()).thenReturn(peerId);
     when(peer.getGossipScore()).thenReturn(1.0);
+    when(networkDataProvider.getReputationManager()).thenReturn(reputationManager);
+    when(reputationManager.getReputationScore(any())).thenReturn(OptionalInt.empty());
+    when(reputationManager.getLastAdjustment(any())).thenReturn(Optional.empty());
   }
 
   @Test
@@ -53,7 +63,9 @@ public class GetPeersScoreTest extends AbstractMigratedBeaconHandlerTest {
     handler.handleRequest(request);
 
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
-    assertThat(request.getResponseBody()).isEqualTo(List.of(peer));
+    assertThat(request.getResponseBody())
+        .isEqualTo(
+            List.of(new PeerScore(peerId.toBase58(), 1.0, Optional.empty(), Optional.empty())));
   }
 
   @Test
@@ -67,12 +79,34 @@ public class GetPeersScoreTest extends AbstractMigratedBeaconHandlerTest {
   }
 
   @Test
-  void metadata_shouldHandle200() throws IOException {
-    final List<Eth2Peer> responseData = List.of(peer);
+  void metadata_shouldHandle200_withoutLastAction() throws IOException {
+    final List<PeerScore> responseData =
+        List.of(new PeerScore(peerId.toBase58(), 1.0, Optional.empty(), Optional.empty()));
 
     final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
     final String expected =
         "{\"data\":[{\"peer_id\":\"1111111111111111111111111111177em\",\"gossip_score\":1.0}]}";
+    AssertionsForClassTypes.assertThat(data).isEqualTo(expected);
+  }
+
+  @Test
+  void metadata_shouldHandle200_withReputationAndLastAction() throws IOException {
+    final List<PeerScore> responseData =
+        List.of(
+            new PeerScore(
+                peerId.toBase58(),
+                1.0,
+                Optional.of(3),
+                Optional.of(new LastAction("SMALL_PENALTY", -3.0, 12))));
+
+    final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
+    final String expected =
+        "{\"data\":[{"
+            + "\"peer_id\":\"1111111111111111111111111111177em\","
+            + "\"gossip_score\":1.0,"
+            + "\"reputation_score\":3,"
+            + "\"last_action\":{\"reason\":\"SMALL_PENALTY\",\"delta\":-3.0,\"seconds_ago\":12}"
+            + "}]}";
     AssertionsForClassTypes.assertThat(data).isEqualTo(expected);
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NetworkDataProvider.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryService;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 
 public class NetworkDataProvider {
@@ -127,6 +128,10 @@ public class NetworkDataProvider {
 
   public List<Eth2Peer> getPeerScores() {
     return network.streamPeers().toList();
+  }
+
+  public ReputationManager getReputationManager() {
+    return network.getReputationManager();
   }
 
   public Optional<Eth2PeerWithEnr> getEth2PeerById(final String peerId) {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/provider/Peer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/provider/Peer.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -59,18 +60,71 @@ public class Peer {
   @JsonProperty("direction")
   public final Direction direction;
 
+  @JsonProperty("agent_version")
+  @Schema(
+      type = "string",
+      nullable = true,
+      description =
+          "libp2p identify agent version string for the peer, when it has been received.",
+      example = "teku/v25.4.0")
+  public final String agentVersion;
+
+  @JsonProperty("score")
+  @Schema(
+      type = "number",
+      nullable = true,
+      description =
+          "Client-internal reputation score for the peer. The unit and range are "
+              + "implementation-defined; consumers should treat it as a relative ordering only.")
+  public final Double score;
+
+  @JsonProperty("disconnect_reason")
+  @Schema(
+      type = "string",
+      nullable = true,
+      description =
+          "Last observed disconnect reason for the peer, mapped to the simplified beacon-API "
+              + "peer scoring vocabulary.")
+  public final String disconnectReason;
+
+  @JsonProperty("downscore_reasons")
+  @Schema(
+      type = "array",
+      nullable = true,
+      description =
+          "Recent reasons the peer's score was reduced, mapped to the simplified beacon-API "
+              + "peer scoring vocabulary.")
+  public final List<String> downscoreReasons;
+
+  public Peer(
+      final String peerId,
+      final String enr,
+      final String address,
+      final State state,
+      final Direction direction) {
+    this(peerId, enr, address, state, direction, null, null, null, null);
+  }
+
   @JsonCreator
   public Peer(
       @JsonProperty("peer_id") final String peerId,
       @JsonProperty("enr") final String enr,
       @JsonProperty("last_seen_p2p_address") final String address,
       @JsonProperty("state") final State state,
-      @JsonProperty("direction") final Direction direction) {
+      @JsonProperty("direction") final Direction direction,
+      @JsonProperty("agent_version") final String agentVersion,
+      @JsonProperty("score") final Double score,
+      @JsonProperty("disconnect_reason") final String disconnectReason,
+      @JsonProperty("downscore_reasons") final List<String> downscoreReasons) {
     this.peerId = peerId;
     this.enr = enr;
     this.address = address;
     this.state = state;
     this.direction = direction;
+    this.agentVersion = agentVersion;
+    this.score = score;
+    this.disconnectReason = disconnectReason;
+    this.downscoreReasons = downscoreReasons;
   }
 
   @Override
@@ -86,11 +140,24 @@ public class Peer {
         && Objects.equals(enr, peer.enr)
         && Objects.equals(address, peer.address)
         && state == peer.state
-        && direction == peer.direction;
+        && direction == peer.direction
+        && Objects.equals(agentVersion, peer.agentVersion)
+        && Objects.equals(score, peer.score)
+        && Objects.equals(disconnectReason, peer.disconnectReason)
+        && Objects.equals(downscoreReasons, peer.downscoreReasons);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(peerId, enr, address, state, direction);
+    return Objects.hash(
+        peerId,
+        enr,
+        address,
+        state,
+        direction,
+        agentVersion,
+        score,
+        disconnectReason,
+        downscoreReasons);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.network.DelegatingP2PNetwork;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
@@ -79,6 +80,7 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
   private final SubnetSubscriptionService executionProofSubnetService;
   private final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider;
   private final AtomicBoolean gossipStarted = new AtomicBoolean(false);
+  private final ReputationManager reputationManager;
 
   private final GossipForkManager gossipForkManager;
 
@@ -105,7 +107,8 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
       final GossipEncoding gossipEncoding,
       final GossipConfigurator gossipConfigurator,
       final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider,
-      final boolean allTopicsFilterEnabled) {
+      final boolean allTopicsFilterEnabled,
+      final ReputationManager reputationManager) {
     super(discoveryNetwork);
     this.spec = spec;
     this.asyncRunner = asyncRunner;
@@ -122,6 +125,12 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
     this.executionProofSubnetService = executionProofSubnetService;
     this.processedAttestationSubscriptionProvider = processedAttestationSubscriptionProvider;
     this.allTopicsFilterEnabled = allTopicsFilterEnabled;
+    this.reputationManager = reputationManager;
+  }
+
+  @Override
+  public ReputationManager getReputationManager() {
+    return reputationManager;
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetwork.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
@@ -67,4 +68,13 @@ public interface Eth2P2PNetwork extends P2PNetwork<Eth2Peer> {
   void publishPayloadAttestationMessage(PayloadAttestationMessage payloadAttestationMessage);
 
   void publishProposerPreferences(SignedProposerPreferences signedProposerPreferences);
+
+  /**
+   * Expose the underlying reputation manager so REST handlers can surface per-peer reputation
+   * scores and the last reputation-affecting action. Defaults to a no-op manager so test/mock
+   * networks don't need to override it.
+   */
+  default ReputationManager getReputationManager() {
+    return ReputationManager.NOOP;
+  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -161,6 +161,7 @@ public class Eth2P2PNetworkBuilder {
   private DasReqRespLogger dasReqRespLogger;
   private Supplier<Boolean> isSuperNodeSupplier;
   private DataColumnSidecarArchiveReconstructor dataColumnSidecarArchiveReconstructor;
+  private ReputationManager builtReputationManager;
 
   protected Eth2P2PNetworkBuilder() {}
 
@@ -237,7 +238,8 @@ public class Eth2P2PNetworkBuilder {
         gossipEncoding,
         config.getGossipConfigurator(),
         processedAttestationSubscriptionProvider,
-        config.isAllTopicsFilterEnabled());
+        config.isAllTopicsFilterEnabled(),
+        builtReputationManager);
   }
 
   private GossipForkManager buildGossipForkManager(
@@ -518,6 +520,7 @@ public class Eth2P2PNetworkBuilder {
     final ReputationManager reputationManager =
         new DefaultReputationManager(
             metricsSystem, timeProvider, Constants.REPUTATION_MANAGER_CAPACITY, peerPools);
+    this.builtReputationManager = reputationManager;
     PreparedGossipMessageFactory defaultMessageFactory =
         gossipEncoding.createPreparedGossipMessageFactory(
             combinedChainDataClient.getRecentChainData()::getMilestoneByForkDigest);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
+import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -455,6 +456,7 @@ public class ActiveEth2P2PNetworkTest {
         gossipEncoding,
         gossipConfigurator,
         processedAttestationSubscriptionProvider,
-        true);
+        true,
+        ReputationManager.NOOP);
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -420,7 +420,8 @@ public class Eth2P2PNetworkFactory {
             gossipEncoding,
             GossipConfigurator.NOOP,
             processedAttestationSubscriptionProvider,
-            config.isAllTopicsFilterEnabled());
+            config.isAllTopicsFilterEnabled(),
+            reputationManager);
       }
     }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -142,6 +142,11 @@ public class LibP2PPeer implements Peer {
   }
 
   @Override
+  public Optional<String> getAgentVersion() {
+    return maybeAgentString;
+  }
+
+  @Override
   public void disconnectImmediately(
       final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
     if (connected.getAndSet(false)) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
@@ -58,6 +58,11 @@ public class DelegatingPeer implements Peer {
   }
 
   @Override
+  public Optional<String> getAgentVersion() {
+    return peer.getAgentVersion();
+  }
+
+  @Override
   public <
           TOutgoingHandler extends RpcRequestHandler,
           TRequest extends RpcRequest,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
@@ -43,6 +43,13 @@ public interface Peer {
     return PeerClientType.UNKNOWN;
   }
 
+  /**
+   * Returns the libp2p identify agent version string for this peer, if it has been received yet.
+   */
+  default Optional<String> getAgentVersion() {
+    return Optional.empty();
+  }
+
   default void checkPeerIdentity() {}
 
   void disconnectImmediately(Optional<DisconnectReason> reason, boolean locallyInitiated);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
@@ -16,8 +16,10 @@ package tech.pegasys.teku.networking.p2p.reputation;
 import com.google.common.base.MoreObjects;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.collections.cache.Cache;
 import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
@@ -124,6 +126,19 @@ public class DefaultReputationManager implements ReputationManager {
     return peerPools.getPeerConnectionType(peerAddress.getId()).equals(PeerConnectionType.STATIC);
   }
 
+  @Override
+  public OptionalInt getReputationScore(final NodeId nodeId) {
+    return peerReputations
+        .getCached(nodeId)
+        .map(reputation -> OptionalInt.of(reputation.getScore()))
+        .orElseGet(OptionalInt::empty);
+  }
+
+  @Override
+  public Optional<LastAdjustment> getLastAdjustment(final NodeId nodeId) {
+    return peerReputations.getCached(nodeId).flatMap(Reputation::getLastAdjustment);
+  }
+
   private static class Reputation {
     private static final int DEFAULT_SCORE = 0;
     private static final EnumSet<DisconnectReason> BAN_REASONS =
@@ -134,6 +149,19 @@ public class DefaultReputationManager implements ReputationManager {
 
     private volatile Optional<UInt64> suitableAfter = Optional.empty();
     private final AtomicInteger score = new AtomicInteger(DEFAULT_SCORE);
+    private final AtomicReference<LastAdjustment> lastAdjustment = new AtomicReference<>();
+
+    public int getScore() {
+      return score.get();
+    }
+
+    public Optional<LastAdjustment> getLastAdjustment() {
+      return Optional.ofNullable(lastAdjustment.get());
+    }
+
+    protected void recordLastAdjustment(final String reason, final double delta) {
+      lastAdjustment.set(new LastAdjustment(reason, delta, System.currentTimeMillis()));
+    }
 
     public void reportInitiatedConnectionFailed(final UInt64 failureTime) {
       suitableAfter = Optional.of(failureTime.plus(COOLDOWN_PERIOD));
@@ -155,6 +183,7 @@ public class DefaultReputationManager implements ReputationManager {
         final UInt64 disconnectTime,
         final Optional<DisconnectReason> reason,
         final boolean locallyInitiated) {
+      reason.ifPresent(r -> recordLastAdjustment(r.name(), 0.0));
       if (isLocallyConsideredUnsuitable(reason, locallyInitiated)
           || reason.map(DisconnectReason::isPermanent).orElse(false)) {
         suitableAfter = Optional.of(disconnectTime.plus(BAN_PERIOD));
@@ -170,6 +199,7 @@ public class DefaultReputationManager implements ReputationManager {
     }
 
     public boolean adjustReputation(final ReputationAdjustment effect, final UInt64 currentTime) {
+      recordLastAdjustment(effect.name(), effect.getScoreChange());
       // No extra penalizing if already not suitable
       if (!isSuitableAt(currentTime)) {
         return score.get() <= DISCONNECT_THRESHOLD;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/ReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/ReputationManager.java
@@ -14,8 +14,10 @@
 package tech.pegasys.teku.networking.p2p.reputation;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.NodeId;
 
 public interface ReputationManager {
   ReputationManager NOOP =
@@ -56,4 +58,31 @@ public interface ReputationManager {
    * @return boolean representing whether the manager should disconnect.
    */
   boolean adjustReputation(final PeerAddress peerAddress, final ReputationAdjustment effect);
+
+  /**
+   * Return the current internal reputation score for the given peer, if one is tracked.
+   *
+   * @param nodeId the id of the peer.
+   * @return the integer reputation score, or {@link OptionalInt#empty()} if the peer is not
+   *     tracked.
+   */
+  default OptionalInt getReputationScore(final NodeId nodeId) {
+    return OptionalInt.empty();
+  }
+
+  /**
+   * Return the most recent reputation adjustment (or disconnect event) recorded for the given
+   * peer, if any.
+   */
+  default Optional<LastAdjustment> getLastAdjustment(final NodeId nodeId) {
+    return Optional.empty();
+  }
+
+  /**
+   * Snapshot of the most recent event that influenced a peer's reputation. {@code reason} is
+   * either a {@link ReputationAdjustment} or {@link DisconnectReason} enum name. {@code delta} is
+   * the change applied to the internal reputation score (0 for disconnects that don't move the
+   * score). {@code atMs} is the wall-clock time the event occurred, in milliseconds since epoch.
+   */
+  record LastAdjustment(String reason, double delta, long atMs) {}
 }


### PR DESCRIPTION
## Summary

Extends `/eth/v1/node/peers` (and `/eth/v1/node/peers/{peer_id}`) with four optional fields per a simplified beacon-API spec extension currently under discussion:

- `agent_version` — from libp2p identify (via `LibP2PPeer.maybeAgentString`)
- `score` — from `ReputationManager.getReputationScore(nodeId)`
- `disconnect_reason` — from `LastAdjustment.reason` when it matches a `DisconnectReason` enum
- `downscore_reasons` — single-element array, currently always `["unknown"]` for penalty events (see Notes)

## Spec proposal

ethereum/beacon-APIs#606

## What's in this PR

1. **`Peer` interface** (`networking/p2p/src/main/java/.../peer/Peer.java`) — adds `default Optional<String> getAgentVersion()`.
2. **`LibP2PPeer.getAgentVersion()` override** + `DelegatingPeer` delegation.
3. **`provider.Peer`** (`data/serializer/.../api/provider/Peer.java`) — adds 4 nullable Jackson fields with `@JsonInclude(NON_NULL)` and a 5-arg backward-compat constructor.
4. **Handler wiring** (`GetPeers.java`, `GetPeerById.java`) — introduces a `PeerView` record wrapping `Eth2PeerWithEnr` + reputation data; threads `ReputationManager` through via existing `NetworkDataProvider.getReputationManager()`.
5. **`PeerScoreReasonMapper`** (new) — controlled-vocab translator for `ReputationAdjustment` and `DisconnectReason`.

## Notes

- Teku's `ReputationAdjustment` enum (`LARGE_PENALTY`/`SMALL_PENALTY`/`LARGE_REWARD`/`SMALL_REWARD`) carries no granular cause information. `downscore_reasons` is therefore `["unknown"]` whenever a penalty event is recorded, or `null` (omitted) when the last event was a reward / disconnect. Surfacing a finer-grained reason would require extending `ReputationAdjustment` itself — happy to follow up.
- `disconnect_reason` only populates when `LastAdjustment.reason` matches a `DisconnectReason` enum name (this is already how Teku's reputation manager records disconnects via `DefaultReputationManager.Reputation.reportDisconnection`).

## Coordinated implementations

Part of a coordinated multi-client effort — see ethereum/beacon-APIs#606 for the other five client PRs.

## Status

**Draft.** `:data:serializer:compileJava` + `:data:beaconrestapi:compileJava` clean (errorprone with `-Werror` passes). Existing `GetPeersTest` / `GetPeerByIdTest` may need follow-up updates since the response wrapper now nests a `PeerView`; production code is fine.