### PR TITLE
Avoid recursive data column sidecar range sends

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandler.java
@@ -209,21 +209,40 @@ public class DataColumnSidecarsByRangeMessageHandler
   }
 
   private SafeFuture<RequestState> sendDataColumnSidecars(final RequestState requestState) {
+    SafeFuture<Boolean> dataColumnSidecarFuture = processNextDataColumnSidecar(requestState);
+    // Avoid risk of StackOverflowException by iterating when the sidecar future is already
+    // complete. Using thenCompose on the completed future would execute immediately and recurse
+    // back into this method to send the next sidecar. When not already complete, thenCompose is
+    // executed on a separate thread so doesn't recurse on the same stack.
+    while (dataColumnSidecarFuture.isDone()
+        && !dataColumnSidecarFuture.isCompletedExceptionally()) {
+      if (dataColumnSidecarFuture.join()) {
+        return SafeFuture.completedFuture(requestState);
+      }
+      dataColumnSidecarFuture = processNextDataColumnSidecar(requestState);
+    }
+    return dataColumnSidecarFuture.thenCompose(
+        complete ->
+            complete
+                ? SafeFuture.completedFuture(requestState)
+                : sendDataColumnSidecars(requestState));
+  }
+
+  private SafeFuture<Boolean> processNextDataColumnSidecar(final RequestState requestState) {
     return requestState
         .loadNextDataColumnSidecar()
         .thenCompose(
             maybeDataColumnSidecar ->
-                maybeDataColumnSidecar
-                    .map(requestState::sendDataColumnSidecar)
-                    .orElse(SafeFuture.COMPLETE))
-        .thenCompose(
-            __ -> {
-              if (requestState.isComplete()) {
-                return SafeFuture.completedFuture(requestState);
-              } else {
-                return sendDataColumnSidecars(requestState);
-              }
-            });
+                handleLoadedDataColumnSidecar(requestState, maybeDataColumnSidecar));
+  }
+
+  /** Sends the data column sidecar and returns true if the request is now complete. */
+  private SafeFuture<Boolean> handleLoadedDataColumnSidecar(
+      final RequestState requestState, final Optional<DataColumnSidecar> maybeDataColumnSidecar) {
+    return maybeDataColumnSidecar
+        .map(requestState::sendDataColumnSidecar)
+        .orElse(SafeFuture.COMPLETE)
+        .thenApply(__ -> requestState.isComplete());
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeMessageHandlerTest.java
@@ -99,6 +99,7 @@ public class DataColumnSidecarsByRangeMessageHandlerTest {
       dataColumnSidecarsByRangeRequestMessageSchema;
   private UInt64 startSlot;
   private int slotsPerEpoch;
+  private int numberOfColumns;
   private UInt64 maxRequestDataColumnSidecars;
   private final UInt64 count = UInt64.valueOf(5);
   private final List<UInt64> columnIndices = List.of(ZERO, ONE);
@@ -116,6 +117,7 @@ public class DataColumnSidecarsByRangeMessageHandlerTest {
     dataStructureUtil = new DataStructureUtil(spec);
     final SpecVersion specVersionFulu = spec.atEpoch(currentForkEpoch);
     final SpecConfigFulu specConfigFulu = SpecConfigFulu.required(specVersionFulu.getConfig());
+    numberOfColumns = specConfigFulu.getNumberOfColumns();
     maxRequestDataColumnSidecars = UInt64.valueOf(specConfigFulu.getMaxRequestDataColumnSidecars());
     handler =
         new DataColumnSidecarsByRangeMessageHandler(
@@ -282,6 +284,36 @@ public class DataColumnSidecarsByRangeMessageHandlerTest {
     final List<DataColumnSidecar> actualSent = argumentCaptor.getAllValues();
     verify(listener).completeSuccessfully();
     AssertionsForInterfaceTypes.assertThat(actualSent).hasSameElementsAs(expectedSent);
+  }
+
+  @TestTemplate
+  public void shouldSendMaximumDataColumnSidecarsWhenFuturesCompleteImmediately() {
+    final List<UInt64> allColumnIndices =
+        UInt64.rangeClosed(ZERO, UInt64.valueOf(numberOfColumns - 1)).toList();
+    final UInt64 requestSlotCount =
+        UInt64.valueOf(maxRequestDataColumnSidecars.longValue() / numberOfColumns);
+    final DataColumnSidecarsByRangeRequestMessage request =
+        dataColumnSidecarsByRangeRequestMessageSchema.create(
+            startSlot, requestSlotCount, allColumnIndices);
+    final List<DataColumnSlotAndIdentifier> dataColumnIdentifiers =
+        setupDataColumnSidecarIdentifiers(startSlot, request.getMaxSlot(), allColumnIndices)
+            .stream()
+            .map(Pair::getValue)
+            .toList();
+    final DataColumnSidecar dataColumnSidecar = mock(DataColumnSidecar.class);
+
+    when(combinedChainDataClient.getFinalizedBlockSlot())
+        .thenReturn(Optional.of(request.getMaxSlot()));
+    when(combinedChainDataClient.getDataColumnIdentifiers(
+            eq(startSlot), eq(request.getMaxSlot()), any(UInt64.class)))
+        .thenReturn(SafeFuture.completedFuture(dataColumnIdentifiers));
+    when(combinedChainDataClient.getSidecar(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(dataColumnSidecar)));
+
+    handler.onIncomingMessage(protocolId, peer, request, listener);
+
+    verify(listener, times(maxRequestDataColumnSidecars.intValue())).respond(dataColumnSidecar);
+    verify(listener).completeSuccessfully();
   }
 
   @TestTemplate


### PR DESCRIPTION
Iterate through already-completed sidecar futures so max-size DataColumnSidecarsByRange responses do not overflow the stack.

Add a regression test for immediate-completion response paths.

fixes #10793

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches P2P req/resp handling for Fulu data column sidecars; behavior should be equivalent but incorrect iteration logic could affect large peer responses or completion signaling.
> 
> **Overview**
> Fixes **StackOverflowException** when serving max-size **DataColumnSidecarsByRange** responses where each sidecar load and `respond` future completes synchronously.
> 
> **`sendDataColumnSidecars`** no longer relies only on recursive `thenCompose`. It **loops** while the per-sidecar future is already complete (non-exceptional), advancing with `processNextDataColumnSidecar` until the request finishes or an async step remains; only then does it use `thenCompose` again (async continuation avoids same-stack recursion). Loading/sending is split into **`processNextDataColumnSidecar`** and **`handleLoadedDataColumnSidecar`**, which returns whether the range request is complete.
> 
> Adds **`shouldSendMaximumDataColumnSidecarsWhenFuturesCompleteImmediately`**: mocks identifiers and sidecars as immediately-complete futures for a spec-max sidecar count across all columns, asserting every sidecar is sent and the handler completes successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 652692cef215eae0b6facba10c89f3f7198434cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->