### PR TITLE
Add debug logging for computeEquivocatingCommitteeWeight()

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayload
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
@@ -20,6 +20,9 @@ import static tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayload
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -54,6 +57,9 @@ import tech.pegasys.teku.spec.logic.versions.gloas.statetransition.epoch.EpochPr
 import tech.pegasys.teku.spec.logic.versions.gloas.withdrawals.WithdrawalsHelpersGloas;
 
 public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
+
+  private static final Logger LOG = LogManager.getLogger();
+
   private final BeaconStateMutatorsGloas beaconStateMutatorsGloas;
   private final WithdrawalsHelpersGloas withdrawalsHelpers;
   private final ExecutionRequestsProcessorGloas executionRequestsProcessor;
@@ -375,8 +381,14 @@ public class ForkChoiceUtilGloas extends ForkChoiceUtilFulu {
     final ReadOnlyForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
     final Optional<UInt64> maybeHeadSlot = forkChoiceStrategy.blockSlot(root);
     if (maybeHeadSlot.isPresent()) {
+      final long start = System.currentTimeMillis();
       final UInt64 equivocatingWeight =
           computeEquivocatingCommitteeWeight(maybeHeadSlot.get(), store, headState, justifiedState);
+      LOG.debug(
+          "Computed equivocating committee weight {} for head {}, took {} ms",
+          equivocatingWeight,
+          root,
+          System.currentTimeMillis() - start);
       headWeight = headWeight.plus(equivocatingWeight);
     }
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add debug log to measure computeEquivocatingCommitteeWeight performance

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Part of #10609

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change at DEBUG level; no fork-choice or consensus logic is modified.
> 
> **Overview**
> Adds **debug-only instrumentation** in Gloas fork-choice `isHeadWeak` when it calls `computeEquivocatingCommitteeWeight`: a Log4j logger on `ForkChoiceUtilGloas` and a `LOG.debug` line that records the computed equivocating committee weight, head root, and elapsed milliseconds.
> 
> Fork-choice / weak-head logic is unchanged; this supports performance investigation (e.g. issue #10609) where that committee scan may be expensive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db11d94e7ccfba945747003465eed2950b45b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->