### PR TITLE
add Gloas full payload attestation gossip validation

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -174,7 +174,7 @@ public class BatchImporter {
                   block.getSlot(),
                   block.getRoot());
               return executionPayloadManager
-                  .importExecutionPayload(executionPayload.get())
+                  .importExecutionPayload(executionPayload.get(), false)
                   .thenApply(
                       executionPayloadImportResult ->
                           new SingleImportResult(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
@@ -464,7 +464,7 @@ public class PeerSync {
               }
               final SignedExecutionPayloadEnvelope executionPayload = maybeExecutionPayload.get();
               return executionPayloadManager
-                  .importExecutionPayload(executionPayload)
+                  .importExecutionPayload(executionPayload, false)
                   .thenAccept(
                       executionPayloadImportResult -> {
                         LOG.trace(

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -290,9 +290,9 @@ class BatchImporterTest {
 
     when(blockImporter.importBlock(block1)).thenReturn(blockImportResult1);
     when(blockImporter.importBlock(block2)).thenReturn(blockImportResult2);
-    when(executionPayloadManager.importExecutionPayload(executionPayload1))
+    when(executionPayloadManager.importExecutionPayload(executionPayload1, false))
         .thenReturn(executionPayloadImportResult1);
-    when(executionPayloadManager.importExecutionPayload(executionPayload2))
+    when(executionPayloadManager.importExecutionPayload(executionPayload2, false))
         .thenReturn(executionPayloadImportResult2);
 
     final SafeFuture<BatchImportResult> result = importer.importBatch(batch);
@@ -338,7 +338,7 @@ class BatchImporterTest {
   private void executionPayloadImportedSuccessfully(
       final SignedExecutionPayloadEnvelope executionPayload,
       final SafeFuture<ExecutionPayloadImportResult> importResult) {
-    ignoreFuture(verify(executionPayloadManager).importExecutionPayload(executionPayload));
+    ignoreFuture(verify(executionPayloadManager).importExecutionPayload(executionPayload, false));
     verifyNoMoreInteractions(executionPayloadManager);
     importResult.complete(ExecutionPayloadImportResult.successful(executionPayload));
   }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -119,7 +119,7 @@ public class PeerSyncTest extends AbstractSyncTest {
                 SafeFuture.completedFuture(
                     BlockImportResult.successful(invocationOnMock.getArgument(0))));
     when(blobSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(false);
-    when(executionPayloadManager.importExecutionPayload(any()))
+    when(executionPayloadManager.importExecutionPayload(any(), anyBoolean()))
         .thenAnswer(
             invocationOnMock ->
                 SafeFuture.completedFuture(
@@ -687,7 +687,7 @@ public class PeerSyncTest extends AbstractSyncTest {
         .values()
         .forEach(
             executionPayload ->
-                verify(executionPayloadManager).importExecutionPayload(executionPayload));
+                verify(executionPayloadManager).importExecutionPayload(executionPayload, false));
 
     // Check that the sync is done and the peer was not disconnected.
     assertThat(syncFuture).isCompleted();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAggregateAndProofTestExecutor.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
@@ -172,7 +173,9 @@ public class GossipBeaconAggregateAndProofTestExecutor implements TestExecutor {
             AsyncBLSSignatureVerifier.wrap(blsVerifier),
             createGossipValidationHelper(
                 spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
-            invalidBlockRoots);
+            invalidBlockRoots,
+            Set.of(),
+            __ -> true);
     final AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(
             spec, attestationValidator, AsyncBLSSignatureVerifier.wrap(blsVerifier));

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/gossip/GossipBeaconAttestationTestExecutor.java
@@ -179,7 +179,9 @@ public class GossipBeaconAttestationTestExecutor implements TestExecutor {
             AsyncBLSSignatureVerifier.wrap(blsVerifier),
             createGossipValidationHelper(
                 spec, recentChainData, metricsSystem, customFinalizedCheckpoint),
-            invalidBlockRoots);
+            invalidBlockRoots,
+            Set.of(),
+            __ -> true);
 
     // Track seen attestations (by hash tree root) for "already seen" duplicate detection
     final Set<Bytes32> seenAttestationRoots = new HashSet<>();

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestati
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.AfterEach;
@@ -108,7 +109,12 @@ class AttestationManagerIntegrationTest {
       new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem());
   private final AttestationValidator attestationValidator =
       new AttestationValidator(
-          spec, signatureVerificationService, gossipValidationHelper, new ConcurrentHashMap<>());
+          spec,
+          signatureVerificationService,
+          gossipValidationHelper,
+          new ConcurrentHashMap<>(),
+          Set.of(),
+          __ -> true);
   private final ActiveValidatorChannel activeValidatorChannel = mock(ActiveValidatorChannel.class);
 
   private final AttestationManager attestationManager =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -84,7 +84,7 @@ public class DefaultExecutionPayloadManager
   private final ReceivedExecutionPayloadEventsChannel
       receivedExecutionPayloadEventsChannelPublisher;
   private final RecentChainData recentChainData;
-  private final Set<Bytes32> invalidExecutionPayloadRoots;
+  private final Set<Bytes32> blockRootsWithInvalidExecutionPayload;
   private final Function<SignedExecutionPayloadEnvelope, SafeFuture<Void>>
       executionPayloadPublisher;
 
@@ -96,7 +96,7 @@ public class DefaultExecutionPayloadManager
       final ExecutionLayerChannel executionLayer,
       final ReceivedExecutionPayloadEventsChannel receivedExecutionPayloadEventsChannelPublisher,
       final RecentChainData recentChainData,
-      final Set<Bytes32> invalidExecutionPayloadRoots,
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload,
       final Function<SignedExecutionPayloadEnvelope, SafeFuture<Void>> executionPayloadPublisher) {
     this.spec = spec;
     this.asyncRunner = asyncRunner;
@@ -106,7 +106,7 @@ public class DefaultExecutionPayloadManager
     this.receivedExecutionPayloadEventsChannelPublisher =
         receivedExecutionPayloadEventsChannelPublisher;
     this.recentChainData = recentChainData;
-    this.invalidExecutionPayloadRoots = invalidExecutionPayloadRoots;
+    this.blockRootsWithInvalidExecutionPayload = blockRootsWithInvalidExecutionPayload;
     this.executionPayloadPublisher = executionPayloadPublisher;
   }
 
@@ -152,7 +152,7 @@ public class DefaultExecutionPayloadManager
               recentSeenExecutionPayloads.add(signedExecutionPayload.getBeaconBlockRoot());
               recordExecutionPayloadAvailability(
                   signedExecutionPayload, earliestExecutionPayloadArrivalTimestamp);
-              importExecutionPayload(signedExecutionPayload).finishError(LOG);
+              importExecutionPayload(signedExecutionPayload, true).finishError(LOG);
             }
             case SAVE_FOR_FUTURE -> {
               if (recentChainData.containsBlock(signedExecutionPayload.getBeaconBlockRoot())) {
@@ -190,7 +190,8 @@ public class DefaultExecutionPayloadManager
 
   @Override
   public SafeFuture<ExecutionPayloadImportResult> importExecutionPayload(
-      final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+      final SignedExecutionPayloadEnvelope signedExecutionPayload,
+      final boolean payloadCommitmentVerified) {
     return asyncRunner
         .runAsync(
             () -> forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
@@ -205,8 +206,9 @@ public class DefaultExecutionPayloadManager
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload, result.isImportedOptimistically());
               } else {
-                if (isInvalidExecutionPayload(result)) {
-                  invalidExecutionPayloadRoots.add(signedExecutionPayload.getBeaconBlockRoot());
+                if (payloadCommitmentVerified && isInvalidExecutionPayload(result)) {
+                  blockRootsWithInvalidExecutionPayload.add(
+                      signedExecutionPayload.getBeaconBlockRoot());
                 }
                 switch (result.getFailureReason()) {
                   case FAILED_EXECUTION -> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -60,6 +60,8 @@ public class DefaultExecutionPayloadManager
 
   private final Set<Bytes32> recentSeenExecutionPayloads =
       LimitedSet.createSynchronizedNatural(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+  private final Set<Bytes32> successfullyImportedExecutionPayloads =
+      LimitedSet.createSynchronizedNatural(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
   private final Set<Bytes32> executionPayloadsSeenBeforePayloadDue =
       LimitedSet.createSynchronizedNatural(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
   private final Set<Bytes32> acceptedExecutionPayloadEnvelopeRoots =
@@ -120,7 +122,7 @@ public class DefaultExecutionPayloadManager
 
   @Override
   public boolean isExecutionPayloadSeenForFullPayloadAttestation(final Bytes32 beaconBlockRoot) {
-    if (recentSeenExecutionPayloads.contains(beaconBlockRoot)) {
+    if (successfullyImportedExecutionPayloads.contains(beaconBlockRoot)) {
       return true;
     }
     return recentChainData.containsExecutionPayload(beaconBlockRoot);
@@ -198,6 +200,8 @@ public class DefaultExecutionPayloadManager
                 LOG.debug(
                     "Successfully imported execution payload {}",
                     signedExecutionPayload::toLogString);
+                successfullyImportedExecutionPayloads.add(
+                    signedExecutionPayload.getBeaconBlockRoot());
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload, result.isImportedOptimistically());
               } else {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -82,6 +82,7 @@ public class DefaultExecutionPayloadManager
   private final ReceivedExecutionPayloadEventsChannel
       receivedExecutionPayloadEventsChannelPublisher;
   private final RecentChainData recentChainData;
+  private final Set<Bytes32> invalidExecutionPayloadRoots;
   private final Function<SignedExecutionPayloadEnvelope, SafeFuture<Void>>
       executionPayloadPublisher;
 
@@ -93,6 +94,7 @@ public class DefaultExecutionPayloadManager
       final ExecutionLayerChannel executionLayer,
       final ReceivedExecutionPayloadEventsChannel receivedExecutionPayloadEventsChannelPublisher,
       final RecentChainData recentChainData,
+      final Set<Bytes32> invalidExecutionPayloadRoots,
       final Function<SignedExecutionPayloadEnvelope, SafeFuture<Void>> executionPayloadPublisher) {
     this.spec = spec;
     this.asyncRunner = asyncRunner;
@@ -102,6 +104,7 @@ public class DefaultExecutionPayloadManager
     this.receivedExecutionPayloadEventsChannelPublisher =
         receivedExecutionPayloadEventsChannelPublisher;
     this.recentChainData = recentChainData;
+    this.invalidExecutionPayloadRoots = invalidExecutionPayloadRoots;
     this.executionPayloadPublisher = executionPayloadPublisher;
   }
 
@@ -190,6 +193,9 @@ public class DefaultExecutionPayloadManager
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload, result.isImportedOptimistically());
               } else {
+                if (isInvalidExecutionPayload(result)) {
+                  invalidExecutionPayloadRoots.add(signedExecutionPayload.getBeaconBlockRoot());
+                }
                 switch (result.getFailureReason()) {
                   case FAILED_EXECUTION -> {
                     LOG.error(
@@ -219,6 +225,16 @@ public class DefaultExecutionPayloadManager
               LOG.error(internalErrorMessage, ex);
               return ExecutionPayloadImportResult.internalError(ex);
             });
+  }
+
+  private boolean isInvalidExecutionPayload(final ExecutionPayloadImportResult result) {
+    return switch (result.getFailureReason()) {
+      case FAILED_EXECUTION, FAILED_VERIFICATION, FAILED_DATA_AVAILABILITY_CHECK_INVALID -> true;
+      case UNKNOWN_BEACON_BLOCK_ROOT,
+          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
+          INTERNAL_ERROR ->
+          false;
+    };
   }
 
   private void logFailedExecutionPayloadImport(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -202,7 +202,6 @@ public class DefaultExecutionPayloadManager
                     signedExecutionPayload::toLogString);
                 successfullyImportedExecutionPayloads.add(
                     signedExecutionPayload.getBeaconBlockRoot());
-                invalidExecutionPayloadRoots.remove(signedExecutionPayload.getBeaconBlockRoot());
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload, result.isImportedOptimistically());
               } else {
@@ -242,8 +241,9 @@ public class DefaultExecutionPayloadManager
 
   private boolean isInvalidExecutionPayload(final ExecutionPayloadImportResult result) {
     return switch (result.getFailureReason()) {
-      case FAILED_EXECUTION, FAILED_VERIFICATION, FAILED_DATA_AVAILABILITY_CHECK_INVALID -> true;
+      case FAILED_VERIFICATION, FAILED_DATA_AVAILABILITY_CHECK_INVALID -> true;
       case UNKNOWN_BEACON_BLOCK_ROOT,
+          FAILED_EXECUTION,
           FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
           INTERNAL_ERROR ->
           false;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -202,6 +202,7 @@ public class DefaultExecutionPayloadManager
                     signedExecutionPayload::toLogString);
                 successfullyImportedExecutionPayloads.add(
                     signedExecutionPayload.getBeaconBlockRoot());
+                invalidExecutionPayloadRoots.remove(signedExecutionPayload.getBeaconBlockRoot());
                 receivedExecutionPayloadEventsChannelPublisher.onExecutionPayloadImported(
                     signedExecutionPayload, result.isImportedOptimistically());
               } else {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -118,6 +118,14 @@ public class DefaultExecutionPayloadManager
     return executionPayloadsSeenBeforePayloadDue.contains(beaconBlockRoot);
   }
 
+  @Override
+  public boolean isExecutionPayloadSeenForFullPayloadAttestation(final Bytes32 beaconBlockRoot) {
+    if (recentSeenExecutionPayloads.contains(beaconBlockRoot)) {
+      return true;
+    }
+    return recentChainData.containsExecutionPayload(beaconBlockRoot);
+  }
+
   @SuppressWarnings("FutureReturnValueIgnored")
   @Override
   public SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -53,7 +53,8 @@ public interface ExecutionPayloadManager {
 
         @Override
         public SafeFuture<ExecutionPayloadImportResult> importExecutionPayload(
-            final SignedExecutionPayloadEnvelope signedExecutionPayload) {
+            final SignedExecutionPayloadEnvelope signedExecutionPayload,
+            final boolean payloadCommitmentVerified) {
           return SafeFuture.completedFuture(
               ExecutionPayloadImportResult.successful(signedExecutionPayload));
         }
@@ -101,10 +102,18 @@ public interface ExecutionPayloadManager {
   /**
    * Imports execution payload via fork choice `on_execution_payload`
    *
+   * @param payloadCommitmentVerified whether the envelope has been proven to be the block's
+   *     committed payload, i.e. its bid consistency (builder index, payload block hash, execution
+   *     requests root) and builder signature were verified (as done by gossip validation). Only
+   *     when {@code true} may an invalid import result be cached against the beacon block root, so
+   *     that full-payload attestation gossip validation can reject votes for it. Callers that have
+   *     not verified the commitment (e.g. sync or RPC-by-root imports) MUST pass {@code false}, as
+   *     a forged/mismatched envelope for an honest block would otherwise poison the invalid-payload
+   *     cache and cause legitimate attestations to be rejected.
    * @return the execution payload import result
    */
   SafeFuture<ExecutionPayloadImportResult> importExecutionPayload(
-      SignedExecutionPayloadEnvelope signedExecutionPayload);
+      SignedExecutionPayloadEnvelope signedExecutionPayload, boolean payloadCommitmentVerified);
 
   /** Retrieves parent execution requests (used in block production) */
   SafeFuture<ExecutionRequests> getParentExecutionRequestsForBlock(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -39,6 +39,12 @@ public interface ExecutionPayloadManager {
         }
 
         @Override
+        public boolean isExecutionPayloadSeenForFullPayloadAttestation(
+            final Bytes32 beaconBlockRoot) {
+          return false;
+        }
+
+        @Override
         public SafeFuture<InternalValidationResult> validateAndImportExecutionPayload(
             final SignedExecutionPayloadEnvelope signedExecutionPayload,
             final Optional<UInt64> arrivalTimestamp) {
@@ -76,6 +82,12 @@ public interface ExecutionPayloadManager {
    * method is used for the `payload_present` vote.
    */
   boolean isExecutionPayloadAvailableForPayloadAttestation(Bytes32 beaconBlockRoot);
+
+  /**
+   * {@link SignedExecutionPayloadEnvelope} has been seen or already imported for the block. This
+   * method is used for full-payload beacon attestation gossip validation.
+   */
+  boolean isExecutionPayloadSeenForFullPayloadAttestation(Bytes32 beaconBlockRoot);
 
   /**
    * Performs gossip validation on the {@code signedExecutionPayload} and imports it async if

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/ExecutionPayloadManager.java
@@ -84,8 +84,8 @@ public interface ExecutionPayloadManager {
   boolean isExecutionPayloadAvailableForPayloadAttestation(Bytes32 beaconBlockRoot);
 
   /**
-   * {@link SignedExecutionPayloadEnvelope} has been seen or already imported for the block. This
-   * method is used for full-payload beacon attestation gossip validation.
+   * {@link SignedExecutionPayloadEnvelope} has been successfully imported or is already available
+   * for the block. This method is used for full-payload beacon attestation gossip validation.
    */
   boolean isExecutionPayloadSeenForFullPayloadAttestation(Bytes32 beaconBlockRoot);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/FailedExecutionPayloadPool.java
@@ -119,8 +119,12 @@ public class FailedExecutionPayloadPool {
 
   private synchronized void retryExecution(final SignedExecutionPayloadEnvelope executionPayload) {
     LOG.debug("Retrying execution of execution payload {}", executionPayload.toLogString());
+    // Retried payloads may have originated from either gossip-validated or sync/RPC imports and the
+    // pool does not track their provenance, so we deliberately import them as commitment-unverified
+    // to avoid poisoning the invalid-payload cache with envelopes that were never proven to be the
+    // block's committed payload.
     executionPayloadManager
-        .importExecutionPayload(executionPayload)
+        .importExecutionPayload(executionPayload, false)
         .thenAccept(result -> handleExecutionResult(executionPayload, result))
         .finish(
             error -> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.validation;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.ACCEPT;
 
+import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Map;
 import java.util.Optional;
@@ -45,7 +46,8 @@ public class AttestationValidator {
   private final Set<Bytes32> invalidExecutionPayloadRoots;
   private final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation;
 
-  public AttestationValidator(
+  @VisibleForTesting
+  AttestationValidator(
       final Spec spec,
       final AsyncBLSSignatureVerifier signatureVerifier,
       final GossipValidationHelper gossipValidationHelper,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -43,7 +43,7 @@ public class AttestationValidator {
   private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
   private final Set<Bytes32> invalidExecutionPayloadRoots;
-  private final Predicate<Bytes32> executionPayloadAvailableForPayloadAttestation;
+  private final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation;
 
   public AttestationValidator(
       final Spec spec,
@@ -59,14 +59,14 @@ public class AttestationValidator {
       final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final Set<Bytes32> invalidExecutionPayloadRoots,
-      final Predicate<Bytes32> executionPayloadAvailableForPayloadAttestation) {
+      final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation) {
     this.spec = spec;
     this.signatureVerifier = signatureVerifier;
     this.gossipValidationHelper = gossipValidationHelper;
     this.invalidBlockRoots = invalidBlockRoots;
     this.invalidExecutionPayloadRoots = invalidExecutionPayloadRoots;
-    this.executionPayloadAvailableForPayloadAttestation =
-        executionPayloadAvailableForPayloadAttestation;
+    this.executionPayloadSeenForFullPayloadAttestation =
+        executionPayloadSeenForFullPayloadAttestation;
   }
 
   public SafeFuture<InternalValidationResult> validate(
@@ -191,7 +191,7 @@ public class AttestationValidator {
                 "Execution payload for full payload attestation is invalid"));
       }
       // [IGNORE] If index == 1, the execution payload for block has been seen.
-      if (!executionPayloadAvailableForPayloadAttestation.test(blockRoot)) {
+      if (!executionPayloadSeenForFullPayloadAttestation.test(blockRoot)) {
         return completedFuture(InternalValidationResultWithState.saveForFuture());
       }
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -43,7 +43,7 @@ public class AttestationValidator {
   private final AsyncBLSSignatureVerifier signatureVerifier;
   private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
-  private final Set<Bytes32> invalidExecutionPayloadRoots;
+  private final Set<Bytes32> blockRootsWithInvalidExecutionPayload;
   private final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation;
 
   @VisibleForTesting
@@ -60,13 +60,13 @@ public class AttestationValidator {
       final AsyncBLSSignatureVerifier signatureVerifier,
       final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
-      final Set<Bytes32> invalidExecutionPayloadRoots,
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload,
       final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation) {
     this.spec = spec;
     this.signatureVerifier = signatureVerifier;
     this.gossipValidationHelper = gossipValidationHelper;
     this.invalidBlockRoots = invalidBlockRoots;
-    this.invalidExecutionPayloadRoots = invalidExecutionPayloadRoots;
+    this.blockRootsWithInvalidExecutionPayload = blockRootsWithInvalidExecutionPayload;
     this.executionPayloadSeenForFullPayloadAttestation =
         executionPayloadSeenForFullPayloadAttestation;
   }
@@ -187,7 +187,7 @@ public class AttestationValidator {
     final Bytes32 blockRoot = data.getBeaconBlockRoot();
     if (spec.atSlot(data.getSlot()).getForkChoiceUtil().getFullPayloadVoteHint(data.getIndex())) {
       // [REJECT] If index == 1, the execution payload for block passes validation.
-      if (invalidExecutionPayloadRoots.contains(blockRoot)) {
+      if (blockRootsWithInvalidExecutionPayload.contains(blockRoot)) {
         return completedFuture(
             InternalValidationResultWithState.reject(
                 "Execution payload for full payload attestation is invalid"));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -20,6 +20,8 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
@@ -40,16 +42,31 @@ public class AttestationValidator {
   private final AsyncBLSSignatureVerifier signatureVerifier;
   private final GossipValidationHelper gossipValidationHelper;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
+  private final Set<Bytes32> invalidExecutionPayloadRoots;
+  private final Predicate<Bytes32> executionPayloadAvailableForPayloadAttestation;
 
   public AttestationValidator(
       final Spec spec,
       final AsyncBLSSignatureVerifier signatureVerifier,
       final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots) {
+    this(spec, signatureVerifier, gossipValidationHelper, invalidBlockRoots, Set.of(), __ -> true);
+  }
+
+  public AttestationValidator(
+      final Spec spec,
+      final AsyncBLSSignatureVerifier signatureVerifier,
+      final GossipValidationHelper gossipValidationHelper,
+      final Map<Bytes32, BlockImportResult> invalidBlockRoots,
+      final Set<Bytes32> invalidExecutionPayloadRoots,
+      final Predicate<Bytes32> executionPayloadAvailableForPayloadAttestation) {
     this.spec = spec;
     this.signatureVerifier = signatureVerifier;
     this.gossipValidationHelper = gossipValidationHelper;
     this.invalidBlockRoots = invalidBlockRoots;
+    this.invalidExecutionPayloadRoots = invalidExecutionPayloadRoots;
+    this.executionPayloadAvailableForPayloadAttestation =
+        executionPayloadAvailableForPayloadAttestation;
   }
 
   public SafeFuture<InternalValidationResult> validate(
@@ -163,6 +180,20 @@ public class AttestationValidator {
     // If it's not in the store, it may not have been processed yet so save for future.
     if (!gossipValidationHelper.isBlockAvailable(data.getBeaconBlockRoot())) {
       return completedFuture(InternalValidationResultWithState.saveForFuture());
+    }
+
+    final Bytes32 blockRoot = data.getBeaconBlockRoot();
+    if (spec.atSlot(data.getSlot()).getForkChoiceUtil().getFullPayloadVoteHint(data.getIndex())) {
+      // [REJECT] If index == 1, the execution payload for block passes validation.
+      if (invalidExecutionPayloadRoots.contains(blockRoot)) {
+        return completedFuture(
+            InternalValidationResultWithState.reject(
+                "Execution payload for full payload attestation is invalid"));
+      }
+      // [IGNORE] If index == 1, the execution payload for block has been seen.
+      if (!executionPayloadAvailableForPayloadAttestation.test(blockRoot)) {
+        return completedFuture(InternalValidationResultWithState.saveForFuture());
+      }
     }
 
     return gossipValidationHelper

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -252,7 +252,7 @@ class DefaultExecutionPayloadManagerTest {
     }
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
-    assertExecutionPayloadRecentlySeen(signedExecutionPayload);
+    assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
     assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -130,6 +130,7 @@ class DefaultExecutionPayloadManagerTest {
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
     assertExecutionPayloadNotAvailableForPayloadAttestation(signedExecutionPayload);
+    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test
@@ -197,6 +198,32 @@ class DefaultExecutionPayloadManagerTest {
     verifyNoInteractions(forkChoice);
     assertThat(resultFuture).isCompletedWithValue(rejectedResult);
     assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+  }
+
+  @Test
+  public void shouldReportExecutionPayloadSeenForFullPayloadAttestationWhenPresentInStore() {
+    when(recentChainData.containsExecutionPayload(signedExecutionPayload.getBeaconBlockRoot()))
+        .thenReturn(true);
+
+    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
+    assertExecutionPayloadNotRecentlySeen(signedExecutionPayload);
+    assertExecutionPayloadNotAvailableForPayloadAttestation(signedExecutionPayload);
+  }
+
+  @Test
+  public void shouldThrowWhenStoreUnavailableForFullPayloadAttestationCheck() {
+    when(recentChainData.containsExecutionPayload(signedExecutionPayload.getBeaconBlockRoot()))
+        .thenThrow(
+            new IllegalStateException(
+                "Store is unavailable while checking execution payload availability"));
+
+    assertThatThrownBy(
+            () ->
+                executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
+                    signedExecutionPayload.getBeaconBlockRoot()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Store is unavailable while checking execution payload availability");
   }
 
   @Test
@@ -394,6 +421,22 @@ class DefaultExecutionPayloadManagerTest {
       final SignedExecutionPayloadEnvelope executionPayload) {
     assertThat(
             executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(
+                executionPayload.getBeaconBlockRoot()))
+        .isFalse();
+  }
+
+  private void assertExecutionPayloadSeenForFullPayloadAttestation(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    assertThat(
+            executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
+                executionPayload.getBeaconBlockRoot()))
+        .isTrue();
+  }
+
+  private void assertExecutionPayloadNotSeenForFullPayloadAttestation(
+      final SignedExecutionPayloadEnvelope executionPayload) {
+    assertThat(
+            executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
                 executionPayload.getBeaconBlockRoot()))
         .isFalse();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -70,7 +70,7 @@ class DefaultExecutionPayloadManagerTest {
           mock(ReceivedExecutionPayloadEventsChannel.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final UpdatableStore store = mock(UpdatableStore.class);
-  private final Set<Bytes32> invalidExecutionPayloadRoots = new HashSet<>();
+  private final Set<Bytes32> blockRootsWithInvalidExecutionPayload = new HashSet<>();
   private Optional<SignedExecutionPayloadEnvelope> publishedExecutionPayload = Optional.empty();
 
   private final DefaultExecutionPayloadManager executionPayloadManager =
@@ -82,7 +82,7 @@ class DefaultExecutionPayloadManagerTest {
           executionLayer,
           receivedExecutionPayloadEventsChannelPublisher,
           recentChainData,
-          invalidExecutionPayloadRoots,
+          blockRootsWithInvalidExecutionPayload,
           executionPayload -> {
             publishedExecutionPayload = Optional.of(executionPayload);
             return SafeFuture.COMPLETE;
@@ -264,11 +264,11 @@ class DefaultExecutionPayloadManagerTest {
         .thenReturn(completedFuture(failedImportResult));
 
     final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
     asyncRunner.executeDueActions();
 
     assertThat(resultFuture).isCompletedWithValue(failedImportResult);
-    assertThat(invalidExecutionPayloadRoots)
+    assertThat(blockRootsWithInvalidExecutionPayload)
         .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
     assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
@@ -281,11 +281,12 @@ class DefaultExecutionPayloadManagerTest {
         .thenReturn(completedFuture(failedImportResult));
 
     final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
     asyncRunner.executeDueActions();
 
     assertThat(resultFuture).isCompletedWithValue(failedImportResult);
-    assertThat(invalidExecutionPayloadRoots).contains(signedExecutionPayload.getBeaconBlockRoot());
+    assertThat(blockRootsWithInvalidExecutionPayload)
+        .contains(signedExecutionPayload.getBeaconBlockRoot());
     assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
@@ -298,11 +299,31 @@ class DefaultExecutionPayloadManagerTest {
         .thenReturn(completedFuture(failedImportResult));
 
     final SafeFuture<ExecutionPayloadImportResult> resultFuture =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload, true);
     asyncRunner.executeDueActions();
 
     assertThat(resultFuture).isCompletedWithValue(failedImportResult);
-    assertThat(invalidExecutionPayloadRoots).contains(signedExecutionPayload.getBeaconBlockRoot());
+    assertThat(blockRootsWithInvalidExecutionPayload)
+        .contains(signedExecutionPayload.getBeaconBlockRoot());
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+  }
+
+  @Test
+  public void shouldNotCacheInvalidExecutionPayloadWhenCommitmentNotVerified() {
+    final ExecutionPayloadImportResult failedImportResult =
+        ExecutionPayloadImportResult.failedVerification(new RuntimeException("invalid"));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(completedFuture(failedImportResult));
+
+    // Imports that did not verify the payload commitment (e.g. sync or RPC-by-root) must not poison
+    // the invalid-payload cache, even when the import fails verification.
+    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload, false);
+    asyncRunner.executeDueActions();
+
+    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
+    assertThat(blockRootsWithInvalidExecutionPayload)
+        .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
     assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -257,48 +257,53 @@ class DefaultExecutionPayloadManagerTest {
   }
 
   @Test
-  public void shouldCacheInvalidExecutionPayloadWhenImportFailsExecution() {
+  public void shouldNotCacheInvalidExecutionPayloadWhenImportFailsExecution() {
     final ExecutionPayloadImportResult failedImportResult =
-        ExecutionPayloadImportResult.failedExecution(new RuntimeException("invalid"));
-    givenValidationResult(signedExecutionPayload, ACCEPT);
+        ExecutionPayloadImportResult.failedExecution(new RuntimeException("execution failed"));
     when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
         .thenReturn(completedFuture(failedImportResult));
 
-    final SafeFuture<InternalValidationResult> resultFuture =
-        validateAndImport(signedExecutionPayload);
+    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
     asyncRunner.executeDueActions();
 
-    assertThat(resultFuture).isCompletedWithValue(ACCEPT);
+    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
+    assertThat(invalidExecutionPayloadRoots)
+        .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+  }
+
+  @Test
+  public void shouldCacheInvalidExecutionPayloadWhenImportFailsVerification() {
+    final ExecutionPayloadImportResult failedImportResult =
+        ExecutionPayloadImportResult.failedVerification(new RuntimeException("invalid"));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(completedFuture(failedImportResult));
+
+    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
+    asyncRunner.executeDueActions();
+
+    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
     assertThat(invalidExecutionPayloadRoots).contains(signedExecutionPayload.getBeaconBlockRoot());
     assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test
-  public void shouldClearInvalidExecutionPayloadWhenLaterImportSucceeds() {
+  public void shouldCacheInvalidExecutionPayloadWhenDataAvailabilityCheckIsInvalid() {
     final ExecutionPayloadImportResult failedImportResult =
-        ExecutionPayloadImportResult.failedExecution(new RuntimeException("invalid"));
+        ExecutionPayloadImportResult.failedDataAvailabilityCheckInvalid(
+            Optional.of(new RuntimeException("invalid")));
     when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
-        .thenReturn(completedFuture(failedImportResult))
-        .thenReturn(
-            completedFuture(ExecutionPayloadImportResult.successful(signedExecutionPayload)));
+        .thenReturn(completedFuture(failedImportResult));
 
-    final SafeFuture<ExecutionPayloadImportResult> failedResult =
+    final SafeFuture<ExecutionPayloadImportResult> resultFuture =
         executionPayloadManager.importExecutionPayload(signedExecutionPayload);
     asyncRunner.executeDueActions();
 
-    assertThat(failedResult).isCompletedWithValue(failedImportResult);
+    assertThat(resultFuture).isCompletedWithValue(failedImportResult);
     assertThat(invalidExecutionPayloadRoots).contains(signedExecutionPayload.getBeaconBlockRoot());
     assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
-
-    final SafeFuture<ExecutionPayloadImportResult> successfulResult =
-        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
-    asyncRunner.executeDueActions();
-
-    assertThat(successfulResult)
-        .isCompletedWithValueMatching(ExecutionPayloadImportResult::isSuccessful);
-    assertThat(invalidExecutionPayloadRoots)
-        .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
-    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -28,9 +28,12 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.infrastructure.logging.LogCaptor;
@@ -67,6 +70,7 @@ class DefaultExecutionPayloadManagerTest {
           mock(ReceivedExecutionPayloadEventsChannel.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final UpdatableStore store = mock(UpdatableStore.class);
+  private final Set<Bytes32> invalidExecutionPayloadRoots = new HashSet<>();
   private Optional<SignedExecutionPayloadEnvelope> publishedExecutionPayload = Optional.empty();
 
   private final DefaultExecutionPayloadManager executionPayloadManager =
@@ -78,6 +82,7 @@ class DefaultExecutionPayloadManagerTest {
           executionLayer,
           receivedExecutionPayloadEventsChannelPublisher,
           recentChainData,
+          invalidExecutionPayloadRoots,
           executionPayload -> {
             publishedExecutionPayload = Optional.of(executionPayload);
             return SafeFuture.COMPLETE;
@@ -210,6 +215,22 @@ class DefaultExecutionPayloadManagerTest {
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
     assertExecutionPayloadRecentlySeen(signedExecutionPayload);
+  }
+
+  @Test
+  public void shouldCacheInvalidExecutionPayloadWhenImportFailsExecution() {
+    final ExecutionPayloadImportResult failedImportResult =
+        ExecutionPayloadImportResult.failedExecution(new RuntimeException("invalid"));
+    givenValidationResult(signedExecutionPayload, ACCEPT);
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(completedFuture(failedImportResult));
+
+    final SafeFuture<InternalValidationResult> resultFuture =
+        validateAndImport(signedExecutionPayload);
+    asyncRunner.executeDueActions();
+
+    assertThat(resultFuture).isCompletedWithValue(ACCEPT);
+    assertThat(invalidExecutionPayloadRoots).contains(signedExecutionPayload.getBeaconBlockRoot());
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -212,18 +212,29 @@ class DefaultExecutionPayloadManagerTest {
   }
 
   @Test
-  public void shouldThrowWhenStoreUnavailableForFullPayloadAttestationCheck() {
-    when(recentChainData.containsExecutionPayload(signedExecutionPayload.getBeaconBlockRoot()))
-        .thenThrow(
-            new IllegalStateException(
-                "Store is unavailable while checking execution payload availability"));
+  public void shouldNotReportExecutionPayloadSeenForFullPayloadAttestationWhenStoreUnavailable() {
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+  }
 
-    assertThatThrownBy(
-            () ->
-                executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
-                    signedExecutionPayload.getBeaconBlockRoot()))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Store is unavailable while checking execution payload availability");
+  @Test
+  public void shouldNotReportExecutionPayloadSeenForFullPayloadAttestationUntilImportCompletes() {
+    final SafeFuture<ExecutionPayloadImportResult> importResult = new SafeFuture<>();
+    givenValidationResult(signedExecutionPayload, ACCEPT);
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(importResult);
+
+    final SafeFuture<InternalValidationResult> resultFuture =
+        validateAndImport(signedExecutionPayload);
+
+    asyncRunner.executeDueActions();
+
+    assertThat(resultFuture).isCompletedWithValue(ACCEPT);
+    assertExecutionPayloadRecentlySeen(signedExecutionPayload);
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+
+    importResult.complete(ExecutionPayloadImportResult.successful(signedExecutionPayload));
+
+    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test
@@ -242,6 +253,7 @@ class DefaultExecutionPayloadManagerTest {
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
     assertExecutionPayloadRecentlySeen(signedExecutionPayload);
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test
@@ -258,6 +270,7 @@ class DefaultExecutionPayloadManagerTest {
 
     assertThat(resultFuture).isCompletedWithValue(ACCEPT);
     assertThat(invalidExecutionPayloadRoots).contains(signedExecutionPayload.getBeaconBlockRoot());
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManagerTest.java
@@ -274,6 +274,34 @@ class DefaultExecutionPayloadManagerTest {
   }
 
   @Test
+  public void shouldClearInvalidExecutionPayloadWhenLaterImportSucceeds() {
+    final ExecutionPayloadImportResult failedImportResult =
+        ExecutionPayloadImportResult.failedExecution(new RuntimeException("invalid"));
+    when(forkChoice.onExecutionPayloadEnvelope(signedExecutionPayload, executionLayer))
+        .thenReturn(completedFuture(failedImportResult))
+        .thenReturn(
+            completedFuture(ExecutionPayloadImportResult.successful(signedExecutionPayload)));
+
+    final SafeFuture<ExecutionPayloadImportResult> failedResult =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
+    asyncRunner.executeDueActions();
+
+    assertThat(failedResult).isCompletedWithValue(failedImportResult);
+    assertThat(invalidExecutionPayloadRoots).contains(signedExecutionPayload.getBeaconBlockRoot());
+    assertExecutionPayloadNotSeenForFullPayloadAttestation(signedExecutionPayload);
+
+    final SafeFuture<ExecutionPayloadImportResult> successfulResult =
+        executionPayloadManager.importExecutionPayload(signedExecutionPayload);
+    asyncRunner.executeDueActions();
+
+    assertThat(successfulResult)
+        .isCompletedWithValueMatching(ExecutionPayloadImportResult::isSuccessful);
+    assertThat(invalidExecutionPayloadRoots)
+        .doesNotContain(signedExecutionPayload.getBeaconBlockRoot());
+    assertExecutionPayloadSeenForFullPayloadAttestation(signedExecutionPayload);
+  }
+
+  @Test
   public void shouldProcessExecutionPayloadWhichHasBeenReceivedBeforeTheBlock() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(42);
     final SignedExecutionPayloadEnvelope signedExecutionPayload =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
@@ -14,18 +14,27 @@
 package tech.pegasys.teku.statetransition.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTest {
 
@@ -149,6 +158,50 @@ public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTe
   }
 
   @Test
+  public void shouldSaveFullPayloadAttestationForFutureWhenPayloadHasNotBeenSeen() {
+    final Bytes32 blockRoot = Bytes32.random();
+    final Attestation attestation = fullPayloadAttestationForPastBlock(blockRoot);
+    final GossipValidationHelper gossipValidationHelper =
+        mockGossipValidationForFullPayloadRule(attestation, blockRoot);
+
+    final AttestationValidator validator =
+        new AttestationValidator(
+            spec,
+            signatureVerifier,
+            gossipValidationHelper,
+            invalidBlockRoots,
+            Set.of(),
+            __ -> false);
+
+    assertThat(validator.validate(ValidatableAttestation.fromNetwork(spec, attestation, 0)))
+        .isCompletedWithValue(InternalValidationResult.SAVE_FOR_FUTURE);
+  }
+
+  @Test
+  public void shouldRejectFullPayloadAttestationWhenPayloadIsKnownInvalid() {
+    final Bytes32 blockRoot = Bytes32.random();
+    final Attestation attestation = fullPayloadAttestationForPastBlock(blockRoot);
+    final GossipValidationHelper gossipValidationHelper =
+        mockGossipValidationForFullPayloadRule(attestation, blockRoot);
+    final Set<Bytes32> invalidExecutionPayloadRoots = new HashSet<>();
+    invalidExecutionPayloadRoots.add(blockRoot);
+
+    final AttestationValidator validator =
+        new AttestationValidator(
+            spec,
+            signatureVerifier,
+            gossipValidationHelper,
+            invalidBlockRoots,
+            invalidExecutionPayloadRoots,
+            __ -> true);
+
+    assertThat(validator.validate(ValidatableAttestation.fromNetwork(spec, attestation, 0)))
+        .matches(
+            rejected("Execution payload for full payload attestation is invalid"),
+            "Rejected invalid execution payload");
+  }
+
+  @Test
   public void shouldRejectAggregateAttestationWithIncorrectPayloadStatus() {
     final Attestation attestation =
         attestationGenerator.validAttestation(storageSystem.getChainHead());
@@ -179,5 +232,31 @@ public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTe
         .isEqualTo(
             InternalValidationResult.reject(
                 "Payload status must be 0, but was %s.", wrongAttestation.getData().getIndex()));
+  }
+
+  private GossipValidationHelper mockGossipValidationForFullPayloadRule(
+      final Attestation attestation, final Bytes32 blockRoot) {
+    final GossipValidationHelper gossipValidationHelper = mock(GossipValidationHelper.class);
+    when(gossipValidationHelper.getSlotForBlockRoot(blockRoot)).thenReturn(Optional.of(ZERO));
+    when(gossipValidationHelper.getGenesisTime()).thenReturn(ZERO);
+    when(gossipValidationHelper.getCurrentTimeMillis())
+        .thenReturn(spec.computeTimeMillisAtSlot(attestation.getData().getSlot(), ZERO));
+    when(gossipValidationHelper.isBlockAvailable(blockRoot)).thenReturn(true);
+    return gossipValidationHelper;
+  }
+
+  private Attestation fullPayloadAttestationForPastBlock(final Bytes32 blockRoot) {
+    final AttestationData data =
+        new AttestationData(
+            ONE,
+            ONE,
+            blockRoot,
+            new Checkpoint(ZERO, Bytes32.ZERO),
+            new Checkpoint(spec.computeEpochAtSlot(ONE), Bytes32.ZERO));
+    return attestationSchema.create(
+        attestationSchema.getAggregationBitsSchema().ofBits(1, 0),
+        data,
+        BLSSignature.empty(),
+        () -> attestationSchema.getCommitteeBitsSchema().orElseThrow().ofBits(1));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
@@ -183,8 +183,8 @@ public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTe
     final Attestation attestation = fullPayloadAttestationForPastBlock(blockRoot);
     final GossipValidationHelper gossipValidationHelper =
         mockGossipValidationForFullPayloadRule(attestation, blockRoot);
-    final Set<Bytes32> invalidExecutionPayloadRoots = new HashSet<>();
-    invalidExecutionPayloadRoots.add(blockRoot);
+    final Set<Bytes32> blockRootsWithInvalidExecutionPayload = new HashSet<>();
+    blockRootsWithInvalidExecutionPayload.add(blockRoot);
 
     final AttestationValidator validator =
         new AttestationValidator(
@@ -192,7 +192,7 @@ public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTe
             signatureVerifier,
             gossipValidationHelper,
             invalidBlockRoots,
-            invalidExecutionPayloadRoots,
+            blockRootsWithInvalidExecutionPayload,
             __ -> true);
 
     assertThat(validator.validate(ValidatableAttestation.fromNetwork(spec, attestation, 0)))

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1305,7 +1305,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         .subscribe(FinalizedCheckpointChannel.class, pendingBlockPool)
         .subscribe(SlotEventsChannel.class, pendingBlockPool);
     invalidBlockRoots = LimitedMap.createSynchronizedLRU(500);
-    invalidExecutionPayloadRoots = LimitedSet.createSynchronized(500);
+    invalidExecutionPayloadRoots = LimitedSet.createSynchronizedLRU(500);
   }
 
   protected void initBlockBlobSidecarsTrackersPool() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1913,7 +1913,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             invalidExecutionPayloadRoots,
             blockRoot ->
                 executionPayloadManager != null
-                    && executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(
+                    && executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(
                         blockRoot));
     AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(spec, attestationValidator, signatureVerificationService);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -77,6 +78,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.AsyncRunnerEventThread;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
+import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.PortAvailability;
@@ -379,6 +381,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
   protected volatile DataColumnSidecarELManager dataColumnSidecarELManager;
   protected volatile Map<Bytes32, BlockImportResult> invalidBlockRoots;
+  protected volatile Set<Bytes32> invalidExecutionPayloadRoots;
   protected volatile CoalescingChainHeadChannel coalescingChainHeadChannel;
   protected volatile ActiveValidatorTracker activeValidatorTracker;
   protected volatile AttestationTopicSubscriber attestationTopicSubscriber;
@@ -980,6 +983,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               executionLayer,
               receivedExecutionPayloadEventsChannelPublisher,
               recentChainData,
+              invalidExecutionPayloadRoots,
               executionPayloadGossipChannel::publishExecutionPayload);
       final FailedExecutionPayloadPool failedExecutionPayloadPool =
           new FailedExecutionPayloadPool(executionPayloadManager, beaconAsyncRunner);
@@ -1301,6 +1305,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         .subscribe(FinalizedCheckpointChannel.class, pendingBlockPool)
         .subscribe(SlotEventsChannel.class, pendingBlockPool);
     invalidBlockRoots = LimitedMap.createSynchronizedLRU(500);
+    invalidExecutionPayloadRoots = LimitedSet.createSynchronized(500);
   }
 
   protected void initBlockBlobSidecarsTrackersPool() {
@@ -1901,7 +1906,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
             "attestations");
     AttestationValidator attestationValidator =
         new AttestationValidator(
-            spec, signatureVerificationService, gossipValidationHelper, invalidBlockRoots);
+            spec,
+            signatureVerificationService,
+            gossipValidationHelper,
+            invalidBlockRoots,
+            invalidExecutionPayloadRoots,
+            blockRoot ->
+                executionPayloadManager != null
+                    && executionPayloadManager.isExecutionPayloadAvailableForPayloadAttestation(
+                        blockRoot));
     AggregateAttestationValidator aggregateValidator =
         new AggregateAttestationValidator(spec, attestationValidator, signatureVerificationService);
     blockImporter.subscribeToVerifiedBlockAttestations(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -381,7 +381,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
   protected volatile DataColumnSidecarELManager dataColumnSidecarELManager;
   protected volatile Map<Bytes32, BlockImportResult> invalidBlockRoots;
-  protected volatile Set<Bytes32> invalidExecutionPayloadRoots;
+  protected volatile Set<Bytes32> blockRootsWithInvalidExecutionPayload;
   protected volatile CoalescingChainHeadChannel coalescingChainHeadChannel;
   protected volatile ActiveValidatorTracker activeValidatorTracker;
   protected volatile AttestationTopicSubscriber attestationTopicSubscriber;
@@ -521,7 +521,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     recentExecutionPayloadsFetcher.subscribeExecutionPayloadFetched(
         executionPayload ->
             executionPayloadManager
-                .importExecutionPayload(executionPayload)
+                .importExecutionPayload(executionPayload, false)
                 .finish(
                     err ->
                         LOG.error("Failed to process recently fetched execution payload.", err)));
@@ -983,7 +983,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               executionLayer,
               receivedExecutionPayloadEventsChannelPublisher,
               recentChainData,
-              invalidExecutionPayloadRoots,
+              blockRootsWithInvalidExecutionPayload,
               executionPayloadGossipChannel::publishExecutionPayload);
       final FailedExecutionPayloadPool failedExecutionPayloadPool =
           new FailedExecutionPayloadPool(executionPayloadManager, beaconAsyncRunner);
@@ -1305,7 +1305,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         .subscribe(FinalizedCheckpointChannel.class, pendingBlockPool)
         .subscribe(SlotEventsChannel.class, pendingBlockPool);
     invalidBlockRoots = LimitedMap.createSynchronizedLRU(500);
-    invalidExecutionPayloadRoots = LimitedSet.createSynchronizedLRU(500);
+    blockRootsWithInvalidExecutionPayload = LimitedSet.createSynchronizedLRU(500);
   }
 
   protected void initBlockBlobSidecarsTrackersPool() {
@@ -1910,7 +1910,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             signatureVerificationService,
             gossipValidationHelper,
             invalidBlockRoots,
-            invalidExecutionPayloadRoots,
+            blockRootsWithInvalidExecutionPayload,
             blockRoot ->
                 executionPayloadManager != null
                     && executionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -660,6 +660,12 @@ public abstract class RecentChainData
     return Optional.ofNullable(store).map(s -> s.containsBlock(root)).orElse(false);
   }
 
+  public boolean containsExecutionPayload(final Bytes32 blockRoot) {
+    return Optional.ofNullable(store)
+        .map(s -> s.getExecutionPayloadIfAvailable(blockRoot).isPresent())
+        .orElse(false);
+  }
+
   public Optional<UInt64> getSlotForBlockRoot(final Bytes32 root) {
     return getForkChoiceStrategy().flatMap(forkChoice -> forkChoice.blockSlot(root));
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -581,6 +581,49 @@ class RecentChainDataTest {
   }
 
   @Test
+  public void containsExecutionPayload_shouldReturnFalseWhenStoreUnavailable() {
+    initPreGenesis();
+
+    assertThat(recentChainData.containsExecutionPayload(Bytes32.ZERO)).isFalse();
+  }
+
+  @Test
+  public void containsExecutionPayload_shouldReturnFalseWhenPayloadUnavailable() {
+    initPostGenesis();
+
+    assertThat(recentChainData.containsExecutionPayload(dataStructureUtil.randomBytes32()))
+        .isFalse();
+  }
+
+  @Test
+  public void containsExecutionPayload_shouldReturnTrueWhenPayloadAvailable() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final StorageSystem gloasStorage =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(gloasSpec)
+            .storageMode(StateStorageMode.PRUNE)
+            .storeConfig(StoreConfig.builder().build())
+            .build();
+    final ChainBuilder gloasChainBuilder = gloasStorage.chainBuilder();
+    final RecentChainData gloasRecentChainData = gloasStorage.recentChainData();
+    final SignedBlockAndState gloasGenesis = gloasChainBuilder.generateGenesis();
+    gloasRecentChainData.initializeFromGenesis(gloasGenesis.getState(), UInt64.ZERO);
+
+    final SignedBlockAndState block = gloasChainBuilder.generateBlockAtSlot(1);
+    final SignedExecutionPayloadEnvelope executionPayload =
+        gloasChainBuilder.getExecutionPayloadAtSlot(block.getSlot()).orElseThrow();
+
+    assertThat(gloasRecentChainData.containsExecutionPayload(block.getRoot())).isFalse();
+
+    final StoreTransaction transaction = gloasRecentChainData.startStoreTransaction();
+    transaction.putBlockAndState(block, gloasSpec.calculateBlockCheckpoints(block.getState()));
+    transaction.putExecutionPayload(executionPayload, false);
+    transaction.commit().join();
+
+    assertThat(gloasRecentChainData.containsExecutionPayload(block.getRoot())).isTrue();
+  }
+
+  @Test
   public void updateHead_reorgEventWhenChainSwitchesToNewBlockAtSameSlot() {
     initPreGenesis();
     final ChainBuilder chainBuilder =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Implements the missing Gloas full-payload attestation gossip checks:
- Reject full payload attestations when the referenced execution payload is known invalid
- Queue full payload attestations for future processing when the payload has not been seen yet
- Track invalid execution payload roots 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
partially fixes #10795 
required for #10772 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus gossip validation and fork-choice payload import paths; incorrect cache poisoning could reject legitimate full-payload attestations, though unverified import paths are explicitly excluded.
> 
> **Overview**
> Adds **Gloas full-payload attestation gossip validation** so votes with payload index `1` are **rejected** when the beacon block’s execution payload is known invalid, and **deferred** until that payload has been successfully imported or is already in the store.
> 
> `AttestationValidator` now takes a shared LRU set of invalid payload block roots and a predicate from `ExecutionPayloadManager.isExecutionPayloadSeenForFullPayloadAttestation`. `importExecutionPayload` gains a **`payloadCommitmentVerified`** flag: gossip-validated imports pass `true` so verification/DA failures can populate the invalid-payload cache; **sync, RPC-by-root, and retry** paths pass `false` so unproven envelopes cannot poison that cache. Successful imports are tracked separately from “recently seen,” and `RecentChainData.containsExecutionPayload` backs store lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e21a5b0249fdad21e51ba3493d54a5c15b02cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->