### PR TITLE
`ExecutionPayloadManager` simplification

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -670,8 +670,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
               }
               final SignedBeaconBlock block = maybeBlock.get();
               final boolean payloadPresent =
-                  executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(
-                      block.getRoot());
+                  executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(block.getRoot());
               // if execution payload is in the store, blob data is available
               final boolean blobDataAvailable =
                   combinedChainDataClient

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -1446,7 +1446,7 @@ class ValidatorApiHandlerTest {
 
     when(chainDataClient.getBlockInEffectAtSlot(eq(newSlot)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
-    when(executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(block.getRoot()))
+    when(executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(block.getRoot()))
         .thenReturn(true);
 
     final Optional<PayloadAttestationData> result =
@@ -1469,7 +1469,7 @@ class ValidatorApiHandlerTest {
 
     when(chainDataClient.getBlockInEffectAtSlot(eq(newSlot)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
-    when(executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(block.getRoot()))
+    when(executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(block.getRoot()))
         .thenReturn(false);
 
     final Optional<PayloadAttestationData> result =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -174,8 +174,7 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             createGossipValidationHelper(
                 spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
             invalidBlockRoots,
-            Set.of(),
-            __ -> true);
+            Set.of());
     final AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(
             spec, attestationValidator, AsyncBLSSignatureVerifier.wrap(blsVerifier));

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -180,8 +180,7 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
             createGossipValidationHelper(
                 spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
             invalidBlockRoots,
-            Set.of(),
-            __ -> true);
+            Set.of());
 
     // Track seen attestations (by hash tree root) for "already seen" duplicate detection
     final Set<Bytes32> seenAttestationRoots = new HashSet<>();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -24,9 +24,9 @@ public class Constants {
   public static final int VALID_BLOCK_SET_SIZE = 1000;
   // Target holding 2 slots worth of payload attestations
   public static final int VALID_PAYLOAD_ATTESTATION_SET_SIZE = 512 * 2;
-  // The cache is used for the `payload_present` voting and gossip validation, so no need for a long
-  // term caching
-  public static final int RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE = 32;
+  // The cache is used for the `payload_present` voting, gossip and RPC fetch de-duplication, so no
+  // need for a long term caching
+  public static final int SEEN_EXECUTION_PAYLOADS_CACHE_SIZE = 32;
   // Target holding two slots worth of aggregators (16 aggregators, 64 committees and 2 slots)
   public static final int VALID_AGGREGATE_SET_SIZE = 16 * 64 * 2;
   // Tracking 10 slots worth of bids

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -25,8 +25,8 @@ public class Constants {
   // Target holding 2 slots worth of payload attestations
   public static final int VALID_PAYLOAD_ATTESTATION_SET_SIZE = 512 * 2;
   // The cache is used for the `payload_present` voting, gossip and RPC fetch de-duplication, so no
-  // need for a long term caching
-  public static final int SEEN_EXECUTION_PAYLOADS_CACHE_SIZE = 32;
+  // need for a long term caching (1 epoch)
+  public static final int VALID_EXECUTION_PAYLOADS_SET_SIZE = 32;
   // Target holding two slots worth of aggregators (16 aggregators, 64 committees and 2 slots)
   public static final int VALID_AGGREGATE_SET_SIZE = 16 * 64 * 2;
   // Tracking 10 slots worth of bids

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -113,8 +113,7 @@ class AttestationManagerIntegrationTest {
           signatureVerificationService,
           gossipValidationHelper,
           new ConcurrentHashMap<>(),
-          Set.of(),
-          __ -> true);
+          Set.of());
   private final ActiveValidatorChannel activeValidatorChannel = mock(ActiveValidatorChannel.class);
 
   private final AttestationManager attestationManager =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -54,8 +54,6 @@ public class DefaultExecutionPayloadManager
   private static final int PENDING_EXECUTION_PAYLOADS_CACHE_SIZE =
       SEEN_EXECUTION_PAYLOADS_CACHE_SIZE * 2;
 
-  private final Set<Bytes32> recentSeenExecutionPayloads =
-      LimitedSet.createSynchronizedNatural(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
   private final Set<Bytes32> executionPayloadsSeenBeforePayloadDue =
       LimitedSet.createSynchronizedNatural(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
@@ -99,7 +97,7 @@ public class DefaultExecutionPayloadManager
 
   @Override
   public boolean isExecutionPayloadRecentlySeen(final Bytes32 beaconBlockRoot) {
-    return recentSeenExecutionPayloads.contains(beaconBlockRoot);
+    return executionPayloadGossipValidator.isPayloadSeen(beaconBlockRoot);
   }
 
   @Override
@@ -122,7 +120,6 @@ public class DefaultExecutionPayloadManager
             case ACCEPT -> {
               receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
                   signedExecutionPayload);
-              recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
               recordIfExecutionPayloadIsSeenBeforeDeadline(
                   signedExecutionPayload, arrivalTimestamp);
               importExecutionPayload(signedExecutionPayload).finishError(LOG);
@@ -140,6 +137,8 @@ public class DefaultExecutionPayloadManager
                     .finishError(LOG);
               } else {
                 // import will be triggered when the corresponding block is imported
+                // since no slashing is implemented in order to prevent DoS, we just keep the first
+                // payload that arrives at this step
                 pendingExecutionPayloads.putIfAbsent(
                     signedExecutionPayload.getBlockRootAndBuilderIndex(),
                     new PendingExecutionPayload(signedExecutionPayload, arrivalTimestamp));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -108,14 +108,6 @@ public class DefaultExecutionPayloadManager
     return executionPayloadsSeenBeforePayloadDue.contains(beaconBlockRoot);
   }
 
-  @Override
-  public boolean isExecutionPayloadSeenForFullPayloadAttestation(final Bytes32 beaconBlockRoot) {
-    if (successfullyImportedExecutionPayloads.contains(beaconBlockRoot)) {
-      return true;
-    }
-    return recentChainData.containsExecutionPayload(beaconBlockRoot);
-  }
-
   @SuppressWarnings("FutureReturnValueIgnored")
   @Override
   public SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
@@ -133,7 +125,7 @@ public class DefaultExecutionPayloadManager
                   signedExecutionPayload);
               recordIfExecutionPayloadIsSeenBeforeDeadline(
                   signedExecutionPayload, arrivalTimestamp);
-              importExecutionPayload(signedExecutionPayload).finishError(LOG);
+              importExecutionPayload(signedExecutionPayload, true).finishError(LOG);
             }
             case SAVE_FOR_FUTURE -> {
               if (recentChainData.containsBlock(signedExecutionPayload.getBeaconBlockRoot())) {
@@ -147,12 +139,13 @@ public class DefaultExecutionPayloadManager
                         Duration.ofMillis(100))
                     .finishError(LOG);
               } else {
-                // import will be triggered when the corresponding block is imported
-                // since no slashing is implemented in order to prevent DoS, we just keep the first
-                // payload that arrives at this step
-                pendingExecutionPayloads.putIfAbsent(
+                // since no slashing is implemented in order to prevent DoS, we keep one pending
+                // payload: the latest candidate received before payload due, or the first candidate
+                // if none arrived before payload due
+                pendingExecutionPayloads.merge(
                     signedExecutionPayload.getBlockRootAndBuilderIndex(),
-                    new PendingExecutionPayload(signedExecutionPayload, arrivalTimestamp));
+                    new PendingExecutionPayload(signedExecutionPayload, arrivalTimestamp),
+                    this::selectPendingExecutionPayload);
               }
             }
             case IGNORE, REJECT -> {}
@@ -174,38 +167,35 @@ public class DefaultExecutionPayloadManager
                 LOG.debug(
                     "Successfully imported execution payload {}",
                     signedExecutionPayload::toLogString);
-                successfullyImportedExecutionPayloads.add(
-                    signedExecutionPayload.getBeaconBlockRoot());
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload, result.isImportedOptimistically());
-              } else {
-                recentSeenExecutionPayloads.remove(signedExecutionPayload.getBeaconBlockRoot());
-                if (payloadCommitmentVerified && isInvalidExecutionPayload(result)) {
-                  blockRootsWithInvalidExecutionPayload.add(
-                      signedExecutionPayload.getBeaconBlockRoot());
+                return;
+              }
+              switch (result.getFailureReason()) {
+                case FAILED_EXECUTION -> {
+                  LOG.error(
+                      "Unable to import execution payload {}. Execution Client returned an error: {}",
+                      signedExecutionPayload::toLogString,
+                      () -> result.getFailureCause().map(Throwable::getMessage).orElse(""));
+                  failedPayloadExecutionSubscribers.deliver(
+                      FailedPayloadExecutionSubscriber::onPayloadExecutionFailed,
+                      signedExecutionPayload);
                 }
-                switch (result.getFailureReason()) {
-                  case FAILED_EXECUTION -> {
-                    LOG.error(
-                        "Unable to import execution payload {}. Execution Client returned an error: {}",
-                        signedExecutionPayload::toLogString,
-                        () -> result.getFailureCause().map(Throwable::getMessage).orElse(""));
-                    failedPayloadExecutionSubscribers.deliver(
-                        FailedPayloadExecutionSubscriber::onPayloadExecutionFailed,
-                        signedExecutionPayload);
+                case FAILED_VERIFICATION, FAILED_DATA_AVAILABILITY_CHECK_INVALID -> {
+                  if (payloadCommitmentVerified) {
+                    blockRootsWithInvalidExecutionPayload.add(
+                        signedExecutionPayload.getBeaconBlockRoot());
                   }
-                  case INTERNAL_ERROR,
-                      UNKNOWN_BEACON_BLOCK_ROOT,
-                      FAILED_VERIFICATION,
-                      FAILED_DATA_AVAILABILITY_CHECK_INVALID,
-                      FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
-                      logFailedExecutionPayloadImport(signedExecutionPayload, result);
+                  logFailedExecutionPayloadImport(signedExecutionPayload, result);
                 }
+                case INTERNAL_ERROR,
+                    UNKNOWN_BEACON_BLOCK_ROOT,
+                    FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE ->
+                    logFailedExecutionPayloadImport(signedExecutionPayload, result);
               }
             })
         .exceptionally(
             ex -> {
-              recentSeenExecutionPayloads.remove(signedExecutionPayload.getBeaconBlockRoot());
               final String internalErrorMessage =
                   String.format(
                       "Internal error while importing execution payload: %s. Execution payload content: %s",
@@ -214,17 +204,6 @@ public class DefaultExecutionPayloadManager
               LOG.error(internalErrorMessage, ex);
               return ExecutionPayloadImportResult.internalError(ex);
             });
-  }
-
-  private boolean isInvalidExecutionPayload(final ExecutionPayloadImportResult result) {
-    return switch (result.getFailureReason()) {
-      case FAILED_VERIFICATION, FAILED_DATA_AVAILABILITY_CHECK_INVALID -> true;
-      case UNKNOWN_BEACON_BLOCK_ROOT,
-          FAILED_EXECUTION,
-          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
-          INTERNAL_ERROR ->
-          false;
-    };
   }
 
   private void logFailedExecutionPayloadImport(
@@ -292,14 +271,27 @@ public class DefaultExecutionPayloadManager
 
   private void recordIfExecutionPayloadIsSeenBeforeDeadline(
       final SignedExecutionPayloadEnvelope signedExecutionPayload, final UInt64 arrivalTimestamp) {
+    if (isBeforePayloadDue(signedExecutionPayload, arrivalTimestamp)) {
+      executionPayloadsSeenBeforePayloadDue.add(signedExecutionPayload.getBeaconBlockRoot());
+    }
+  }
+
+  private PendingExecutionPayload selectPendingExecutionPayload(
+      final PendingExecutionPayload existing, final PendingExecutionPayload candidate) {
+    if (isBeforePayloadDue(candidate.executionPayload(), candidate.arrivalTimestamp())) {
+      return candidate;
+    }
+    return existing;
+  }
+
+  private boolean isBeforePayloadDue(
+      final SignedExecutionPayloadEnvelope signedExecutionPayload, final UInt64 arrivalTimestamp) {
     final UInt64 slot = signedExecutionPayload.getSlot();
-    if (spec.isBeforeTimeInSlot(
+    return spec.isBeforeTimeInSlot(
         slot,
         recentChainData.getGenesisTimeMillis(),
         arrivalTimestamp,
-        spec.getPayloadDueMillis(slot).orElseThrow())) {
-      executionPayloadsSeenBeforePayloadDue.add(signedExecutionPayload.getBeaconBlockRoot());
-    }
+        spec.getPayloadDueMillis(slot).orElseThrow());
   }
 
   // publish payload in cases where initial validation wasn't accepted

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import static tech.pegasys.teku.spec.config.Constants.SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
+import static tech.pegasys.teku.spec.config.Constants.VALID_EXECUTION_PAYLOADS_SET_SIZE;
 
 import java.time.Duration;
 import java.util.Map;
@@ -52,10 +52,10 @@ public class DefaultExecutionPayloadManager
   private static final Logger LOG = LogManager.getLogger();
 
   private static final int PENDING_EXECUTION_PAYLOADS_CACHE_SIZE =
-      SEEN_EXECUTION_PAYLOADS_CACHE_SIZE * 2;
+      VALID_EXECUTION_PAYLOADS_SET_SIZE * 2;
 
   private final Set<Bytes32> executionPayloadsSeenBeforePayloadDue =
-      LimitedSet.createSynchronizedNatural(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+      LimitedSet.createSynchronizedNatural(VALID_EXECUTION_PAYLOADS_SET_SIZE);
 
   // pending pool
   private final Map<BlockRootAndBuilderIndex, PendingExecutionPayload> pendingExecutionPayloads =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -13,12 +13,9 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import static com.google.common.base.Preconditions.checkState;
-import static tech.pegasys.teku.spec.config.Constants.RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
+import static tech.pegasys.teku.spec.config.Constants.SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
 
 import java.time.Duration;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -40,7 +37,6 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedEx
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
-import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -54,22 +50,18 @@ public class DefaultExecutionPayloadManager
     implements ExecutionPayloadManager, ReceivedBlockEventsChannel {
 
   private static final Logger LOG = LogManager.getLogger();
-  private static final int UNVALIDATED_EXECUTION_PAYLOADS_CACHE_MULTIPLIER = 2;
-  private static final int UNVALIDATED_EXECUTION_PAYLOADS_CACHE_SIZE =
-      RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE * UNVALIDATED_EXECUTION_PAYLOADS_CACHE_MULTIPLIER;
+
+  private static final int PENDING_EXECUTION_PAYLOADS_CACHE_SIZE =
+      SEEN_EXECUTION_PAYLOADS_CACHE_SIZE * 2;
 
   private final Set<Bytes32> recentSeenExecutionPayloads =
-      LimitedSet.createSynchronizedNatural(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+      LimitedSet.createSynchronizedNatural(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
   private final Set<Bytes32> executionPayloadsSeenBeforePayloadDue =
-      LimitedSet.createSynchronizedNatural(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
-  private final Set<Bytes32> acceptedExecutionPayloadEnvelopeRoots =
-      LimitedSet.createSynchronizedNatural(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
-  private final Map<Bytes32, UInt64> executionPayloadArrivalTimestamps =
-      LimitedMap.createSynchronizedNatural(UNVALIDATED_EXECUTION_PAYLOADS_CACHE_SIZE);
+      LimitedSet.createSynchronizedNatural(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
   // pending pool
-  private final Map<BlockRootAndBuilderIndex, PendingExecutionPayloads> pendingExecutionPayloads =
-      LimitedMap.createSynchronizedNatural(UNVALIDATED_EXECUTION_PAYLOADS_CACHE_SIZE);
+  private final Map<BlockRootAndBuilderIndex, PendingExecutionPayload> pendingExecutionPayloads =
+      LimitedMap.createSynchronizedNatural(PENDING_EXECUTION_PAYLOADS_CACHE_SIZE);
 
   private final Subscribers<FailedPayloadExecutionSubscriber> failedPayloadExecutionSubscribers =
       Subscribers.create(true);
@@ -111,7 +103,7 @@ public class DefaultExecutionPayloadManager
   }
 
   @Override
-  public boolean isExecutionPayloadAvailableForPayloadAttestation(final Bytes32 beaconBlockRoot) {
+  public boolean isExecutionPayloadSeenBeforeDeadline(final Bytes32 beaconBlockRoot) {
     return executionPayloadsSeenBeforePayloadDue.contains(beaconBlockRoot);
   }
 
@@ -119,13 +111,9 @@ public class DefaultExecutionPayloadManager
   @Override
   public SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayload,
-      final Optional<UInt64> arrivalTimestamp) {
-    final UInt64 executionPayloadArrivalTimestamp =
-        arrivalTimestamp.orElseGet(this::getStoreTimeInMillis);
-    final UInt64 earliestExecutionPayloadArrivalTimestamp =
-        recordExecutionPayloadArrivalTimestamp(
-            signedExecutionPayload, executionPayloadArrivalTimestamp);
-    final Bytes32 executionPayloadEnvelopeRoot = signedExecutionPayload.hashTreeRoot();
+      final Optional<UInt64> maybeArrivalTimestamp) {
+    final UInt64 arrivalTimestamp =
+        maybeArrivalTimestamp.orElseGet(() -> recentChainData.getStore().getTimeInMillis());
     final SafeFuture<InternalValidationResult> validationResult =
         executionPayloadGossipValidator.validate(signedExecutionPayload);
     validationResult.thenAccept(
@@ -134,11 +122,9 @@ public class DefaultExecutionPayloadManager
             case ACCEPT -> {
               receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadValidated(
                   signedExecutionPayload);
-              acceptedExecutionPayloadEnvelopeRoots.add(executionPayloadEnvelopeRoot);
-              // cache the seen `beacon_block_root` when the gossip checks pass
               recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
-              recordExecutionPayloadAvailability(
-                  signedExecutionPayload, earliestExecutionPayloadArrivalTimestamp);
+              recordIfExecutionPayloadIsSeenBeforeDeadline(
+                  signedExecutionPayload, arrivalTimestamp);
               importExecutionPayload(signedExecutionPayload).finishError(LOG);
             }
             case SAVE_FOR_FUTURE -> {
@@ -148,28 +134,18 @@ public class DefaultExecutionPayloadManager
                     .runAfterDelay(
                         () ->
                             validateAndImportExecutionPayload(
-                                    signedExecutionPayload,
-                                    Optional.of(executionPayloadArrivalTimestamp))
+                                    signedExecutionPayload, Optional.of(arrivalTimestamp))
                                 .thenCompose(r -> publishPayload(r, signedExecutionPayload)),
                         Duration.ofMillis(100))
                     .finishError(LOG);
               } else {
                 // import will be triggered when the corresponding block is imported
-                pendingExecutionPayloads.merge(
+                pendingExecutionPayloads.putIfAbsent(
                     signedExecutionPayload.getBlockRootAndBuilderIndex(),
-                    PendingExecutionPayloads.create(
-                        new PendingExecutionPayload(
-                            signedExecutionPayload, earliestExecutionPayloadArrivalTimestamp)),
-                    PendingExecutionPayloads::merge);
+                    new PendingExecutionPayload(signedExecutionPayload, arrivalTimestamp));
               }
             }
-            case IGNORE -> {
-              if (acceptedExecutionPayloadEnvelopeRoots.contains(executionPayloadEnvelopeRoot)) {
-                recordExecutionPayloadAvailability(
-                    signedExecutionPayload, earliestExecutionPayloadArrivalTimestamp);
-              }
-            }
-            case REJECT -> {}
+            case IGNORE, REJECT -> {}
           }
         });
     return validationResult;
@@ -265,7 +241,7 @@ public class DefaultExecutionPayloadManager
 
   @Override
   public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
-    // Process pending execution payloads
+    // Process pending execution payload
     block
         .getMessage()
         .getBody()
@@ -275,49 +251,25 @@ public class DefaultExecutionPayloadManager
             bid ->
                 new BlockRootAndBuilderIndex(block.getRoot(), bid.getMessage().getBuilderIndex()))
         .map(pendingExecutionPayloads::remove)
-        .ifPresent(this::validateAndImportPendingExecutionPayloads);
-  }
-
-  private UInt64 recordExecutionPayloadArrivalTimestamp(
-      final SignedExecutionPayloadEnvelope signedExecutionPayload, final UInt64 arrivalTimestamp) {
-    return executionPayloadArrivalTimestamps.merge(
-        signedExecutionPayload.hashTreeRoot(), arrivalTimestamp, UInt64::min);
-  }
-
-  private void validateAndImportPendingExecutionPayloads(
-      final PendingExecutionPayloads pendingExecutionPayloads) {
-    pendingExecutionPayloads
-        .values()
-        .forEach(
+        .ifPresent(
             pendingExecutionPayload ->
                 validateAndImportExecutionPayload(
                         pendingExecutionPayload.executionPayload(),
                         Optional.of(pendingExecutionPayload.arrivalTimestamp()))
-                    .thenCompose(
-                        result ->
-                            publishPayload(result, pendingExecutionPayload.executionPayload()))
+                    .thenCompose(r -> publishPayload(r, pendingExecutionPayload.executionPayload()))
                     .finishError(LOG));
   }
 
-  private void recordExecutionPayloadAvailability(
+  private void recordIfExecutionPayloadIsSeenBeforeDeadline(
       final SignedExecutionPayloadEnvelope signedExecutionPayload, final UInt64 arrivalTimestamp) {
     final UInt64 slot = signedExecutionPayload.getSlot();
     if (spec.isBeforeTimeInSlot(
-            slot,
-            recentChainData.getGenesisTimeMillis(),
-            arrivalTimestamp,
-            spec.getPayloadDueMillis(slot).orElseThrow())
-        && !executionPayloadsSeenBeforePayloadDue.contains(
-            signedExecutionPayload.getBeaconBlockRoot())) {
+        slot,
+        recentChainData.getGenesisTimeMillis(),
+        arrivalTimestamp,
+        spec.getPayloadDueMillis(slot).orElseThrow())) {
       executionPayloadsSeenBeforePayloadDue.add(signedExecutionPayload.getBeaconBlockRoot());
     }
-  }
-
-  private UInt64 getStoreTimeInMillis() {
-    final ReadOnlyStore store = recentChainData.getStore();
-    checkState(
-        store != null, "Store is unavailable while resolving execution payload arrival time");
-    return store.getTimeInMillis();
   }
 
   // publish payload in cases where initial validation wasn't accepted
@@ -330,44 +282,6 @@ public class DefaultExecutionPayloadManager
     return SafeFuture.COMPLETE;
   }
 
-  private record PendingExecutionPayload(
-      SignedExecutionPayloadEnvelope executionPayload, UInt64 arrivalTimestamp) {
-    private Bytes32 envelopeRoot() {
-      return executionPayload.hashTreeRoot();
-    }
-
-    private PendingExecutionPayload earliest(final PendingExecutionPayload other) {
-      return arrivalTimestamp.isLessThanOrEqualTo(other.arrivalTimestamp) ? this : other;
-    }
-  }
-
-  private record PendingExecutionPayloads(Map<Bytes32, PendingExecutionPayload> payloads) {
-    private PendingExecutionPayloads(final Map<Bytes32, PendingExecutionPayload> payloads) {
-      final Map<Bytes32, PendingExecutionPayload> limitedPayloads =
-          LimitedMap.createSynchronizedNatural(UNVALIDATED_EXECUTION_PAYLOADS_CACHE_SIZE);
-      limitedPayloads.putAll(payloads);
-      this.payloads = Collections.unmodifiableMap(limitedPayloads);
-    }
-
-    private static PendingExecutionPayloads create(
-        final PendingExecutionPayload pendingExecutionPayload) {
-      return new PendingExecutionPayloads(
-          Map.of(pendingExecutionPayload.envelopeRoot(), pendingExecutionPayload));
-    }
-
-    private PendingExecutionPayloads merge(final PendingExecutionPayloads other) {
-      final Map<Bytes32, PendingExecutionPayload> mergedPayloads =
-          LimitedMap.createSynchronizedNatural(UNVALIDATED_EXECUTION_PAYLOADS_CACHE_SIZE);
-      mergedPayloads.putAll(payloads);
-      other.payloads.forEach(
-          (envelopeRoot, pendingExecutionPayload) ->
-              mergedPayloads.merge(
-                  envelopeRoot, pendingExecutionPayload, PendingExecutionPayload::earliest));
-      return new PendingExecutionPayloads(mergedPayloads);
-    }
-
-    private Collection<PendingExecutionPayload> values() {
-      return payloads.values();
-    }
-  }
+  public record PendingExecutionPayload(
+      SignedExecutionPayloadEnvelope executionPayload, UInt64 arrivalTimestamp) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -33,15 +33,14 @@ public interface ExecutionPayloadManager {
         }
 
         @Override
-        public boolean isExecutionPayloadAvailableForPayloadAttestation(
-            final Bytes32 beaconBlockRoot) {
+        public boolean isExecutionPayloadSeenBeforeDeadline(final Bytes32 beaconBlockRoot) {
           return false;
         }
 
         @Override
         public SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
             final SignedExecutionPayloadEnvelope signedExecutionPayload,
-            final Optional<UInt64> arrivalTimestamp) {
+            final Optional<UInt64> maybeArrivalTimestamp) {
           return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
         }
 
@@ -67,7 +66,7 @@ public interface ExecutionPayloadManager {
 
   /**
    * {@link SignedExecutionPayloadEnvelope} has been recently seen referencing the block. This is
-   * used for fetch de-duplication.
+   * used for RPC fetch de-duplication.
    */
   boolean isExecutionPayloadRecentlySeen(Bytes32 beaconBlockRoot);
 
@@ -75,7 +74,7 @@ public interface ExecutionPayloadManager {
    * {@link SignedExecutionPayloadEnvelope} was seen before {@code get_payload_due_ms()}. This
    * method is used for the `payload_present` vote.
    */
-  boolean isExecutionPayloadAvailableForPayloadAttestation(Bytes32 beaconBlockRoot);
+  boolean isExecutionPayloadSeenBeforeDeadline(Bytes32 beaconBlockRoot);
 
   /**
    * Performs gossip validation on the {@code signedExecutionPayload} and imports it async if
@@ -84,7 +83,8 @@ public interface ExecutionPayloadManager {
    * @return the gossip validation result
    */
   SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
-      SignedExecutionPayloadEnvelope signedExecutionPayload, Optional<UInt64> arrivalTimestamp);
+      SignedExecutionPayloadEnvelope signedExecutionPayload,
+      Optional<UInt64> maybeArrivalTimestamp);
 
   /**
    * Imports execution payload via fork choice `on_execution_payload`

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -38,12 +38,6 @@ public interface ExecutionPayloadManager {
         }
 
         @Override
-        public boolean isExecutionPayloadSeenForFullPayloadAttestation(
-            final Bytes32 beaconBlockRoot) {
-          return false;
-        }
-
-        @Override
         public SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
             final SignedExecutionPayloadEnvelope signedExecutionPayload,
             final Optional<UInt64> maybeArrivalTimestamp) {
@@ -82,12 +76,6 @@ public interface ExecutionPayloadManager {
    * method is used for the `payload_present` vote.
    */
   boolean isExecutionPayloadSeenBeforeDeadline(Bytes32 beaconBlockRoot);
-
-  /**
-   * {@link SignedExecutionPayloadEnvelope} has been successfully imported or is already available
-   * for the block. This method is used for full-payload beacon attestation gossip validation.
-   */
-  boolean isExecutionPayloadSeenForFullPayloadAttestation(Bytes32 beaconBlockRoot);
 
   /**
    * Performs gossip validation on the {@code signedExecutionPayload} and imports it async if

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
@@ -44,7 +43,6 @@ public class AttestationValidator {
   private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
   private final Set<Bytes32> blockRootsWithInvalidExecutionPayload;
-  private final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation;
 
   @VisibleForTesting
   AttestationValidator(
@@ -52,7 +50,7 @@ public class AttestationValidator {
       final AsyncBLSSignatureVerifier signatureVerifier,
       final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots) {
-    this(spec, signatureVerifier, gossipValidationHelper, invalidBlockRoots, Set.of(), __ -> true);
+    this(spec, signatureVerifier, gossipValidationHelper, invalidBlockRoots, Set.of());
   }
 
   public AttestationValidator(
@@ -60,15 +58,12 @@ public class AttestationValidator {
       final AsyncBLSSignatureVerifier signatureVerifier,
       final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
-      final Set<Bytes32> blockRootsWithInvalidExecutionPayload,
-      final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation) {
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload) {
     this.spec = spec;
     this.signatureVerifier = signatureVerifier;
     this.gossipValidationHelper = gossipValidationHelper;
     this.invalidBlockRoots = invalidBlockRoots;
     this.blockRootsWithInvalidExecutionPayload = blockRootsWithInvalidExecutionPayload;
-    this.executionPayloadSeenForFullPayloadAttestation =
-        executionPayloadSeenForFullPayloadAttestation;
   }
 
   public SafeFuture<InternalValidationResult> validate(
@@ -193,7 +188,7 @@ public class AttestationValidator {
                 "Execution payload for full payload attestation is invalid"));
       }
       // [IGNORE] If index == 1, the execution payload for block has been seen.
-      if (!executionPayloadSeenForFullPayloadAttestation.test(blockRoot)) {
+      if (gossipValidationHelper.getRecentlyImportedExecutionPayload(blockRoot).isEmpty()) {
         return completedFuture(InternalValidationResultWithState.saveForFuture());
       }
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.statetransition.validation;
 
-import static tech.pegasys.teku.spec.config.Constants.SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
+import static tech.pegasys.teku.spec.config.Constants.VALID_EXECUTION_PAYLOADS_SET_SIZE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
@@ -49,7 +49,7 @@ public class ExecutionPayloadGossipValidator {
   private final SigningRootUtil signingRootUtil;
 
   private final Set<BlockRootAndBuilderIndex> seenPayloads =
-      LimitedSet.createSynchronizedLRU(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+      LimitedSet.createSynchronizedLRU(VALID_EXECUTION_PAYLOADS_SET_SIZE);
 
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -83,6 +83,13 @@ public class ExecutionPayloadGossipValidator {
                                 .thenApply(result -> markAsSeen(result, envelope))));
   }
 
+  public boolean isPayloadSeen(final Bytes32 beaconBlockRoot) {
+    return seenPayloads.stream()
+        .anyMatch(
+            blockRootAndBuilderIndex ->
+                blockRootAndBuilderIndex.blockRoot().equals(beaconBlockRoot));
+  }
+
   private SafeFuture<Optional<InternalValidationResult>> performWithBlockValidation(
       final ExecutionPayloadEnvelope envelope) {
     return gossipValidationHelper

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -49,7 +49,7 @@ public class ExecutionPayloadGossipValidator {
   private final SigningRootUtil signingRootUtil;
 
   private final Set<BlockRootAndBuilderIndex> seenPayloads =
-      LimitedSet.createSynchronized(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+      LimitedSet.createSynchronizedLRU(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.statetransition.validation;
 
-import static tech.pegasys.teku.spec.config.Constants.RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
+import static tech.pegasys.teku.spec.config.Constants.SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
@@ -49,7 +49,7 @@ public class ExecutionPayloadGossipValidator {
   private final SigningRootUtil signingRootUtil;
 
   private final Set<BlockRootAndBuilderIndex> seenPayloads =
-      LimitedSet.createSynchronized(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+      LimitedSet.createSynchronized(SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -253,10 +253,13 @@ public class GossipValidationHelper {
     return maybeBlockHash.isPresent() && blockHash.equals(maybeBlockHash.get());
   }
 
+  public Optional<SignedExecutionPayloadEnvelope> getRecentlyImportedExecutionPayload(
+      final Bytes32 blockRoot) {
+    return recentChainData.getStore().getExecutionPayloadIfAvailable(blockRoot);
+  }
+
   public Optional<UInt64> getGasLimitForExecutionPayload(final Bytes32 blockRoot) {
-    return recentChainData
-        .getStore()
-        .getExecutionPayloadIfAvailable(blockRoot)
+    return getRecentlyImportedExecutionPayload(blockRoot)
         .map(SignedExecutionPayloadEnvelope::getMessage)
         .map(envelope -> envelope.getPayload().getGasLimit());
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -14,23 +14,16 @@
 package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
-import static tech.pegasys.teku.spec.config.Constants.RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
-import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.infrastructure.logging.LogCaptor;
@@ -110,73 +103,22 @@ class DefaultExecutionPayloadManagerTest {
     verify(receivedExecutionPayloadEventsChannelPublisher)
         .onExecutionPayloadImported(signedExecutionPayload, false);
     assertExecutionPayloadRecentlySeen(signedExecutionPayload);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
+    assertExecutionPayloadSeenBeforeDeadline(signedExecutionPayload);
   }
 
   @Test
-  public void shouldNotMarkExecutionPayloadAvailableWhenValidatedAtPayloadDueDeadline() {
+  public void shouldNotMarkExecutionPayloadSeenBeforeDeadlineWhenReceivedAfterTheDeadline() {
     givenValidationResult(signedExecutionPayload, ACCEPT);
     givenSuccessfulImport(signedExecutionPayload);
 
     final SafeFuture<InternalValidationResult> resultFuture =
-        validateAndImport(signedExecutionPayload, payloadDueDeadlineMillis(signedExecutionPayload));
+        validateAndImport(
+            signedExecutionPayload, payloadDueDeadlineMillis(signedExecutionPayload).plus(1));
 
     asyncRunner.executeDueActions();
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadNotAvailableForPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldThrowWhenStoreIsUnavailableForArrivalTimestampFallback() {
-    when(recentChainData.getStore()).thenReturn(null);
-
-    assertThatThrownBy(
-            () -> executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Store is unavailable while resolving execution payload arrival time");
-    verifyNoInteractions(executionPayloadGossipValidator);
-  }
-
-  @Test
-  public void shouldKeepExecutionPayloadAvailableWhenDuplicateArrivesAfterPayloadDueDeadline() {
-    givenValidationResult(signedExecutionPayload, ACCEPT);
-    givenSuccessfulImport(signedExecutionPayload);
-
-    final SafeFuture<InternalValidationResult> earlyResult =
-        validateAndImport(signedExecutionPayload, UInt64.ZERO);
-    final SafeFuture<InternalValidationResult> lateResult =
-        validateAndImport(signedExecutionPayload, payloadDueDeadlineMillis(signedExecutionPayload));
-
-    asyncRunner.executeDueActions();
-
-    assertThat(earlyResult).isCompletedWithValue(ACCEPT);
-    assertThat(lateResult).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldKeepExecutionPayloadAvailableWhenLaterDuplicateValidatesFirst() {
-    final SafeFuture<InternalValidationResult> earlyValidation = new SafeFuture<>();
-    final SafeFuture<InternalValidationResult> lateValidation = new SafeFuture<>();
-    givenValidationResults(signedExecutionPayload, earlyValidation, lateValidation);
-    givenSuccessfulImport(signedExecutionPayload);
-
-    final SafeFuture<InternalValidationResult> earlyResult =
-        validateAndImport(signedExecutionPayload, UInt64.ZERO);
-    final SafeFuture<InternalValidationResult> lateResult =
-        validateAndImport(signedExecutionPayload, payloadDueDeadlineMillis(signedExecutionPayload));
-
-    lateValidation.complete(ACCEPT);
-    asyncRunner.executeDueActions();
-
-    assertThat(lateResult).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
-
-    earlyValidation.complete(IGNORE);
-
-    assertThat(earlyResult).isCompletedWithValue(IGNORE);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
+    assertExecutionPayloadNotSeenBeforeDeadline(signedExecutionPayload);
   }
 
   @Test
@@ -220,8 +162,6 @@ class DefaultExecutionPayloadManagerTest {
     givenValidationResult(signedExecutionPayload, SAVE_FOR_FUTURE);
 
     validateAndImportAndJoin(signedExecutionPayload, UInt64.ZERO);
-    validateAndImportAndJoin(
-        signedExecutionPayload, payloadDueDeadlineMillis(signedExecutionPayload));
 
     asyncRunner.executeDueActions();
     verifyNoInteractions(receivedExecutionPayloadEventsChannelPublisher);
@@ -235,57 +175,7 @@ class DefaultExecutionPayloadManagerTest {
     verify(receivedExecutionPayloadEventsChannelPublisher)
         .onExecutionPayloadImported(signedExecutionPayload, false);
     assertThat(publishedExecutionPayload).hasValue(signedExecutionPayload);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldProcessLaterValidPendingExecutionPayloadWhenEarlierCandidateRejected() {
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
-    final SignedExecutionPayloadEnvelope invalidExecutionPayload =
-        signedExecutionPayloadForBlock(block);
-    final SignedExecutionPayloadEnvelope validExecutionPayload =
-        signedExecutionPayloadForBlock(block);
-    givenValidationResults(invalidExecutionPayload, SAVE_FOR_FUTURE, reject("invalid"));
-    givenValidationResults(validExecutionPayload, SAVE_FOR_FUTURE, ACCEPT);
-    givenSuccessfulImport(validExecutionPayload);
-
-    validateAndImportAndJoin(invalidExecutionPayload, UInt64.ZERO);
-    validateAndImportAndJoin(validExecutionPayload, UInt64.ONE);
-
-    executionPayloadManager.onBlockImported(block, false);
-    asyncRunner.executeDueActions();
-
-    verify(receivedExecutionPayloadEventsChannelPublisher)
-        .onExecutionPayloadImported(validExecutionPayload, false);
-    assertThat(publishedExecutionPayload).hasValue(validExecutionPayload);
-  }
-
-  @Test
-  public void shouldLimitPendingExecutionPayloadCandidatesForSameBlockAndBuilder() {
-    final int pendingPayloadLimit = RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE * 2;
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
-    final List<SignedExecutionPayloadEnvelope> executionPayloads =
-        IntStream.rangeClosed(0, pendingPayloadLimit)
-            .mapToObj(__ -> signedExecutionPayloadForBlock(block))
-            .toList();
-    executionPayloads.forEach(
-        executionPayload -> {
-          givenValidationResults(executionPayload, SAVE_FOR_FUTURE, ACCEPT);
-          givenSuccessfulImport(executionPayload);
-        });
-
-    for (int i = 0; i < executionPayloads.size(); i++) {
-      validateAndImportAndJoin(executionPayloads.get(i), UInt64.valueOf(i));
-    }
-
-    executionPayloadManager.onBlockImported(block, false);
-    asyncRunner.executeDueActions();
-
-    verify(executionPayloadGossipValidator, times(1)).validate(executionPayloads.get(0));
-    verify(forkChoice, never())
-        .onExecutionPayloadEnvelope(executionPayloads.get(0), executionLayer);
-    verify(executionPayloadGossipValidator, times(2)).validate(executionPayloads.get(1));
-    assertThat(publishedExecutionPayload).hasValue(executionPayloads.get(pendingPayloadLimit));
+    assertExecutionPayloadSeenBeforeDeadline(signedExecutionPayload);
   }
 
   private void givenValidationResult(
@@ -293,24 +183,6 @@ class DefaultExecutionPayloadManagerTest {
       final InternalValidationResult validationResult) {
     when(executionPayloadGossipValidator.validate(executionPayload))
         .thenReturn(completedFuture(validationResult));
-  }
-
-  private void givenValidationResults(
-      final SignedExecutionPayloadEnvelope executionPayload,
-      final InternalValidationResult firstResult,
-      final InternalValidationResult secondResult) {
-    when(executionPayloadGossipValidator.validate(executionPayload))
-        .thenReturn(completedFuture(firstResult))
-        .thenReturn(completedFuture(secondResult));
-  }
-
-  private void givenValidationResults(
-      final SignedExecutionPayloadEnvelope executionPayload,
-      final SafeFuture<InternalValidationResult> firstResult,
-      final SafeFuture<InternalValidationResult> secondResult) {
-    when(executionPayloadGossipValidator.validate(executionPayload))
-        .thenReturn(firstResult)
-        .thenReturn(secondResult);
   }
 
   private void givenSuccessfulImport(final SignedExecutionPayloadEnvelope executionPayload) {
@@ -361,18 +233,18 @@ class DefaultExecutionPayloadManagerTest {
         .isFalse();
   }
 
-  private void assertExecutionPayloadAvailableForPayloadAttestation(
+  private void assertExecutionPayloadSeenBeforeDeadline(
       final SignedExecutionPayloadEnvelope executionPayload) {
     assertThat(
-            executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(
+            executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(
                 executionPayload.getBeaconBlockRoot()))
         .isTrue();
   }
 
-  private void assertExecutionPayloadNotAvailableForPayloadAttestation(
+  private void assertExecutionPayloadNotSeenBeforeDeadline(
       final SignedExecutionPayloadEnvelope executionPayload) {
     assertThat(
-            executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(
+            executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(
                 executionPayload.getBeaconBlockRoot()))
         .isFalse();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -23,7 +24,9 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,8 +63,9 @@ class DefaultExecutionPayloadManagerTest {
       receivedExecutionPayloadEventsChannelPublisher =
           mock(ReceivedExecutionPayloadEventsChannel.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
-  private final UpdatableStore store = mock(UpdatableStore.class);
   private final Set<Bytes32> blockRootsWithInvalidExecutionPayload = new HashSet<>();
+  private final UpdatableStore store = mock(UpdatableStore.class);
+
   private Optional<SignedExecutionPayloadEnvelope> publishedExecutionPayload = Optional.empty();
 
   private final DefaultExecutionPayloadManager executionPayloadManager =
@@ -128,60 +132,6 @@ class DefaultExecutionPayloadManagerTest {
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
     assertExecutionPayloadNotSeenBeforeDeadline(signedExecutionPayload);
-    assertExecutionPayloadNotAvailableForPayloadAttestation(signedExecutionPayload);
-    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldThrowWhenStoreIsUnavailableForArrivalTimestampFallback() {
-    when(recentChainData.getStore()).thenReturn(null);
-
-    assertThatThrownBy(
-            () -> executionPayloadManager.validateAndImportExecutionPayload(signedExecutionPayload))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Store is unavailable while resolving execution payload arrival time");
-    verifyNoInteractions(executionPayloadGossipValidator);
-  }
-
-  @Test
-  public void shouldKeepExecutionPayloadAvailableWhenDuplicateArrivesAfterPayloadDueDeadline() {
-    givenValidationResult(signedExecutionPayload, ACCEPT);
-    givenSuccessfulImport(signedExecutionPayload);
-
-    final SafeFuture<InternalValidationResult> earlyResult =
-        validateAndImport(signedExecutionPayload, UInt64.ZERO);
-    final SafeFuture<InternalValidationResult> lateResult =
-        validateAndImport(signedExecutionPayload, payloadDueDeadlineMillis(signedExecutionPayload));
-
-    asyncRunner.executeDueActions();
-
-    assertThat(earlyResult).isCompletedWithValue(ACCEPT);
-    assertThat(lateResult).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldKeepExecutionPayloadAvailableWhenLaterDuplicateValidatesFirst() {
-    final SafeFuture<InternalValidationResult> earlyValidation = new SafeFuture<>();
-    final SafeFuture<InternalValidationResult> lateValidation = new SafeFuture<>();
-    givenValidationResults(signedExecutionPayload, earlyValidation, lateValidation);
-    givenSuccessfulImport(signedExecutionPayload);
-
-    final SafeFuture<InternalValidationResult> earlyResult =
-        validateAndImport(signedExecutionPayload, UInt64.ZERO);
-    final SafeFuture<InternalValidationResult> lateResult =
-        validateAndImport(signedExecutionPayload, payloadDueDeadlineMillis(signedExecutionPayload));
-
-    lateValidation.complete(ACCEPT);
-    asyncRunner.executeDueActions();
-
-    assertThat(lateResult).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
-
-    earlyValidation.complete(IGNORE);
-
-    assertThat(earlyResult).isCompletedWithValue(IGNORE);
-    assertExecutionPayloadAvailableForPayloadAttestation(signedExecutionPayload);
   }
 
   @Test
@@ -196,44 +146,6 @@ class DefaultExecutionPayloadManagerTest {
 
     verifyNoInteractions(forkChoice);
     assertThat(resultFuture).isCompletedWithValue(rejectedResult);
-    assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldReportExecutionPayloadSeenForFullPayloadAttestationWhenPresentInStore() {
-    when(recentChainData.containsExecutionPayload(signedExecutionPayload.getBeaconBlockRoot()))
-        .thenReturn(true);
-
-    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
-    assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
-    assertExecutionPayloadNotAvailableForPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldNotReportExecutionPayloadSeenForFullPayloadAttestationWhenStoreUnavailable() {
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldNotReportExecutionPayloadSeenForFullPayloadAttestationUntilImportCompletes() {
-    final SafeFuture<ExecutionPayloadImportResult> importResult = new SafeFuture<>();
-    givenValidationResult(signedExecutionPayload, ACCEPT);
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(importResult);
-
-    final SafeFuture<InternalValidationResult> resultFuture =
-        validateAndImport(signedExecutionPayload);
-
-    asyncRunner.executeDueActions();
-
-    assertThat(resultFuture).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadRecentlySeen(signedExecutionPayload);
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
-
-    importResult.complete(ExecutionPayloadImportResult.successful(signedExecutionPayload));
-
-    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test
@@ -251,100 +163,90 @@ class DefaultExecutionPayloadManagerTest {
     }
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test
-  public void shouldOnlyMarkExecutionPayloadRecentlySeenWhileFailedImportIsInProgress() {
-    givenValidationResult(signedExecutionPayload, ACCEPT);
-    final SafeFuture<ExecutionPayloadImportResult> importResult = new SafeFuture<>();
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(importResult);
+  public void shouldPreferPendingExecutionPayloadReceivedBeforeDeadlineOverEarlierLatePayload() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
+    final SignedExecutionPayloadEnvelope lateExecutionPayload =
+        signedExecutionPayloadForBlock(block);
+    final SignedExecutionPayloadEnvelope earlyExecutionPayload =
+        signedExecutionPayloadForBlock(block);
+    givenValidationResult(lateExecutionPayload, SAVE_FOR_FUTURE);
+    givenValidationResult(earlyExecutionPayload, SAVE_FOR_FUTURE);
 
-    final SafeFuture<InternalValidationResult> resultFuture =
-        validateAndImport(signedExecutionPayload);
+    validateAndImportAndJoin(
+        lateExecutionPayload, payloadDueDeadlineMillis(lateExecutionPayload).plus(1));
+    validateAndImportAndJoin(earlyExecutionPayload, UInt64.ZERO);
+
+    givenValidationResult(earlyExecutionPayload, ACCEPT);
+    givenSuccessfulImport(earlyExecutionPayload);
+    executionPayloadManager.onBlockImported(block, false);
 
     asyncRunner.executeDueActions();
 
-    assertThat(resultFuture).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadRecentlySeen(signedExecutionPayload);
-
-    importResult.complete(
-        ExecutionPayloadImportResult.failedDataAvailabilityCheckNotAvailable(Optional.empty()));
-
-    assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
+    verify(receivedExecutionPayloadEventsChannelPublisher)
+        .onExecutionPayloadImported(earlyExecutionPayload, false);
+    verify(forkChoice).onExecutionPayloadEnvelope(earlyExecutionPayload, executionLayer);
+    verify(forkChoice, never()).onExecutionPayloadEnvelope(lateExecutionPayload, executionLayer);
+    assertThat(publishedExecutionPayload).hasValue(earlyExecutionPayload);
+    assertExecutionPayloadSeenBeforeDeadline(earlyExecutionPayload);
   }
 
   @Test
-  public void shouldNotCacheInvalidExecutionPayloadWhenImportFailsExecution() {
-    final ExecutionPayloadImportResult failedImportResult =
-        ExecutionPayloadImportResult.failedExecution(new RuntimeException("execution failed"));
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(completedFuture(failedImportResult));
+  public void shouldNotReplacePendingExecutionPayloadReceivedBeforeDeadlineWithLatePayload() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
+    final SignedExecutionPayloadEnvelope earlyExecutionPayload =
+        signedExecutionPayloadForBlock(block);
+    final SignedExecutionPayloadEnvelope lateExecutionPayload =
+        signedExecutionPayloadForBlock(block);
+    givenValidationResult(earlyExecutionPayload, SAVE_FOR_FUTURE);
+    givenValidationResult(lateExecutionPayload, SAVE_FOR_FUTURE);
 
-    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
+    validateAndImportAndJoin(earlyExecutionPayload, UInt64.ZERO);
+    validateAndImportAndJoin(
+        lateExecutionPayload, payloadDueDeadlineMillis(lateExecutionPayload).plus(1));
+
+    givenValidationResult(earlyExecutionPayload, ACCEPT);
+    givenSuccessfulImport(earlyExecutionPayload);
+    executionPayloadManager.onBlockImported(block, false);
+
     asyncRunner.executeDueActions();
 
-    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
-    assertThat(blockRootsWithInvalidExecutionPayload)
-        .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+    verify(receivedExecutionPayloadEventsChannelPublisher)
+        .onExecutionPayloadImported(earlyExecutionPayload, false);
+    verify(forkChoice).onExecutionPayloadEnvelope(earlyExecutionPayload, executionLayer);
+    verify(forkChoice, never()).onExecutionPayloadEnvelope(lateExecutionPayload, executionLayer);
+    assertThat(publishedExecutionPayload).hasValue(earlyExecutionPayload);
+    assertExecutionPayloadSeenBeforeDeadline(earlyExecutionPayload);
   }
 
   @Test
-  public void shouldCacheInvalidExecutionPayloadWhenImportFailsVerification() {
-    final ExecutionPayloadImportResult failedImportResult =
-        ExecutionPayloadImportResult.failedVerification(new RuntimeException("invalid"));
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(completedFuture(failedImportResult));
+  public void shouldReplacePendingExecutionPayloadReceivedBeforeDeadlineWithLaterBeforeDeadline() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
+    final SignedExecutionPayloadEnvelope firstExecutionPayload =
+        signedExecutionPayloadForBlock(block);
+    final SignedExecutionPayloadEnvelope secondExecutionPayload =
+        signedExecutionPayloadForBlock(block);
+    givenValidationResult(firstExecutionPayload, SAVE_FOR_FUTURE);
+    givenValidationResult(secondExecutionPayload, SAVE_FOR_FUTURE);
 
-    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
+    validateAndImportAndJoin(firstExecutionPayload, UInt64.ZERO);
+    validateAndImportAndJoin(secondExecutionPayload, UInt64.ONE);
+
+    givenValidationResult(firstExecutionPayload, reject("unexpected"));
+    givenValidationResult(secondExecutionPayload, ACCEPT);
+    givenSuccessfulImport(secondExecutionPayload);
+    executionPayloadManager.onBlockImported(block, false);
+
     asyncRunner.executeDueActions();
 
-    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
-    assertThat(blockRootsWithInvalidExecutionPayload)
-        .contains(signedExecutionPayload.getBeaconBlockRoot());
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldCacheInvalidExecutionPayloadWhenDataAvailabilityCheckIsInvalid() {
-    final ExecutionPayloadImportResult failedImportResult =
-        ExecutionPayloadImportResult.failedDataAvailabilityCheckInvalid(
-            Optional.of(new RuntimeException("invalid")));
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(completedFuture(failedImportResult));
-
-    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
-    asyncRunner.executeDueActions();
-
-    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
-    assertThat(blockRootsWithInvalidExecutionPayload)
-        .contains(signedExecutionPayload.getBeaconBlockRoot());
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
-  }
-
-  @Test
-  public void shouldNotCacheInvalidExecutionPayloadWhenCommitmentNotVerified() {
-    final ExecutionPayloadImportResult failedImportResult =
-        ExecutionPayloadImportResult.failedVerification(new RuntimeException("invalid"));
-    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(completedFuture(failedImportResult));
-
-    // Imports that did not verify the payload commitment (e.g. sync or RPC-by-root) must not poison
-    // the invalid-payload cache, even when the import fails verification.
-    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload, false);
-    asyncRunner.executeDueActions();
-
-    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
-    assertThat(blockRootsWithInvalidExecutionPayload)
-        .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
-    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+    verify(receivedExecutionPayloadEventsChannelPublisher)
+        .onExecutionPayloadImported(secondExecutionPayload, false);
+    verify(forkChoice).onExecutionPayloadEnvelope(secondExecutionPayload, executionLayer);
+    verify(forkChoice, never()).onExecutionPayloadEnvelope(firstExecutionPayload, executionLayer);
+    assertThat(publishedExecutionPayload).hasValue(secondExecutionPayload);
+    assertExecutionPayloadSeenBeforeDeadline(secondExecutionPayload);
   }
 
   @Test
@@ -369,6 +271,57 @@ class DefaultExecutionPayloadManagerTest {
         .onExecutionPayloadImported(signedExecutionPayload, false);
     assertThat(publishedExecutionPayload).hasValue(signedExecutionPayload);
     assertExecutionPayloadSeenBeforeDeadline(signedExecutionPayload);
+  }
+
+  @Test
+  public void shouldCacheInvalidExecutionPayloadWhenImportFailsVerification() {
+    final ExecutionPayloadImportResult failedImportResult =
+        ExecutionPayloadImportResult.failedVerification(new RuntimeException("invalid"));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(completedFuture(failedImportResult));
+
+    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
+    asyncRunner.executeDueActions();
+
+    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
+    assertThat(blockRootsWithInvalidExecutionPayload)
+        .contains(signedExecutionPayload.getBeaconBlockRoot());
+  }
+
+  @Test
+  public void shouldCacheInvalidExecutionPayloadWhenDataAvailabilityCheckIsInvalid() {
+    final ExecutionPayloadImportResult failedImportResult =
+        ExecutionPayloadImportResult.failedDataAvailabilityCheckInvalid(
+            Optional.of(new RuntimeException("invalid")));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(completedFuture(failedImportResult));
+
+    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
+    asyncRunner.executeDueActions();
+
+    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
+    assertThat(blockRootsWithInvalidExecutionPayload)
+        .contains(signedExecutionPayload.getBeaconBlockRoot());
+  }
+
+  @Test
+  public void shouldNotCacheInvalidExecutionPayloadWhenCommitmentNotVerified() {
+    final ExecutionPayloadImportResult failedImportResult =
+        ExecutionPayloadImportResult.failedVerification(new RuntimeException("invalid"));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(completedFuture(failedImportResult));
+
+    // Imports that did not verify the payload commitment (e.g. sync or RPC-by-root) must not poison
+    // the invalid-payload cache, even when the import fails verification.
+    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload, false);
+    asyncRunner.executeDueActions();
+
+    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
+    assertThat(blockRootsWithInvalidExecutionPayload)
+        .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
   }
 
   private void givenValidationResult(
@@ -422,22 +375,6 @@ class DefaultExecutionPayloadManagerTest {
       final SignedExecutionPayloadEnvelope executionPayload) {
     assertThat(
             executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(
-                executionPayload.getBeaconBlockRoot()))
-        .isFalse();
-  }
-
-  private void assertExecutionPayloadSeenForFullPayloadAttestation(
-      final SignedExecutionPayloadEnvelope executionPayload) {
-    assertThat(
-            executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
-                executionPayload.getBeaconBlockRoot()))
-        .isTrue();
-  }
-
-  private void assertExecutionPayloadNotSeenForFullPayloadAttestation(
-      final SignedExecutionPayloadEnvelope executionPayload) {
-    assertThat(
-            executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
                 executionPayload.getBeaconBlockRoot()))
         .isFalse();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.infrastructure.logging.LogCaptor;
@@ -87,6 +88,13 @@ class DefaultExecutionPayloadManagerTest {
   }
 
   @Test
+  public void shouldDelegateIsExecutionPayloadRecentlySeenToTheGossipValidator() {
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    when(executionPayloadGossipValidator.isPayloadSeen(beaconBlockRoot)).thenReturn(true);
+    assertThat(executionPayloadManager.isExecutionPayloadRecentlySeen(beaconBlockRoot)).isTrue();
+  }
+
+  @Test
   public void shouldValidateAndImport() {
     givenValidationResult(signedExecutionPayload, ACCEPT);
     givenSuccessfulImport(signedExecutionPayload);
@@ -102,7 +110,6 @@ class DefaultExecutionPayloadManagerTest {
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
     verify(receivedExecutionPayloadEventsChannelPublisher)
         .onExecutionPayloadImported(signedExecutionPayload, false);
-    assertExecutionPayloadRecentlySeen(signedExecutionPayload);
     assertExecutionPayloadSeenBeforeDeadline(signedExecutionPayload);
   }
 
@@ -133,7 +140,6 @@ class DefaultExecutionPayloadManagerTest {
 
     verifyNoInteractions(forkChoice);
     assertThat(resultFuture).isCompletedWithValue(rejectedResult);
-    assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
   }
 
   @Test
@@ -151,7 +157,6 @@ class DefaultExecutionPayloadManagerTest {
     }
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadRecentlySeen(signedExecutionPayload);
   }
 
   @Test
@@ -215,22 +220,6 @@ class DefaultExecutionPayloadManagerTest {
   private SignedExecutionPayloadEnvelope signedExecutionPayloadForBlock(
       final SignedBeaconBlock block) {
     return dataStructureUtil.randomSignedExecutionPayloadEnvelopeForBlock(block);
-  }
-
-  private void assertExecutionPayloadRecentlySeen(
-      final SignedExecutionPayloadEnvelope executionPayload) {
-    assertThat(
-            executionPayloadManager.isExecutionPayloadRecentlySeen(
-                executionPayload.getBeaconBlockRoot()))
-        .isTrue();
-  }
-
-  private void assertExecutionPayloadNotRecentlySeen(
-      final SignedExecutionPayloadEnvelope executionPayload) {
-    assertThat(
-            executionPayloadManager.isExecutionPayloadRecentlySeen(
-                executionPayload.getBeaconBlockRoot()))
-        .isFalse();
   }
 
   private void assertExecutionPayloadSeenBeforeDeadline(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
@@ -166,12 +166,7 @@ public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTe
 
     final AttestationValidator validator =
         new AttestationValidator(
-            spec,
-            signatureVerifier,
-            gossipValidationHelper,
-            invalidBlockRoots,
-            Set.of(),
-            __ -> false);
+            spec, signatureVerifier, gossipValidationHelper, invalidBlockRoots, Set.of());
 
     assertThat(validator.validate(ValidatableAttestation.fromNetwork(spec, attestation, 0)))
         .isCompletedWithValue(InternalValidationResult.SAVE_FOR_FUTURE);
@@ -192,8 +187,7 @@ public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTe
             signatureVerifier,
             gossipValidationHelper,
             invalidBlockRoots,
-            blockRootsWithInvalidExecutionPayload,
-            __ -> true);
+            blockRootsWithInvalidExecutionPayload);
 
     assertThat(validator.validate(ValidatableAttestation.fromNetwork(spec, attestation, 0)))
         .matches(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1910,11 +1910,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             signatureVerificationService,
             gossipValidationHelper,
             invalidBlockRoots,
-            blockRootsWithInvalidExecutionPayload,
-            blockRoot ->
-                executionPayloadManager != null
-                    && executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
-                        blockRoot));
+            blockRootsWithInvalidExecutionPayload);
     AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(spec, attestationValidator, signatureVerificationService);
     blockImporter.subscribeToVerifiedBlockAttestations(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Also made `AttestationValidator` use recent chain data from GossipValidationHelper to determine if payload has been recently imported, I don't see the big point of caching in this case, since recent chain data is also a map with O(1) access.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Gloas execution-payload timing, pending selection, and full-payload attestation validation paths; behavior shifts from manager caches to gossip validator and store lookups.
> 
> **Overview**
> Simplifies **Gloas/EPBS execution payload** tracking by trimming `DefaultExecutionPayloadManager` and aligning naming with protocol semantics.
> 
> **`ExecutionPayloadManager`** drops `isExecutionPayloadAvailableForPayloadAttestation` / `isExecutionPayloadSeenForFullPayloadAttestation` in favor of **`isExecutionPayloadSeenBeforeDeadline`** for `payload_present` voting. **`isExecutionPayloadRecentlySeen`** now delegates to **`ExecutionPayloadGossipValidator.isPayloadSeen`** instead of a separate manager cache. Several internal sets (recent seen, successfully imported, accepted envelope roots, arrival timestamps) are removed; **`RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE`** is renamed to **`VALID_EXECUTION_PAYLOADS_SET_SIZE`**.
> 
> **Pending payloads** change from merging many candidates per block/builder to **one** entry, chosen by preferring arrivals before payload due (DoS mitigation). **IGNORE** handling no longer records early availability from duplicate accepts. Failed imports no longer roll back “recently seen” state.
> 
> **Full-payload attestation gossip** no longer injects a predicate from `ExecutionPayloadManager`; **`AttestationValidator`** uses **`GossipValidationHelper.getRecentlyImportedExecutionPayload`** (store lookup) to decide SAVE_FOR_FUTURE vs proceed. **`ValidatorApiHandler`** uses the renamed deadline API for payload attestation data.
> 
> Tests and wiring (reference tests, integration test, `BeaconChainController`) are updated for the slimmer **`AttestationValidator`** constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4cb436f33254c709a19fdce39051b072a13d648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->