### PR TITLE
reference test shard sort and fix config loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,7 +583,8 @@ jobs:
           CLASSNAMES=$(find . -type f -name "*.java" -path "$SRC_PATTERN" \
             | sed "s@.*/$SRC_ROOT/@@" \
             | sed 's@/@.@g' \
-            | sed 's/.\{5\}$//')
+            | sed 's/.\{5\}$//' \
+            | sort)
           # 2) Modulo split
           CLASSES_FOR_SHARD=$(printf "%s\n" "$CLASSNAMES" \
             | awk -v shards=${{ matrix.total }} -v shard=${{ matrix.shard }} '((NR-1) % shards) == shard')

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/PyspecTestFinder.java
@@ -17,20 +17,14 @@ import static tech.pegasys.teku.ethtests.finder.ReferenceTestFinder.unchecked;
 
 import com.google.errorprone.annotations.MustBeClosed;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
-import tech.pegasys.teku.spec.config.YamlConfigReader;
 
 @SuppressWarnings("MustBeClosedChecker")
 public class PyspecTestFinder implements TestFinder {
-
-  private final YamlConfigReader yamlConfigReader = new YamlConfigReader();
 
   public static final String PYSPEC_TEST_DIRECTORY_NAME = "pyspec_tests";
 
@@ -76,22 +70,11 @@ public class PyspecTestFinder implements TestFinder {
     return Files.list(pyspecDir)
         .filter(testDir -> !testDir.getFileName().toString().equals(".DS_Store"))
         .map(
-            unchecked(
-                testDir -> {
-                  final String testName = pyspecDir.relativize(testDir).toString();
-                  // some reference tests ship a partial config.yaml overriding a handful of
-                  // constants on top of the builtin config
-                  final Path configOverridesYaml = testDir.resolve("config.yaml");
-                  return new TestDefinition(
-                      fork,
-                      config,
-                      testType,
-                      testName,
-                      testRoot.relativize(testDir),
-                      Files.exists(configOverridesYaml)
-                          ? Optional.of(readConfigOverrides(configOverridesYaml))
-                          : Optional.empty());
-                }))
+            testDir -> {
+              final String testName = pyspecDir.relativize(testDir).toString();
+              return new TestDefinition(
+                  fork, config, testType, testName, testRoot.relativize(testDir));
+            })
         .filter(
             testDefinition ->
                 onlyTestsToRun.isEmpty()
@@ -102,12 +85,5 @@ public class PyspecTestFinder implements TestFinder {
             testDefinition ->
                 testsToIgnore.stream()
                     .noneMatch(testFilter -> testDefinition.getDisplayName().contains(testFilter)));
-  }
-
-  private Map<String, Object> readConfigOverrides(final Path configOverridesYaml)
-      throws IOException {
-    try (final InputStream in = Files.newInputStream(configOverridesYaml)) {
-      return yamlConfigReader.readValues(in);
-    }
   }
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -136,6 +136,8 @@ public class TestDefinition {
         .resolve(pathFromPhaseTestDir);
   }
 
+  /// some reference tests ship a partial `config.yaml` overriding a handful of constants on top of
+  /// the builtin config
   private Map<String, Object> readConfigOverrides() {
     final Path configOverridesYaml = getTestDirectory().resolve("config.yaml");
     if (!Files.exists(configOverridesYaml)) {

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -19,7 +19,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethtests.TestFork;
@@ -39,7 +38,6 @@ public class TestDefinition {
   private final String testType;
   private final String testName;
   private final Path pathFromPhaseTestDir;
-  private final Optional<Map<String, Object>> configOverrides;
 
   private Spec spec;
 
@@ -49,28 +47,11 @@ public class TestDefinition {
       final String testType,
       final String testName,
       final Path pathFromPhaseTestDir) {
-    this(
-        fork,
-        configName,
-        testType,
-        testName,
-        pathFromPhaseTestDir,
-        readConfigOverrides(configName, fork, pathFromPhaseTestDir));
-  }
-
-  public TestDefinition(
-      final String fork,
-      final String configName,
-      final String testType,
-      final String testName,
-      final Path pathFromPhaseTestDir,
-      final Optional<Map<String, Object>> configOverrides) {
     this.configName = configName;
     this.fork = fork;
     this.testType = testType.replace("\\", "/");
     this.testName = testName.replace("\\", "/");
     this.pathFromPhaseTestDir = pathFromPhaseTestDir;
-    this.configOverrides = configOverrides;
   }
 
   public String getConfigName() {
@@ -125,7 +106,7 @@ public class TestDefinition {
                 builder
                     .blsSignatureVerifier(blsSignatureVerifier)
                     .batchSignatureVerifierSupplier(batchSignatureVerifierSupplier),
-            configOverrides.orElseGet(Map::of));
+            readConfigOverrides());
   }
 
   public String getTestType() {
@@ -155,18 +136,13 @@ public class TestDefinition {
         .resolve(pathFromPhaseTestDir);
   }
 
-  private static Optional<Map<String, Object>> readConfigOverrides(
-      final String configName, final String fork, final Path pathFromPhaseTestDir) {
-    final Path configOverridesYaml =
-        ReferenceTestFinder.findReferenceTestRootDirectory()
-            .resolve(Path.of(configName, fork))
-            .resolve(pathFromPhaseTestDir)
-            .resolve("config.yaml");
+  private Map<String, Object> readConfigOverrides() {
+    final Path configOverridesYaml = getTestDirectory().resolve("config.yaml");
     if (!Files.exists(configOverridesYaml)) {
-      return Optional.empty();
+      return Map.of();
     }
     try (final InputStream in = Files.newInputStream(configOverridesYaml)) {
-      return Optional.of(new YamlConfigReader().readValues(in));
+      return new YamlConfigReader().readValues(in);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -13,6 +13,10 @@
 
 package tech.pegasys.teku.ethtests.finder;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -23,6 +27,7 @@ import tech.pegasys.teku.ethtests.TestSpecConfig;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.YamlConfigReader;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BatchSignatureVerifierImpl;
 import tech.pegasys.teku.spec.networks.Eth2Network;
@@ -44,7 +49,13 @@ public class TestDefinition {
       final String testType,
       final String testName,
       final Path pathFromPhaseTestDir) {
-    this(fork, configName, testType, testName, pathFromPhaseTestDir, Optional.empty());
+    this(
+        fork,
+        configName,
+        testType,
+        testName,
+        pathFromPhaseTestDir,
+        readConfigOverrides(configName, fork, pathFromPhaseTestDir));
   }
 
   public TestDefinition(
@@ -142,5 +153,22 @@ public class TestDefinition {
     return ReferenceTestFinder.findReferenceTestRootDirectory()
         .resolve(Path.of(configName, fork))
         .resolve(pathFromPhaseTestDir);
+  }
+
+  private static Optional<Map<String, Object>> readConfigOverrides(
+      final String configName, final String fork, final Path pathFromPhaseTestDir) {
+    final Path configOverridesYaml =
+        ReferenceTestFinder.findReferenceTestRootDirectory()
+            .resolve(Path.of(configName, fork))
+            .resolve(pathFromPhaseTestDir)
+            .resolve("config.yaml");
+    if (!Files.exists(configOverridesYaml)) {
+      return Optional.empty();
+    }
+    try (final InputStream in = Files.newInputStream(configOverridesYaml)) {
+      return Optional.of(new YamlConfigReader().readValues(in));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 }


### PR DESCRIPTION
Sort the generated reference test class list before applying modulo sharding, so every matrix runner computes the same deterministic order and shards do not overlap.

Also fixes the config loading when running on CI

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect CI sharding and test harness config loading only; no production runtime paths.
> 
> **Overview**
> Makes **reference test CI sharding deterministic** by sorting generated test class FQNs before the modulo split in `ci.yml`, so parallel matrix jobs agree on ordering and avoid overlapping or skipped tests.
> 
> **Defers pyspec `config.yaml` loading** from `PyspecTestFinder` into `TestDefinition`: overrides are read lazily when building the `Spec`, using `getTestDirectory()` (canonical reference-test root resolution) instead of paths computed during discovery. That fixes CI cases where per-test config overrides were not applied correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a768e5689dc9d40b6a22f380b6c798459e5efdb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->