### PR TITLE
update block gossip validation when execution payload is delayed

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -144,7 +144,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
 
     if (!miscHelpersGloas.isExecutionPayloadBidForFullParent(state, bid)) {
       // Parent was EMPTY -- no execution requests expected
-      if (!miscHelpersGloas.isDefaultExecutionRequests(requests)) {
+      if (!miscHelpersGloas.isEmptyExecutionRequests(requests)) {
         throw new BlockProcessingException(
             "No execution requests were expected for an EMPTY parent");
       }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -140,12 +140,11 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
     final BeaconBlockBodyGloas body = BeaconBlockBodyGloas.required(beaconBlock.getBody());
     final ExecutionPayloadBid bid = body.getSignedExecutionPayloadBid().getMessage();
-    final ExecutionPayloadBid parentBid = stateGloas.getLatestExecutionPayloadBid();
     final ExecutionRequests requests = body.getParentExecutionRequests();
 
-    if (!bid.getParentBlockHash().equals(parentBid.getBlockHash())) {
+    if (!miscHelpersGloas.isExecutionPayloadBidForFullParent(state, bid)) {
       // Parent was EMPTY -- no execution requests expected
-      if (!requests.equals(schemaDefinitionsGloas.getExecutionRequestsSchema().getDefault())) {
+      if (!miscHelpersGloas.isDefaultExecutionRequests(requests)) {
         throw new BlockProcessingException(
             "No execution requests were expected for an EMPTY parent");
       }
@@ -153,7 +152,8 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     }
 
     // Parent was FULL -- verify the bid commitment and apply the payload
-    if (!requests.hashTreeRoot().equals(parentBid.getExecutionRequestsRoot())) {
+    if (!miscHelpersGloas.isExecutionRequestsRootMatchingLatestExecutionPayloadBid(
+        state, requests)) {
       throw new BlockProcessingException(
           "The execution requests root in the latest committed bid does not match the parent execution requests in the block");
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -257,7 +257,7 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
         .equals(BeaconStateGloas.required(state).getLatestExecutionPayloadBid().getBlockHash());
   }
 
-  public boolean isDefaultExecutionRequests(final ExecutionRequests executionRequests) {
+  public boolean isEmptyExecutionRequests(final ExecutionRequests executionRequests) {
     return executionRequests.equals(
         schemaDefinitionsGloas.getExecutionRequestsSchema().getDefault());
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -245,7 +245,10 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
 
   public boolean isExecutionPayloadBidForEmptyParent(
       final BeaconState state, final ExecutionPayloadBid bid) {
-    return bid.getParentBlockHash().equals(BeaconStateGloas.required(state).getLatestBlockHash());
+    final BeaconStateGloas stateGloas = BeaconStateGloas.required(state);
+    return bid.getParentBlockHash().equals(stateGloas.getLatestBlockHash())
+        && !bid.getParentBlockHash()
+            .equals(stateGloas.getLatestExecutionPayloadBid().getBlockHash());
   }
 
   public boolean isExecutionPayloadBidForFullParent(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -43,11 +43,14 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.MatrixEntry;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.BlobAndCellProofs;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
@@ -238,6 +241,32 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
 
   public boolean isActiveBuilder(final BeaconState state, final UInt64 builderIndex) {
     return predicates.isActiveBuilder(state, builderIndex);
+  }
+
+  public boolean isExecutionPayloadBidForEmptyParent(
+      final BeaconState state, final ExecutionPayloadBid bid) {
+    return bid.getParentBlockHash().equals(BeaconStateGloas.required(state).getLatestBlockHash());
+  }
+
+  public boolean isExecutionPayloadBidForFullParent(
+      final BeaconState state, final ExecutionPayloadBid bid) {
+    return bid.getParentBlockHash()
+        .equals(BeaconStateGloas.required(state).getLatestExecutionPayloadBid().getBlockHash());
+  }
+
+  public boolean isDefaultExecutionRequests(final ExecutionRequests executionRequests) {
+    return executionRequests.equals(
+        schemaDefinitionsGloas.getExecutionRequestsSchema().getDefault());
+  }
+
+  public boolean isExecutionRequestsRootMatchingLatestExecutionPayloadBid(
+      final BeaconState state, final ExecutionRequests executionRequests) {
+    return executionRequests
+        .hashTreeRoot()
+        .equals(
+            BeaconStateGloas.required(state)
+                .getLatestExecutionPayloadBid()
+                .getExecutionRequestsRoot());
   }
 
   // Check if a pending deposit with a valid signature is in the queue for the given pubkey.

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloasTest.java
@@ -15,14 +15,20 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class MiscHelpersGloasTest {
 
   private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil data = new DataStructureUtil(spec);
 
   private final MiscHelpersGloas miscHelpers =
       MiscHelpersGloas.required(spec.getGenesisSpec().miscHelpers());
@@ -37,5 +43,35 @@ public class MiscHelpersGloasTest {
     assertThat(predicates.isBuilderIndex(validatorIndex)).isTrue();
     assertThat(miscHelpers.convertValidatorIndexToBuilderIndex(validatorIndex))
         .isEqualTo(builderIndex);
+  }
+
+  @Test
+  public void isExecutionPayloadBidForEmptyParent_shouldBeFalseWhenBidAlsoMatchesFullParent() {
+    final Bytes32 fullParentBlockHash = data.randomBytes32();
+    final ExecutionPayloadBid latestExecutionPayloadBid =
+        data.randomExecutionPayloadBid(
+            data.randomSlot(),
+            data.randomBuilderIndex(),
+            fullParentBlockHash,
+            data.randomBytes32());
+    final BeaconState state =
+        data.randomBeaconState()
+            .updated(
+                mutableState -> {
+                  final MutableBeaconStateGloas stateGloas =
+                      MutableBeaconStateGloas.required(mutableState);
+                  stateGloas.setLatestBlockHash(fullParentBlockHash);
+                  stateGloas.setLatestExecutionPayloadBid(latestExecutionPayloadBid);
+                });
+    final ExecutionPayloadBid childBid =
+        data.randomExecutionPayloadBid(
+            fullParentBlockHash,
+            data.randomSlot(),
+            data.randomBuilderIndex(),
+            UInt64.ZERO,
+            UInt64.ZERO);
+
+    assertThat(miscHelpers.isExecutionPayloadBidForFullParent(state, childBid)).isTrue();
+    assertThat(miscHelpers.isExecutionPayloadBidForEmptyParent(state, childBid)).isFalse();
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -309,15 +309,9 @@ public class BlockGossipValidator {
     }
 
     final ExecutionRequests parentExecutionRequests = maybeParentExecutionRequests.get();
-    // Gloas process_parent_execution_payload treats a parent as EMPTY unless the child bid
-    // references the latest committed FULL parent bid. EMPTY parents have no payload to wait for.
-    if (miscHelpersGloas.isExecutionPayloadBidForEmptyParent(parentState, executionPayloadBid)) {
-      if (!miscHelpersGloas.isDefaultExecutionRequests(parentExecutionRequests)) {
-        return Optional.of(reject("No execution requests were expected for an EMPTY parent"));
-      }
-      return Optional.empty();
-    }
-
+    // Gloas process_parent_execution_payload treats a parent as FULL when the child bid references
+    // the latest committed FULL parent bid. Check this before EMPTY because the FULL bid hash can
+    // equal latest_block_hash at Gloas genesis or fork transition.
     if (miscHelpersGloas.isExecutionPayloadBidForFullParent(parentState, executionPayloadBid)) {
       if (!miscHelpersGloas.isExecutionRequestsRootMatchingLatestExecutionPayloadBid(
           parentState, parentExecutionRequests)) {
@@ -330,6 +324,13 @@ public class BlockGossipValidator {
               executionPayloadBid.getParentBlockHash(), block.getParentRoot());
       if (!parentExecutionPayloadKnown) {
         return Optional.of(InternalValidationResult.SAVE_FOR_FUTURE);
+      }
+      return Optional.empty();
+    }
+
+    if (miscHelpersGloas.isExecutionPayloadBidForEmptyParent(parentState, executionPayloadBid)) {
+      if (!miscHelpersGloas.isDefaultExecutionRequests(parentExecutionRequests)) {
+        return Optional.of(reject("No execution requests were expected for an EMPTY parent"));
       }
       return Optional.empty();
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -293,18 +293,8 @@ public class BlockGossipValidator {
       final SignedBeaconBlock block,
       final BeaconState parentState,
       final ExecutionPayloadBid executionPayloadBid) {
-    return validateExecutionPayloadBidParent(
-        block,
-        parentState,
-        executionPayloadBid,
-        MiscHelpersGloas.required(spec.atSlot(block.getSlot()).miscHelpers()));
-  }
-
-  private Optional<InternalValidationResult> validateExecutionPayloadBidParent(
-      final SignedBeaconBlock block,
-      final BeaconState parentState,
-      final ExecutionPayloadBid executionPayloadBid,
-      final MiscHelpersGloas miscHelpersGloas) {
+    final MiscHelpersGloas miscHelpersGloas =
+        MiscHelpersGloas.required(spec.atSlot(block.getSlot()).miscHelpers());
     final Optional<ExecutionRequests> maybeParentExecutionRequests =
         block.getMessage().getBody().getOptionalParentExecutionRequests();
     if (maybeParentExecutionRequests.isEmpty()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -293,14 +293,14 @@ public class BlockGossipValidator {
       final SignedBeaconBlock block,
       final BeaconState parentState,
       final ExecutionPayloadBid executionPayloadBid) {
-    return validateGloasExecutionPayloadBidParent(
+    return validateExecutionPayloadBidParent(
         block,
         parentState,
         executionPayloadBid,
         MiscHelpersGloas.required(spec.atSlot(block.getSlot()).miscHelpers()));
   }
 
-  private Optional<InternalValidationResult> validateGloasExecutionPayloadBidParent(
+  private Optional<InternalValidationResult> validateExecutionPayloadBidParent(
       final SignedBeaconBlock block,
       final BeaconState parentState,
       final ExecutionPayloadBid executionPayloadBid,
@@ -332,7 +332,7 @@ public class BlockGossipValidator {
     }
 
     if (miscHelpersGloas.isExecutionPayloadBidForEmptyParent(parentState, executionPayloadBid)) {
-      if (!miscHelpersGloas.isDefaultExecutionRequests(parentExecutionRequests)) {
+      if (!miscHelpersGloas.isEmptyExecutionRequests(parentExecutionRequests)) {
         return Optional.of(reject("No execution requests were expected for an EMPTY parent"));
       }
       return Optional.empty();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -34,15 +34,15 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
 import tech.pegasys.teku.spec.signatures.SigningRootUtil;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 
@@ -188,15 +188,12 @@ public class BlockGossipValidator {
     return gossipValidationHelper
         .getParentStateInBlockEpoch(parentBlockSlot, block.getParentRoot(), block.getSlot())
         .thenApply(
-            maybeParentState ->
-                performStatefulValidation(
-                    block, maybeParentState, parentBlockSlot, markAsReceived));
+            maybeParentState -> performStatefulValidation(block, maybeParentState, markAsReceived));
   }
 
   private InternalValidationResult performStatefulValidation(
       final SignedBeaconBlock block,
       final Optional<BeaconState> maybeParentState,
-      final UInt64 parentBlockSlot,
       final boolean markAsReceived) {
 
     if (maybeParentState.isEmpty()) {
@@ -251,20 +248,10 @@ public class BlockGossipValidator {
             executionPayloadBid.getParentBlockRoot(), block.getParentRoot());
       }
 
-      /*
-       * If execution_payload verification of block's execution payload parent by an execution node is complete:
-       * [REJECT] The block's execution payload parent (defined by bid.parent_block_hash) passes all validation
-       */
-      if (!gossipValidationHelper.isBlockHashKnown(
-          executionPayloadBid.getParentBlockHash(), block.getParentRoot())) {
-        if (isParentFullPayloadDependency(parentBlockSlot, parentState, executionPayloadBid)) {
-          LOG.trace(
-              "Block requires parent execution payload that is not available. Saving for future processing.");
-          return InternalValidationResult.SAVE_FOR_FUTURE;
-        }
-        return reject(
-            "The parent block hash %s from the bid is not present or hasn't been passed validation",
-            executionPayloadBid.getParentBlockHash());
+      final Optional<InternalValidationResult> maybeParentExecutionPayloadValidationResult =
+          validateExecutionPayloadBidParent(block, parentState, executionPayloadBid);
+      if (maybeParentExecutionPayloadValidationResult.isPresent()) {
+        return maybeParentExecutionPayloadValidationResult.get();
       }
     }
 
@@ -296,18 +283,77 @@ public class BlockGossipValidator {
     };
   }
 
-  private boolean isParentFullPayloadDependency(
-      final UInt64 parentBlockSlot,
+  private Optional<InternalValidationResult> validateExecutionPayloadBidParent(
+      final SignedBeaconBlock block,
       final BeaconState parentState,
       final ExecutionPayloadBid executionPayloadBid) {
-    if (spec.atSlot(parentBlockSlot).getMilestone().isLessThan(SpecMilestone.GLOAS)) {
-      return false;
-    }
-    return parentState
+    return spec.atSlot(parentState.getSlot())
+        .miscHelpers()
         .toVersionGloas()
-        .map(BeaconStateGloas::getLatestExecutionPayloadBid)
-        .map(parentBid -> parentBid.getBlockHash().equals(executionPayloadBid.getParentBlockHash()))
-        .orElse(false);
+        .map(
+            miscHelpersGloas ->
+                validateGloasExecutionPayloadBidParent(
+                    block, parentState, executionPayloadBid, miscHelpersGloas))
+        .orElseGet(() -> validateKnownParentBlockHash(executionPayloadBid, block.getParentRoot()));
+  }
+
+  private Optional<InternalValidationResult> validateGloasExecutionPayloadBidParent(
+      final SignedBeaconBlock block,
+      final BeaconState parentState,
+      final ExecutionPayloadBid executionPayloadBid,
+      final MiscHelpersGloas miscHelpersGloas) {
+    final Optional<ExecutionRequests> maybeParentExecutionRequests =
+        block.getMessage().getBody().getOptionalParentExecutionRequests();
+    if (maybeParentExecutionRequests.isEmpty()) {
+      return Optional.of(reject("Missing parent execution requests"));
+    }
+
+    final ExecutionRequests parentExecutionRequests = maybeParentExecutionRequests.get();
+    // Gloas process_parent_execution_payload treats a parent as EMPTY unless the child bid
+    // references the latest committed FULL parent bid. EMPTY parents have no payload to wait for.
+    if (miscHelpersGloas.isExecutionPayloadBidForEmptyParent(parentState, executionPayloadBid)) {
+      if (!miscHelpersGloas.isDefaultExecutionRequests(parentExecutionRequests)) {
+        return Optional.of(reject("No execution requests were expected for an EMPTY parent"));
+      }
+      return Optional.empty();
+    }
+
+    if (miscHelpersGloas.isExecutionPayloadBidForFullParent(parentState, executionPayloadBid)) {
+      if (!miscHelpersGloas.isExecutionRequestsRootMatchingLatestExecutionPayloadBid(
+          parentState, parentExecutionRequests)) {
+        return Optional.of(
+            reject(
+                "The execution requests root in the latest committed bid does not match the parent execution requests in the block"));
+      }
+      final boolean parentExecutionPayloadKnown =
+          gossipValidationHelper.isBlockHashKnown(
+              executionPayloadBid.getParentBlockHash(), block.getParentRoot());
+      if (!parentExecutionPayloadKnown) {
+        return Optional.of(InternalValidationResult.SAVE_FOR_FUTURE);
+      }
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        reject(
+            "The parent block hash %s from the bid is not present or hasn't been passed validation",
+            executionPayloadBid.getParentBlockHash()));
+  }
+
+  private Optional<InternalValidationResult> validateKnownParentBlockHash(
+      final ExecutionPayloadBid executionPayloadBid, final Bytes32 parentBlockRoot) {
+    /*
+     * If execution_payload verification of block's execution payload parent by an execution node is complete:
+     * [REJECT] The block's execution payload parent (defined by bid.parent_block_hash) passes all validation
+     */
+    if (gossipValidationHelper.isBlockHashKnown(
+        executionPayloadBid.getParentBlockHash(), parentBlockRoot)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        reject(
+            "The parent block hash %s from the bid is not present or hasn't been passed validation",
+            executionPayloadBid.getParentBlockHash()));
   }
 
   synchronized EquivocationCheckResult performBlockEquivocationCheck(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
@@ -248,6 +248,12 @@ public class BlockGossipValidator {
             executionPayloadBid.getParentBlockRoot(), block.getParentRoot());
       }
 
+      /*
+       * [REJECT] The block's execution payload parent (defined by bid.parent_block_hash) passes
+       * validation.
+       * Gloas distinguishes EMPTY parents from FULL parents whose payload may arrive
+       * later, so this may also SAVE_FOR_FUTURE while waiting for the parent execution payload.
+       */
       final Optional<InternalValidationResult> maybeParentExecutionPayloadValidationResult =
           validateExecutionPayloadBidParent(block, parentState, executionPayloadBid);
       if (maybeParentExecutionPayloadValidationResult.isPresent()) {
@@ -287,14 +293,11 @@ public class BlockGossipValidator {
       final SignedBeaconBlock block,
       final BeaconState parentState,
       final ExecutionPayloadBid executionPayloadBid) {
-    return spec.atSlot(parentState.getSlot())
-        .miscHelpers()
-        .toVersionGloas()
-        .map(
-            miscHelpersGloas ->
-                validateGloasExecutionPayloadBidParent(
-                    block, parentState, executionPayloadBid, miscHelpersGloas))
-        .orElseGet(() -> validateKnownParentBlockHash(executionPayloadBid, block.getParentRoot()));
+    return validateGloasExecutionPayloadBidParent(
+        block,
+        parentState,
+        executionPayloadBid,
+        MiscHelpersGloas.required(spec.atSlot(block.getSlot()).miscHelpers()));
   }
 
   private Optional<InternalValidationResult> validateGloasExecutionPayloadBidParent(
@@ -335,22 +338,6 @@ public class BlockGossipValidator {
       return Optional.empty();
     }
 
-    return Optional.of(
-        reject(
-            "The parent block hash %s from the bid is not present or hasn't been passed validation",
-            executionPayloadBid.getParentBlockHash()));
-  }
-
-  private Optional<InternalValidationResult> validateKnownParentBlockHash(
-      final ExecutionPayloadBid executionPayloadBid, final Bytes32 parentBlockRoot) {
-    /*
-     * If execution_payload verification of block's execution payload parent by an execution node is complete:
-     * [REJECT] The block's execution payload parent (defined by bid.parent_block_hash) passes all validation
-     */
-    if (gossipValidationHelper.isBlockHashKnown(
-        executionPayloadBid.getParentBlockHash(), parentBlockRoot)) {
-      return Optional.empty();
-    }
     return Optional.of(
         reject(
             "The parent block hash %s from the bid is not present or hasn't been passed validation",

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloa
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -482,6 +483,69 @@ public class BlockGossipValidatorTest {
         storageSystem.chainBuilder().generateBlockAtSlot(childSlot);
     storageSystem.chainUpdater().setCurrentSlot(childSlot);
 
+    assertThat(blockGossipValidator.validate(childBlockAndState.getBlock(), true))
+        .isCompletedWithValueMatching(InternalValidationResult::isSaveForFuture);
+  }
+
+  @TestTemplate
+  void shouldSaveForFutureWhenParentFullPayloadHashAlsoMatchesLatestBlockHash(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+
+    final UInt64 parentSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState parentBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(parentSlot);
+    final ExecutionPayloadBid parentBid =
+        parentBlockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .orElseThrow()
+            .getMessage();
+    final SignedBlockAndState parentBlockAndStateWithOverlappingPayloadHashes =
+        new SignedBlockAndState(
+            parentBlockAndState.getBlock(),
+            parentBlockAndState
+                .getState()
+                .updated(
+                    state ->
+                        MutableBeaconStateGloas.required(state)
+                            .setLatestBlockHash(parentBid.getBlockHash())));
+    storageSystem.chainUpdater().saveBlock(parentBlockAndStateWithOverlappingPayloadHashes);
+
+    final UInt64 childSlot = parentSlot.plus(ONE);
+    final SignedBlockAndState childBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(childSlot);
+    final ExecutionPayloadBid childBid =
+        childBlockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .orElseThrow()
+            .getMessage();
+    final ExecutionRequests parentExecutionRequests =
+        childBlockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalParentExecutionRequests()
+            .orElseThrow();
+    final ExecutionRequests defaultParentExecutionRequests =
+        SchemaDefinitionsGloas.required(spec.atSlot(childSlot).getSchemaDefinitions())
+            .getExecutionRequestsSchema()
+            .getDefault();
+    storageSystem.chainUpdater().setCurrentSlot(childSlot);
+
+    assertThat(childBid.getParentBlockHash()).isEqualTo(parentBid.getBlockHash());
+    assertThat(
+            BeaconStateGloas.required(parentBlockAndStateWithOverlappingPayloadHashes.getState())
+                .getLatestBlockHash())
+        .isEqualTo(parentBid.getBlockHash());
+    assertThat(parentExecutionRequests.hashTreeRoot())
+        .isEqualTo(parentBid.getExecutionRequestsRoot());
+    assertThat(parentExecutionRequests).isNotEqualTo(defaultParentExecutionRequests);
     assertThat(blockGossipValidator.validate(childBlockAndState.getBlock(), true))
         .isCompletedWithValueMatching(InternalValidationResult::isSaveForFuture);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -40,9 +40,12 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyBuilderGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
@@ -484,6 +487,145 @@ public class BlockGossipValidatorTest {
   }
 
   @TestTemplate
+  void shouldAcceptGloasBlockBuildingOnEmptyParentWhenParentFullPayloadIsAvailable(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+
+    final UInt64 parentSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState parentBlockAndState =
+        storageSystem.chainUpdater().advanceChain(parentSlot);
+    final ExecutionPayloadBid parentBid =
+        parentBlockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .orElseThrow()
+            .getMessage();
+    final Bytes32 parentEmptyExecutionBlockHash =
+        BeaconStateGloas.required(parentBlockAndState.getState()).getLatestBlockHash();
+
+    final UInt64 childSlot = parentSlot.plus(ONE);
+    final SignedBlockAndState childBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(childSlot);
+    final ExecutionRequests defaultParentExecutionRequests =
+        SchemaDefinitionsGloas.required(spec.atSlot(childSlot).getSchemaDefinitions())
+            .getExecutionRequestsSchema()
+            .getDefault();
+    final SignedBeaconBlock emptyParentChildBlock =
+        createBlockWithModifiedExecutionPayloadBid(
+            childBlockAndState,
+            originalExecutionPayloadBid ->
+                originalExecutionPayloadBid
+                    .getSchema()
+                    .create(
+                        parentEmptyExecutionBlockHash,
+                        originalExecutionPayloadBid.getParentBlockRoot(),
+                        originalExecutionPayloadBid.getBlockHash(),
+                        originalExecutionPayloadBid.getPrevRandao(),
+                        originalExecutionPayloadBid.getFeeRecipient(),
+                        originalExecutionPayloadBid.getGasLimit(),
+                        originalExecutionPayloadBid.getBuilderIndex(),
+                        originalExecutionPayloadBid.getSlot(),
+                        originalExecutionPayloadBid.getValue(),
+                        originalExecutionPayloadBid.getExecutionPayment(),
+                        originalExecutionPayloadBid.getBlobKzgCommitments(),
+                        defaultParentExecutionRequests.hashTreeRoot()),
+            defaultParentExecutionRequests);
+    storageSystem.chainUpdater().setCurrentSlot(childSlot);
+
+    assertThat(parentBid.getBlockHash()).isNotEqualTo(parentEmptyExecutionBlockHash);
+    assertResultIsAccept(
+        emptyParentChildBlock, blockGossipValidator.validate(emptyParentChildBlock, true));
+  }
+
+  @TestTemplate
+  void shouldRejectGloasBlockBuildingOnEmptyParentWithParentExecutionRequests(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+
+    final UInt64 parentSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState parentBlockAndState =
+        storageSystem.chainUpdater().advanceChain(parentSlot);
+    final Bytes32 parentEmptyExecutionBlockHash =
+        BeaconStateGloas.required(parentBlockAndState.getState()).getLatestBlockHash();
+
+    final UInt64 childSlot = parentSlot.plus(ONE);
+    final SignedBlockAndState childBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(childSlot);
+    final ExecutionRequests parentExecutionRequests =
+        specContext.getDataStructureUtil().randomExecutionRequests();
+    final SignedBeaconBlock invalidEmptyParentChildBlock =
+        createBlockWithModifiedExecutionPayloadBid(
+            childBlockAndState,
+            originalExecutionPayloadBid ->
+                originalExecutionPayloadBid
+                    .getSchema()
+                    .create(
+                        parentEmptyExecutionBlockHash,
+                        originalExecutionPayloadBid.getParentBlockRoot(),
+                        originalExecutionPayloadBid.getBlockHash(),
+                        originalExecutionPayloadBid.getPrevRandao(),
+                        originalExecutionPayloadBid.getFeeRecipient(),
+                        originalExecutionPayloadBid.getGasLimit(),
+                        originalExecutionPayloadBid.getBuilderIndex(),
+                        originalExecutionPayloadBid.getSlot(),
+                        originalExecutionPayloadBid.getValue(),
+                        originalExecutionPayloadBid.getExecutionPayment(),
+                        originalExecutionPayloadBid.getBlobKzgCommitments(),
+                        parentExecutionRequests.hashTreeRoot()),
+            parentExecutionRequests);
+    storageSystem.chainUpdater().setCurrentSlot(childSlot);
+
+    assertThat(blockGossipValidator.validate(invalidEmptyParentChildBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "Parent execution requests must be empty when the Gloas bid does not build on the parent execution payload")));
+  }
+
+  @TestTemplate
+  void shouldRejectGloasBlockBuildingOnFullParentWithIncorrectParentExecutionRequests(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+
+    final UInt64 parentSlot = recentChainData.getHeadSlot().plus(ONE);
+    final SignedBlockAndState parentBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(parentSlot);
+    storageSystem.chainUpdater().saveBlock(parentBlockAndState);
+    final ExecutionPayloadBid parentBid =
+        parentBlockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .orElseThrow()
+            .getMessage();
+
+    final UInt64 childSlot = parentSlot.plus(ONE);
+    final SignedBlockAndState childBlockAndState =
+        storageSystem.chainBuilder().generateBlockAtSlot(childSlot);
+    final ExecutionRequests incorrectParentExecutionRequests =
+        SchemaDefinitionsGloas.required(spec.atSlot(childSlot).getSchemaDefinitions())
+            .getExecutionRequestsSchema()
+            .getDefault();
+    final SignedBeaconBlock invalidFullParentChildBlock =
+        createBlockWithModifiedExecutionPayloadBid(
+            childBlockAndState, Function.identity(), incorrectParentExecutionRequests);
+    storageSystem.chainUpdater().setCurrentSlot(childSlot);
+
+    assertThat(incorrectParentExecutionRequests.hashTreeRoot())
+        .isNotEqualTo(parentBid.getExecutionRequestsRoot());
+    assertThat(blockGossipValidator.validate(invalidFullParentChildBlock, true))
+        .isCompletedWithValueMatching(
+            result ->
+                result.equals(
+                    InternalValidationResult.reject(
+                        "The execution requests root in the latest committed bid does not match the parent execution requests in the block")));
+  }
+
+  @TestTemplate
   void shouldRejectBlockWithIncorrectExecutionPayloadBidParentRoot(final SpecContext specContext) {
     specContext.assumeGloasActive();
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
@@ -525,6 +667,21 @@ public class BlockGossipValidatorTest {
   private SignedBeaconBlock createBlockWithModifiedExecutionPayloadBid(
       final SignedBlockAndState baseBlockAndState,
       final Function<ExecutionPayloadBid, ExecutionPayloadBid> bidModifier) {
+    return createBlockWithModifiedExecutionPayloadBid(
+        baseBlockAndState,
+        bidModifier,
+        baseBlockAndState
+            .getBlock()
+            .getMessage()
+            .getBody()
+            .getOptionalParentExecutionRequests()
+            .orElseThrow());
+  }
+
+  private SignedBeaconBlock createBlockWithModifiedExecutionPayloadBid(
+      final SignedBlockAndState baseBlockAndState,
+      final Function<ExecutionPayloadBid, ExecutionPayloadBid> bidModifier,
+      final ExecutionRequests parentExecutionRequests) {
     final SignedBeaconBlock originalSignedBeaconBlock = baseBlockAndState.getBlock();
     final BeaconBlockBody originalBeaconBlockBody =
         originalSignedBeaconBlock.getMessage().getBody();
@@ -552,8 +709,7 @@ public class BlockGossipValidatorTest {
                 originalBeaconBlockBody.getOptionalBlsToExecutionChanges().orElseThrow())
             .payloadAttestations(
                 originalBeaconBlockBody.getOptionalPayloadAttestations().orElseThrow())
-            .parentExecutionRequests(
-                originalBeaconBlockBody.getOptionalParentExecutionRequests().orElseThrow())
+            .parentExecutionRequests(parentExecutionRequests)
             .signedExecutionPayloadBid(modifiedSignedBid)
             .build();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -582,7 +582,7 @@ public class BlockGossipValidatorTest {
             result ->
                 result.equals(
                     InternalValidationResult.reject(
-                        "Parent execution requests must be empty when the Gloas bid does not build on the parent execution payload")));
+                        "No execution requests were expected for an EMPTY parent")));
   }
 
   @TestTemplate

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -467,6 +468,57 @@ public class BlockGossipValidatorTest {
                     InternalValidationResult.reject(
                         "The parent block hash %s from the bid is not present or hasn't been passed validation",
                         notValidatedParentBlockHash)));
+  }
+
+  @TestTemplate
+  void shouldAcceptFirstGloasBlockWithPreGloasParent(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+
+    final Spec forkTransitionSpec = TestSpecFactory.createMinimalWithGloasForkEpoch(ONE);
+    final StorageSystem forkTransitionStorageSystem =
+        InMemoryStorageSystemBuilder.buildDefault(forkTransitionSpec);
+    forkTransitionStorageSystem.chainUpdater().initializeGenesis();
+    final ReceivedBlockEventsChannel forkTransitionReceivedBlockEventsChannelPublisher =
+        mock(ReceivedBlockEventsChannel.class);
+    final GossipValidationHelper forkTransitionGossipValidationHelper =
+        new GossipValidationHelper(
+            forkTransitionSpec,
+            forkTransitionStorageSystem.recentChainData(),
+            forkTransitionStorageSystem.getMetricsSystem());
+    final BlockGossipValidator forkTransitionBlockGossipValidator =
+        new BlockGossipValidator(
+            forkTransitionSpec,
+            forkTransitionGossipValidationHelper,
+            forkTransitionReceivedBlockEventsChannelPublisher);
+
+    final UInt64 firstGloasSlot = forkTransitionSpec.computeStartSlotAtEpoch(ONE);
+    final UInt64 preGloasParentSlot = firstGloasSlot.minus(ONE);
+    final SignedBlockAndState preGloasParentBlockAndState =
+        forkTransitionStorageSystem.chainUpdater().advanceChain(preGloasParentSlot);
+    final SignedBlockAndState firstGloasBlockAndState =
+        forkTransitionStorageSystem.chainBuilder().generateBlockAtSlot(firstGloasSlot);
+    final SignedBeaconBlock firstGloasBlock = firstGloasBlockAndState.getBlock();
+    forkTransitionStorageSystem.chainUpdater().setCurrentSlot(firstGloasSlot);
+
+    assertThat(
+            forkTransitionSpec
+                .atSlot(preGloasParentBlockAndState.getSlot())
+                .getMilestone()
+                .isLessThan(SpecMilestone.GLOAS))
+        .isTrue();
+    assertThat(forkTransitionSpec.atSlot(firstGloasBlock.getSlot()).getMilestone())
+        .isEqualTo(SpecMilestone.GLOAS);
+    assertThat(
+            forkTransitionGossipValidationHelper
+                .getParentStateInBlockEpoch(
+                    preGloasParentSlot, firstGloasBlock.getParentRoot(), firstGloasSlot)
+                .join()
+                .orElseThrow()
+                .toVersionGloas())
+        .isPresent();
+    assertThat(forkTransitionBlockGossipValidator.validate(firstGloasBlock, true))
+        .isCompletedWithValueMatching(InternalValidationResult::isAccept);
+    verify(forkTransitionReceivedBlockEventsChannelPublisher).onBlockValidated(firstGloasBlock);
   }
 
   @TestTemplate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
- Updates Gloas block gossip validation to distinguish between blocks building on an EMPTY parent and blocks building on a FULL parent execution payload
- Previously we required every `execution_payload_bid.parent_block_hash` to already be known by the execution layer, which could incorrectly reject valid Gloas blocks and downscore peers
- Now, EMPTY parent blocks are accepted when `parent_execution_requests` are empty, while FULL parent blocks wait for the missing parent execution payload with `SAVE_FOR_FUTURE`.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-adjacent gossip validation for Gloas EPBS; incorrect EMPTY/FULL classification could accept bad blocks or reject/downscore peers, though behavior is aligned with block processing and heavily tested.
> 
> **Overview**
> **Gloas block gossip** no longer treats every `execution_payload_bid.parent_block_hash` as something the execution layer must already know. Validation now mirrors `process_parent_execution_payload`: **FULL** parents (bid hash matches `latest_execution_payload_bid`) require matching `parent_execution_requests` and return **`SAVE_FOR_FUTURE`** until the parent payload hash is known; **EMPTY** parents (hash matches `latest_block_hash` but not the latest bid) accept blocks only when `parent_execution_requests` are empty. FULL is checked before EMPTY so fork-transition cases where both hashes align are handled correctly.
> 
> Shared predicates live in **`MiscHelpersGloas`** (`isExecutionPayloadBidForFullParent`, `isExecutionPayloadBidForEmptyParent`, `isEmptyExecutionRequests`, `isExecutionRequestsRootMatchingLatestExecutionPayloadBid`), used by **`BlockProcessorGloas`** and gossip. Tests cover fork entry, delayed full payloads, empty-parent acceptance/rejection, and overlapping hash edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d609bdb73394184fd6463f4a52ce6ed5bb03f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->