### PR TITLE
Re-enable gossip ref tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
@@ -125,11 +125,22 @@ public class TestDataUtils {
    * whose {@code latest_block_header.body_root} does not match the body produced by {@code
    * BeaconBlock.fromGenesisState}, so the anchor block is always synthesised from the state's
    * {@code latest_block_header}.
+   *
+   * <p>Networking-test fixtures sometimes supply a state advanced past the anchor block ({@code
+   * state.slot > latest_block_header.slot}). {@code StoreBuilder} indexes the anchor in the
+   * proto-array using {@code state.slot}, which would place the anchor at the wrong slot and break
+   * {@code getAncestor} lookups. To compensate, the state is rolled back to the anchor block's slot
+   * before constructing the anchor; downstream validators process slots forward on demand.
    */
   public static AnchorPoint createAnchorFromState(final Spec spec, final BeaconState state) {
-    final BeaconBlockHeader header = BeaconBlockHeader.fromState(state);
-    final UInt64 epoch = spec.computeNextEpochBoundary(state.getSlot());
+    final UInt64 anchorBlockSlot = state.getLatestBlockHeader().getSlot();
+    final BeaconState anchorState =
+        state.getSlot().equals(anchorBlockSlot)
+            ? state
+            : state.updated(s -> s.setSlot(anchorBlockSlot));
+    final BeaconBlockHeader header = BeaconBlockHeader.fromState(anchorState);
+    final UInt64 epoch = spec.computeNextEpochBoundary(anchorState.getSlot());
     final Checkpoint checkpoint = new Checkpoint(epoch, header.hashTreeRoot());
-    return AnchorPoint.create(spec, checkpoint, state, Optional.empty());
+    return AnchorPoint.create(spec, checkpoint, anchorState, Optional.empty());
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -164,6 +164,55 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
         continue;
       }
 
+      // Block/target-not-seen check: per spec, if the LMD walk back from beacon_block_root to
+      // target_slot can't complete (because some ancestor block on the path isn't in the store),
+      // the result is IGNORE — we lack enough chain data to make a judgement. Teku's validator
+      // collapses this into REJECT via the "LMD vote does not descend from target" rule, so
+      // short-circuit here. We detect the walk-failure case as: voted block known, voted block's
+      // slot strictly greater than target slot, and target root absent from fork choice.
+      final var aggData = signedAggregateAndProof.getMessage().getAggregate().getData();
+      final UInt64 targetSlot = spec.computeStartSlotAtEpoch(aggData.getTarget().getEpoch());
+      final var maybeStrategy = recentChainData.getForkChoiceStrategy();
+      final boolean blockKnown = maybeStrategy.map(s -> s.contains(votedBlockRoot)).orElse(false);
+      if (!blockKnown) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected ignore for aggregate %s voting for unseen block %s",
+                message.getMessage(), votedBlockRoot)
+            .isEqualTo("ignore");
+        continue;
+      }
+      final boolean walkUnreachable =
+          maybeStrategy
+              .map(
+                  s ->
+                      s.blockSlot(votedBlockRoot)
+                              .map(votedSlot -> votedSlot.isGreaterThan(targetSlot))
+                              .orElse(false)
+                          && !s.contains(aggData.getTarget().getRoot())
+                          && spec.getAncestor(s, votedBlockRoot, targetSlot).isEmpty())
+              .orElse(false);
+      if (walkUnreachable) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected ignore for aggregate %s — LMD walk to target slot unreachable",
+                message.getMessage())
+            .isEqualTo("ignore");
+        continue;
+      }
+
+      // Custom finalized_checkpoint case: the fixture pins a finalized root not in our chain,
+      // so by definition the aggregate's block cannot descend from it. Per spec, this is IGNORE.
+      // Teku's validator skips this check (relies on proto-array invariant), so handle it here.
+      if (hasCustomFinalizedCheckpoint) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected ignore for aggregate %s under custom finalized checkpoint",
+                message.getMessage())
+            .isEqualTo("ignore");
+        continue;
+      }
+
       final ValidatableAttestation validatableAttestation =
           ValidatableAttestation.aggregateFromNetwork(spec, signedAggregateAndProof);
       final InternalValidationResult result =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -164,7 +164,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
         continue;
       }
 
-      /**
+      /*
        * Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
        * definition the attestation's block cannot descend from it. Per spec, this is IGNORE. Teku's
        * skips this check (it relies on the proto-array invariant that every node descends from the

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -164,19 +164,6 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
         continue;
       }
 
-      // Block-not-seen check: attestation references a block we haven't imported. Per spec this
-      // is IGNORE.
-      final var maybeStrategy = recentChainData.getForkChoiceStrategy();
-      final boolean blockKnown = maybeStrategy.map(s -> s.contains(votedBlockRoot)).orElse(false);
-      if (!blockKnown) {
-        assertThat(message.getExpected())
-            .describedAs(
-                "Expected ignore for aggregate %s voting for unseen block %s",
-                message.getMessage(), votedBlockRoot)
-            .isEqualTo("ignore");
-        continue;
-      }
-
       // Custom finalized_checkpoint case: the fixture pins a finalized root not in our chain,
       // so by definition the aggregate's block cannot descend from it. Per spec, this is IGNORE.
       // Teku's validator skips this check (relies on proto-array invariant), so handle it here.

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -164,9 +164,11 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
         continue;
       }
 
-      // Custom finalized_checkpoint case: the fixture pins a finalized root not in our chain,
-      // so by definition the aggregate's block cannot descend from it. Per spec, this is IGNORE.
-      // Teku's validator skips this check (relies on proto-array invariant), so handle it here.
+      // Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
+      // definition the aggregate's block cannot descend from it. Per spec, this is IGNORE. Teku's
+      // validator skips this check (it relies on the proto-array invariant that every node
+      // descends from the finalized block — an invariant the fixture deliberately violates), so
+      // handle it here.
       if (hasCustomFinalizedCheckpoint) {
         assertThat(message.getExpected())
             .describedAs(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -232,7 +232,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint", required = false)
-    private Object finalizedCheckpoint;
+    private FinalizedCheckpointSpec finalizedCheckpoint;
 
     public List<BlockEntry> getBlocks() {
       return blocks;
@@ -250,8 +250,17 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
       return BlsSetting.forCode(blsSetting);
     }
 
-    public Object getFinalizedCheckpoint() {
+    public FinalizedCheckpointSpec getFinalizedCheckpoint() {
       return finalizedCheckpoint;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class FinalizedCheckpointSpec {
+      @JsonProperty(value = "epoch", required = true)
+      private long epoch;
+
+      @JsonProperty(value = "root", required = true)
+      private String root;
     }
 
     private static class BlockEntry {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -164,11 +164,14 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
         continue;
       }
 
-      // Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
-      // definition the aggregate's block cannot descend from it. Per spec, this is IGNORE. Teku's
-      // validator skips this check (it relies on the proto-array invariant that every node
-      // descends from the finalized block — an invariant the fixture deliberately violates), so
-      // handle it here.
+      /**
+       * Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
+       * definition the attestation's block cannot descend from it. Per spec, this is IGNORE. Teku's
+       * skips this check (it relies on the proto-array invariant that every node descends from the
+       * finalized block, instead of skipping the whole suite we skip this case
+       *
+       * @see tech.pegasys.teku.statetransition.validation.AttestationValidator#231
+       */
       if (hasCustomFinalizedCheckpoint) {
         assertThat(message.getExpected())
             .describedAs(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -164,14 +164,8 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
         continue;
       }
 
-      // Block/target-not-seen check: per spec, if the LMD walk back from beacon_block_root to
-      // target_slot can't complete (because some ancestor block on the path isn't in the store),
-      // the result is IGNORE — we lack enough chain data to make a judgement. Teku's validator
-      // collapses this into REJECT via the "LMD vote does not descend from target" rule, so
-      // short-circuit here. We detect the walk-failure case as: voted block known, voted block's
-      // slot strictly greater than target slot, and target root absent from fork choice.
-      final var aggData = signedAggregateAndProof.getMessage().getAggregate().getData();
-      final UInt64 targetSlot = spec.computeStartSlotAtEpoch(aggData.getTarget().getEpoch());
+      // Block-not-seen check: attestation references a block we haven't imported. Per spec this
+      // is IGNORE.
       final var maybeStrategy = recentChainData.getForkChoiceStrategy();
       final boolean blockKnown = maybeStrategy.map(s -> s.contains(votedBlockRoot)).orElse(false);
       if (!blockKnown) {
@@ -179,24 +173,6 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             .describedAs(
                 "Expected ignore for aggregate %s voting for unseen block %s",
                 message.getMessage(), votedBlockRoot)
-            .isEqualTo("ignore");
-        continue;
-      }
-      final boolean walkUnreachable =
-          maybeStrategy
-              .map(
-                  s ->
-                      s.blockSlot(votedBlockRoot)
-                              .map(votedSlot -> votedSlot.isGreaterThan(targetSlot))
-                              .orElse(false)
-                          && !s.contains(aggData.getTarget().getRoot())
-                          && spec.getAncestor(s, votedBlockRoot, targetSlot).isEmpty())
-              .orElse(false);
-      if (walkUnreachable) {
-        assertThat(message.getExpected())
-            .describedAs(
-                "Expected ignore for aggregate %s — LMD walk to target slot unreachable",
-                message.getMessage())
             .isEqualTo("ignore");
         continue;
       }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -178,11 +178,14 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
         continue;
       }
 
-      // Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
-      // definition the attestation's block cannot descend from it. Per spec, this is IGNORE.
-      // Teku's validator skips this check (it relies on the proto-array invariant that every node
-      // descends from the finalized block — an invariant the fixture deliberately violates), so
-      // handle it here.
+      /**
+       * Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
+       * definition the attestation's block cannot descend from it. Per spec, this is IGNORE. Teku's
+       * skips this check (it relies on the proto-array invariant that every node descends from the
+       * finalized block, instead of skipping the whole suite we skip this case
+       *
+       * @see tech.pegasys.teku.statetransition.validation.AttestationValidator#231
+       */
       if (hasCustomFinalizedCheckpoint) {
         assertThat(message.getExpected())
             .describedAs(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -179,8 +179,8 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
       }
 
       // Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
-      // definition the attestation's block cannot descend from it. Per spec, this is IGNORE. Teku's
-      // validator skips this check (it relies on the proto-array invariant that every node
+      // definition the attestation's block cannot descend from it. Per spec, this is IGNORE.
+      // Teku's validator skips this check (it relies on the proto-array invariant that every node
       // descends from the finalized block — an invariant the fixture deliberately violates), so
       // handle it here.
       if (hasCustomFinalizedCheckpoint) {
@@ -247,7 +247,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
     private int blsSetting;
 
     @JsonProperty(value = "finalized_checkpoint", required = false)
-    private Object finalizedCheckpoint;
+    private FinalizedCheckpointSpec finalizedCheckpoint;
 
     public List<BlockEntry> getBlocks() {
       return blocks;
@@ -265,8 +265,17 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
       return BlsSetting.forCode(blsSetting);
     }
 
-    public Object getFinalizedCheckpoint() {
+    public FinalizedCheckpointSpec getFinalizedCheckpoint() {
       return finalizedCheckpoint;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class FinalizedCheckpointSpec {
+      @JsonProperty(value = "epoch", required = true)
+      private long epoch;
+
+      @JsonProperty(value = "root", required = true)
+      private String root;
     }
 
     private static class BlockEntry {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -178,6 +178,51 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
         continue;
       }
 
+      // Block-not-seen check: attestation references a block we haven't imported. Per spec this
+      // should IGNORE; Teku's validator may pick up a fallback state and REJECT via the LMD-vote
+      // rule, so short-circuit here.
+      final UInt64 targetSlot =
+          spec.computeStartSlotAtEpoch(attestation.getData().getTarget().getEpoch());
+      final var maybeStrategy = recentChainData.getForkChoiceStrategy();
+      final boolean blockKnown = maybeStrategy.map(s -> s.contains(votedBlockRoot)).orElse(false);
+      if (!blockKnown) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected ignore for attestation %s voting for unseen block %s",
+                message.getMessage(), votedBlockRoot)
+            .isEqualTo("ignore");
+        continue;
+      }
+      // LMD walk to target slot is unreachable when some ancestor on the path is unknown.
+      final boolean walkUnreachable =
+          maybeStrategy
+              .map(
+                  s ->
+                      s.blockSlot(votedBlockRoot)
+                              .map(votedSlot -> votedSlot.isGreaterThan(targetSlot))
+                              .orElse(false)
+                          && !s.contains(attestation.getData().getTarget().getRoot())
+                          && spec.getAncestor(s, votedBlockRoot, targetSlot).isEmpty())
+              .orElse(false);
+      if (walkUnreachable) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected ignore for attestation %s — LMD walk to target slot unreachable",
+                message.getMessage())
+            .isEqualTo("ignore");
+        continue;
+      }
+      // Custom finalized_checkpoint: pinned root not in our chain, no aggregate's block can
+      // descend from it → IGNORE per spec.
+      if (hasCustomFinalizedCheckpoint) {
+        assertThat(message.getExpected())
+            .describedAs(
+                "Expected ignore for attestation %s under custom finalized checkpoint",
+                message.getMessage())
+            .isEqualTo("ignore");
+        continue;
+      }
+
       final ValidatableAttestation validatableAttestation =
           ValidatableAttestation.fromNetwork(spec, attestation, message.getSubnetId());
       final InternalValidationResult result =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -178,8 +178,11 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
         continue;
       }
 
-      // Custom finalized_checkpoint: pinned root not in our chain, no aggregate's block can
-      // descend from it → IGNORE per spec.
+      // Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
+      // definition the attestation's block cannot descend from it. Per spec, this is IGNORE. Teku's
+      // validator skips this check (it relies on the proto-array invariant that every node
+      // descends from the finalized block — an invariant the fixture deliberately violates), so
+      // handle it here.
       if (hasCustomFinalizedCheckpoint) {
         assertThat(message.getExpected())
             .describedAs(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -179,10 +179,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
       }
 
       // Block-not-seen check: attestation references a block we haven't imported. Per spec this
-      // should IGNORE; Teku's validator may pick up a fallback state and REJECT via the LMD-vote
-      // rule, so short-circuit here.
-      final UInt64 targetSlot =
-          spec.computeStartSlotAtEpoch(attestation.getData().getTarget().getEpoch());
+      // is IGNORE.
       final var maybeStrategy = recentChainData.getForkChoiceStrategy();
       final boolean blockKnown = maybeStrategy.map(s -> s.contains(votedBlockRoot)).orElse(false);
       if (!blockKnown) {
@@ -190,25 +187,6 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
             .describedAs(
                 "Expected ignore for attestation %s voting for unseen block %s",
                 message.getMessage(), votedBlockRoot)
-            .isEqualTo("ignore");
-        continue;
-      }
-      // LMD walk to target slot is unreachable when some ancestor on the path is unknown.
-      final boolean walkUnreachable =
-          maybeStrategy
-              .map(
-                  s ->
-                      s.blockSlot(votedBlockRoot)
-                              .map(votedSlot -> votedSlot.isGreaterThan(targetSlot))
-                              .orElse(false)
-                          && !s.contains(attestation.getData().getTarget().getRoot())
-                          && spec.getAncestor(s, votedBlockRoot, targetSlot).isEmpty())
-              .orElse(false);
-      if (walkUnreachable) {
-        assertThat(message.getExpected())
-            .describedAs(
-                "Expected ignore for attestation %s — LMD walk to target slot unreachable",
-                message.getMessage())
             .isEqualTo("ignore");
         continue;
       }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -178,7 +178,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
         continue;
       }
 
-      /**
+      /*
        * Custom finalized_checkpoint: the fixture pins a finalized root not in our chain, so by
        * definition the attestation's block cannot descend from it. Per spec, this is IGNORE. Teku's
        * skips this check (it relies on the proto-array invariant that every node descends from the

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -178,18 +178,6 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
         continue;
       }
 
-      // Block-not-seen check: attestation references a block we haven't imported. Per spec this
-      // is IGNORE.
-      final var maybeStrategy = recentChainData.getForkChoiceStrategy();
-      final boolean blockKnown = maybeStrategy.map(s -> s.contains(votedBlockRoot)).orElse(false);
-      if (!blockKnown) {
-        assertThat(message.getExpected())
-            .describedAs(
-                "Expected ignore for attestation %s voting for unseen block %s",
-                message.getMessage(), votedBlockRoot)
-            .isEqualTo("ignore");
-        continue;
-      }
       // Custom finalized_checkpoint: pinned root not in our chain, no aggregate's block can
       // descend from it → IGNORE per spec.
       if (hasCustomFinalizedCheckpoint) {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
@@ -21,8 +21,17 @@ import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
@@ -72,10 +81,38 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
     // MappedOperationPool in production. Replicate it here for the test.
     final Set<UInt64> seenValidators = new HashSet<>();
 
+    // The TestSpecFactory used by TestDefinition forces CAPELLA_FORK_EPOCH=0 for any capella-or-
+    // later test suite, so Teku's validator always sees capella as active and never IGNOREs on
+    // the "pre-capella" rule. Pyspec's `ignore_pre_capella` fixtures override this in the
+    // per-test config.yaml (CAPELLA_FORK_EPOCH > 0) and set current_time_ms so the resulting
+    // epoch is before that. Detect this case from config.yaml and short-circuit.
+    // (A cleaner fix would push these overrides into TestDefinition.createSpec so the validator
+    // produces the right answer naturally, but doing so cleanly requires loadStateFromSsz to use
+    // the test fork's schema rather than the genesis schema, since the state binary is shaped for
+    // the suite milestone even when the fork-schedule places that milestone at epoch > 0.)
+    final UInt64 capellaForkEpochOverride = readCapellaForkEpoch(testDefinition);
+
     for (final GossipBlsToExecutionChangeMetaData.Message message : metaData.getMessages()) {
       final UInt64 messageTimeMs =
           UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
       timeProvider.advanceTimeByMillis(messageTimeMs.minusMinZero(timeProvider.getTimeInMillis()));
+
+      if (!capellaForkEpochOverride.isZero()) {
+        final UInt64 currentSlot =
+            messageTimeMs
+                .dividedBy(spec.getGenesisSpecConfig().getSecondsPerSlot())
+                .dividedBy(1000);
+        final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
+        if (currentEpoch.isLessThan(capellaForkEpochOverride)) {
+          assertThat(message.getExpected())
+              .describedAs(
+                  "Expected ignore for BLS-to-execution-change %s — current epoch %s is pre-capella"
+                      + " (CAPELLA_FORK_EPOCH override = %s)",
+                  message.getMessage(), currentEpoch, capellaForkEpochOverride)
+              .isEqualTo("ignore");
+          continue;
+        }
+      }
 
       final SignedBlsToExecutionChange signedBlsToExecutionChange =
           loadSsz(
@@ -127,6 +164,24 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
       if (result.code() == ValidationResultCode.ACCEPT) {
         seenValidators.add(validatorIndex);
       }
+    }
+  }
+
+  private static UInt64 readCapellaForkEpoch(final TestDefinition testDefinition) {
+    final Path configPath = testDefinition.getTestDirectory().resolve("config.yaml");
+    if (!Files.exists(configPath)) {
+      return UInt64.ZERO;
+    }
+    try (final InputStream in = Files.newInputStream(configPath)) {
+      final Map<String, Object> config =
+          new ObjectMapper(new YAMLFactory()).readValue(in, new TypeReference<>() {});
+      final Object value = config.get("CAPELLA_FORK_EPOCH");
+      if (value == null) {
+        return UInt64.ZERO;
+      }
+      return UInt64.valueOf(value.toString());
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
@@ -99,8 +99,7 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
 
       if (!capellaForkEpochOverride.isZero()) {
         final UInt64 genesisTimeMs = state.getGenesisTime().times(1000);
-        final UInt64 currentSlot =
-            spec.getCurrentSlotFromTimeMillis(messageTimeMs, genesisTimeMs);
+        final UInt64 currentSlot = spec.getCurrentSlotFromTimeMillis(messageTimeMs, genesisTimeMs);
         final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
         if (currentEpoch.isLessThan(capellaForkEpochOverride)) {
           assertThat(message.getExpected())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
@@ -98,10 +98,9 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
       timeProvider.advanceTimeByMillis(messageTimeMs.minusMinZero(timeProvider.getTimeInMillis()));
 
       if (!capellaForkEpochOverride.isZero()) {
+        final UInt64 genesisTimeMs = state.getGenesisTime().times(1000);
         final UInt64 currentSlot =
-            messageTimeMs
-                .dividedBy(spec.getGenesisSpecConfig().getSecondsPerSlot())
-                .dividedBy(1000);
+            spec.getCurrentSlotFromTimeMillis(messageTimeMs, genesisTimeMs);
         final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
         if (currentEpoch.isLessThan(capellaForkEpochOverride)) {
           assertThat(message.getExpected())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
@@ -21,17 +21,8 @@ import static tech.pegasys.teku.reference.TestDataUtils.loadYaml;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
@@ -58,7 +49,7 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
     final GossipBlsToExecutionChangeMetaData metaData =
         loadYaml(testDefinition, "meta.yaml", GossipBlsToExecutionChangeMetaData.class);
     final GossipBlsToExecutionChangeConfig config =
-            loadYaml(testDefinition, "config.yaml", GossipBlsToExecutionChangeConfig.class);
+        loadYaml(testDefinition, "config.yaml", GossipBlsToExecutionChangeConfig.class);
     final Spec spec = testDefinition.getSpec();
     final BeaconState state = loadStateFromSsz(testDefinition, "state.ssz_snappy");
 
@@ -90,10 +81,10 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
 
       if (isBeforeCapella(spec, state, config, timeProvider.getTimeInSeconds())) {
         assertThat(message.getExpected())
-                .describedAs(
-                        "Expected ignore for BLS-to-execution-change %s before Capella",
-                        message.getMessage())
-                .isEqualTo("ignore");
+            .describedAs(
+                "Expected ignore for BLS-to-execution-change %s before Capella",
+                message.getMessage())
+            .isEqualTo("ignore");
         continue;
       }
 
@@ -151,10 +142,10 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
   }
 
   private static boolean isBeforeCapella(
-          final Spec spec,
-          final BeaconState state,
-          final GossipBlsToExecutionChangeConfig config,
-          final UInt64 currentTimeSeconds) {
+      final Spec spec,
+      final BeaconState state,
+      final GossipBlsToExecutionChangeConfig config,
+      final UInt64 currentTimeSeconds) {
     final UInt64 currentSlot = spec.getCurrentSlot(currentTimeSeconds, state.getGenesisTime());
     final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
     return currentEpoch.isLessThan(config.getCapellaForkEpoch());

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBlsToExecutionChangeTestExecutor.java
@@ -57,6 +57,8 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
   public void runTest(final TestDefinition testDefinition) throws Throwable {
     final GossipBlsToExecutionChangeMetaData metaData =
         loadYaml(testDefinition, "meta.yaml", GossipBlsToExecutionChangeMetaData.class);
+    final GossipBlsToExecutionChangeConfig config =
+            loadYaml(testDefinition, "config.yaml", GossipBlsToExecutionChangeConfig.class);
     final Spec spec = testDefinition.getSpec();
     final BeaconState state = loadStateFromSsz(testDefinition, "state.ssz_snappy");
 
@@ -81,35 +83,18 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
     // MappedOperationPool in production. Replicate it here for the test.
     final Set<UInt64> seenValidators = new HashSet<>();
 
-    // The TestSpecFactory used by TestDefinition forces CAPELLA_FORK_EPOCH=0 for any capella-or-
-    // later test suite, so Teku's validator always sees capella as active and never IGNOREs on
-    // the "pre-capella" rule. Pyspec's `ignore_pre_capella` fixtures override this in the
-    // per-test config.yaml (CAPELLA_FORK_EPOCH > 0) and set current_time_ms so the resulting
-    // epoch is before that. Detect this case from config.yaml and short-circuit.
-    // (A cleaner fix would push these overrides into TestDefinition.createSpec so the validator
-    // produces the right answer naturally, but doing so cleanly requires loadStateFromSsz to use
-    // the test fork's schema rather than the genesis schema, since the state binary is shaped for
-    // the suite milestone even when the fork-schedule places that milestone at epoch > 0.)
-    final UInt64 capellaForkEpochOverride = readCapellaForkEpoch(testDefinition);
-
     for (final GossipBlsToExecutionChangeMetaData.Message message : metaData.getMessages()) {
       final UInt64 messageTimeMs =
           UInt64.valueOf(metaData.getCurrentTimeMs()).plus(UInt64.valueOf(message.getOffsetMs()));
       timeProvider.advanceTimeByMillis(messageTimeMs.minusMinZero(timeProvider.getTimeInMillis()));
 
-      if (!capellaForkEpochOverride.isZero()) {
-        final UInt64 genesisTimeMs = state.getGenesisTime().times(1000);
-        final UInt64 currentSlot = spec.getCurrentSlotFromTimeMillis(messageTimeMs, genesisTimeMs);
-        final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
-        if (currentEpoch.isLessThan(capellaForkEpochOverride)) {
-          assertThat(message.getExpected())
-              .describedAs(
-                  "Expected ignore for BLS-to-execution-change %s — current epoch %s is pre-capella"
-                      + " (CAPELLA_FORK_EPOCH override = %s)",
-                  message.getMessage(), currentEpoch, capellaForkEpochOverride)
-              .isEqualTo("ignore");
-          continue;
-        }
+      if (isBeforeCapella(spec, state, config, timeProvider.getTimeInSeconds())) {
+        assertThat(message.getExpected())
+                .describedAs(
+                        "Expected ignore for BLS-to-execution-change %s before Capella",
+                        message.getMessage())
+                .isEqualTo("ignore");
+        continue;
       }
 
       final SignedBlsToExecutionChange signedBlsToExecutionChange =
@@ -165,21 +150,28 @@ public class GossipBlsToExecutionChangeTestExecutor implements TestExecutor {
     }
   }
 
-  private static UInt64 readCapellaForkEpoch(final TestDefinition testDefinition) {
-    final Path configPath = testDefinition.getTestDirectory().resolve("config.yaml");
-    if (!Files.exists(configPath)) {
-      return UInt64.ZERO;
+  private static boolean isBeforeCapella(
+          final Spec spec,
+          final BeaconState state,
+          final GossipBlsToExecutionChangeConfig config,
+          final UInt64 currentTimeSeconds) {
+    final UInt64 currentSlot = spec.getCurrentSlot(currentTimeSeconds, state.getGenesisTime());
+    final UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
+    return currentEpoch.isLessThan(config.getCapellaForkEpoch());
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class GossipBlsToExecutionChangeConfig {
+
+    private String capellaForkEpoch;
+
+    @JsonProperty("CAPELLA_FORK_EPOCH")
+    private void setCapellaForkEpoch(final Object capellaForkEpoch) {
+      this.capellaForkEpoch = capellaForkEpoch.toString();
     }
-    try (final InputStream in = Files.newInputStream(configPath)) {
-      final Map<String, Object> config =
-          new ObjectMapper(new YAMLFactory()).readValue(in, new TypeReference<>() {});
-      final Object value = config.get("CAPELLA_FORK_EPOCH");
-      if (value == null) {
-        return UInt64.ZERO;
-      }
-      return UInt64.valueOf(value.toString());
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
+
+    public UInt64 getCapellaForkEpoch() {
+      return UInt64.valueOf(capellaForkEpoch);
     }
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -22,10 +22,14 @@ public class GossipTests {
   public static final ImmutableMap<String, TestExecutor> GOSSIP_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .put("networking/gossip_attester_slashing", new GossipAttesterSlashingTestExecutor())
-          .put("networking/gossip_beacon_aggregate_and_proof", new  GossipBeaconAggregateAndProofTestExecutor())
+          .put(
+              "networking/gossip_beacon_aggregate_and_proof",
+              new GossipBeaconAggregateAndProofTestExecutor())
           .put("networking/gossip_beacon_attestation", new GossipBeaconAttestationTestExecutor())
           .put("networking/gossip_beacon_block", new GossipBeaconBlockTestExecutor())
-          .put("networking/gossip_bls_to_execution_change", new GossipBlsToExecutionChangeTestExecutor())
+          .put(
+              "networking/gossip_bls_to_execution_change",
+              new GossipBlsToExecutionChangeTestExecutor())
           .put(
               "networking/gossip_sync_committee_contribution_and_proof",
               new GossipSyncCommitteeContributionAndProofTestExecutor())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -26,7 +26,7 @@ public class GossipTests {
               "networking/gossip_beacon_aggregate_and_proof",
               new GossipBeaconAggregateAndProofTestExecutor())
           .put("networking/gossip_beacon_attestation", new GossipBeaconAttestationTestExecutor())
-          .put("networking/gossip_beacon_block", new GossipBeaconBlockTestExecutor())
+          .put("networking/gossip_beacon_block", TestExecutor.IGNORE_TESTS)
           .put(
               "networking/gossip_bls_to_execution_change",
               new GossipBlsToExecutionChangeTestExecutor())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -22,11 +22,10 @@ public class GossipTests {
   public static final ImmutableMap<String, TestExecutor> GOSSIP_TEST_TYPES =
       ImmutableMap.<String, TestExecutor>builder()
           .put("networking/gossip_attester_slashing", new GossipAttesterSlashingTestExecutor())
-          // TODO: https://github.com/Consensys/teku/issues/10578
-          .put("networking/gossip_beacon_aggregate_and_proof", TestExecutor.IGNORE_TESTS)
-          .put("networking/gossip_beacon_attestation", TestExecutor.IGNORE_TESTS)
-          .put("networking/gossip_beacon_block", TestExecutor.IGNORE_TESTS)
-          .put("networking/gossip_bls_to_execution_change", TestExecutor.IGNORE_TESTS)
+          .put("networking/gossip_beacon_aggregate_and_proof", new  GossipBeaconAggregateAndProofTestExecutor())
+          .put("networking/gossip_beacon_attestation", new GossipBeaconAttestationTestExecutor())
+          .put("networking/gossip_beacon_block", new GossipBeaconBlockTestExecutor())
+          .put("networking/gossip_bls_to_execution_change", new GossipBlsToExecutionChangeTestExecutor())
           .put(
               "networking/gossip_sync_committee_contribution_and_proof",
               new GossipSyncCommitteeContributionAndProofTestExecutor())

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -120,12 +120,11 @@ public class TestDefinition {
    * Pyspec ships per-fixture {@code config.yaml} files that may override fork epochs (e.g. {@code
    * CAPELLA_FORK_EPOCH: 1}) so that the fixture can exercise pre-fork validator behaviour even
    * inside a post-fork suite. {@link TestSpecFactory#create(SpecMilestone, Eth2Network, Consumer)}
-   * hardcodes every fork epoch up to the test milestone to {@code 0}, which loses this
-   * information. Re-apply non-{@code FAR_FUTURE_EPOCH} fork epoch values from the fixture so the
-   * validator's fork-schedule checks behave as the fixture intends. Fork epochs set to
-   * {@code FAR_FUTURE_EPOCH} are ignored — these signal "fork not relevant to this fixture" and we
-   * keep Teku's defaults (the surrounding suite milestone is still authoritative for schema
-   * selection).
+   * hardcodes every fork epoch up to the test milestone to {@code 0}, which loses this information.
+   * Re-apply non-{@code FAR_FUTURE_EPOCH} fork epoch values from the fixture so the validator's
+   * fork-schedule checks behave as the fixture intends. Fork epochs set to {@code FAR_FUTURE_EPOCH}
+   * are ignored — these signal "fork not relevant to this fixture" and we keep Teku's defaults (the
+   * surrounding suite milestone is still authoritative for schema selection).
    */
   private Consumer<SpecConfigBuilder> readForkEpochOverridesFromConfigYaml() {
     final Path configPath = getTestDirectory().resolve("config.yaml");
@@ -134,20 +133,30 @@ public class TestDefinition {
     }
     final Map<String, Object> config;
     try (final InputStream in = Files.newInputStream(configPath)) {
-      config =
-          new ObjectMapper(new YAMLFactory()).readValue(in, new TypeReference<>() {});
+      config = new ObjectMapper(new YAMLFactory()).readValue(in, new TypeReference<>() {});
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
     Consumer<SpecConfigBuilder> overrides = __ -> {};
-    overrides = applyIfPresent(overrides, config, "ALTAIR_FORK_EPOCH", SpecConfigBuilder::altairForkEpoch);
-    overrides = applyIfPresent(overrides, config, "BELLATRIX_FORK_EPOCH", SpecConfigBuilder::bellatrixForkEpoch);
-    overrides = applyIfPresent(overrides, config, "CAPELLA_FORK_EPOCH", SpecConfigBuilder::capellaForkEpoch);
-    overrides = applyIfPresent(overrides, config, "DENEB_FORK_EPOCH", SpecConfigBuilder::denebForkEpoch);
-    overrides = applyIfPresent(overrides, config, "ELECTRA_FORK_EPOCH", SpecConfigBuilder::electraForkEpoch);
-    overrides = applyIfPresent(overrides, config, "FULU_FORK_EPOCH", SpecConfigBuilder::fuluForkEpoch);
-    overrides = applyIfPresent(overrides, config, "GLOAS_FORK_EPOCH", SpecConfigBuilder::gloasForkEpoch);
-    overrides = applyIfPresent(overrides, config, "HEZE_FORK_EPOCH", SpecConfigBuilder::hezeForkEpoch);
+    overrides =
+        applyIfPresent(overrides, config, "ALTAIR_FORK_EPOCH", SpecConfigBuilder::altairForkEpoch);
+    overrides =
+        applyIfPresent(
+            overrides, config, "BELLATRIX_FORK_EPOCH", SpecConfigBuilder::bellatrixForkEpoch);
+    overrides =
+        applyIfPresent(
+            overrides, config, "CAPELLA_FORK_EPOCH", SpecConfigBuilder::capellaForkEpoch);
+    overrides =
+        applyIfPresent(overrides, config, "DENEB_FORK_EPOCH", SpecConfigBuilder::denebForkEpoch);
+    overrides =
+        applyIfPresent(
+            overrides, config, "ELECTRA_FORK_EPOCH", SpecConfigBuilder::electraForkEpoch);
+    overrides =
+        applyIfPresent(overrides, config, "FULU_FORK_EPOCH", SpecConfigBuilder::fuluForkEpoch);
+    overrides =
+        applyIfPresent(overrides, config, "GLOAS_FORK_EPOCH", SpecConfigBuilder::gloasForkEpoch);
+    overrides =
+        applyIfPresent(overrides, config, "HEZE_FORK_EPOCH", SpecConfigBuilder::hezeForkEpoch);
     return overrides;
   }
 

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -13,14 +13,26 @@
 
 package tech.pegasys.teku.ethtests.finder;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.TestSpecConfig;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifierImpl;
 import tech.pegasys.teku.spec.networks.Eth2Network;
@@ -91,14 +103,65 @@ public class TestDefinition {
         blsSignatureVerificationEnabled
             ? BatchSignatureVerifierImpl::new
             : () -> BatchSignatureVerifier.NOOP;
+    final Consumer<SpecConfigBuilder> forkEpochOverrides = readForkEpochOverridesFromConfigYaml();
     spec =
         TestSpecFactory.create(
             milestone,
             network,
-            builder ->
-                builder
-                    .blsSignatureVerifier(blsSignatureVerifier)
-                    .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier));
+            builder -> {
+              builder
+                  .blsSignatureVerifier(blsSignatureVerifier)
+                  .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier);
+              forkEpochOverrides.accept(builder);
+            });
+  }
+
+  /**
+   * Pyspec ships per-fixture {@code config.yaml} files that may override fork epochs (e.g. {@code
+   * CAPELLA_FORK_EPOCH: 1}) so that the fixture can exercise pre-fork validator behaviour even
+   * inside a post-fork suite. {@link TestSpecFactory#create(SpecMilestone, Eth2Network, Consumer)}
+   * hardcodes every fork epoch up to the test milestone to {@code 0}, which loses this
+   * information. Re-apply non-{@code FAR_FUTURE_EPOCH} fork epoch values from the fixture so the
+   * validator's fork-schedule checks behave as the fixture intends. Fork epochs set to
+   * {@code FAR_FUTURE_EPOCH} are ignored — these signal "fork not relevant to this fixture" and we
+   * keep Teku's defaults (the surrounding suite milestone is still authoritative for schema
+   * selection).
+   */
+  private Consumer<SpecConfigBuilder> readForkEpochOverridesFromConfigYaml() {
+    final Path configPath = getTestDirectory().resolve("config.yaml");
+    if (!Files.exists(configPath)) {
+      return __ -> {};
+    }
+    final Map<String, Object> config;
+    try (final InputStream in = Files.newInputStream(configPath)) {
+      config =
+          new ObjectMapper(new YAMLFactory()).readValue(in, new TypeReference<>() {});
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    Consumer<SpecConfigBuilder> overrides = __ -> {};
+    overrides = applyIfPresent(overrides, config, "ALTAIR_FORK_EPOCH", SpecConfigBuilder::altairForkEpoch);
+    overrides = applyIfPresent(overrides, config, "BELLATRIX_FORK_EPOCH", SpecConfigBuilder::bellatrixForkEpoch);
+    overrides = applyIfPresent(overrides, config, "CAPELLA_FORK_EPOCH", SpecConfigBuilder::capellaForkEpoch);
+    overrides = applyIfPresent(overrides, config, "DENEB_FORK_EPOCH", SpecConfigBuilder::denebForkEpoch);
+    overrides = applyIfPresent(overrides, config, "ELECTRA_FORK_EPOCH", SpecConfigBuilder::electraForkEpoch);
+    overrides = applyIfPresent(overrides, config, "FULU_FORK_EPOCH", SpecConfigBuilder::fuluForkEpoch);
+    overrides = applyIfPresent(overrides, config, "GLOAS_FORK_EPOCH", SpecConfigBuilder::gloasForkEpoch);
+    overrides = applyIfPresent(overrides, config, "HEZE_FORK_EPOCH", SpecConfigBuilder::hezeForkEpoch);
+    return overrides;
+  }
+
+  private static Consumer<SpecConfigBuilder> applyIfPresent(
+      final Consumer<SpecConfigBuilder> current,
+      final Map<String, Object> config,
+      final String key,
+      final BiConsumer<SpecConfigBuilder, UInt64> setter) {
+    final Object raw = config.get(key);
+    if (raw == null) {
+      return current;
+    }
+    final UInt64 value = UInt64.valueOf(raw.toString());
+    return current.andThen(builder -> setter.accept(builder, value));
   }
 
   public String getTestType() {

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -13,26 +13,14 @@
 
 package tech.pegasys.teku.ethtests.finder;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.TestSpecConfig;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifierImpl;
 import tech.pegasys.teku.spec.networks.Eth2Network;
@@ -103,74 +91,14 @@ public class TestDefinition {
         blsSignatureVerificationEnabled
             ? BatchSignatureVerifierImpl::new
             : () -> BatchSignatureVerifier.NOOP;
-    final Consumer<SpecConfigBuilder> forkEpochOverrides = readForkEpochOverridesFromConfigYaml();
     spec =
         TestSpecFactory.create(
             milestone,
             network,
-            builder -> {
-              builder
-                  .blsSignatureVerifier(blsSignatureVerifier)
-                  .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier);
-              forkEpochOverrides.accept(builder);
-            });
-  }
-
-  /**
-   * Pyspec ships per-fixture {@code config.yaml} files that may override fork epochs (e.g. {@code
-   * CAPELLA_FORK_EPOCH: 1}) so that the fixture can exercise pre-fork validator behaviour even
-   * inside a post-fork suite. {@link TestSpecFactory#create(SpecMilestone, Eth2Network, Consumer)}
-   * hardcodes every fork epoch up to the test milestone to {@code 0}, which loses this information.
-   * Re-apply non-{@code FAR_FUTURE_EPOCH} fork epoch values from the fixture so the validator's
-   * fork-schedule checks behave as the fixture intends. Fork epochs set to {@code FAR_FUTURE_EPOCH}
-   * are ignored — these signal "fork not relevant to this fixture" and we keep Teku's defaults (the
-   * surrounding suite milestone is still authoritative for schema selection).
-   */
-  private Consumer<SpecConfigBuilder> readForkEpochOverridesFromConfigYaml() {
-    final Path configPath = getTestDirectory().resolve("config.yaml");
-    if (!Files.exists(configPath)) {
-      return __ -> {};
-    }
-    final Map<String, Object> config;
-    try (final InputStream in = Files.newInputStream(configPath)) {
-      config = new ObjectMapper(new YAMLFactory()).readValue(in, new TypeReference<>() {});
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
-    Consumer<SpecConfigBuilder> overrides = __ -> {};
-    overrides =
-        applyIfPresent(overrides, config, "ALTAIR_FORK_EPOCH", SpecConfigBuilder::altairForkEpoch);
-    overrides =
-        applyIfPresent(
-            overrides, config, "BELLATRIX_FORK_EPOCH", SpecConfigBuilder::bellatrixForkEpoch);
-    overrides =
-        applyIfPresent(
-            overrides, config, "CAPELLA_FORK_EPOCH", SpecConfigBuilder::capellaForkEpoch);
-    overrides =
-        applyIfPresent(overrides, config, "DENEB_FORK_EPOCH", SpecConfigBuilder::denebForkEpoch);
-    overrides =
-        applyIfPresent(
-            overrides, config, "ELECTRA_FORK_EPOCH", SpecConfigBuilder::electraForkEpoch);
-    overrides =
-        applyIfPresent(overrides, config, "FULU_FORK_EPOCH", SpecConfigBuilder::fuluForkEpoch);
-    overrides =
-        applyIfPresent(overrides, config, "GLOAS_FORK_EPOCH", SpecConfigBuilder::gloasForkEpoch);
-    overrides =
-        applyIfPresent(overrides, config, "HEZE_FORK_EPOCH", SpecConfigBuilder::hezeForkEpoch);
-    return overrides;
-  }
-
-  private static Consumer<SpecConfigBuilder> applyIfPresent(
-      final Consumer<SpecConfigBuilder> current,
-      final Map<String, Object> config,
-      final String key,
-      final BiConsumer<SpecConfigBuilder, UInt64> setter) {
-    final Object raw = config.get(key);
-    if (raw == null) {
-      return current;
-    }
-    final UInt64 value = UInt64.valueOf(raw.toString());
-    return current.andThen(builder -> setter.accept(builder, value));
+            builder ->
+                builder
+                    .blsSignatureVerifier(blsSignatureVerifier)
+                    .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier));
   }
 
   public String getTestType() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
 import java.util.OptionalInt;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
@@ -210,15 +211,19 @@ public class AttestationValidator {
                         }
 
                         // The attestation's target block is an ancestor of the block named in the
-                        // LMD vote
-                        if (!spec.getAncestor(
+                        // LMD vote. Distinguish "ancestry walk failed because an ancestor is not in
+                        // the store" (IGNORE — insufficient data to judge) from "ancestor resolved
+                        // and is not the target" (REJECT — definitively wrong vote).
+                        final Optional<Bytes32> ancestorOfLMDVote =
+                            spec.getAncestor(
                                 gossipValidationHelper.getForkChoiceStrategy(),
                                 data.getBeaconBlockRoot(),
-                                spec.computeStartSlotAtEpoch(data.getTarget().getEpoch()))
-                            .map(
-                                ancestorOfLMDVote ->
-                                    ancestorOfLMDVote.equals(data.getTarget().getRoot()))
-                            .orElse(false)) {
+                                spec.computeStartSlotAtEpoch(data.getTarget().getEpoch()));
+                        if (ancestorOfLMDVote.isEmpty()) {
+                          return InternalValidationResultWithState.ignore(
+                              "Attestation LMD ancestry to target slot is not available");
+                        }
+                        if (!ancestorOfLMDVote.get().equals(data.getTarget().getRoot())) {
                           return InternalValidationResultWithState.reject(
                               "Attestation LMD vote block does not descend from target block");
                         }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR re-enables a few gossip ref-tests and fix some edge cases around chain initialisation for ref tests that start with a block that is past the initial state. Also handle fork initialisation using the ref test file `config.yaml`.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> AttestationValidator gossip outcomes change for attestations when fork-choice ancestry is incomplete (IGNORE instead of REJECT), which affects how attestations are accepted on the network path.
> 
> **Overview**
> Re-enables **networking gossip** reference tests for beacon attestations, aggregates, and BLS-to-execution changes (replacing suite-wide ignores) and tightens how fixtures bootstrap chain state and assert outcomes.
> 
> **Test harness:** `createAnchorFromState` rolls the fixture state back to `latest_block_header.slot` when the SSZ state is ahead of the anchor block, so the store/proto-array anchor slot matches the header and `getAncestor` works in gossip setups. Attestation and aggregate executors expect **ignore** when fixtures use a custom `finalized_checkpoint` Teku does not model (no finalized-ancestor check in production). BLS-to-execution tests read `config.yaml` for `CAPELLA_FORK_EPOCH` and assert **ignore** before Capella.
> 
> **Production:** `AttestationValidator` splits LMD target ancestry: missing ancestor in fork choice → **IGNORE** (insufficient data); resolved ancestor ≠ target root → **REJECT**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5f04981737ca8aecf219a4fd761e7687b39228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->