### PR TITLE
Specrefs alpha8

### DIFF
--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -219,15 +219,6 @@ specrefs:
       - upgrade_lc_store_to_gloas#gloas
       - upgrade_lc_update_to_gloas#gloas
 
-      # Still need to implement this for Electra
-      - compute_weak_subjectivity_period#electra
-
-      # Temporary exceptions: ignored until updated to alpha.8 spec
-      - apply_parent_execution_payload#gloas
-      - get_proposer_head#phase0
-      - prepare_execution_payload#bellatrix
-      - prepare_execution_payload#gloas
-
       # Not implemented: fast confirmation
       - adjust_committee_weight_estimate_to_ensure_safety#phase0
       - compute_adversarial_weight#phase0
@@ -299,7 +290,7 @@ specrefs:
       - verify_partial_data_column_header_inclusion_proof#fulu
       - verify_partial_data_column_sidecar_kzg_proofs#fulu
 
-      # Not needed: gloas
+      # Not implemented: gloas
       - get_proposer_dependent_root#gloas
 
       # Will be fixed later: gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -228,22 +228,6 @@ specrefs:
       - prepare_execution_payload#bellatrix
       - prepare_execution_payload#gloas
 
-      # Will be fixed later
-      - get_payload_due_ms#gloas
-      - is_gas_limit_target_compatible#gloas
-      - payload_data_availability#gloas
-      - payload_timeliness#gloas
-      - should_build_on_full#gloas
-      - validate_beacon_aggregate_and_proof_gossip#deneb
-      - validate_beacon_aggregate_and_proof_gossip#electra
-      - validate_beacon_attestation_gossip#deneb
-      - validate_beacon_attestation_gossip#electra
-      - validate_beacon_block_gossip#deneb
-      - validate_beacon_block_gossip#electra
-      - validate_blob_sidecar_gossip#deneb
-      - validate_blob_sidecar_gossip#electra
-      - validate_voluntary_exit_gossip#deneb
-
       # Not implemented: fast confirmation
       - adjust_committee_weight_estimate_to_ensure_safety#phase0
       - compute_adversarial_weight#phase0
@@ -318,8 +302,8 @@ specrefs:
       # Not needed: gloas
       - get_proposer_dependent_root#gloas
 
-      # Not implemented: gloas
-      - compute_weak_subjectivity_period#gloas
+      # Will be fixed later: gloas
+      - get_payload_due_ms#gloas
 
       # Not implemented: heze
       - get_forkchoice_store#heze

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -613,9 +613,7 @@
     </spec>
 
 - name: PAYLOAD_DUE_BPS#gloas
-  sources:
-    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
-      search: "PAYLOAD_DUE_BPS:"
+  sources: []
   spec: |
     <spec config_var="PAYLOAD_DUE_BPS" fork="gloas" hash="ee4d44de">
     PAYLOAD_DUE_BPS: uint64 = 7500

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -613,7 +613,9 @@
     </spec>
 
 - name: PAYLOAD_DUE_BPS#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
+      search: "PAYLOAD_DUE_BPS:"
   spec: |
     <spec config_var="PAYLOAD_DUE_BPS" fork="gloas" hash="ee4d44de">
     PAYLOAD_DUE_BPS: uint64 = 7500

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -2126,6 +2126,31 @@
     +    return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
     </spec>
 
+- name: compute_weak_subjectivity_period#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/weaksubjectivity/WeakSubjectivityCalculatorGloas.java
+      search: public UInt64 computeWeakSubjectivityPeriod(
+  spec: |
+    <spec fn="compute_weak_subjectivity_period" fork="gloas" hash="8b1ddc92">
+    def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
+        """
+        Returns the weak subjectivity period for the current ``state``.
+        This computation takes into account the effect of:
+            - exit churn (weighted 2/3)
+            - activation churn (weighted 1/3)
+            - consolidation churn (weighted 1)
+        """
+        t = get_total_active_balance(state)
+        # [Modified in Gloas:EIP8061]
+        delta = (
+            2 * get_exit_churn_limit(state) // 3
+            + get_activation_churn_limit(state) // 3
+            + get_consolidation_churn_limit(state)
+        )
+        epochs_for_validator_set_churn = SAFETY_DECAY * t // (2 * delta * 100)
+        return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
+    </spec>
+
 - name: construct_vanishing_polynomial#fulu
   sources: []
   spec: |
@@ -5467,16 +5492,6 @@
     </spec>
 
 - name: get_payload_due_ms#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
-      search: public Optional<Integer> getPayloadDueMillis()
-  spec: |
-    <spec fn="get_payload_due_ms" fork="gloas" hash="6ccf7f5c">
-    def get_payload_due_ms() -> uint64:
-        return get_slot_component_duration_ms(PAYLOAD_DUE_BPS)
-    </spec>
-
-- name: get_payload_due_ms#gloas
   sources: []
   spec: |
     <spec fn="get_payload_due_ms" fork="gloas" hash="6ccf7f5c">
@@ -7269,28 +7284,6 @@
             and validator.withdrawable_epoch <= epoch
             and balance > 0
         )
-    </spec>
-
-- name: is_gas_limit_target_compatible#gloas
-  sources: []
-  spec: |
-    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="3fa22023">
-    def is_gas_limit_target_compatible(
-        parent_gas_limit: uint64, gas_limit: uint64, target_gas_limit: uint64
-    ) -> bool:
-        """
-        Check if ``gas_limit`` is compatible with ``target_gas_limit`` under the
-        EIP-1559 transition rule from ``parent_gas_limit``.
-        """
-        max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
-        min_gas_limit = parent_gas_limit - max_gas_limit_difference
-        max_gas_limit = parent_gas_limit + max_gas_limit_difference
-
-        if target_gas_limit >= min_gas_limit and target_gas_limit <= max_gas_limit:
-            return gas_limit == target_gas_limit
-        if target_gas_limit > max_gas_limit:
-            return gas_limit == max_gas_limit
-        return gas_limit == min_gas_limit
     </spec>
 
 - name: is_gas_limit_target_compatible#gloas

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -5467,6 +5467,16 @@
     </spec>
 
 - name: get_payload_due_ms#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public Optional<Integer> getPayloadDueMillis()
+  spec: |
+    <spec fn="get_payload_due_ms" fork="gloas" hash="6ccf7f5c">
+    def get_payload_due_ms() -> uint64:
+        return get_slot_component_duration_ms(PAYLOAD_DUE_BPS)
+    </spec>
+
+- name: get_payload_due_ms#gloas
   sources: []
   spec: |
     <spec fn="get_payload_due_ms" fork="gloas" hash="6ccf7f5c">
@@ -7283,6 +7293,30 @@
         return gas_limit == min_gas_limit
     </spec>
 
+- name: is_gas_limit_target_compatible#gloas
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+      search: static boolean isGasLimitTargetCompatible(
+  spec: |
+    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="3fa22023">
+    def is_gas_limit_target_compatible(
+        parent_gas_limit: uint64, gas_limit: uint64, target_gas_limit: uint64
+    ) -> bool:
+        """
+        Check if ``gas_limit`` is compatible with ``target_gas_limit`` under the
+        EIP-1559 transition rule from ``parent_gas_limit``.
+        """
+        max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
+        min_gas_limit = parent_gas_limit - max_gas_limit_difference
+        max_gas_limit = parent_gas_limit + max_gas_limit_difference
+
+        if target_gas_limit >= min_gas_limit and target_gas_limit <= max_gas_limit:
+            return gas_limit == target_gas_limit
+        if target_gas_limit > max_gas_limit:
+            return gas_limit == max_gas_limit
+        return gas_limit == min_gas_limit
+    </spec>
+
 - name: is_head_late#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -8750,7 +8784,9 @@
     </spec>
 
 - name: payload_data_availability#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: private boolean payloadDataAvailability(
   spec: |
     <spec fn="payload_data_availability" fork="gloas" hash="9d298e0e">
     def payload_data_availability(store: Store, root: Root, available: bool) -> bool:
@@ -8772,7 +8808,9 @@
     </spec>
 
 - name: payload_timeliness#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: private boolean payloadTimeliness(
   spec: |
     <spec fn="payload_timeliness" fork="gloas" hash="4490a649">
     def payload_timeliness(store: Store, root: Root, timely: bool) -> bool:
@@ -11926,7 +11964,9 @@
     </spec>
 
 - name: should_build_on_full#gloas
-  sources: []
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+      search: public boolean shouldBuildOnFull(
   spec: |
     <spec fn="should_build_on_full" fork="gloas" hash="229e3638">
     def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
@@ -13470,7 +13510,9 @@
     </spec>
 
 - name: validate_beacon_aggregate_and_proof_gossip#deneb
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+      search: validate(final ValidatableAttestation attestation)
   spec: |
     <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="ec1dcf12">
     def validate_beacon_aggregate_and_proof_gossip(
@@ -13601,7 +13643,9 @@
     </spec>
 
 - name: validate_beacon_aggregate_and_proof_gossip#electra
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+      search: validate(final ValidatableAttestation attestation)
   spec: |
     <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="fd4d3e8f">
     def validate_beacon_aggregate_and_proof_gossip(
@@ -13835,7 +13879,9 @@
     </spec>
 
 - name: validate_beacon_attestation_gossip#deneb
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="fc0076a8">
     def validate_beacon_attestation_gossip(
@@ -13942,7 +13988,9 @@
     </spec>
 
 - name: validate_beacon_attestation_gossip#electra
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="02f0dc34">
     def validate_beacon_attestation_gossip(
@@ -14329,7 +14377,9 @@
     </spec>
 
 - name: validate_beacon_block_gossip#deneb
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_block_gossip" fork="deneb" hash="4ab38790">
     def validate_beacon_block_gossip(
@@ -14428,7 +14478,9 @@
     </spec>
 
 - name: validate_beacon_block_gossip#electra
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_block_gossip" fork="electra" hash="8439df67">
     def validate_beacon_block_gossip(
@@ -14527,7 +14579,9 @@
     </spec>
 
 - name: validate_blob_sidecar_gossip#deneb
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
     <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="df80723a">
     def validate_blob_sidecar_gossip(
@@ -14622,7 +14676,9 @@
     </spec>
 
 - name: validate_blob_sidecar_gossip#electra
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
     <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="184a7f15">
     def validate_blob_sidecar_gossip(
@@ -15319,7 +15375,9 @@
     </spec>
 
 - name: validate_voluntary_exit_gossip#deneb
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
+      search: validateForGossip(final SignedVoluntaryExit exit)
   spec: |
     <spec fn="validate_voluntary_exit_gossip" fork="deneb" hash="59c64424">
     def validate_voluntary_exit_gossip(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -241,7 +241,9 @@
     </spec>
 
 - name: apply_parent_execution_payload#gloas
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+      search: public void applyParentExecutionPayload(
   spec: |
     <spec fn="apply_parent_execution_payload" fork="gloas" hash="44874701">
     def apply_parent_execution_payload(
@@ -2086,7 +2088,9 @@
     </spec>
 
 - name: compute_weak_subjectivity_period#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/weaksubjectivity/WeakSubjectivityCalculatorElectra.java
+      search: public UInt64 computeWeakSubjectivityPeriod(
   spec: |
     <spec fn="compute_weak_subjectivity_period" fork="electra" style="diff" hash="8d95104c">
     --- phase0
@@ -5659,7 +5663,9 @@
     </spec>
 
 - name: get_proposer_head#phase0
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+      search: public ForkChoiceNode getProposerHead(
   spec: |
     <spec fn="get_proposer_head" fork="phase0" hash="99e8fc05">
     def get_proposer_head(store: Store, head_root: Root, slot: Slot) -> Root:
@@ -8839,7 +8845,16 @@
     </spec>
 
 - name: prepare_execution_payload#bellatrix
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+      search: final Optional<Bytes32> terminalBlockHash) {
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+      search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+      search: public Optional<SafeFuture<ForkChoiceUpdatedResult>> send(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+      search: ^  SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated\(
+      regex: true
   spec: |
     <spec fn="prepare_execution_payload" fork="bellatrix" hash="6af4de76">
     def prepare_execution_payload(
@@ -8956,7 +8971,11 @@
     </spec>
 
 - name: prepare_execution_payload#gloas
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+      search: private Optional<ChainHead> resolveProposerHeadOverride(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+      search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
   spec: |
     <spec fn="prepare_execution_payload" fork="gloas" hash="193044fa">
     def prepare_execution_payload(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

I will toggle payload_due specrefs in #10749 after this

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and spec-tracking metadata only; runtime behavior is unchanged unless separate Java work lands elsewhere.
> 
> **Overview**
> Bumps **ethspecify** tracking to **v1.7.0-alpha.8** by refreshing `specrefs/.ethspecify.yml` and `specrefs/functions.yml`.
> 
> **Exception list cleanup:** Removes many temporary “ignored until alpha.8” entries (gossip validators, `prepare_execution_payload`, fork-choice helpers, Electra weak subjectivity, etc.). Only **`get_payload_due_ms#gloas`** stays under “Will be fixed later”; **`get_proposer_dependent_root#gloas`** is reclassified as not implemented.
> 
> **Spec ↔ code linkage:** For previously unmapped or excepted functions, adds **`sources`** entries pointing at existing Teku classes (e.g. `WeakSubjectivityCalculatorElectra` / `WeakSubjectivityCalculatorGloas`, `ForkChoiceModelGloas`, gossip validators, `BlockProcessorGloas.applyParentExecutionPayload`). Documents **Electra** weak-subjectivity spec text as a diff from phase0 and adds a full **Gloas** `compute_weak_subjectivity_period` spec block. Updates embedded **`prepare_execution_payload`** spec snippets (e.g. `parent_beacon_block_root` on Bellatrix) to match alpha.8 wording.
> 
> No application logic changes in this diff—only spec reference and compliance metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d118fa88af46887be7e122bfa6c54752b952994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->