### PR TITLE
Updated jvm-libp2p to 1.3.1

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -37,7 +37,7 @@ dependencyManagement {
 			entry 'javalin-rendering-thymeleaf'
 		}
 
-		dependency 'io.libp2p:jvm-libp2p:1.3.0-RELEASE'
+		dependency 'io.libp2p:jvm-libp2p:1.3.1-RELEASE'
 		dependency 'tech.pegasys:jblst:0.3.15'
 		dependency 'io.consensys.protocols:jc-kzg-4844:2.1.6'
 		dependency 'io.github.crate-crypto:java-eth-kzg:0.10.0'


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> libp2p underpins beacon node P2P networking; a patch library upgrade can still affect peer connectivity or gossip behavior without application code changes.
> 
> **Overview**
> Bumps the centrally managed **`io.libp2p:jvm-libp2p`** dependency from **1.3.0-RELEASE** to **1.3.1-RELEASE** in `gradle/versions.gradle`. Modules that declare `io.libp2p:jvm-libp2p` without a version (for example acceptance test fixtures) will resolve to the new release on the next build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7b046e00576f3cdfa9e36a8cbf919958f26f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->