### PR TITLE
Added compatibility for 26.4 rocksdb

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DatabaseCompatibilityAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/DatabaseCompatibilityAcceptanceTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.teku.test.acceptance.dsl.TekuBeaconNode;
+import tech.pegasys.teku.test.acceptance.dsl.TekuDockerVersion;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfig;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfigBuilder;
+
+public class DatabaseCompatibilityAcceptanceTest extends AcceptanceTestBase {
+
+  private static final String ROCKSDB_V6 = "6";
+
+  @Test
+  void shouldStartLastReleaseFromRocksDbDatabaseCreatedByLocalBuild() throws Exception {
+    final TekuBeaconNode localNode =
+        createTekuBeaconNode(TekuDockerVersion.LOCAL_BUILD, createRocksDbBeaconNodeConfig());
+    localNode.start();
+    localNode.waitForLogMessageContaining("Created RocksDB V6 Hot and Finalized database (6)");
+    localNode.waitForNewBlock();
+    final UInt64 genesisTime = localNode.getGenesisTime();
+    final File dataDirectory = localNode.stopAndGetDataDirectoryFromContainer();
+
+    final TekuBeaconNode lastReleaseNode =
+        createTekuBeaconNode(TekuDockerVersion.LAST_RELEASE, createBeaconNodeConfig());
+    lastReleaseNode.copyContentsToWorkingDirectory(dataDirectory);
+
+    lastReleaseNode.start();
+    lastReleaseNode.waitForGenesisTime(genesisTime);
+    lastReleaseNode.waitForNewBlock();
+  }
+
+  private TekuNodeConfig createRocksDbBeaconNodeConfig() throws IOException {
+    final TekuNodeConfig config = createBeaconNodeConfig();
+    config.getConfigMap().put("Xdata-storage-create-db-version", ROCKSDB_V6);
+    return config;
+  }
+
+  private TekuNodeConfig createBeaconNodeConfig() throws IOException {
+    return TekuNodeConfigBuilder.createBeaconNode().build();
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -128,6 +128,14 @@ public abstract class TekuNode extends Node {
     return dbTar;
   }
 
+  public File stopAndGetDataDirectoryFromContainer() throws Exception {
+    assertThat(started).isTrue();
+    container.getDockerClient().stopContainerCmd(container.getContainerId()).exec();
+    final File dataDirectory = getDataDirectoryFromContainer();
+    stop();
+    return dataDirectory;
+  }
+
   public void waitForOwnedValidatorCount(final int expectedValidatorCount) {
     LOG.debug("Waiting for validator count to be {}", expectedValidatorCount);
     waitFor(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.storage.server.rocksdb;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.HashSet;
 import java.util.List;
@@ -27,10 +26,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.rocksdb.AbstractRocksIterator;
+import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.TransactionDB;
+import tech.pegasys.teku.storage.server.DatabaseStorageException;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor;
@@ -41,7 +42,8 @@ public class RocksDbInstance implements KvStoreAccessor {
 
   private final TransactionDB db;
   private final ColumnFamilyHandle defaultHandle;
-  private final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
+  private final Map<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
+  private final Map<KvStoreColumn<?, ?>, ColumnFamilyDescriptor> columnDescriptors;
   private final List<AutoCloseable> resources;
   private final Set<RocksDbTransaction> openTransactions = new HashSet<>();
 
@@ -50,11 +52,13 @@ public class RocksDbInstance implements KvStoreAccessor {
   RocksDbInstance(
       final TransactionDB db,
       final ColumnFamilyHandle defaultHandle,
-      final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles,
+      final Map<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles,
+      final Map<KvStoreColumn<?, ?>, ColumnFamilyDescriptor> columnDescriptors,
       final List<AutoCloseable> resources) {
     this.db = db;
     this.defaultHandle = defaultHandle;
     this.columnHandles = columnHandles;
+    this.columnDescriptors = columnDescriptors;
     this.resources = resources;
   }
 
@@ -77,10 +81,13 @@ public class RocksDbInstance implements KvStoreAccessor {
   @Override
   public <K, V> Optional<V> get(final KvStoreColumn<K, V> column, final K key) {
     assertOpen();
-    final ColumnFamilyHandle handle = columnHandles.get(column);
+    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
+    if (maybeHandle.isEmpty()) {
+      return Optional.empty();
+    }
     final byte[] keyBytes = column.getKeySerializer().serialize(key);
     try {
-      return Optional.ofNullable(db.get(handle, keyBytes))
+      return Optional.ofNullable(db.get(maybeHandle.get(), keyBytes))
           .map(data -> column.getValueSerializer().deserialize(data));
     } catch (RocksDBException e) {
       throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
@@ -126,8 +133,11 @@ public class RocksDbInstance implements KvStoreAccessor {
   @Override
   public <K, V> Optional<K> getLastKey(final KvStoreColumn<K, V> column) {
     assertOpen();
-    final ColumnFamilyHandle handle = columnHandles.get(column);
-    try (final RocksIterator rocksDbIterator = db.newIterator(handle)) {
+    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
+    if (maybeHandle.isEmpty()) {
+      return Optional.empty();
+    }
+    try (final RocksIterator rocksDbIterator = db.newIterator(maybeHandle.get())) {
       rocksDbIterator.seekToLast();
       return rocksDbIterator.isValid()
           ? Optional.of(column.getKeySerializer().deserialize(rocksDbIterator.key()))
@@ -166,10 +176,13 @@ public class RocksDbInstance implements KvStoreAccessor {
   @Override
   public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
     assertOpen();
-    final ColumnFamilyHandle handle = columnHandles.get(column);
+    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
+    if (maybeHandle.isEmpty()) {
+      return Optional.empty();
+    }
     final byte[] keyBytes = column.getKeySerializer().serialize(key);
     try {
-      return Optional.ofNullable(db.get(handle, keyBytes)).map(Bytes::wrap);
+      return Optional.ofNullable(db.get(maybeHandle.get(), keyBytes)).map(Bytes::wrap);
     } catch (RocksDBException e) {
       throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
     }
@@ -202,7 +215,12 @@ public class RocksDbInstance implements KvStoreAccessor {
   public synchronized KvStoreTransaction startTransaction() {
     assertOpen();
     final RocksDbTransaction tx =
-        new RocksDbTransaction(db, defaultHandle, columnHandles, openTransactions::remove);
+        new RocksDbTransaction(
+            db,
+            defaultHandle,
+            this::getColumnHandleForWrite,
+            this::getColumnHandle,
+            openTransactions::remove);
     openTransactions.add(tx);
     return tx;
   }
@@ -250,8 +268,11 @@ public class RocksDbInstance implements KvStoreAccessor {
       final Consumer<RocksIterator> setupIterator,
       final Predicate<K> continueTest) {
     assertOpen();
-    final ColumnFamilyHandle handle = columnHandles.get(column);
-    final RocksIterator rocksDbIterator = db.newIterator(handle);
+    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
+    if (maybeHandle.isEmpty()) {
+      return Stream.empty();
+    }
+    final RocksIterator rocksDbIterator = db.newIterator(maybeHandle.get());
     setupIterator.accept(rocksDbIterator);
     return RocksDbIterator.create(column, rocksDbIterator, continueTest, closed::get).toStream();
   }
@@ -263,8 +284,11 @@ public class RocksDbInstance implements KvStoreAccessor {
       final Consumer<RocksIterator> setupIterator,
       final Predicate<K> continueTest) {
     assertOpen();
-    final ColumnFamilyHandle handle = columnHandles.get(column);
-    final RocksIterator rocksDbIterator = db.newIterator(handle);
+    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
+    if (maybeHandle.isEmpty()) {
+      return Stream.empty();
+    }
+    final RocksIterator rocksDbIterator = db.newIterator(maybeHandle.get());
     setupIterator.accept(rocksDbIterator);
     return RocksDbKeyIterator.create(column, rocksDbIterator, continueTest, closed::get).toStream();
   }
@@ -285,6 +309,34 @@ public class RocksDbInstance implements KvStoreAccessor {
   private void assertOpen() {
     if (closed.get()) {
       throw new ShuttingDownException();
+    }
+  }
+
+  private synchronized Optional<ColumnFamilyHandle> getColumnHandle(
+      final KvStoreColumn<?, ?> column) {
+    return Optional.ofNullable(columnHandles.get(column));
+  }
+
+  private synchronized ColumnFamilyHandle getColumnHandleForWrite(
+      final KvStoreColumn<?, ?> column) {
+    assertOpen();
+    final ColumnFamilyHandle existingHandle = columnHandles.get(column);
+    if (existingHandle != null) {
+      return existingHandle;
+    }
+
+    final ColumnFamilyDescriptor descriptor = columnDescriptors.get(column);
+    if (descriptor == null) {
+      throw DatabaseStorageException.unrecoverable("Column is not defined in the RocksDB schema");
+    }
+
+    try {
+      final ColumnFamilyHandle columnHandle = db.createColumnFamily(descriptor);
+      columnHandles.put(column, columnHandle);
+      resources.add(Math.max(0, resources.size() - 1), columnHandle);
+      return columnHandle;
+    } catch (RocksDBException e) {
+      throw RocksDbExceptionUtil.wrapException("Failed to create column family", e);
     }
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.server.rocksdb;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +43,7 @@ public class RocksDbInstance implements KvStoreAccessor {
 
   private final TransactionDB db;
   private final ColumnFamilyHandle defaultHandle;
-  private final Map<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
+  private volatile ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
   private final Map<KvStoreColumn<?, ?>, ColumnFamilyDescriptor> columnDescriptors;
   private final List<AutoCloseable> resources;
   private final Set<RocksDbTransaction> openTransactions = new HashSet<>();
@@ -52,7 +53,7 @@ public class RocksDbInstance implements KvStoreAccessor {
   RocksDbInstance(
       final TransactionDB db,
       final ColumnFamilyHandle defaultHandle,
-      final Map<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles,
+      final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles,
       final Map<KvStoreColumn<?, ?>, ColumnFamilyDescriptor> columnDescriptors,
       final List<AutoCloseable> resources) {
     this.db = db;
@@ -81,13 +82,13 @@ public class RocksDbInstance implements KvStoreAccessor {
   @Override
   public <K, V> Optional<V> get(final KvStoreColumn<K, V> column, final K key) {
     assertOpen();
-    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
-    if (maybeHandle.isEmpty()) {
+    final ColumnFamilyHandle handle = getColumnHandle(column);
+    if (handle == null) {
       return Optional.empty();
     }
     final byte[] keyBytes = column.getKeySerializer().serialize(key);
     try {
-      return Optional.ofNullable(db.get(maybeHandle.get(), keyBytes))
+      return Optional.ofNullable(db.get(handle, keyBytes))
           .map(data -> column.getValueSerializer().deserialize(data));
     } catch (RocksDBException e) {
       throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
@@ -133,11 +134,11 @@ public class RocksDbInstance implements KvStoreAccessor {
   @Override
   public <K, V> Optional<K> getLastKey(final KvStoreColumn<K, V> column) {
     assertOpen();
-    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
-    if (maybeHandle.isEmpty()) {
+    final ColumnFamilyHandle handle = getColumnHandle(column);
+    if (handle == null) {
       return Optional.empty();
     }
-    try (final RocksIterator rocksDbIterator = db.newIterator(maybeHandle.get())) {
+    try (final RocksIterator rocksDbIterator = db.newIterator(handle)) {
       rocksDbIterator.seekToLast();
       return rocksDbIterator.isValid()
           ? Optional.of(column.getKeySerializer().deserialize(rocksDbIterator.key()))
@@ -176,13 +177,13 @@ public class RocksDbInstance implements KvStoreAccessor {
   @Override
   public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
     assertOpen();
-    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
-    if (maybeHandle.isEmpty()) {
+    final ColumnFamilyHandle handle = getColumnHandle(column);
+    if (handle == null) {
       return Optional.empty();
     }
     final byte[] keyBytes = column.getKeySerializer().serialize(key);
     try {
-      return Optional.ofNullable(db.get(maybeHandle.get(), keyBytes)).map(Bytes::wrap);
+      return Optional.ofNullable(db.get(handle, keyBytes)).map(Bytes::wrap);
     } catch (RocksDBException e) {
       throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
     }
@@ -268,11 +269,11 @@ public class RocksDbInstance implements KvStoreAccessor {
       final Consumer<RocksIterator> setupIterator,
       final Predicate<K> continueTest) {
     assertOpen();
-    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
-    if (maybeHandle.isEmpty()) {
+    final ColumnFamilyHandle handle = getColumnHandle(column);
+    if (handle == null) {
       return Stream.empty();
     }
-    final RocksIterator rocksDbIterator = db.newIterator(maybeHandle.get());
+    final RocksIterator rocksDbIterator = db.newIterator(handle);
     setupIterator.accept(rocksDbIterator);
     return RocksDbIterator.create(column, rocksDbIterator, continueTest, closed::get).toStream();
   }
@@ -284,11 +285,11 @@ public class RocksDbInstance implements KvStoreAccessor {
       final Consumer<RocksIterator> setupIterator,
       final Predicate<K> continueTest) {
     assertOpen();
-    final Optional<ColumnFamilyHandle> maybeHandle = getColumnHandle(column);
-    if (maybeHandle.isEmpty()) {
+    final ColumnFamilyHandle handle = getColumnHandle(column);
+    if (handle == null) {
       return Stream.empty();
     }
-    final RocksIterator rocksDbIterator = db.newIterator(maybeHandle.get());
+    final RocksIterator rocksDbIterator = db.newIterator(handle);
     setupIterator.accept(rocksDbIterator);
     return RocksDbKeyIterator.create(column, rocksDbIterator, continueTest, closed::get).toStream();
   }
@@ -312,9 +313,8 @@ public class RocksDbInstance implements KvStoreAccessor {
     }
   }
 
-  private synchronized Optional<ColumnFamilyHandle> getColumnHandle(
-      final KvStoreColumn<?, ?> column) {
-    return Optional.ofNullable(columnHandles.get(column));
+  private ColumnFamilyHandle getColumnHandle(final KvStoreColumn<?, ?> column) {
+    return columnHandles.get(column);
   }
 
   private synchronized ColumnFamilyHandle getColumnHandleForWrite(
@@ -332,8 +332,12 @@ public class RocksDbInstance implements KvStoreAccessor {
 
     try {
       final ColumnFamilyHandle columnHandle = db.createColumnFamily(descriptor);
-      columnHandles.put(column, columnHandle);
       resources.add(Math.max(0, resources.size() - 1), columnHandle);
+      columnHandles =
+          ImmutableMap.<KvStoreColumn<?, ?>, ColumnFamilyHandle>builder()
+              .putAll(columnHandles)
+              .put(column, columnHandle)
+              .build();
       return columnHandle;
     } catch (RocksDBException e) {
       throw RocksDbExceptionUtil.wrapException("Failed to create column family", e);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
@@ -142,11 +142,7 @@ public class RocksDbInstanceFactory {
       rocksDbStats.registerMetrics(db);
 
       return new RocksDbInstance(
-          db,
-          defaultHandle,
-          new HashMap<>(columnHandlesMap),
-          columnFamilyDescriptors.byColumn(),
-          resources);
+          db, defaultHandle, columnHandlesMap, columnFamilyDescriptors.byColumn(), resources);
     } catch (RocksDBException e) {
       throw RocksDbExceptionUtil.wrapException(
           "Failed to open database at path: " + configuration.getDatabaseDir(), e);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactory.java
@@ -23,7 +23,7 @@ import static tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration.WAL_
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -42,6 +42,8 @@ import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Statistics;
 import org.rocksdb.TransactionDB;
@@ -94,9 +96,19 @@ public class RocksDbInstanceFactory {
         new ArrayList<>(
             List.of(txOptions, dbOptions, columnFamilyOptions, rocksDbStats, blockCache));
 
-    List<ColumnFamilyDescriptor> columnDescriptors =
+    final ColumnFamilyDescriptors columnFamilyDescriptors =
         createColumnFamilyDescriptors(
             configuration, columns, deletedColumns, columnFamilyOptions, resources);
+    final List<ColumnFamilyDescriptor> columnDescriptors =
+        getExistingColumnIds(configuration).stream()
+            .map(
+                id ->
+                    columnFamilyDescriptors
+                        .byId()
+                        .getOrDefault(
+                            id,
+                            new ColumnFamilyDescriptor(id.toArrayUnsafe(), columnFamilyOptions)))
+            .collect(Collectors.toCollection(ArrayList::new));
     Map<Bytes, KvStoreColumn<?, ?>> columnsById =
         columns.stream().collect(Collectors.toMap(KvStoreColumn::getId, Function.identity()));
 
@@ -129,7 +141,12 @@ public class RocksDbInstanceFactory {
 
       rocksDbStats.registerMetrics(db);
 
-      return new RocksDbInstance(db, defaultHandle, columnHandlesMap, resources);
+      return new RocksDbInstance(
+          db,
+          defaultHandle,
+          new HashMap<>(columnHandlesMap),
+          columnFamilyDescriptors.byColumn(),
+          resources);
     } catch (RocksDBException e) {
       throw RocksDbExceptionUtil.wrapException(
           "Failed to open database at path: " + configuration.getDatabaseDir(), e);
@@ -160,7 +177,6 @@ public class RocksDbInstanceFactory {
             .setMaxBackgroundJobs(configuration.getMaxBackgroundJobs())
             .setDbWriteBufferSize(configuration.getWriteBufferCapacity())
             .setMaxOpenFiles(configuration.getMaxOpenFiles())
-            .setCreateMissingColumnFamilies(true)
             .setLogFileTimeToRoll(TIME_TO_ROLL_LOG_FILE)
             .setKeepLogFileNum(NUMBER_OF_LOG_FILES_TO_KEEP)
             .setEnv(Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()))
@@ -185,7 +201,7 @@ public class RocksDbInstanceFactory {
         .setTableFormatConfig(createBlockBasedTableConfig(cache));
   }
 
-  private static List<ColumnFamilyDescriptor> createColumnFamilyDescriptors(
+  private static ColumnFamilyDescriptors createColumnFamilyDescriptors(
       final KvStoreConfiguration configuration,
       final Collection<KvStoreColumn<?, ?>> columns,
       final Collection<Bytes> deletedColumns,
@@ -195,42 +211,53 @@ public class RocksDbInstanceFactory {
     final ColumnFamilyOptions columnFamilyOptionsWithBlobDb =
         new ColumnFamilyOptions(columnFamilyOptions);
     resources.add(columnFamilyOptionsWithBlobDb);
-    final List<ColumnFamilyDescriptor> columnDescriptors;
-
     if (configuration.blobDbEnabled()) {
-
-      columnDescriptors =
-          columns.stream()
-              .filter(KvStoreColumn::containsStaticData)
-              .map(
-                  column ->
-                      new ColumnFamilyDescriptor(
-                          column.getId().toArrayUnsafe(),
-                          columnFamilyOptionsWithBlobDb
-                              .setEnableBlobFiles(true)
-                              .setMinBlobSize(100)
-                              .setBlobCompressionType(CompressionType.LZ4_COMPRESSION)
-                              .setEnableBlobGarbageCollection(true)))
-              .collect(Collectors.toCollection(ArrayList::new));
-
-      columnDescriptors.addAll(
-          Stream.concat(
-                  columns.stream()
-                      .filter(column -> !column.containsStaticData())
-                      .map(KvStoreColumn::getId),
-                  deletedColumns.stream())
-              .map(id -> new ColumnFamilyDescriptor(id.toArrayUnsafe(), columnFamilyOptions))
-              .collect(Collectors.toCollection(ArrayList::new)));
-
-    } else {
-      columnDescriptors =
-          Stream.concat(columns.stream().map(KvStoreColumn::getId), deletedColumns.stream())
-              .map(id -> new ColumnFamilyDescriptor(id.toArrayUnsafe(), columnFamilyOptions))
-              .collect(Collectors.toCollection(ArrayList::new));
+      columnFamilyOptionsWithBlobDb
+          .setEnableBlobFiles(true)
+          .setMinBlobSize(100)
+          .setBlobCompressionType(CompressionType.LZ4_COMPRESSION)
+          .setEnableBlobGarbageCollection(true);
     }
-    columnDescriptors.add(
+
+    final Map<Bytes, ColumnFamilyDescriptor> descriptorsById = new HashMap<>();
+    final Map<KvStoreColumn<?, ?>, ColumnFamilyDescriptor> descriptorsByColumn = new HashMap<>();
+    for (KvStoreColumn<?, ?> column : columns) {
+      final ColumnFamilyDescriptor descriptor =
+          new ColumnFamilyDescriptor(
+              column.getId().toArrayUnsafe(),
+              configuration.blobDbEnabled() && column.containsStaticData()
+                  ? columnFamilyOptionsWithBlobDb
+                  : columnFamilyOptions);
+      descriptorsById.put(column.getId(), descriptor);
+      descriptorsByColumn.put(column, descriptor);
+    }
+    for (Bytes deletedColumn : deletedColumns) {
+      descriptorsById.put(
+          deletedColumn,
+          new ColumnFamilyDescriptor(deletedColumn.toArrayUnsafe(), columnFamilyOptions));
+    }
+    descriptorsById.put(
+        Schema.DEFAULT_COLUMN_ID,
         new ColumnFamilyDescriptor(Schema.DEFAULT_COLUMN_ID.toArrayUnsafe(), columnFamilyOptions));
-    return Collections.unmodifiableList(columnDescriptors);
+    return new ColumnFamilyDescriptors(
+        ImmutableMap.copyOf(descriptorsById), ImmutableMap.copyOf(descriptorsByColumn));
+  }
+
+  private static List<Bytes> getExistingColumnIds(final KvStoreConfiguration configuration) {
+    if (!configuration.getDatabaseDir().resolve("CURRENT").toFile().exists()) {
+      return List.of(Schema.DEFAULT_COLUMN_ID);
+    }
+
+    try (final Options options = new Options()) {
+      final List<Bytes> existingColumnIds =
+          RocksDB.listColumnFamilies(options, configuration.getDatabaseDir().toString()).stream()
+              .map(Bytes::wrap)
+              .collect(Collectors.toCollection(ArrayList::new));
+      return existingColumnIds.isEmpty() ? List.of(Schema.DEFAULT_COLUMN_ID) : existingColumnIds;
+    } catch (RocksDBException e) {
+      throw RocksDbExceptionUtil.wrapException(
+          "Failed to list column families at path: " + configuration.getDatabaseDir(), e);
+    }
   }
 
   private static BlockBasedTableConfig createBlockBasedTableConfig(final Cache cache) {
@@ -242,4 +269,8 @@ public class RocksDbInstanceFactory {
         .setCacheIndexAndFilterBlocks(false)
         .setBlockSize(ROCKSDB_BLOCK_SIZE);
   }
+
+  private record ColumnFamilyDescriptors(
+      ImmutableMap<Bytes, ColumnFamilyDescriptor> byId,
+      ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyDescriptor> byColumn) {}
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.storage.server.rocksdb;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -33,7 +32,7 @@ import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreVariable;
 public class RocksDbTransaction implements KvStoreTransaction {
   private final ColumnFamilyHandle defaultHandle;
   private final Function<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandleForWrite;
-  private final Function<KvStoreColumn<?, ?>, Optional<ColumnFamilyHandle>> columnHandle;
+  private final Function<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandle;
   private final Transaction rocksDbTx;
   private final WriteOptions writeOptions;
 
@@ -46,7 +45,7 @@ public class RocksDbTransaction implements KvStoreTransaction {
       final TransactionDB db,
       final ColumnFamilyHandle defaultHandle,
       final Function<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandleForWrite,
-      final Function<KvStoreColumn<?, ?>, Optional<ColumnFamilyHandle>> columnHandle,
+      final Function<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandle,
       final Consumer<RocksDbTransaction> onClosed) {
     this.defaultHandle = defaultHandle;
     this.columnHandleForWrite = columnHandleForWrite;
@@ -119,12 +118,12 @@ public class RocksDbTransaction implements KvStoreTransaction {
   public <K, V> void delete(final KvStoreColumn<K, V> column, final K key) {
     applyUpdate(
         () -> {
-          final Optional<ColumnFamilyHandle> maybeHandle = columnHandle.apply(column);
-          if (maybeHandle.isEmpty()) {
+          final ColumnFamilyHandle handle = columnHandle.apply(column);
+          if (handle == null) {
             return;
           }
           try {
-            rocksDbTx.delete(maybeHandle.get(), column.getKeySerializer().serialize(key));
+            rocksDbTx.delete(handle, column.getKeySerializer().serialize(key));
           } catch (RocksDBException e) {
             throw RocksDbExceptionUtil.wrapException("Failed to delete key", e);
           }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbTransaction.java
@@ -13,11 +13,12 @@
 
 package tech.pegasys.teku.storage.server.rocksdb;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
@@ -31,7 +32,8 @@ import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreVariable;
 
 public class RocksDbTransaction implements KvStoreTransaction {
   private final ColumnFamilyHandle defaultHandle;
-  private final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles;
+  private final Function<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandleForWrite;
+  private final Function<KvStoreColumn<?, ?>, Optional<ColumnFamilyHandle>> columnHandle;
   private final Transaction rocksDbTx;
   private final WriteOptions writeOptions;
 
@@ -43,10 +45,12 @@ public class RocksDbTransaction implements KvStoreTransaction {
   RocksDbTransaction(
       final TransactionDB db,
       final ColumnFamilyHandle defaultHandle,
-      final ImmutableMap<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandles,
+      final Function<KvStoreColumn<?, ?>, ColumnFamilyHandle> columnHandleForWrite,
+      final Function<KvStoreColumn<?, ?>, Optional<ColumnFamilyHandle>> columnHandle,
       final Consumer<RocksDbTransaction> onClosed) {
     this.defaultHandle = defaultHandle;
-    this.columnHandles = columnHandles;
+    this.columnHandleForWrite = columnHandleForWrite;
+    this.columnHandle = columnHandle;
     this.writeOptions = new WriteOptions();
     this.rocksDbTx = db.beginTransaction(writeOptions);
     this.onClosed = onClosed;
@@ -82,7 +86,7 @@ public class RocksDbTransaction implements KvStoreTransaction {
       final KvStoreColumn<K, V> column, final Bytes keyBytes, final Bytes valueBytes) {
     applyUpdate(
         () -> {
-          final ColumnFamilyHandle handle = columnHandles.get(column);
+          final ColumnFamilyHandle handle = columnHandleForWrite.apply(column);
           try {
             rocksDbTx.put(handle, keyBytes.toArrayUnsafe(), valueBytes.toArrayUnsafe());
           } catch (RocksDBException e) {
@@ -95,7 +99,10 @@ public class RocksDbTransaction implements KvStoreTransaction {
   public <K, V> void put(final KvStoreColumn<K, V> column, final Map<K, V> data) {
     applyUpdate(
         () -> {
-          final ColumnFamilyHandle handle = columnHandles.get(column);
+          if (data.isEmpty()) {
+            return;
+          }
+          final ColumnFamilyHandle handle = columnHandleForWrite.apply(column);
           for (Map.Entry<K, V> kvEntry : data.entrySet()) {
             final byte[] key = column.getKeySerializer().serialize(kvEntry.getKey());
             final byte[] value = column.getValueSerializer().serialize(kvEntry.getValue());
@@ -112,9 +119,12 @@ public class RocksDbTransaction implements KvStoreTransaction {
   public <K, V> void delete(final KvStoreColumn<K, V> column, final K key) {
     applyUpdate(
         () -> {
-          final ColumnFamilyHandle handle = columnHandles.get(column);
+          final Optional<ColumnFamilyHandle> maybeHandle = columnHandle.apply(column);
+          if (maybeHandle.isEmpty()) {
+            return;
+          }
           try {
-            rocksDbTx.delete(handle, column.getKeySerializer().serialize(key));
+            rocksDbTx.delete(maybeHandle.get(), column.getKeySerializer().serialize(key));
           } catch (RocksDBException e) {
             throw RocksDbExceptionUtil.wrapException("Failed to delete key", e);
           }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactoryTest.java
@@ -19,9 +19,12 @@ import static tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn.asCo
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.UINT64_SERIALIZER;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -67,6 +70,20 @@ class RocksDbInstanceFactoryTest {
 
     try (final KvStoreAccessor db = createDatabase(List.of(firstColumn))) {
       assertThat(db.get(firstColumn, UInt64.ONE)).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldReadWithoutAcquiringDatabaseMonitor() throws Exception {
+    try (final KvStoreAccessor db = createDatabase(List.of(firstColumn))) {
+      synchronized (db) {
+        final CompletableFuture<Optional<UInt64>> readFuture =
+            CompletableFuture.supplyAsync(() -> db.get(firstColumn, UInt64.ONE));
+
+        assertThat(readFuture)
+            .succeedsWithin(Duration.ofSeconds(1))
+            .satisfies(result -> assertThat(result).isEmpty());
+      }
     }
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstanceFactoryTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.STORAGE;
+import static tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn.asColumnId;
+import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.UINT64_SERIALIZER;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor;
+import tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration;
+import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn;
+import tech.pegasys.teku.storage.server.kvstore.schema.Schema;
+
+class RocksDbInstanceFactoryTest {
+
+  private final KvStoreColumn<UInt64, UInt64> firstColumn =
+      KvStoreColumn.create(1, UINT64_SERIALIZER, UINT64_SERIALIZER);
+  private final KvStoreColumn<UInt64, UInt64> secondColumn =
+      KvStoreColumn.create(2, UINT64_SERIALIZER, UINT64_SERIALIZER);
+
+  @TempDir Path databaseDir;
+
+  @Test
+  void shouldNotCreateUnusedColumnFamiliesOnOpen() throws Exception {
+    try (final KvStoreAccessor db = createDatabase(List.of(firstColumn, secondColumn))) {
+      assertThat(db.get(firstColumn, UInt64.ONE)).isEmpty();
+      assertThat(db.size(secondColumn)).isZero();
+    }
+
+    assertThat(existingColumnFamilyIds()).containsExactlyInAnyOrder(Schema.DEFAULT_COLUMN_ID);
+  }
+
+  @Test
+  void shouldOpenDatabaseWithUnknownExistingColumnFamily() throws Exception {
+    try (final KvStoreAccessor db = createDatabase(List.of(firstColumn, secondColumn));
+        final KvStoreAccessor.KvStoreTransaction transaction = db.startTransaction()) {
+      transaction.put(secondColumn, UInt64.ONE, UInt64.valueOf(2));
+      transaction.commit();
+    }
+
+    assertThat(existingColumnFamilyIds())
+        .containsExactlyInAnyOrder(Schema.DEFAULT_COLUMN_ID, asColumnId(2));
+
+    try (final KvStoreAccessor db = createDatabase(List.of(firstColumn))) {
+      assertThat(db.get(firstColumn, UInt64.ONE)).isEmpty();
+    }
+  }
+
+  private KvStoreAccessor createDatabase(final Collection<KvStoreColumn<?, ?>> columns) {
+    return RocksDbInstanceFactory.create(
+        new StubMetricsSystem(),
+        STORAGE,
+        KvStoreConfiguration.v6SingleDefaults().withDatabaseDir(databaseDir),
+        columns,
+        List.of(),
+        List.of(),
+        List.of());
+  }
+
+  private Set<Bytes> existingColumnFamilyIds() throws Exception {
+    RocksDB.loadLibrary();
+    try (final Options options = new Options()) {
+      return RocksDB.listColumnFamilies(options, databaseDir.toString()).stream()
+          .map(Bytes::wrap)
+          .collect(Collectors.toSet());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Avoid creating RocksDB column families just by opening a database.
- Treat missing known column families as empty for reads/streams.
- Lazily create column families only when data is actually written.
- Allow databases with unknown existing column families to open, so newer Teku can avoid breaking downgrade to released versions when no new-column data has been written.

## Motivation

Opening `master` against a `26.4.0` V6 database could create newly added column families eagerly. After that, `26.4.0` could no longer reopen the database because RocksDB requires every existing column family to be explicitly opened.

This preserves compatibility without bumping the database version for open-only/no-write cases.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core beacon chain persistence and column-family lifecycle; incorrect open/create behavior could corrupt data or break upgrades/downgrades between releases.
> 
> **Overview**
> Changes RocksDB V6 open behavior so **only column families already on disk** are opened, instead of eagerly creating every schema column at startup. **`createMissingColumnFamilies`** is removed; new families are created **lazily on first write** via `getColumnHandleForWrite`, while reads/streams/deletes treat a missing handle as **empty**.
> 
> `RocksDbInstanceFactory` now **lists existing column IDs** when opening and can attach **unknown** families so newer Teku can run read-only against older DBs without breaking **downgrade to 26.4** when no new-column data was written.
> 
> Adds **`RocksDbInstanceFactoryTest`**, acceptance **`DatabaseCompatibilityAcceptanceTest`** (local RocksDB V6 → last-release startup), and **`TekuNode.stopAndGetDataDirectoryFromContainer`** for capturing node data dirs in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e05b30faf68c1069d5bb5cb387c7c1b62d65c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->