### PR TITLE
Add experimental QUIC transport support

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/LibP2PDiscoveryNodeIdExtractor.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/LibP2PDiscoveryNodeIdExtractor.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.networking.eth2.peers;
 
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.networking.p2p.discovery.discv5.DiscV5Service;
@@ -21,6 +23,8 @@ import tech.pegasys.teku.networking.p2p.libp2p.LibP2PPeer;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 
 public class LibP2PDiscoveryNodeIdExtractor implements DiscoveryNodeIdExtractor {
+  private static final Logger LOG = LogManager.getLogger();
+
   @Override
   public Optional<UInt256> calculateDiscoveryNodeId(final Peer peer) {
     if (peer instanceof LibP2PPeer libP2PPeer) {
@@ -30,7 +34,8 @@ public class LibP2PDiscoveryNodeIdExtractor implements DiscoveryNodeIdExtractor 
             DiscV5Service.DEFAULT_NODE_RECORD_CONVERTER.convertPublicKeyToNodeId(
                 libP2PPeerPublicKey);
         return Optional.of(UInt256.fromBytes(discoveryNodeIdBytes));
-      } catch (final Exception ignored) {
+      } catch (final Exception e) {
+        LOG.debug("Failed to calculate discovery node id for peer {}", peer.getId(), e);
         return Optional.empty();
       }
     }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SubnetScorerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/SubnetScorerTest.java
@@ -214,6 +214,7 @@ class SubnetScorerTest {
           DEFAULT_NODE_RECORD_CONVERTER.convertPublicKeyToNodeId(pubKey),
           new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
           Optional.empty(),
+          Optional.empty(),
           attSubnets,
           syncSubnets,
           Optional.empty(),

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerSelectionStrategyTest.java
@@ -338,6 +338,7 @@ class Eth2PeerSelectionStrategyTest {
         peerId,
         peerId,
         new InetSocketAddress(InetAddress.getLoopbackAddress(), peerId.trimLeadingZeros().toInt()),
+        Optional.empty(),
         ENR_FORK_ID,
         SCHEMA_DEFINITIONS.getAttnetsENRFieldSchema().ofBits(attnets),
         SCHEMA_DEFINITIONS.getSyncnetsENRFieldSchema().getDefault(),

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryPeer.java
@@ -26,6 +26,7 @@ public class DiscoveryPeer {
   private final Bytes publicKey;
   private final Bytes nodeId;
   private final InetSocketAddress nodeAddress;
+  private final Optional<InetSocketAddress> quicAddress;
   private final Optional<EnrForkId> enrForkId;
   private final SszBitvector persistentAttestationSubnets;
   private final SszBitvector syncCommitteeSubnets;
@@ -36,6 +37,7 @@ public class DiscoveryPeer {
       final Bytes publicKey,
       final Bytes nodeId,
       final InetSocketAddress nodeAddress,
+      final Optional<InetSocketAddress> quicAddress,
       final Optional<EnrForkId> enrForkId,
       final SszBitvector persistentAttestationSubnets,
       final SszBitvector syncCommitteeSubnets,
@@ -44,6 +46,7 @@ public class DiscoveryPeer {
     this.publicKey = publicKey;
     this.nodeId = nodeId;
     this.nodeAddress = nodeAddress;
+    this.quicAddress = quicAddress;
     this.enrForkId = enrForkId;
     this.persistentAttestationSubnets = persistentAttestationSubnets;
     this.syncCommitteeSubnets = syncCommitteeSubnets;
@@ -61,6 +64,10 @@ public class DiscoveryPeer {
 
   public InetSocketAddress getNodeAddress() {
     return nodeAddress;
+  }
+
+  public Optional<InetSocketAddress> getQuicAddress() {
+    return quicAddress;
   }
 
   public Optional<EnrForkId> getEnrForkId() {
@@ -94,6 +101,7 @@ public class DiscoveryPeer {
     DiscoveryPeer that = (DiscoveryPeer) o;
     return Objects.equal(getPublicKey(), that.getPublicKey())
         && Objects.equal(getNodeAddress(), that.getNodeAddress())
+        && Objects.equal(getQuicAddress(), that.getQuicAddress())
         && Objects.equal(getEnrForkId(), that.getEnrForkId())
         && Objects.equal(getPersistentAttestationSubnets(), that.getPersistentAttestationSubnets())
         && Objects.equal(getSyncCommitteeSubnets(), that.getSyncCommitteeSubnets())
@@ -106,6 +114,7 @@ public class DiscoveryPeer {
     return Objects.hashCode(
         getPublicKey(),
         getNodeAddress(),
+        getQuicAddress(),
         getEnrForkId(),
         getPersistentAttestationSubnets(),
         getSyncCommitteeSubnets(),
@@ -118,6 +127,7 @@ public class DiscoveryPeer {
     return MoreObjects.toStringHelper(this)
         .add("publicKey", publicKey)
         .add("nodeAddress", nodeAddress)
+        .add("quicAddress", quicAddress)
         .add("enrForkId", enrForkId)
         .add("persistentSubnets", persistentAttestationSubnets)
         .add("syncCommitteeSubnets", syncCommitteeSubnets)

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -128,7 +128,12 @@ public class DiscV5Service extends Service implements DiscoveryService {
         "The configured advertised IPs must be either 1 or 2");
     if (advertisedIps.size() == 1) {
       nodeRecordBuilder.address(
-          advertisedIps.get(0), discoConfig.getAdvertisedUdpPort(), p2pConfig.getAdvertisedPort());
+          advertisedIps.get(0),
+          discoConfig.getAdvertisedUdpPort(),
+          p2pConfig.getAdvertisedPort(),
+          p2pConfig.isQuicEnabled()
+              ? Optional.of(p2pConfig.getAdvertisedQuicPort())
+              : Optional.empty());
     } else {
       // IPv4 and IPv6 (dual-stack)
       advertisedIps.forEach(
@@ -144,7 +149,16 @@ public class DiscV5Service extends Service implements DiscoveryService {
                   case IP_V4 -> p2pConfig.getAdvertisedPort();
                   case IP_V6 -> p2pConfig.getAdvertisedPortIpv6();
                 };
-            nodeRecordBuilder.address(advertisedIp, advertisedUdpPort, advertisedTcpPort);
+            final Optional<Integer> advertisedQuicPort =
+                p2pConfig.isQuicEnabled()
+                    ? Optional.of(
+                        switch (ipVersion) {
+                          case IP_V4 -> p2pConfig.getAdvertisedQuicPort();
+                          case IP_V6 -> p2pConfig.getAdvertisedQuicPortIpv6();
+                        })
+                    : Optional.empty();
+            nodeRecordBuilder.address(
+                advertisedIp, advertisedUdpPort, advertisedTcpPort, advertisedQuicPort);
           });
     }
     final NodeRecord localNodeRecord = nodeRecordBuilder.build();
@@ -174,8 +188,12 @@ public class DiscV5Service extends Service implements DiscoveryService {
     } else {
       return (oldRecord, newAddress) -> {
         final int newTcpPort;
+        Optional<Integer> newQuicPort = Optional.empty();
         if (p2pConfig.getNetworkInterfaces().size() == 1) {
           newTcpPort = p2pConfig.getAdvertisedPort();
+          if (p2pConfig.isQuicEnabled()) {
+            newQuicPort = Optional.of(p2pConfig.getAdvertisedQuicPort());
+          }
         } else {
           // IPv4 and IPv6 (dual-stack)
           newTcpPort =
@@ -183,10 +201,18 @@ public class DiscV5Service extends Service implements DiscoveryService {
                 case IP_V4 -> p2pConfig.getAdvertisedPort();
                 case IP_V6 -> p2pConfig.getAdvertisedPortIpv6();
               };
+          if (p2pConfig.isQuicEnabled()) {
+            newQuicPort =
+                Optional.of(
+                    switch (IPVersionResolver.resolve(newAddress)) {
+                      case IP_V4 -> p2pConfig.getAdvertisedQuicPort();
+                      case IP_V6 -> p2pConfig.getAdvertisedQuicPortIpv6();
+                    });
+          }
         }
         return Optional.of(
             oldRecord.withNewAddress(
-                newAddress, Optional.of(newTcpPort), Optional.empty(), localNodeSigner));
+                newAddress, Optional.of(newTcpPort), newQuicPort, localNodeSigner));
       };
     }
   }
@@ -286,6 +312,7 @@ public class DiscV5Service extends Service implements DiscoveryService {
                           (Bytes) nodeRecord.get(EnrField.PKEY_SECP256K1),
                           nodeRecord.getNodeId(),
                           updAddress,
+                          Optional.empty(),
                           Optional.empty(),
                           currentSchemaDefinitionsSupplier.getAttnetsENRFieldSchema().getDefault(),
                           currentSchemaDefinitionsSupplier.getSyncnetsENRFieldSchema().getDefault(),

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -210,9 +210,10 @@ public class DiscV5Service extends Service implements DiscoveryService {
                     });
           }
         }
+        final Optional<Integer> advertisedTcpPort =
+            p2pConfig.isTcpEnabled() ? Optional.of(newTcpPort) : Optional.empty();
         return Optional.of(
-            oldRecord.withNewAddress(
-                newAddress, Optional.of(newTcpPort), newQuicPort, localNodeSigner));
+            oldRecord.withNewAddress(newAddress, advertisedTcpPort, newQuicPort, localNodeSigner));
       };
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
@@ -50,20 +50,25 @@ public class NodeRecordConverter {
       final boolean supportsIpv6,
       final SchemaDefinitions schemaDefinitions) {
     final Optional<InetSocketAddress> tcpAddress;
+    final Optional<InetSocketAddress> quicAddress;
     if (supportsIpv6) {
       // prefer IPv6 address
       tcpAddress = nodeRecord.getTcp6Address().or(nodeRecord::getTcpAddress);
+      quicAddress = nodeRecord.getQuic6Address().or(nodeRecord::getQuicAddress);
     } else {
       tcpAddress = nodeRecord.getTcpAddress();
+      quicAddress = nodeRecord.getQuicAddress();
     }
     return tcpAddress.map(
-        address -> socketAddressToDiscoveryPeer(schemaDefinitions, nodeRecord, address));
+        address ->
+            socketAddressToDiscoveryPeer(schemaDefinitions, nodeRecord, address, quicAddress));
   }
 
   private static DiscoveryPeer socketAddressToDiscoveryPeer(
       final SchemaDefinitions schemaDefinitions,
       final NodeRecord nodeRecord,
-      final InetSocketAddress address) {
+      final InetSocketAddress address,
+      final Optional<InetSocketAddress> quicAddress) {
 
     final Optional<EnrForkId> enrForkId =
         parseField(nodeRecord, ETH2_ENR_FIELD, EnrForkId.SSZ_SCHEMA::sszDeserialize);
@@ -95,6 +100,7 @@ public class NodeRecordConverter {
         ((Bytes) nodeRecord.get(EnrField.PKEY_SECP256K1)),
         nodeRecord.getNodeId(),
         address,
+        quicAddress,
         enrForkId,
         persistentAttestationSubnets,
         syncCommitteeSubnets,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -56,6 +56,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   private final List<Multiaddr> advertisedAddresses;
   private final GossipNetwork gossipNetwork;
   private final List<Integer> listenPorts;
+  private final boolean quicEnabled;
 
   private final AtomicReference<State> state = new AtomicReference<>(State.IDLE);
 
@@ -66,7 +67,8 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
       final PeerManager peerManager,
       final List<Multiaddr> advertisedAddresses,
       final GossipNetwork gossipNetwork,
-      final List<Integer> listenPorts) {
+      final List<Integer> listenPorts,
+      final boolean quicEnabled) {
     this.privKey = privKey;
     this.nodeId = nodeId;
     this.host = host;
@@ -74,6 +76,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
     this.advertisedAddresses = advertisedAddresses;
     this.gossipNetwork = gossipNetwork;
     this.listenPorts = listenPorts;
+    this.quicEnabled = quicEnabled;
   }
 
   @Override
@@ -113,7 +116,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
 
   @Override
   public PeerAddress createPeerAddress(final DiscoveryPeer discoveryPeer) {
-    return MultiaddrPeerAddress.fromDiscoveryPeer(discoveryPeer);
+    return MultiaddrPeerAddress.fromDiscoveryPeer(discoveryPeer, quicEnabled);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.p2p.libp2p;
 import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_OPEN_STREAMS_RATE_LIMIT;
 import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Host;
@@ -36,9 +37,8 @@ import io.libp2p.transport.tcp.TcpTransport;
 import io.netty.handler.logging.LogLevel;
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.io.IPVersionResolver;
@@ -109,69 +109,15 @@ public class LibP2PNetworkBuilder {
     final PrivKey privKey = privateKeyProvider.get();
     final NodeId nodeId = new LibP2PNodeId(PeerId.fromPubKey(privKey.publicKey()));
 
-    final List<Multiaddr> advertisedAddresses;
-    final List<String> advertisedIps = config.getAdvertisedIps();
     Preconditions.checkState(
-        advertisedIps.size() == 1 || advertisedIps.size() == 2,
-        "The configured advertised IPs must be either 1 or 2");
-    if (advertisedIps.size() == 1) {
-      final Multiaddr advertisedAddr =
-          MultiaddrUtil.fromInetSocketAddress(
-              new InetSocketAddress(advertisedIps.get(0), config.getAdvertisedPort()), nodeId);
-      if (config.isQuicEnabled()) {
-        final Multiaddr advertisedQuicAddr =
-            MultiaddrUtil.fromInetSocketAddressAsQuic(
-                new InetSocketAddress(advertisedIps.get(0), config.getAdvertisedQuicPort()),
-                nodeId);
-        advertisedAddresses = List.of(advertisedAddr, advertisedQuicAddr);
-      } else {
-        advertisedAddresses = Collections.singletonList(advertisedAddr);
-      }
-    } else {
-      // IPv4 and IPv6 (dual-stack)
-      advertisedAddresses =
-          advertisedIps.stream()
-              .flatMap(
-                  advertisedIp -> {
-                    final int advertisedPort =
-                        switch (IPVersionResolver.resolve(advertisedIp)) {
-                          case IP_V4 -> config.getAdvertisedPort();
-                          case IP_V6 -> config.getAdvertisedPortIpv6();
-                        };
-                    final Multiaddr advertisedAddr =
-                        MultiaddrUtil.fromInetSocketAddress(
-                            new InetSocketAddress(advertisedIp, advertisedPort), nodeId);
-                    if (config.isQuicEnabled()) {
-                      final int advertisedQuicPort =
-                          switch (IPVersionResolver.resolve(advertisedIp)) {
-                            case IP_V4 -> config.getAdvertisedQuicPort();
-                            case IP_V6 -> config.getAdvertisedQuicPortIpv6();
-                          };
-                      final Multiaddr advertisedQuicAddr =
-                          MultiaddrUtil.fromInetSocketAddressAsQuic(
-                              new InetSocketAddress(advertisedIp, advertisedQuicPort), nodeId);
-                      return Stream.of(advertisedAddr, advertisedQuicAddr);
-                    } else {
-                      return Stream.of(advertisedAddr);
-                    }
-                  })
-              .toList();
-    }
+        config.isTcpEnabled() || config.isQuicEnabled(),
+        "At least one of the TCP or QUIC transports must be enabled");
+
+    final List<Multiaddr> advertisedAddresses = buildAdvertisedAddresses(config, nodeId);
 
     host = createHost(privKey, advertisedAddresses);
 
-    final List<Integer> listenPorts =
-        advertisedAddresses.size() == 2
-            ? config.isQuicEnabled()
-                ? List.of(
-                    config.getListenPort(),
-                    config.getListenPortIpv6(),
-                    config.getListenQuicPort(),
-                    config.getListenQuicPortIpv6())
-                : List.of(config.getListenPort(), config.getListenPortIpv6())
-            : config.isQuicEnabled()
-                ? List.of(config.getListenPort(), config.getListenQuicPort())
-                : List.of(config.getListenPort());
+    final List<Integer> listenPorts = buildListenPorts(config);
 
     return new LibP2PNetwork(
         host.getPrivKey(),
@@ -181,6 +127,143 @@ public class LibP2PNetworkBuilder {
         advertisedAddresses,
         gossipNetwork,
         listenPorts);
+  }
+
+  /**
+   * Builds the multiaddrs advertised to peers (e.g. via the discovery ENR). Only enabled transports
+   * are advertised, so peers are never told to dial a transport the node is not serving.
+   */
+  @VisibleForTesting
+  static List<Multiaddr> buildAdvertisedAddresses(final NetworkConfig config, final NodeId nodeId) {
+    final List<String> advertisedIps = config.getAdvertisedIps();
+    Preconditions.checkState(
+        advertisedIps.size() == 1 || advertisedIps.size() == 2,
+        "The configured advertised IPs must be either 1 or 2");
+    final boolean singleStack = advertisedIps.size() == 1;
+    return advertisedIps.stream()
+        .flatMap(
+            advertisedIp -> {
+              final List<Multiaddr> addresses = new ArrayList<>();
+              if (config.isTcpEnabled()) {
+                addresses.add(
+                    MultiaddrUtil.fromInetSocketAddress(
+                        new InetSocketAddress(
+                            advertisedIp, advertisedTcpPort(config, advertisedIp, singleStack)),
+                        nodeId));
+              }
+              if (config.isQuicEnabled()) {
+                addresses.add(
+                    MultiaddrUtil.fromInetSocketAddressAsQuic(
+                        new InetSocketAddress(
+                            advertisedIp, advertisedQuicPort(config, advertisedIp, singleStack)),
+                        nodeId));
+              }
+              return addresses.stream();
+            })
+        .toList();
+  }
+
+  /** Builds the listen multiaddrs for the host, including only enabled transports. */
+  @VisibleForTesting
+  static String[] buildListenAddresses(final NetworkConfig config) {
+    final List<String> networkInterfaces = config.getNetworkInterfaces();
+    Preconditions.checkState(
+        networkInterfaces.size() == 1 || networkInterfaces.size() == 2,
+        "The configured network interfaces must be either 1 or 2");
+    final boolean singleStack = networkInterfaces.size() == 1;
+    return networkInterfaces.stream()
+        .flatMap(
+            networkInterface -> {
+              final List<String> addresses = new ArrayList<>();
+              if (config.isTcpEnabled()) {
+                addresses.add(
+                    MultiaddrUtil.fromInetSocketAddress(
+                            new InetSocketAddress(
+                                networkInterface,
+                                listenTcpPort(config, networkInterface, singleStack)))
+                        .toString());
+              }
+              if (config.isQuicEnabled()) {
+                addresses.add(
+                    MultiaddrUtil.fromInetSocketAddressAsQuic(
+                            new InetSocketAddress(
+                                networkInterface,
+                                listenQuicPort(config, networkInterface, singleStack)))
+                        .toString());
+              }
+              return addresses.stream();
+            })
+        .toArray(String[]::new);
+  }
+
+  /**
+   * Builds the list of ports the node listens on, including only enabled transports. Used for
+   * diagnostics (e.g. reporting which ports failed to bind).
+   */
+  @VisibleForTesting
+  static List<Integer> buildListenPorts(final NetworkConfig config) {
+    final List<String> networkInterfaces = config.getNetworkInterfaces();
+    Preconditions.checkState(
+        networkInterfaces.size() == 1 || networkInterfaces.size() == 2,
+        "The configured network interfaces must be either 1 or 2");
+    final boolean singleStack = networkInterfaces.size() == 1;
+    return networkInterfaces.stream()
+        .flatMap(
+            networkInterface -> {
+              final List<Integer> ports = new ArrayList<>();
+              if (config.isTcpEnabled()) {
+                ports.add(listenTcpPort(config, networkInterface, singleStack));
+              }
+              if (config.isQuicEnabled()) {
+                ports.add(listenQuicPort(config, networkInterface, singleStack));
+              }
+              return ports.stream();
+            })
+        .toList();
+  }
+
+  private static int advertisedTcpPort(
+      final NetworkConfig config, final String advertisedIp, final boolean singleStack) {
+    if (singleStack) {
+      return config.getAdvertisedPort();
+    }
+    return switch (IPVersionResolver.resolve(advertisedIp)) {
+      case IP_V4 -> config.getAdvertisedPort();
+      case IP_V6 -> config.getAdvertisedPortIpv6();
+    };
+  }
+
+  private static int advertisedQuicPort(
+      final NetworkConfig config, final String advertisedIp, final boolean singleStack) {
+    if (singleStack) {
+      return config.getAdvertisedQuicPort();
+    }
+    return switch (IPVersionResolver.resolve(advertisedIp)) {
+      case IP_V4 -> config.getAdvertisedQuicPort();
+      case IP_V6 -> config.getAdvertisedQuicPortIpv6();
+    };
+  }
+
+  private static int listenTcpPort(
+      final NetworkConfig config, final String networkInterface, final boolean singleStack) {
+    if (singleStack) {
+      return config.getListenPort();
+    }
+    return switch (IPVersionResolver.resolve(networkInterface)) {
+      case IP_V4 -> config.getListenPort();
+      case IP_V6 -> config.getListenPortIpv6();
+    };
+  }
+
+  private static int listenQuicPort(
+      final NetworkConfig config, final String networkInterface, final boolean singleStack) {
+    if (singleStack) {
+      return config.getListenQuicPort();
+    }
+    return switch (IPVersionResolver.resolve(networkInterface)) {
+      case IP_V4 -> config.getListenQuicPort();
+      case IP_V6 -> config.getListenQuicPortIpv6();
+    };
   }
 
   protected List<? extends RpcHandler<?, ?, ?>> createRpcHandlers() {
@@ -211,53 +294,7 @@ public class LibP2PNetworkBuilder {
 
   @SuppressWarnings("AddressSelection")
   protected Host createHost(final PrivKey privKey, final List<Multiaddr> advertisedAddresses) {
-    final String[] listenAddrs;
-    final List<String> networkInterfaces = config.getNetworkInterfaces();
-    Preconditions.checkState(
-        networkInterfaces.size() == 1 || networkInterfaces.size() == 2,
-        "The configured network interfaces must be either 1 or 2");
-    if (networkInterfaces.size() == 1) {
-      final Multiaddr addr =
-          MultiaddrUtil.fromInetSocketAddress(
-              new InetSocketAddress(networkInterfaces.get(0), config.getListenPort()));
-      if (config.isQuicEnabled()) {
-        final Multiaddr quicAddr =
-            MultiaddrUtil.fromInetSocketAddressAsQuic(
-                new InetSocketAddress(networkInterfaces.get(0), config.getListenQuicPort()));
-        listenAddrs = new String[] {addr.toString(), quicAddr.toString()};
-      } else {
-        listenAddrs = new String[] {addr.toString()};
-      }
-    } else {
-      // IPv4 and IPv6 (dual-stack)
-      listenAddrs =
-          networkInterfaces.stream()
-              .flatMap(
-                  networkInterface -> {
-                    final int listenPort =
-                        switch (IPVersionResolver.resolve(networkInterface)) {
-                          case IP_V4 -> config.getListenPort();
-                          case IP_V6 -> config.getListenPortIpv6();
-                        };
-                    final Multiaddr addr =
-                        MultiaddrUtil.fromInetSocketAddress(
-                            new InetSocketAddress(networkInterface, listenPort));
-                    if (config.isQuicEnabled()) {
-                      final int listenQuicPort =
-                          switch (IPVersionResolver.resolve(networkInterface)) {
-                            case IP_V4 -> config.getListenQuicPort();
-                            case IP_V6 -> config.getListenQuicPortIpv6();
-                          };
-                      final Multiaddr quicAddr =
-                          MultiaddrUtil.fromInetSocketAddressAsQuic(
-                              new InetSocketAddress(networkInterface, listenQuicPort));
-                      return Stream.of(addr.toString(), quicAddr.toString());
-                    } else {
-                      return Stream.of(addr.toString());
-                    }
-                  })
-              .toArray(String[]::new);
-    }
+    final String[] listenAddrs = buildListenAddresses(config);
 
     return BuilderJKt.hostJ(
         hostBuilderDefaults,

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -126,7 +126,8 @@ public class LibP2PNetworkBuilder {
         peerManager,
         advertisedAddresses,
         gossipNetwork,
-        listenPorts);
+        listenPorts,
+        config.isQuicEnabled());
   }
 
   /**

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -31,12 +31,14 @@ import io.libp2p.etc.types.ByteArrayExtKt;
 import io.libp2p.protocol.Identify;
 import io.libp2p.protocol.Ping;
 import io.libp2p.security.noise.NoiseXXSecureChannel;
+import io.libp2p.transport.quic.QuicTransport;
 import io.libp2p.transport.tcp.TcpTransport;
 import io.netty.handler.logging.LogLevel;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.io.IPVersionResolver;
@@ -113,23 +115,45 @@ public class LibP2PNetworkBuilder {
         advertisedIps.size() == 1 || advertisedIps.size() == 2,
         "The configured advertised IPs must be either 1 or 2");
     if (advertisedIps.size() == 1) {
-      advertisedAddresses =
-          Collections.singletonList(
-              MultiaddrUtil.fromInetSocketAddress(
-                  new InetSocketAddress(advertisedIps.get(0), config.getAdvertisedPort()), nodeId));
+      final Multiaddr advertisedAddr =
+          MultiaddrUtil.fromInetSocketAddress(
+              new InetSocketAddress(advertisedIps.get(0), config.getAdvertisedPort()), nodeId);
+      if (config.isQuicEnabled()) {
+        final Multiaddr advertisedQuicAddr =
+            MultiaddrUtil.fromInetSocketAddressAsQuic(
+                new InetSocketAddress(advertisedIps.get(0), config.getAdvertisedQuicPort()),
+                nodeId);
+        advertisedAddresses = List.of(advertisedAddr, advertisedQuicAddr);
+      } else {
+        advertisedAddresses = Collections.singletonList(advertisedAddr);
+      }
     } else {
       // IPv4 and IPv6 (dual-stack)
       advertisedAddresses =
           advertisedIps.stream()
-              .map(
+              .flatMap(
                   advertisedIp -> {
                     final int advertisedPort =
                         switch (IPVersionResolver.resolve(advertisedIp)) {
                           case IP_V4 -> config.getAdvertisedPort();
                           case IP_V6 -> config.getAdvertisedPortIpv6();
                         };
-                    return MultiaddrUtil.fromInetSocketAddress(
-                        new InetSocketAddress(advertisedIp, advertisedPort), nodeId);
+                    final Multiaddr advertisedAddr =
+                        MultiaddrUtil.fromInetSocketAddress(
+                            new InetSocketAddress(advertisedIp, advertisedPort), nodeId);
+                    if (config.isQuicEnabled()) {
+                      final int advertisedQuicPort =
+                          switch (IPVersionResolver.resolve(advertisedIp)) {
+                            case IP_V4 -> config.getAdvertisedQuicPort();
+                            case IP_V6 -> config.getAdvertisedQuicPortIpv6();
+                          };
+                      final Multiaddr advertisedQuicAddr =
+                          MultiaddrUtil.fromInetSocketAddressAsQuic(
+                              new InetSocketAddress(advertisedIp, advertisedQuicPort), nodeId);
+                      return Stream.of(advertisedAddr, advertisedQuicAddr);
+                    } else {
+                      return Stream.of(advertisedAddr);
+                    }
                   })
               .toList();
     }
@@ -138,8 +162,16 @@ public class LibP2PNetworkBuilder {
 
     final List<Integer> listenPorts =
         advertisedAddresses.size() == 2
-            ? List.of(config.getListenPort(), config.getListenPortIpv6())
-            : List.of(config.getListenPort());
+            ? config.isQuicEnabled()
+                ? List.of(
+                    config.getListenPort(),
+                    config.getListenPortIpv6(),
+                    config.getListenQuicPort(),
+                    config.getListenQuicPortIpv6())
+                : List.of(config.getListenPort(), config.getListenPortIpv6())
+            : config.isQuicEnabled()
+                ? List.of(config.getListenPort(), config.getListenQuicPort())
+                : List.of(config.getListenPort());
 
     return new LibP2PNetwork(
         host.getPrivKey(),
@@ -188,12 +220,19 @@ public class LibP2PNetworkBuilder {
       final Multiaddr addr =
           MultiaddrUtil.fromInetSocketAddress(
               new InetSocketAddress(networkInterfaces.get(0), config.getListenPort()));
-      listenAddrs = new String[] {addr.toString()};
+      if (config.isQuicEnabled()) {
+        final Multiaddr quicAddr =
+            MultiaddrUtil.fromInetSocketAddressAsQuic(
+                new InetSocketAddress(networkInterfaces.get(0), config.getListenQuicPort()));
+        listenAddrs = new String[] {addr.toString(), quicAddr.toString()};
+      } else {
+        listenAddrs = new String[] {addr.toString()};
+      }
     } else {
       // IPv4 and IPv6 (dual-stack)
       listenAddrs =
           networkInterfaces.stream()
-              .map(
+              .flatMap(
                   networkInterface -> {
                     final int listenPort =
                         switch (IPVersionResolver.resolve(networkInterface)) {
@@ -203,7 +242,19 @@ public class LibP2PNetworkBuilder {
                     final Multiaddr addr =
                         MultiaddrUtil.fromInetSocketAddress(
                             new InetSocketAddress(networkInterface, listenPort));
-                    return addr.toString();
+                    if (config.isQuicEnabled()) {
+                      final int listenQuicPort =
+                          switch (IPVersionResolver.resolve(networkInterface)) {
+                            case IP_V4 -> config.getListenQuicPort();
+                            case IP_V6 -> config.getListenQuicPortIpv6();
+                          };
+                      final Multiaddr quicAddr =
+                          MultiaddrUtil.fromInetSocketAddressAsQuic(
+                              new InetSocketAddress(networkInterface, listenQuicPort));
+                      return Stream.of(addr.toString(), quicAddr.toString());
+                    } else {
+                      return Stream.of(addr.toString());
+                    }
                   })
               .toArray(String[]::new);
     }
@@ -212,7 +263,12 @@ public class LibP2PNetworkBuilder {
         hostBuilderDefaults,
         b -> {
           b.getIdentity().setFactory(() -> privKey);
-          b.getTransports().add(TcpTransport::new);
+          if (config.isTcpEnabled()) {
+            b.getTransports().add(TcpTransport::new);
+          }
+          if (config.isQuicEnabled()) {
+            b.getSecureTransports().add(QuicTransport::ECDSA);
+          }
           b.getSecureChannels().add(NoiseXXSecureChannel::new);
 
           // Yamux must take precedence during negotiation

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -19,6 +19,7 @@ import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
 import io.libp2p.core.crypto.PubKey;
+import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.protocol.Identify;
 import io.libp2p.protocol.IdentifyController;
 import java.util.List;
@@ -86,7 +87,11 @@ public class LibP2PPeer implements Peer {
     this.pubKey = connection.secureSession().getRemotePubKey();
 
     final NodeId nodeId = new LibP2PNodeId(peerId);
-    peerAddress = new MultiaddrPeerAddress(nodeId, connection.remoteAddress());
+    final Multiaddr remoteAddress = connection.remoteAddress();
+    peerAddress = new MultiaddrPeerAddress(nodeId, remoteAddress);
+    if (remoteAddress != null) {
+      LOG.debug("Connected to peer {} via {}", nodeId, remoteAddress);
+    }
     SafeFuture.of(connection.closeFuture())
         .finish(
             this::handleConnectionClosed,
@@ -151,6 +156,9 @@ public class LibP2PPeer implements Peer {
 
   private void internalDisconnectImmediately(
       final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
+    // capture the remote address before closing the connection as it may no longer be available
+    // afterwards (e.g. for QUIC connections)
+    final Multiaddr remoteAddress = connection.remoteAddress();
     disconnectReason = reason;
     disconnectLocallyInitiated = locallyInitiated;
     SafeFuture.of(connection.close())
@@ -160,7 +168,7 @@ public class LibP2PPeer implements Peer {
                     "Disconnected forcibly {} because {} from {}",
                     locallyInitiated ? "locally" : "remotely",
                     reason,
-                    connection.remoteAddress()),
+                    remoteAddress),
             error -> LOG.warn("Failed to disconnect from peer {}", getId(), error));
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -18,10 +18,14 @@ import static tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue.DEFAULT
 import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
+import io.libp2p.core.crypto.KeyKt;
 import io.libp2p.core.crypto.PubKey;
 import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multiformats.Multihash;
 import io.libp2p.protocol.Identify;
 import io.libp2p.protocol.IdentifyController;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -84,7 +88,14 @@ public class LibP2PPeer implements Peer {
     this.reputationManager = reputationManager;
     this.peerScoreFunction = peerScoreFunction;
     this.peerId = connection.secureSession().getRemoteId();
-    this.pubKey = connection.secureSession().getRemotePubKey();
+    // Prefer the libp2p identity key derived from the peer id. For Noise (TCP) the secure session
+    // already exposes the identity key, but for QUIC the libp2p-TLS session reports the ephemeral
+    // certificate key (ECDSA) instead. Downstream consumers (e.g. discovery node id derivation)
+    // require the secp256k1 identity key, which is recoverable from the peer id whenever it inlines
+    // the key (the case for secp256k1 and Ed25519 identities).
+    this.pubKey =
+        extractIdentityPublicKey(peerId)
+            .orElseGet(() -> connection.secureSession().getRemotePubKey());
 
     final NodeId nodeId = new LibP2PNodeId(peerId);
     final Multiaddr remoteAddress = connection.remoteAddress();
@@ -124,6 +135,25 @@ public class LibP2PPeer implements Peer {
 
   public PubKey getPubKey() {
     return pubKey;
+  }
+
+  /**
+   * Recovers the libp2p identity public key embedded in the peer id. Peer ids inline the identity
+   * key (as an identity multihash) for small key types such as secp256k1 and Ed25519; larger keys
+   * (e.g. RSA) are hashed and cannot be recovered, in which case an empty result is returned.
+   */
+  private static Optional<PubKey> extractIdentityPublicKey(final PeerId peerId) {
+    try {
+      final Multihash multihash = Multihash.Companion.of(Unpooled.wrappedBuffer(peerId.getBytes()));
+      if (multihash.getDesc().getDigest() != Multihash.Digest.Identity) {
+        return Optional.empty();
+      }
+      final byte[] marshalledKey = ByteBufUtil.getBytes(multihash.getValue());
+      return Optional.of(KeyKt.unmarshalPublicKey(marshalledKey));
+    } catch (final Exception e) {
+      LOG.debug("Failed to recover identity public key from peer id {}", peerId, e);
+      return Optional.empty();
+    }
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
@@ -39,8 +39,10 @@ public class MultiaddrPeerAddress extends PeerAddress {
     return fromMultiaddr(multiaddr);
   }
 
-  public static MultiaddrPeerAddress fromDiscoveryPeer(final DiscoveryPeer discoveryPeer) {
-    final Multiaddr multiaddr = MultiaddrUtil.fromDiscoveryPeer(discoveryPeer);
+  public static MultiaddrPeerAddress fromDiscoveryPeer(
+      final DiscoveryPeer discoveryPeer, final boolean localNodeQuicEnabled) {
+    final Multiaddr multiaddr =
+        MultiaddrUtil.fromDiscoveryPeer(discoveryPeer, localNodeQuicEnabled);
     return fromMultiaddr(multiaddr);
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
@@ -26,11 +26,17 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 
 public class MultiaddrUtil {
 
-  public static Multiaddr fromDiscoveryPeer(final DiscoveryPeer peer) {
+  public static Multiaddr fromDiscoveryPeer(
+      final DiscoveryPeer peer, final boolean localNodeQuicEnabled) {
     final NodeId nodeId = getNodeId(peer);
-    return peer.getQuicAddress()
-        .map(quicAddr -> fromInetSocketAddressAsQuic(quicAddr, nodeId))
-        .orElseGet(() -> fromInetSocketAddress(peer.getNodeAddress(), nodeId));
+    // Only dial a peer over QUIC if this node has the QUIC transport enabled, otherwise we have no
+    // QuicTransport to perform the dial and would fail even though the peer also advertises TCP.
+    if (localNodeQuicEnabled) {
+      return peer.getQuicAddress()
+          .map(quicAddr -> fromInetSocketAddressAsQuic(quicAddr, nodeId))
+          .orElseGet(() -> fromInetSocketAddress(peer.getNodeAddress(), nodeId));
+    }
+    return fromInetSocketAddress(peer.getNodeAddress(), nodeId);
   }
 
   public static Multiaddr fromDiscoveryPeerAsUdp(final DiscoveryPeer peer) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtil.java
@@ -27,7 +27,10 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 public class MultiaddrUtil {
 
   public static Multiaddr fromDiscoveryPeer(final DiscoveryPeer peer) {
-    return fromInetSocketAddress(peer.getNodeAddress(), getNodeId(peer));
+    final NodeId nodeId = getNodeId(peer);
+    return peer.getQuicAddress()
+        .map(quicAddr -> fromInetSocketAddressAsQuic(quicAddr, nodeId))
+        .orElseGet(() -> fromInetSocketAddress(peer.getNodeAddress(), nodeId));
   }
 
   public static Multiaddr fromDiscoveryPeerAsUdp(final DiscoveryPeer peer) {
@@ -36,6 +39,16 @@ public class MultiaddrUtil {
 
   static Multiaddr fromInetSocketAddress(final InetSocketAddress address) {
     return fromInetSocketAddress(address, "tcp");
+  }
+
+  static Multiaddr fromInetSocketAddressAsQuic(final InetSocketAddress address) {
+    final String addrString =
+        String.format(
+            "/%s/%s/udp/%d/quic-v1",
+            protocol(address.getAddress()),
+            address.getAddress().getHostAddress(),
+            address.getPort());
+    return Multiaddr.fromString(addrString);
   }
 
   static Multiaddr fromInetSocketAddress(final InetSocketAddress address, final String protocol) {
@@ -52,6 +65,11 @@ public class MultiaddrUtil {
   public static Multiaddr fromInetSocketAddress(
       final InetSocketAddress address, final NodeId nodeId) {
     return addPeerId(fromInetSocketAddress(address, "tcp"), nodeId);
+  }
+
+  public static Multiaddr fromInetSocketAddressAsQuic(
+      final InetSocketAddress address, final NodeId nodeId) {
+    return addPeerId(fromInetSocketAddressAsQuic(address), nodeId);
   }
 
   private static Multiaddr addPeerId(final Multiaddr addr, final NodeId nodeId) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
@@ -202,10 +202,11 @@ public class RpcHandler<
   @Override
   public SafeFuture<Controller<TOutgoingHandler>> initChannel(
       final P2PChannel channel, final String selectedProtocol) {
-    final Connection connection = ((Stream) channel).getConnection();
+    final Stream streamChannel = (Stream) channel;
+    final Connection connection = streamChannel.getConnection();
     final NodeId nodeId = new LibP2PNodeId(connection.secureSession().getRemoteId());
 
-    final Controller<TOutgoingHandler> controller = new Controller<>(nodeId, channel);
+    final Controller<TOutgoingHandler> controller = new Controller<>(nodeId, streamChannel);
     if (!channel.isInitiator()) {
       controller.setIncomingRequestHandler(
           rpcMethod.createIncomingRequestHandler(selectedProtocol));
@@ -219,7 +220,7 @@ public class RpcHandler<
       implements RpcStreamController<TOutgoingHandler> {
 
     private final NodeId nodeId;
-    private final P2PChannel p2pChannel;
+    private final Stream p2pStream;
     private Optional<TOutgoingHandler> outgoingRequestHandler = Optional.empty();
     private Optional<RpcRequestHandler> rpcRequestHandler = Optional.empty();
     private RpcStream rpcStream;
@@ -227,14 +228,14 @@ public class RpcHandler<
 
     protected final SafeFuture<Controller<TOutgoingHandler>> activeFuture = new SafeFuture<>();
 
-    private Controller(final NodeId nodeId, final P2PChannel p2pChannel) {
+    private Controller(final NodeId nodeId, final Stream p2pStream) {
       this.nodeId = nodeId;
-      this.p2pChannel = p2pChannel;
+      this.p2pStream = p2pStream;
     }
 
     @Override
     public void channelActive(final ChannelHandlerContext ctx) {
-      rpcStream = new LibP2PRpcStream(nodeId, p2pChannel, ctx);
+      rpcStream = new LibP2PRpcStream(nodeId, p2pStream, ctx);
       activeFuture.complete(this);
     }
 
@@ -330,7 +331,7 @@ public class RpcHandler<
     @VisibleForTesting
     void closeAbruptly() {
       // We're listening for the result of the close future above, so we can ignore this future
-      ignoreFuture(p2pChannel.close());
+      ignoreFuture(p2pStream.close());
 
       // Make sure to complete activation future in case we are never activated
       activeFuture.completeExceptionally(new StreamClosedException());

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -47,9 +47,9 @@ public class NetworkConfig {
 
   public static final List<String> DEFAULT_P2P_INTERFACE = List.of("0.0.0.0");
   public static final int DEFAULT_P2P_PORT = 9000;
-  public static final int DEFAULT_P2P_QUIC_PORT = 9100;
+  public static final int DEFAULT_P2P_QUIC_PORT = 9001;
   public static final int DEFAULT_P2P_PORT_IPV6 = 9090;
-  public static final int DEFAULT_P2P_QUIC_PORT_IPV6 = 9190;
+  public static final int DEFAULT_P2P_QUIC_PORT_IPV6 = 9091;
   public static final boolean DEFAULT_YAMUX_ENABLED = false;
   public static final boolean DEFAULT_STRICT_CONFIG_LOADING_ENABLED = false;
   public static final boolean DEFAULT_QUIC_ENABLED = false;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -47,9 +47,13 @@ public class NetworkConfig {
 
   public static final List<String> DEFAULT_P2P_INTERFACE = List.of("0.0.0.0");
   public static final int DEFAULT_P2P_PORT = 9000;
+  public static final int DEFAULT_P2P_QUIC_PORT = 9100;
   public static final int DEFAULT_P2P_PORT_IPV6 = 9090;
+  public static final int DEFAULT_P2P_QUIC_PORT_IPV6 = 9190;
   public static final boolean DEFAULT_YAMUX_ENABLED = false;
   public static final boolean DEFAULT_STRICT_CONFIG_LOADING_ENABLED = false;
+  public static final boolean DEFAULT_QUIC_ENABLED = false;
+  public static final boolean DEFAULT_TCP_ENABLED = true;
 
   private final GossipConfig gossipConfig;
   private final WireLogsConfig wireLogsConfig;
@@ -60,9 +64,15 @@ public class NetworkConfig {
   private final Optional<List<String>> advertisedIps;
   private final int listenPort;
   private final int listenPortIpv6;
+  private final int listenQuicPort;
+  private final int listenQuicPortIpv6;
   private final OptionalInt advertisedPort;
   private final OptionalInt advertisedPortIpv6;
+  private final OptionalInt advertisedQuicPort;
+  private final OptionalInt advertisedQuicPortIpv6;
   private final boolean yamuxEnabled;
+  private final boolean quicEnabled;
+  private final boolean tcpEnabled;
 
   private NetworkConfig(
       final boolean isEnabled,
@@ -73,20 +83,32 @@ public class NetworkConfig {
       final Optional<List<String>> advertisedIps,
       final int listenPort,
       final int listenPortIpv6,
+      final int listenQuicPort,
+      final int listenQuicPortIpv6,
       final OptionalInt advertisedPort,
       final OptionalInt advertisedPortIpv6,
-      final boolean yamuxEnabled) {
+      final OptionalInt advertisedQuicPort,
+      final OptionalInt advertisedQuicPortIpv6,
+      final boolean yamuxEnabled,
+      final boolean quicEnabled,
+      final boolean tcpEnabled) {
     this.privateKeySource = privateKeySource;
     this.networkInterfaces = networkInterfaces;
     this.advertisedIps = advertisedIps;
     this.isEnabled = isEnabled;
     this.listenPort = listenPort;
     this.listenPortIpv6 = listenPortIpv6;
+    this.listenQuicPort = listenQuicPort;
+    this.listenQuicPortIpv6 = listenQuicPortIpv6;
     this.advertisedPort = advertisedPort;
     this.advertisedPortIpv6 = advertisedPortIpv6;
+    this.advertisedQuicPort = advertisedQuicPort;
+    this.advertisedQuicPortIpv6 = advertisedQuicPortIpv6;
     this.yamuxEnabled = yamuxEnabled;
     this.gossipConfig = gossipConfig;
     this.wireLogsConfig = wireLogsConfig;
+    this.quicEnabled = quicEnabled;
+    this.tcpEnabled = tcpEnabled;
   }
 
   public static Builder builder() {
@@ -123,6 +145,14 @@ public class NetworkConfig {
     return listenPortIpv6;
   }
 
+  public int getListenQuicPort() {
+    return listenQuicPort;
+  }
+
+  public int getListenQuicPortIpv6() {
+    return listenQuicPortIpv6;
+  }
+
   public int getAdvertisedPort() {
     return advertisedPort.orElse(listenPort);
   }
@@ -131,8 +161,24 @@ public class NetworkConfig {
     return advertisedPortIpv6.orElse(listenPortIpv6);
   }
 
+  public int getAdvertisedQuicPort() {
+    return advertisedQuicPort.orElse(listenQuicPort);
+  }
+
+  public int getAdvertisedQuicPortIpv6() {
+    return advertisedQuicPortIpv6.orElse(listenQuicPortIpv6);
+  }
+
   public boolean isYamuxEnabled() {
     return yamuxEnabled;
+  }
+
+  public boolean isQuicEnabled() {
+    return quicEnabled;
+  }
+
+  public boolean isTcpEnabled() {
+    return tcpEnabled;
   }
 
   public GossipConfig getGossipConfig() {
@@ -218,9 +264,15 @@ public class NetworkConfig {
     private Optional<List<String>> advertisedIps = Optional.empty();
     private int listenPort = DEFAULT_P2P_PORT;
     private int listenPortIpv6 = DEFAULT_P2P_PORT_IPV6;
+    private int listenQuicPort = DEFAULT_P2P_QUIC_PORT;
+    private int listenQuicPortIpv6 = DEFAULT_P2P_QUIC_PORT_IPV6;
     private OptionalInt advertisedPort = OptionalInt.empty();
     private OptionalInt advertisedPortIpv6 = OptionalInt.empty();
+    private OptionalInt advertisedQuicPort = OptionalInt.empty();
+    private OptionalInt advertisedQuicPortIpv6 = OptionalInt.empty();
     private boolean yamuxEnabled = DEFAULT_YAMUX_ENABLED;
+    private boolean quicEnabled = DEFAULT_QUIC_ENABLED;
+    private boolean tcpEnabled = DEFAULT_TCP_ENABLED;
 
     private Builder() {}
 
@@ -244,9 +296,15 @@ public class NetworkConfig {
           advertisedIps,
           listenPort,
           listenPortIpv6,
+          listenQuicPort,
+          listenQuicPortIpv6,
           advertisedPort,
           advertisedPortIpv6,
-          yamuxEnabled);
+          advertisedQuicPort,
+          advertisedQuicPortIpv6,
+          yamuxEnabled,
+          quicEnabled,
+          tcpEnabled);
     }
 
     private Optional<PrivateKeySource> createFileKeySource() {
@@ -344,6 +402,18 @@ public class NetworkConfig {
       return this;
     }
 
+    public Builder listenQuicPort(final int listenQuicPort) {
+      validatePort(listenQuicPort, "--Xp2p-quic-port");
+      this.listenQuicPort = listenQuicPort;
+      return this;
+    }
+
+    public Builder listenQuicPortIpv6(final int listenQuicPortIpv6) {
+      validatePort(listenQuicPortIpv6, "--Xp2p-quic-port-ipv6");
+      this.listenQuicPortIpv6 = listenQuicPortIpv6;
+      return this;
+    }
+
     public Builder advertisedPort(final OptionalInt advertisedPort) {
       checkNotNull(advertisedPort);
       advertisedPort.ifPresent(port -> validatePort(port, "--p2p-advertised-port"));
@@ -358,8 +428,33 @@ public class NetworkConfig {
       return this;
     }
 
+    public Builder advertisedQuicPort(final OptionalInt advertisedQuicPort) {
+      checkNotNull(advertisedQuicPort);
+      advertisedQuicPort.ifPresent(port -> validatePort(port, "--Xp2p-advertised-quic-port"));
+      this.advertisedQuicPort = advertisedQuicPort;
+      return this;
+    }
+
+    public Builder advertisedQuicPortIpv6(final OptionalInt advertisedQuicPortIpv6) {
+      checkNotNull(advertisedQuicPortIpv6);
+      advertisedQuicPortIpv6.ifPresent(
+          port -> validatePort(port, "--Xp2p-advertised-quic-port-ipv6"));
+      this.advertisedQuicPortIpv6 = advertisedQuicPortIpv6;
+      return this;
+    }
+
     public Builder yamuxEnabled(final boolean yamuxEnabled) {
       this.yamuxEnabled = yamuxEnabled;
+      return this;
+    }
+
+    public Builder quicEnabled(final Boolean quicEnabled) {
+      this.quicEnabled = quicEnabled;
+      return this;
+    }
+
+    public Builder tcpEnabled(final boolean tcpEnabled) {
+      this.tcpEnabled = tcpEnabled;
       return this;
     }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManagerTest.java
@@ -582,6 +582,7 @@ class ConnectionManagerTest {
         peerId,
         Bytes32.ZERO,
         new InetSocketAddress(InetAddress.getLoopbackAddress(), peerId.trimLeadingZeros().toInt()),
+        Optional.empty(),
         ENR_FORK_ID,
         SCHEMA_DEFINITIONS_SUPPLIER.getAttnetsENRFieldSchema().ofBits(subnetIds),
         SCHEMA_DEFINITIONS_SUPPLIER.getSyncnetsENRFieldSchema().getDefault(),

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkTest.java
@@ -366,6 +366,7 @@ class DiscoveryNetworkTest {
         BLSPublicKey.empty().toSSZBytes(),
         Bytes32.ZERO,
         InetSocketAddress.createUnresolved("yo", 9999),
+        Optional.empty(),
         maybeForkId,
         SszBitvectorSchema.create(spec.getNetworkingConfig().getAttestationSubnetCount())
             .getDefault(),

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
@@ -82,6 +82,7 @@ class NodeRecordConverterTest {
             nodeId,
             new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
             Optional.empty(),
+            Optional.empty(),
             ATTNETS,
             SYNCNETS,
             Optional.empty(),
@@ -125,6 +126,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 30303),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -161,6 +163,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("129.24.31.22", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -191,6 +194,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -213,6 +217,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("127.0.0.1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -236,6 +241,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 persistentSubnets,
                 SYNCNETS,
@@ -259,6 +265,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATT_SUBNET_SCHEMA.getDefault(),
                 SYNCNETS,
@@ -282,6 +289,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 syncnets,
@@ -307,6 +315,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 ENR_FORK_ID,
                 ATTNETS,
                 SYNCNETS,
@@ -330,6 +339,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
+                Optional.empty(),
                 Optional.of(enrForkId),
                 ATTNETS,
                 SYNCNETS,
@@ -353,6 +363,7 @@ class NodeRecordConverterTest {
                 NODE_ID,
                 new InetSocketAddress("::1", 1234),
                 Optional.empty(),
+                Optional.empty(),
                 ATTNETS,
                 SYNCNETS,
                 Optional.empty(),
@@ -373,6 +384,7 @@ class NodeRecordConverterTest {
                 PUB_KEY,
                 NODE_ID,
                 new InetSocketAddress("127.0.0.1", 1234),
+                Optional.empty(),
                 Optional.empty(),
                 ATTNETS,
                 SYNCNETS,
@@ -395,10 +407,47 @@ class NodeRecordConverterTest {
                 NODE_ID,
                 new InetSocketAddress("127.0.0.1", 1234),
                 Optional.empty(),
+                Optional.empty(),
                 ATTNETS,
                 SYNCNETS,
                 Optional.empty(),
                 Optional.of(nfd)));
+  }
+
+  @Test
+  public void shouldExtractQuicAddressFromEnr() {
+    final Optional<DiscoveryPeer> result =
+        convertNodeRecordWithFields(
+            false,
+            new EnrField(EnrField.IP_V4, Bytes.wrap(new byte[] {127, 0, 0, 1})),
+            new EnrField(EnrField.TCP, 9000),
+            new EnrField(EnrField.QUIC, 9100));
+    assertThat(result).isPresent();
+    assertThat(result.get().getQuicAddress()).contains(new InetSocketAddress("127.0.0.1", 9100));
+    assertThat(result.get().getNodeAddress()).isEqualTo(new InetSocketAddress("127.0.0.1", 9000));
+  }
+
+  @Test
+  public void shouldExtractQuicV6AddressFromEnrWhenIpv6Supported() {
+    final Optional<DiscoveryPeer> result =
+        convertNodeRecordWithFields(
+            true,
+            new EnrField(EnrField.IP_V6, IPV6_LOCALHOST),
+            new EnrField(EnrField.TCP_V6, 9000),
+            new EnrField(EnrField.QUIC_V6, 9100));
+    assertThat(result).isPresent();
+    assertThat(result.get().getQuicAddress()).contains(new InetSocketAddress("::1", 9100));
+  }
+
+  @Test
+  public void shouldHaveEmptyQuicAddressWhenNotAdvertised() {
+    final Optional<DiscoveryPeer> result =
+        convertNodeRecordWithFields(
+            false,
+            new EnrField(EnrField.IP_V4, Bytes.wrap(new byte[] {127, 0, 0, 1})),
+            new EnrField(EnrField.TCP, 9000));
+    assertThat(result).isPresent();
+    assertThat(result.get().getQuicAddress()).isEmpty();
   }
 
   private Optional<DiscoveryPeer> convertNodeRecordWithFields(

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.libp2p;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.libp2p.core.PeerId;
+import io.libp2p.core.multiformats.Multiaddr;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
+import tech.pegasys.teku.networking.p2p.peer.NodeId;
+
+class LibP2PNetworkBuilderTest {
+
+  // Defaults from NetworkConfig: TCP 9000/9090 (v4/v6), QUIC 9001/9091 (v4/v6)
+  private static final NodeId NODE_ID =
+      new LibP2PNodeId(PeerId.fromBase58("16Uiu2HAmFxCpRh2nZevFR3KGXJ3jhpixMYFSuawqKZyZYHrYoiK5"));
+
+  private NetworkConfig.Builder singleStackConfig() {
+    return NetworkConfig.builder()
+        .networkInterface("127.0.0.1")
+        .advertisedIp(Optional.of("127.0.0.1"));
+  }
+
+  private NetworkConfig.Builder dualStackConfig() {
+    return NetworkConfig.builder()
+        .networkInterfaces(List.of("127.0.0.1", "::1"))
+        .advertisedIps(Optional.of(List.of("127.0.0.1", "::1")));
+  }
+
+  // ---- listenPorts ----
+
+  @Test
+  void buildListenPorts_singleStackTcpOnly() {
+    final NetworkConfig config = singleStackConfig().build();
+    assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000);
+  }
+
+  @Test
+  void buildListenPorts_singleStackTcpAndQuic() {
+    final NetworkConfig config = singleStackConfig().quicEnabled(true).build();
+    assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000, 9001);
+  }
+
+  @Test
+  void buildListenPorts_singleStackQuicOnly() {
+    // Regression: single-IP QUIC must not report the IPv6 ports.
+    final NetworkConfig config = singleStackConfig().quicEnabled(true).tcpEnabled(false).build();
+    assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9001);
+  }
+
+  @Test
+  void buildListenPorts_dualStackTcpOnly() {
+    final NetworkConfig config = dualStackConfig().build();
+    assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000, 9090);
+  }
+
+  @Test
+  void buildListenPorts_dualStackTcpAndQuic() {
+    // Regression: dual-stack QUIC must report all four ports, not just two.
+    final NetworkConfig config = dualStackConfig().quicEnabled(true).build();
+    assertThat(LibP2PNetworkBuilder.buildListenPorts(config))
+        .containsExactly(9000, 9001, 9090, 9091);
+  }
+
+  // ---- advertised addresses ----
+
+  @Test
+  void buildAdvertisedAddresses_quicEnabledTcpDisabled_doesNotAdvertiseTcp() {
+    // Regression: a disabled transport must not be advertised to peers (e.g. in the ENR).
+    final NetworkConfig config = singleStackConfig().quicEnabled(true).tcpEnabled(false).build();
+    final List<String> addresses =
+        asStrings(LibP2PNetworkBuilder.buildAdvertisedAddresses(config, NODE_ID));
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).contains("/udp/9001/quic-v1");
+    assertThat(addresses).noneMatch(addr -> addr.contains("/tcp/"));
+  }
+
+  @Test
+  void buildAdvertisedAddresses_tcpAndQuicEnabled_advertisesBoth() {
+    final NetworkConfig config = singleStackConfig().quicEnabled(true).build();
+    final List<String> addresses =
+        asStrings(LibP2PNetworkBuilder.buildAdvertisedAddresses(config, NODE_ID));
+    assertThat(addresses).hasSize(2);
+    assertThat(addresses).anyMatch(addr -> addr.contains("/tcp/9000"));
+    assertThat(addresses).anyMatch(addr -> addr.contains("/udp/9001/quic-v1"));
+  }
+
+  @Test
+  void buildAdvertisedAddresses_dualStackTcpAndQuic_advertisesAllFour() {
+    final NetworkConfig config = dualStackConfig().quicEnabled(true).build();
+    final List<String> addresses =
+        asStrings(LibP2PNetworkBuilder.buildAdvertisedAddresses(config, NODE_ID));
+    assertThat(addresses).hasSize(4);
+    assertThat(addresses).anyMatch(addr -> addr.contains("/tcp/9000"));
+    assertThat(addresses).anyMatch(addr -> addr.contains("/udp/9001/quic-v1"));
+    assertThat(addresses).anyMatch(addr -> addr.contains("/tcp/9090"));
+    assertThat(addresses).anyMatch(addr -> addr.contains("/udp/9091/quic-v1"));
+  }
+
+  // ---- listen addresses ----
+
+  @Test
+  void buildListenAddresses_quicEnabledTcpDisabled_doesNotListenOnTcp() {
+    final NetworkConfig config = singleStackConfig().quicEnabled(true).tcpEnabled(false).build();
+    final List<String> addresses = List.of(LibP2PNetworkBuilder.buildListenAddresses(config));
+    assertThat(addresses).hasSize(1);
+    assertThat(addresses.get(0)).contains("/udp/9001/quic-v1");
+    assertThat(addresses).noneMatch(addr -> addr.contains("/tcp/"));
+  }
+
+  @Test
+  void buildListenAddresses_tcpAndQuicEnabled_listensOnBoth() {
+    final NetworkConfig config = singleStackConfig().quicEnabled(true).build();
+    final List<String> addresses = List.of(LibP2PNetworkBuilder.buildListenAddresses(config));
+    assertThat(addresses).hasSize(2);
+    assertThat(addresses).anyMatch(addr -> addr.contains("/tcp/9000"));
+    assertThat(addresses).anyMatch(addr -> addr.contains("/udp/9001/quic-v1"));
+  }
+
+  private static List<String> asStrings(final List<Multiaddr> addresses) {
+    return addresses.stream().map(Multiaddr::toString).toList();
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
@@ -23,8 +23,11 @@ import static org.mockito.Mockito.when;
 
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
+import io.libp2p.core.crypto.PubKey;
 import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.core.security.SecureChannel.Session;
+import io.libp2p.crypto.keys.EcdsaKt;
+import io.libp2p.crypto.keys.Secp256k1Kt;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -73,6 +76,27 @@ public class LibP2PPeerTest {
     when(secureSession.getRemoteId()).thenReturn(PeerId.fromBase58(PEER_ID));
     libP2PPeer =
         new LibP2PPeer(connection, List.of(rpcHandler), ReputationManager.NOOP, peer -> 0.0);
+  }
+
+  @Test
+  public void getPubKey_recoversIdentityKeyFromPeerIdWhenSecureSessionExposesDifferentKey() {
+    // Simulates a QUIC connection: the libp2p-TLS secure session reports the ephemeral
+    // certificate key (ECDSA) as the remote public key, while the verified peer identity (and
+    // hence the peer id) is derived from the node's secp256k1 identity key. The discovery node id
+    // must be derived from the secp256k1 identity key, so getPubKey() must return that key rather
+    // than the certificate key.
+    final PubKey identityKey = Secp256k1Kt.generateSecp256k1KeyPair().getSecond();
+    final PubKey certificateKey = EcdsaKt.generateEcdsaKeyPair().getSecond();
+
+    final Session secureSession = mock(Session.class);
+    when(connection.secureSession()).thenReturn(secureSession);
+    when(secureSession.getRemoteId()).thenReturn(PeerId.fromPubKey(identityKey));
+    when(secureSession.getRemotePubKey()).thenReturn(certificateKey);
+
+    final LibP2PPeer peer =
+        new LibP2PPeer(connection, List.of(rpcHandler), ReputationManager.NOOP, p -> 0.0);
+
+    assertThat(peer.getPubKey().raw()).isEqualTo(identityKey.raw());
   }
 
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored", "rawtypes"})

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
@@ -88,7 +88,7 @@ class MultiaddrUtilTest {
             SYNC_COMMITTEE_SUBNETS,
             Optional.empty(),
             Optional.empty());
-    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer, true);
     assertThat(result).isEqualTo(Multiaddr.fromString("/ip4/123.34.58.22/tcp/5883/p2p/" + PEER_ID));
     assertThatComponent(result, Protocol.IP4).isEqualTo(ipAddress);
     assertThatComponent(result, Protocol.TCP).isEqualTo(Protocol.TCP.addressToBytes("5883"));
@@ -110,7 +110,7 @@ class MultiaddrUtilTest {
             SYNC_COMMITTEE_SUBNETS,
             Optional.empty(),
             Optional.empty());
-    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer, true);
     assertThat(result)
         .isEqualTo(Multiaddr.fromString("/ip6/3300:4:5000:780:0:12:0:1/tcp/5883/p2p/" + PEER_ID));
     assertThatComponent(result, Protocol.IP6).isEqualTo(ipAddress);
@@ -135,7 +135,7 @@ class MultiaddrUtilTest {
     final Multiaddr expectedMultiAddr =
         Multiaddr.fromString(
             "/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF");
-    assertThat(MultiaddrUtil.fromDiscoveryPeer(peer)).isEqualTo(expectedMultiAddr);
+    assertThat(MultiaddrUtil.fromDiscoveryPeer(peer, true)).isEqualTo(expectedMultiAddr);
   }
 
   @Test
@@ -155,11 +155,36 @@ class MultiaddrUtilTest {
             SYNC_COMMITTEE_SUBNETS,
             Optional.empty(),
             Optional.empty());
-    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer, true);
     assertThat(result)
         .isEqualTo(
             Multiaddr.fromString(
                 "/ip4/127.0.0.1/udp/9100/quic-v1/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF"));
+  }
+
+  @Test
+  public void fromDiscoveryPeer_shouldNotUseQuicWhenLocalNodeQuicDisabled() throws Exception {
+    final byte[] ipAddress = {127, 0, 0, 1};
+    final int tcpPort = 9000;
+    final int quicPort = 9100;
+    final DiscoveryPeer peer =
+        new DiscoveryPeer(
+            Bytes.fromHexString(
+                "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
+            Bytes32.ZERO,
+            new InetSocketAddress(InetAddress.getByAddress(ipAddress), tcpPort),
+            Optional.of(new InetSocketAddress(InetAddress.getByAddress(ipAddress), quicPort)),
+            ENR_FORK_ID,
+            PERSISTENT_ATTESTATION_SUBNETS,
+            SYNC_COMMITTEE_SUBNETS,
+            Optional.empty(),
+            Optional.empty());
+    // The peer advertises QUIC, but this node has QUIC disabled so it must dial over TCP.
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer, false);
+    assertThat(result)
+        .isEqualTo(
+            Multiaddr.fromString(
+                "/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF"));
   }
 
   @Test
@@ -178,7 +203,7 @@ class MultiaddrUtilTest {
             SYNC_COMMITTEE_SUBNETS,
             Optional.empty(),
             Optional.empty());
-    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer, true);
     assertThat(result)
         .isEqualTo(
             Multiaddr.fromString(

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
@@ -82,6 +82,7 @@ class MultiaddrUtilTest {
             PUB_KEY,
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(ipAddress), port),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,
@@ -103,6 +104,7 @@ class MultiaddrUtilTest {
             PUB_KEY,
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(ipAddress), port),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,
@@ -124,6 +126,7 @@ class MultiaddrUtilTest {
                 "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,
@@ -136,6 +139,53 @@ class MultiaddrUtilTest {
   }
 
   @Test
+  public void fromDiscoveryPeer_shouldPreferQuicWhenQuicAddressIsPresent() throws Exception {
+    final byte[] ipAddress = {127, 0, 0, 1};
+    final int tcpPort = 9000;
+    final int quicPort = 9100;
+    final DiscoveryPeer peer =
+        new DiscoveryPeer(
+            Bytes.fromHexString(
+                "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
+            Bytes32.ZERO,
+            new InetSocketAddress(InetAddress.getByAddress(ipAddress), tcpPort),
+            Optional.of(new InetSocketAddress(InetAddress.getByAddress(ipAddress), quicPort)),
+            ENR_FORK_ID,
+            PERSISTENT_ATTESTATION_SUBNETS,
+            SYNC_COMMITTEE_SUBNETS,
+            Optional.empty(),
+            Optional.empty());
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    assertThat(result)
+        .isEqualTo(
+            Multiaddr.fromString(
+                "/ip4/127.0.0.1/udp/9100/quic-v1/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF"));
+  }
+
+  @Test
+  public void fromDiscoveryPeer_shouldFallBackToTcpWhenNoQuicAddress() throws Exception {
+    final byte[] ipAddress = {127, 0, 0, 1};
+    final int tcpPort = 9000;
+    final DiscoveryPeer peer =
+        new DiscoveryPeer(
+            Bytes.fromHexString(
+                "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
+            Bytes32.ZERO,
+            new InetSocketAddress(InetAddress.getByAddress(ipAddress), tcpPort),
+            Optional.empty(),
+            ENR_FORK_ID,
+            PERSISTENT_ATTESTATION_SUBNETS,
+            SYNC_COMMITTEE_SUBNETS,
+            Optional.empty(),
+            Optional.empty());
+    final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
+    assertThat(result)
+        .isEqualTo(
+            Multiaddr.fromString(
+                "/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF"));
+  }
+
+  @Test
   public void fromDiscoveryPeerAsUdp_shouldConvertDiscoveryPeer() throws Exception {
     final DiscoveryPeer peer =
         new DiscoveryPeer(
@@ -143,6 +193,7 @@ class MultiaddrUtilTest {
                 "0x03B86ED9F747A7FA99963F39E3B176B45E9E863108A2D145EA3A4E76D8D0935194"),
             Bytes32.ZERO,
             new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), 9000),
+            Optional.empty(),
             ENR_FORK_ID,
             PERSISTENT_ATTESTATION_SUBNETS,
             SYNC_COMMITTEE_SUBNETS,

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -96,6 +96,43 @@ public class P2POptions {
   private Integer p2pUdpPortIpv6;
 
   @Option(
+      names = {"--Xp2p-quic-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Enables QUIC transport",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean p2pQuicEnabled = NetworkConfig.DEFAULT_QUIC_ENABLED;
+
+  @Option(
+      names = {"--Xp2p-tcp-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Enables TCP transport",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean p2pTcpEnabled = NetworkConfig.DEFAULT_TCP_ENABLED;
+
+  @Option(
+      names = {"--Xp2p-quic-port"},
+      paramLabel = "<INTEGER>",
+      description = "P2P QUIC port",
+      hidden = true,
+      arity = "1")
+  private Integer p2pQuicPort = NetworkConfig.DEFAULT_P2P_QUIC_PORT;
+
+  @Option(
+      names = {"--Xp2p-quic-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          "P2P IPv6 QUIC port. This port is only used when listening over both IPv4 and IPv6.",
+      hidden = true,
+      arity = "1")
+  private int p2pQuicPortIpv6 = NetworkConfig.DEFAULT_P2P_QUIC_PORT_IPV6;
+
+  @Option(
       names = {"--p2p-discovery-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -164,6 +201,26 @@ public class P2POptions {
               The default is the port specified in --p2p-advertised-port-ipv6.""",
       arity = "1")
   private Integer p2pAdvertisedUdpPortIpv6;
+
+  @Option(
+      names = {"--Xp2p-advertised-quic-port"},
+      paramLabel = "<INTEGER>",
+      description =
+          "P2P advertised QUIC port. The default is the port specified in --p2p-quic-port",
+      hidden = true,
+      arity = "1")
+  private Integer p2pAdvertisedQuicPort;
+
+  @Option(
+      names = {"--Xp2p-advertised-quic-port-ipv6"},
+      paramLabel = "<INTEGER>",
+      description =
+          """
+                      P2P advertised IPv6 QUIC port. This port is only used when advertising both IPv4 and IPv6 addresses.
+                      The default is the port specified in --p2p-quic-port-ipv6.""",
+      hidden = true,
+      arity = "1")
+  private Integer p2pAdvertisedQuicPortIpv6;
 
   @Option(
       names = {"--p2p-private-key-file"},
@@ -766,6 +823,12 @@ public class P2POptions {
               if (p2pAdvertisedPortIpv6 != null) {
                 n.advertisedPortIpv6(OptionalInt.of(p2pAdvertisedPortIpv6));
               }
+              if (p2pAdvertisedQuicPort != null) {
+                n.advertisedQuicPort(OptionalInt.of(p2pAdvertisedQuicPort));
+              }
+              if (p2pAdvertisedQuicPortIpv6 != null) {
+                n.advertisedQuicPortIpv6(OptionalInt.of(p2pAdvertisedQuicPortIpv6));
+              }
               if (!p2pDirectPeers.isEmpty()) {
                 n.directPeers(
                     p2pDirectPeers.stream()
@@ -777,8 +840,12 @@ public class P2POptions {
                   .isEnabled(p2pEnabled)
                   .listenPort(p2pPort)
                   .listenPortIpv6(p2pPortIpv6)
+                  .listenQuicPort(p2pQuicPort)
+                  .listenQuicPortIpv6(p2pQuicPortIpv6)
                   .advertisedIps(Optional.ofNullable(p2pAdvertisedIps))
-                  .yamuxEnabled(yamuxEnabled);
+                  .yamuxEnabled(yamuxEnabled)
+                  .quicEnabled(p2pQuicEnabled)
+                  .tcpEnabled(p2pTcpEnabled);
             })
         .sync(
             s ->


### PR DESCRIPTION
Add QUIC transport to the libp2p network, gated behind hidden experimental flags (--Xp2p-quic-enabled, --Xp2p-quic-port, --Xp2p-advertised-quic-port and their IPv6 variants). QUIC is disabled by default and TCP remains enabled, so default behavior is unchanged.

- NetworkConfig gains QUIC listen/advertised ports and quicEnabled/ tcpEnabled flags
- LibP2PNetworkBuilder registers QuicTransport (ECDSA) and builds QUIC listen/advertised multiaddrs, making TCP conditional on tcpEnabled
- Discovery advertises a QUIC address in the ENR; DiscoveryPeer and NodeRecordConverter propagate it, and dialing prefers QUIC when a peer advertises one
- Migrate RPC stream handling from P2PChannel to Stream for libp2p 1.3.1 compatibility
- Derive the discovery node id from the libp2p identity key for QUIC peers. Over QUIC the libp2p-TLS secure session exposes the ephemeral ECDSA certificate key rather than the node's secp256k1 identity key, which previously caused discovery node id derivation to fail (a `NoSuchElementException` from `getDiscoveryNodeId().orElseThrow()` in PeerDAS components). The identity key is now recovered from the verified peer id (which inlines the key for secp256k1/Ed25519 identities), falling back to the secure-session key when not recoverable; Noise/TCP behavior is unchanged. A debug log is also added when node id calculation fails so future key-type mismatches are no longer swallowed silently.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core P2P discovery, dialing, and peer identity used for discovery node IDs; defaults preserve TCP-only behavior but misconfiguration or QUIC-only peers could affect connectivity.
> 
> **Overview**
> Adds **experimental QUIC** libp2p transport behind hidden `--Xp2p-*` flags (QUIC off by default; TCP unchanged unless disabled). `NetworkConfig` gains QUIC/TCP listen and advertised ports plus `quicEnabled` / `tcpEnabled`; the builder registers `QuicTransport`, advertises/listens only on enabled transports, and requires at least one transport.
> 
> **Discovery and dialing:** ENRs and `DiscoveryPeer` carry an optional QUIC socket; conversion from node records prefers QUIC v4/v6 when IPv6 is supported. Outbound multiaddrs prefer QUIC when this node has QUIC enabled and the peer advertises it, otherwise TCP.
> 
> **QUIC correctness:** `LibP2PPeer` recovers the secp256k1 **identity** public key from the peer id when the secure session reports the TLS certificate key (fixes discovery node id / PeerDAS failures on QUIC). RPC handling moves from `P2PChannel` to `Stream` (`closeWrite` for half-close). Failed discovery node id calculation is logged at debug instead of swallowed silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a211053b3cb2594eeda5e95858f6e370b460ab4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->