### PR TITLE
print empty when head is not FULL

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -274,11 +274,11 @@ public class EventLogger {
   public void slotPayloadEvent(
       final UInt64 nodeSlot,
       final UInt64 headSlot,
-      final Bytes32 bestExecutionBlockHash,
+      final Optional<Bytes32> maybeExecutionBlockHash,
       final int numPeers) {
     String executionBlockHash = "                                                       ... empty";
-    if (nodeSlot.equals(headSlot)) {
-      executionBlockHash = LogFormatter.formatHashRoot(bestExecutionBlockHash);
+    if (nodeSlot.equals(headSlot) && maybeExecutionBlockHash.isPresent()) {
+      executionBlockHash = LogFormatter.formatHashRoot(maybeExecutionBlockHash.get());
     }
     final String slotPayloadEventLog =
         String.format(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.NodeSlot;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
@@ -358,7 +359,9 @@ public class SlotProcessor {
                 eventLog.slotPayloadEvent(
                     nodeSlot.getValue(),
                     head.getSlot(),
-                    head.getExecutionBlockHash(),
+                    head.getPayloadStatus() == ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL
+                        ? Optional.of(head.getExecutionBlockHash())
+                        : Optional.empty(),
                     p2pNetwork.getPeerCount()));
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no fork-choice, networking, or consensus logic modified.
> 
> **Overview**
> **Slot Payload Event** logging now treats the execution block hash like the beacon block field in **Slot Event**: it only prints a real hash when the node is on the head slot **and** the head has a **FULL** fork-choice payload.
> 
> `SlotProcessor` passes `Optional.empty()` unless `head.getPayloadStatus()` is `ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL`; otherwise operators see the existing `... empty` placeholder instead of a hash for empty or pending payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11b2ec6effaaf861c87fab8358e172ca28d764d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->