### PR TITLE
Support custom config when running gossip ref tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -32,12 +32,10 @@ public class GossipTests {
           .put("networking/gossip_partial_data_column_sidecar", TestExecutor.IGNORE_TESTS)
           .put(
               "networking/gossip_bls_to_execution_change",
-              new GossipBlsToExecutionChangeTestExecutor())
-          // TODO: this test should be fixed in the next consensus-specs release
-          .put(
-              "networking/gossip_beacon_block",
-              new GossipBeaconBlockTestExecutor(
+              new GossipBlsToExecutionChangeTestExecutor(
+                  // TODO: this test should be fixed in the next consensus-specs release
                   "gossip_bls_to_execution_change__ignore_pre_capella"))
+          .put("networking/gossip_beacon_block", new GossipBeaconBlockTestExecutor())
           .put(
               "networking/gossip_sync_committee_contribution_and_proof",
               new GossipSyncCommitteeContributionAndProofTestExecutor())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipTests.java
@@ -32,13 +32,12 @@ public class GossipTests {
           .put("networking/gossip_partial_data_column_sidecar", TestExecutor.IGNORE_TESTS)
           .put(
               "networking/gossip_bls_to_execution_change",
-              new GossipBlsToExecutionChangeTestExecutor(
-                  "gossip_bls_to_execution_change__ignore_pre_capella"))
-          // TODO: https://github.com/Consensys/teku/issues/10781
+              new GossipBlsToExecutionChangeTestExecutor())
+          // TODO: this test should be fixed in the next consensus-specs release
           .put(
               "networking/gossip_beacon_block",
               new GossipBeaconBlockTestExecutor(
-                  "gossip_beacon_block__valid_at_blob_parameters_limit"))
+                  "gossip_bls_to_execution_change__ignore_pre_capella"))
           .put(
               "networking/gossip_sync_committee_contribution_and_proof",
               new GossipSyncCommitteeContributionAndProofTestExecutor())

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
@@ -17,14 +17,20 @@ import static tech.pegasys.teku.ethtests.finder.ReferenceTestFinder.unchecked;
 
 import com.google.errorprone.annotations.MustBeClosed;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
+import tech.pegasys.teku.spec.config.YamlConfigReader;
 
 @SuppressWarnings("MustBeClosedChecker")
 public class PyspecTestFinder implements TestFinder {
+
+  private final YamlConfigReader yamlConfigReader = new YamlConfigReader();
 
   public static final String PYSPEC_TEST_DIRECTORY_NAME = "pyspec_tests";
 
@@ -70,11 +76,22 @@ public class PyspecTestFinder implements TestFinder {
     return Files.list(pyspecDir)
         .filter(testDir -> !testDir.getFileName().toString().equals(".DS_Store"))
         .map(
-            testDir -> {
-              final String testName = pyspecDir.relativize(testDir).toString();
-              return new TestDefinition(
-                  fork, config, testType, testName, testRoot.relativize(testDir));
-            })
+            unchecked(
+                testDir -> {
+                  final String testName = pyspecDir.relativize(testDir).toString();
+                  // some reference tests ship a partial config.yaml overriding a handful of
+                  // constants on top of the builtin config
+                  final Path customConfig = testDir.resolve("config.yaml");
+                  return new TestDefinition(
+                      fork,
+                      config,
+                      testType,
+                      testName,
+                      testRoot.relativize(testDir),
+                      Files.exists(customConfig)
+                          ? Optional.of(readCustomConfig(customConfig))
+                          : Optional.empty());
+                }))
         .filter(
             testDefinition ->
                 onlyTestsToRun.isEmpty()
@@ -85,5 +102,11 @@ public class PyspecTestFinder implements TestFinder {
             testDefinition ->
                 testsToIgnore.stream()
                     .noneMatch(testFilter -> testDefinition.getDisplayName().contains(testFilter)));
+  }
+
+  private Map<String, Object> readCustomConfig(final Path configFile) throws IOException {
+    try (final InputStream in = Files.newInputStream(configFile)) {
+      return yamlConfigReader.readValues(in);
+    }
   }
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
@@ -81,15 +81,15 @@ public class PyspecTestFinder implements TestFinder {
                   final String testName = pyspecDir.relativize(testDir).toString();
                   // some reference tests ship a partial config.yaml overriding a handful of
                   // constants on top of the builtin config
-                  final Path customConfig = testDir.resolve("config.yaml");
+                  final Path configOverridesYaml = testDir.resolve("config.yaml");
                   return new TestDefinition(
                       fork,
                       config,
                       testType,
                       testName,
                       testRoot.relativize(testDir),
-                      Files.exists(customConfig)
-                          ? Optional.of(readCustomConfig(customConfig))
+                      Files.exists(configOverridesYaml)
+                          ? Optional.of(readConfigOverrides(configOverridesYaml))
                           : Optional.empty());
                 }))
         .filter(
@@ -104,8 +104,9 @@ public class PyspecTestFinder implements TestFinder {
                     .noneMatch(testFilter -> testDefinition.getDisplayName().contains(testFilter)));
   }
 
-  private Map<String, Object> readCustomConfig(final Path configFile) throws IOException {
-    try (final InputStream in = Files.newInputStream(configFile)) {
+  private Map<String, Object> readConfigOverrides(final Path configOverridesYaml)
+      throws IOException {
+    try (final InputStream in = Files.newInputStream(configOverridesYaml)) {
       return yamlConfigReader.readValues(in);
     }
   }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.ethtests.finder;
 
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.TestFork;
@@ -32,6 +34,8 @@ public class TestDefinition {
   private final String testType;
   private final String testName;
   private final Path pathFromPhaseTestDir;
+  private final Optional<Map<String, Object>> configOverrides;
+
   private Spec spec;
 
   public TestDefinition(
@@ -40,11 +44,22 @@ public class TestDefinition {
       final String testType,
       final String testName,
       final Path pathFromPhaseTestDir) {
+    this(fork, configName, testType, testName, pathFromPhaseTestDir, Optional.empty());
+  }
+
+  public TestDefinition(
+      final String fork,
+      final String configName,
+      final String testType,
+      final String testName,
+      final Path pathFromPhaseTestDir,
+      final Optional<Map<String, Object>> configOverrides) {
     this.configName = configName;
     this.fork = fork;
     this.testType = testType.replace("\\", "/");
     this.testName = testName.replace("\\", "/");
     this.pathFromPhaseTestDir = pathFromPhaseTestDir;
+    this.configOverrides = configOverrides;
   }
 
   public String getConfigName() {
@@ -98,7 +113,8 @@ public class TestDefinition {
             builder ->
                 builder
                     .blsSignatureVerifier(blsSignatureVerifier)
-                    .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier));
+                    .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier),
+            configOverrides.orElseGet(Map::of));
   }
 
   public String getTestType() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,6 +69,13 @@ public class SpecConfigLoader {
 
   public static SpecConfigAndParent<? extends SpecConfig> loadConfig(
       final String configName,
+      final Consumer<SpecConfigBuilder> modifier,
+      final Map<String, Object> configOverrides) {
+    return loadConfig(configName, true, true, modifier, configOverrides);
+  }
+
+  public static SpecConfigAndParent<? extends SpecConfig> loadConfig(
+      final String configName,
       final boolean strictConfigLoadingEnabled,
       final Consumer<SpecConfigBuilder> modifier) {
     return loadConfig(configName, strictConfigLoadingEnabled, true, modifier);
@@ -103,9 +111,30 @@ public class SpecConfigLoader {
       final boolean strictConfigLoadingEnabled,
       final boolean isIgnoreUnknownConfigItems,
       final Consumer<SpecConfigBuilder> modifier) {
+    return loadConfig(
+        configName,
+        strictConfigLoadingEnabled,
+        isIgnoreUnknownConfigItems,
+        modifier,
+        Collections.emptyMap());
+  }
+
+  static SpecConfigAndParent<? extends SpecConfig> loadConfig(
+      final String configName,
+      final boolean strictConfigLoadingEnabled,
+      final boolean isIgnoreUnknownConfigItems,
+      final Consumer<SpecConfigBuilder> modifier,
+      final Map<String, Object> configOverrides) {
     final SpecConfigReader reader = new SpecConfigReader();
     processConfig(configName, reader, strictConfigLoadingEnabled, isIgnoreUnknownConfigItems);
-    return reader.build(modifier);
+    return reader.build(
+        builder -> {
+          modifier.accept(builder);
+          // apply any config overrides last
+          if (!configOverrides.isEmpty()) {
+            reader.loadFromMap(configOverrides, isIgnoreUnknownConfigItems);
+          }
+        });
   }
 
   // A little extra configuration is able to be loaded from builtin configs.

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -17,6 +17,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.NoOpKZG;
@@ -373,6 +375,14 @@ public class TestSpecFactory {
       final SpecMilestone specMilestone,
       final Eth2Network network,
       final Consumer<SpecConfigBuilder> configModifier) {
+    return create(specMilestone, network, configModifier, Collections.emptyMap());
+  }
+
+  public static Spec create(
+      final SpecMilestone specMilestone,
+      final Eth2Network network,
+      final Consumer<SpecConfigBuilder> configModifier,
+      final Map<String, Object> configOverrides) {
 
     Consumer<SpecConfigBuilder> defaultModifier = __ -> {};
     if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
@@ -401,7 +411,8 @@ public class TestSpecFactory {
     }
 
     return create(
-        SpecConfigLoader.loadConfig(network.configName(), defaultModifier.andThen(configModifier)),
+        SpecConfigLoader.loadConfig(
+            network.configName(), defaultModifier.andThen(configModifier), configOverrides),
         specMilestone);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add ability to read config.yaml in test directory and load `Spec` with config overrides

## Fixed Issue(s)
fixes #10781

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test discovery and spec loading for reference tests; production config loading paths remain backward-compatible with empty overrides.
> 
> **Overview**
> Adds support for **per-reference-test spec config overrides** by loading an optional `config.yaml` from each pyspec test directory and applying those values when building the test `Spec`.
> 
> `PyspecTestFinder` detects and parses that file; `TestDefinition` carries the overrides through `TestSpecFactory.create` into new `SpecConfigLoader.loadConfig(..., configOverrides)` plumbing, which applies the map **after** the builtin network config and any builder modifiers.
> 
> As a result, **`networking/gossip_beacon_block` no longer needs a hard-coded ignore** for `valid_at_blob_parameters_limit`—that case can use the test’s local `config.yaml` instead (fixes #10781).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33a28a432139b4026d676ff71ab7b5bb5dfc5882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->