### PR TITLE
Upgrade ref tests to v1.7.0-alpha.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -407,7 +407,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.9"
+def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.10"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -75,11 +75,7 @@ public class ReferenceTestFinder {
                               "gloas - minimal - fork_choice/reorg - include_votes_another_empty_chain_with_enough_ffg_votes_previous_epoch",
                               "gloas - minimal - fork_choice/reorg - simple_attempted_reorg_without_enough_ffg_votes",
                               "gloas - minimal - fork_choice/reorg - include_votes_another_empty_chain_with_enough_ffg_votes_current_epoch",
-                              "gloas - minimal - fork_choice/reorg - include_votes_another_empty_chain_without_enough_ffg_votes_current_epoch",
-                              // TODO: Will be fixed in a new consensus-specs release see
-                              // https://discordapp.com/channels/595666850260713488/1511390998456963304
-                              "fulu - minimal - transition/core",
-                              "fulu - mainnet - transition/core")),
+                              "gloas - minimal - fork_choice/reorg - include_votes_another_empty_chain_without_enough_ffg_votes_current_epoch")),
                       new MerkleProofTestFinder())
                   .flatMap(unchecked(finder -> finder.findTests(fork, spec, testsPath)));
             });

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.9
+version: v1.7.0-alpha.10
 style: full
 
 specrefs:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.10

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only version pin and exclusion-list cleanup; no production consensus or networking code changes.
> 
> **Overview**
> Bumps Teku’s **consensus-specs** reference test bundle from **v1.7.0-alpha.9** to **v1.7.0-alpha.10** in `build.gradle` (stable download path) and `specrefs/.ethspecify.yml`.
> 
> Because the new vectors are expected to pass, this PR **stops excluding** two **Fulu** `transition/core` tests (minimal and mainnet) from the pyspec reference test finder. The **Gloas** fork-choice reorg exclusion list is unchanged aside from formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37383df691010723740691614fc5ae86ef68bb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->