### PR TITLE
Fix Gloas empty parent payload withdrawals - block production

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -22,7 +22,6 @@ import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -103,6 +102,7 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateInvariants;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 import tech.pegasys.teku.spec.genesis.GenesisGenerator;
@@ -147,8 +147,8 @@ public class Spec {
       final SpecConfigAndParent<? extends SpecConfig> specConfigAndParent,
       final Map<SpecMilestone, SpecVersion> specVersions,
       final ForkSchedule forkSchedule) {
-    Preconditions.checkArgument(specVersions != null && !specVersions.isEmpty());
-    Preconditions.checkArgument(forkSchedule != null);
+    checkArgument(specVersions != null && !specVersions.isEmpty());
+    checkArgument(forkSchedule != null);
     this.specConfigAndParent = specConfigAndParent;
     this.specVersions = specVersions;
     this.forkSchedule = forkSchedule;
@@ -1066,7 +1066,8 @@ public class Spec {
    * Returns the withdrawals to include in Engine API payload attributes for the supplied
    * post-slot-processing state.
    *
-   * <p>For most parents this is the state's expected withdrawals. For a GLOAS parent with a full
+   * <p>For pre-GLOAS parents this is the state's expected withdrawals. For a GLOAS parent with an
+   * empty payload, this is the state's payload_expected_withdrawals. For a GLOAS parent with a full
    * payload, the parent execution requests must be applied first so the withdrawals reflect the
    * effective state used for payload building.
    */
@@ -1074,19 +1075,22 @@ public class Spec {
       final BeaconState state,
       final ForkChoicePayloadStatus parentPayloadStatus,
       final Optional<ExecutionRequests> parentExecutionRequests) {
-    if (parentPayloadStatus != ForkChoicePayloadStatus.PAYLOAD_STATUS_FULL) {
-      return getExpectedWithdrawals(state);
-    }
-
-    final ExecutionRequests executionRequests =
-        parentExecutionRequests.orElseThrow(
-            () ->
-                new IllegalStateException(
-                    "Parent execution requests are required for GLOAS FULL parent payload attributes"));
-    final ForkChoiceUtilGloas forkChoiceUtilGloas =
-        ForkChoiceUtilGloas.required(atState(state).getForkChoiceUtil());
-    return Optional.of(
-        forkChoiceUtilGloas.getPayloadAttributeWithdrawals(state, executionRequests).asList());
+    return switch (parentPayloadStatus) {
+      case PAYLOAD_STATUS_PENDING -> getExpectedWithdrawals(state);
+      case PAYLOAD_STATUS_EMPTY ->
+          Optional.of(BeaconStateGloas.required(state).getPayloadExpectedWithdrawals().asList());
+      case PAYLOAD_STATUS_FULL -> {
+        final ExecutionRequests executionRequests =
+            parentExecutionRequests.orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Parent execution requests are required for GLOAS FULL parent payload attributes"));
+        final ForkChoiceUtilGloas forkChoiceUtilGloas =
+            ForkChoiceUtilGloas.required(atState(state).getForkChoiceUtil());
+        yield Optional.of(
+            forkChoiceUtilGloas.getPayloadAttributeWithdrawals(state, executionRequests).asList());
+      }
+    };
   }
 
   // Block Processor Utils

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerGloasTest.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdraw
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateSchemaGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.validator.BeaconPreparableProposer;
@@ -152,6 +153,12 @@ class ProposersDataManagerGloasTest {
                       .getBuildersSchema()
                       .createFromElements(
                           List.of(data.builderBuilder().balance(parentPayloadValue).build())));
+              stateGloas.setPayloadExpectedWithdrawals(
+                  schemaDefinitions
+                      .getExecutionPayloadSchema()
+                      .getWithdrawalsSchemaRequired()
+                      .createFromElements(
+                          List.of(data.randomWithdrawal(UInt64.valueOf(7), UInt64.valueOf(11)))));
             });
   }
 
@@ -175,11 +182,19 @@ class ProposersDataManagerGloasTest {
   }
 
   @TestTemplate
-  void calculatePayloadBuildingAttributes_shouldNotFetchParentExecutionRequestsForEmptyParent() {
+  void calculatePayloadBuildingAttributes_shouldUsePayloadExpectedWithdrawalsForEmptyParent() {
     final UInt64 blockSlot = UInt64.valueOf(16);
     final Bytes32 parentRoot = data.randomBytes32();
     final ForkChoiceNode parent = ForkChoiceNode.createEmpty(parentRoot);
-    final BeaconState state = data.randomBeaconState(blockSlot);
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(blockSlot).getSchemaDefinitions());
+    final ExecutionRequests parentExecutionRequests =
+        schemaDefinitions.getExecutionRequestsSchema().getDefault();
+    final BeaconState state =
+        createStateWithFullParentBid(blockSlot, schemaDefinitions, parentExecutionRequests);
+    final Optional<List<Withdrawal>> payloadExpectedWithdrawals =
+        Optional.of(BeaconStateGloas.required(state).getPayloadExpectedWithdrawals().asList());
+    assertThat(payloadExpectedWithdrawals).isNotEqualTo(spec.getExpectedWithdrawals(state));
     final ForkChoiceUpdateData forkChoiceUpdateData = forkChoiceUpdateData(parent, blockSlot);
     prepareLocalProposer(state, blockSlot);
     when(recentChainData.retrieveBlockState(new SlotAndBlockRoot(blockSlot, parentRoot)))
@@ -188,7 +203,7 @@ class ProposersDataManagerGloasTest {
     final PayloadBuildingAttributes attributes =
         safeJoin(calculate(blockSlot, forkChoiceUpdateData)).orElseThrow();
 
-    assertThat(attributes.withdrawals()).isEqualTo(spec.getExpectedWithdrawals(state));
+    assertThat(attributes.withdrawals()).isEqualTo(payloadExpectedWithdrawals);
     verify(recentChainData, never()).retrieveSignedBlindedExecutionPayloadByBlockRoot(any());
   }
 


### PR DESCRIPTION
fixes #10682


### Fix Gloas empty-parent payload withdrawals

For Gloas payload attributes, `PAYLOAD_STATUS_EMPTY` now uses the state's cached `payload_expected_withdrawals` instead of recomputing withdrawals via `getExpectedWithdrawals`.

This matches Gloas processing: when the parent payload is empty, withdrawals are not reprocessed, so the payload attributes must preserve the withdrawals already stored in state.

`PAYLOAD_STATUS_FULL` still applies parent execution requests first, while `PAYLOAD_STATUS_PENDING` keeps the existing pre-Gloas/default behavior.

Added a regression test covering the empty-parent case.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches withdrawal selection for Gloas payload building (consensus-adjacent fork-choice behavior); scope is narrow and covered by a targeted regression test.
> 
> **Overview**
> Fixes **Gloas block production** when the parent fork-choice node has an **empty** execution payload: Engine API payload attributes now take withdrawals from the beacon state’s cached **`payload_expected_withdrawals`** instead of **`getExpectedWithdrawals`**, matching Gloas rules where withdrawals are not reprocessed on an empty parent payload.
> 
> **`Spec.getPayloadAttributeWithdrawals`** is refactored to a **`switch` on `ForkChoicePayloadStatus`**: `PENDING` still uses expected withdrawals (pre-Gloas/default), `EMPTY` reads `BeaconStateGloas.getPayloadExpectedWithdrawals()`, and `FULL` still applies parent execution requests via **`ForkChoiceUtilGloas`** before computing withdrawals. Javadoc is updated accordingly; constructor checks use static **`checkArgument`** imports only.
> 
> A **regression test** in **`ProposersDataManagerGloasTest`** seeds distinct `payload_expected_withdrawals`, asserts they differ from expected withdrawals, and verifies empty-parent payload building uses the cached list without fetching parent execution requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8add035f06ee523b713502d867010f0e54b617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->