### PR TITLE
Preserve data column KZG validation details

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
@@ -110,12 +110,21 @@ public class DataColumnSidecarsByRangeListenerValidatingProxy
           final MetricsHistogram.Timer kzgVerificationTimer =
               dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer();
           return verifyKzgProofs(dataColumnSidecar)
-              .whenComplete((result, error) -> kzgVerificationTimer.closeUnchecked().run())
+              .alwaysRun(kzgVerificationTimer.closeUnchecked())
+              .exceptionallyCompose(
+                  error ->
+                      SafeFuture.failedFuture(
+                          new DataColumnSidecarsResponseInvalidResponseException(
+                              peer,
+                              InvalidResponseType.DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED,
+                              error)))
               .thenCompose(
                   maybeKzgProofsVerificationResult -> {
                     if (maybeKzgProofsVerificationResult.isPresent()) {
                       throw new DataColumnSidecarsResponseInvalidResponseException(
-                          peer, InvalidResponseType.DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED);
+                          peer,
+                          InvalidResponseType.DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED,
+                          maybeKzgProofsVerificationResult.get());
                     }
                     return verifySignature(dataColumnSidecar);
                   })

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
@@ -90,13 +90,22 @@ public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecar
     final MetricsHistogram.Timer kzgVerificationTimer =
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer();
     return verifyKzgProofs(dataColumnSidecar)
-        .whenComplete((result, error) -> kzgVerificationTimer.closeUnchecked().run())
+        .alwaysRun(kzgVerificationTimer.closeUnchecked())
+        .exceptionallyCompose(
+            error ->
+                SafeFuture.failedFuture(
+                    new DataColumnSidecarsResponseInvalidResponseException(
+                        peer,
+                        InvalidResponseType.DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED,
+                        error)))
         .thenCompose(
             maybeKzgProofsValidationResult -> {
               if (maybeKzgProofsValidationResult.isPresent()) {
                 return SafeFuture.failedFuture(
                     new DataColumnSidecarsResponseInvalidResponseException(
-                        peer, InvalidResponseType.DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED));
+                        peer,
+                        InvalidResponseType.DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED,
+                        maybeKzgProofsValidationResult.get()));
               }
               return SafeFuture.COMPLETE;
             });

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsResponseInvalidResponseException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsResponseInvalidResponseException.java
@@ -15,22 +15,40 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import tech.pegasys.teku.networking.eth2.rpc.core.InvalidResponseException;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarValidationError;
 
 public class DataColumnSidecarsResponseInvalidResponseException extends InvalidResponseException {
 
   public DataColumnSidecarsResponseInvalidResponseException(
       final Peer peer, final InvalidResponseType invalidResponseType) {
-    super(
-        String.format(
-            "Received invalid response from peer %s: %s", peer, invalidResponseType.describe()));
+    super(formatMessage(peer, invalidResponseType));
   }
 
   public DataColumnSidecarsResponseInvalidResponseException(
-      final Peer peer, final InvalidResponseType invalidResponseType, final Exception cause) {
-    super(
-        String.format(
-            "Received invalid response from peer %s: %s", peer, invalidResponseType.describe()),
-        cause);
+      final Peer peer,
+      final InvalidResponseType invalidResponseType,
+      final DataColumnSidecarValidationError validationError) {
+    super(formatMessage(peer, invalidResponseType, validationError.description()));
+  }
+
+  public DataColumnSidecarsResponseInvalidResponseException(
+      final Peer peer, final InvalidResponseType invalidResponseType, final Throwable cause) {
+    super(formatMessage(peer, invalidResponseType), asException(cause));
+  }
+
+  private static String formatMessage(
+      final Peer peer, final InvalidResponseType invalidResponseType) {
+    return String.format(
+        "Received invalid response from peer %s: %s", peer, invalidResponseType.describe());
+  }
+
+  private static String formatMessage(
+      final Peer peer, final InvalidResponseType invalidResponseType, final String details) {
+    return String.format("%s: %s", formatMessage(peer, invalidResponseType), details);
+  }
+
+  private static Exception asException(final Throwable cause) {
+    return cause instanceof Exception exception ? exception : new RuntimeException(cause);
   }
 
   public enum InvalidResponseType {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest.java
@@ -270,7 +270,43 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
         .hasMessageContaining(
             DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
                 .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
-                .describe());
+                .describe())
+        .hasMessageContaining("Invalid DataColumnSidecar KZG Proofs");
+  }
+
+  @Test
+  void dataColumnSidecarKzgVerificationExceptionIsWrapped() {
+    when(kzg.verifyCellProofBatch(any(), any(), any()))
+        .thenThrow(new IllegalStateException("KZG verification exception"));
+    final SignedBeaconBlock block1 = createBlock(ONE);
+    final List<UInt64> columns = List.of(ZERO, ONE);
+
+    listenerWrapper =
+        new DataColumnSidecarsByRangeListenerValidatingProxy(
+            spec,
+            peer,
+            listener,
+            metricsSystem,
+            timeProvider,
+            signatureValidator,
+            ONE,
+            UInt64.valueOf(1),
+            columns,
+            combinedChainDataClient);
+
+    final DataColumnSidecar dataColumnSidecar =
+        dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
+
+    final SafeFuture<?> result = listenerWrapper.onResponse(dataColumnSidecar);
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::get)
+        .hasCauseExactlyInstanceOf(DataColumnSidecarsResponseInvalidResponseException.class);
+    assertThatThrownBy(result::get)
+        .hasMessageContaining(
+            DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
+                .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
+                .describe())
+        .hasRootCauseMessage("KZG verification exception");
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootValidatorTest.java
@@ -149,7 +149,36 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
         .hasMessageContaining(
             DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
                 .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
-                .describe());
+                .describe())
+        .hasMessageContaining("Invalid DataColumnSidecar KZG Proofs");
+  }
+
+  @Test
+  void dataColumnSidecarKzgVerificationExceptionIsWrapped() {
+    when(kzg.verifyCellProofBatch(any(), any(), any()))
+        .thenThrow(new IllegalStateException("KZG verification exception"));
+    final SignedBeaconBlock block1 = createBlock(currentForkFirstSlot);
+    final DataColumnSidecar dataColumnSidecar1_0 =
+        dataStructureUtil.randomDataColumnSidecar(block1, UInt64.ZERO);
+    final DataColumnIdentifier sidecarIdentifier1_0 =
+        DataColumnIdentifier.createFromSidecar(dataColumnSidecar1_0);
+    validator =
+        new DataColumnSidecarsByRootValidator(
+            peer,
+            spec,
+            metricsSystem,
+            timeProvider,
+            dataColumnSidecarSignatureValidator,
+            List.of(sidecarIdentifier1_0),
+            combinedChainDataClient);
+
+    assertThatSafeFuture(validator.validate(dataColumnSidecar1_0))
+        .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)
+        .hasMessageContaining(
+            DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
+                .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
+                .describe())
+        .hasRootCauseMessage("KZG verification exception");
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyGloasTest.java
@@ -118,6 +118,7 @@ public class DataColumnSidecarsByRangeListenerValidatingProxyGloasTest
         .hasMessageContaining(
             DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
                 .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
-                .describe());
+                .describe())
+        .hasMessageContaining("DataColumnSidecar's KZG proofs do not match the bid's KZG proofs");
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
@@ -112,6 +112,7 @@ public class DataColumnSidecarsByRootValidatorGloasTest
         .hasMessageContaining(
             DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
                 .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
-                .describe());
+                .describe())
+        .hasMessageContaining("DataColumnSidecar's KZG proofs do not match the bid's KZG proofs");
   }
 }


### PR DESCRIPTION
from glamsterdam-devnet-5 branch ([c52c3cd](https://github.com/Consensys/teku/pull/10790/commits/c52c3cd395bef04cd9e7acdb4104c0259a2d9c20))

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to error messaging and async error mapping around existing KZG validation; no change to pass/fail criteria.
> 
> **Overview**
> **Data column RPC validation** now surfaces **why** KZG checks failed instead of only the generic invalid-response type.
> 
> `DataColumnSidecarsResponseInvalidResponseException` gains overloads that append a `DataColumnSidecarValidationError` description or attach a `Throwable` cause (with non-`Exception` causes wrapped in `RuntimeException`). **By-range** and **by-root** validators pass the optional validation error from `verifyKzgProofs` into those exceptions, and use `exceptionallyCompose` so failures from the KZG future are mapped to the same typed exception with the original error preserved. KZG timing metrics still close via `alwaysRun` instead of `whenComplete`.
> 
> Tests assert the richer messages (e.g. invalid proofs vs Gloas bid mismatch) and that thrown KZG errors appear as root causes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4ea36631f30f9b045ab5061edd1e88e083b28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->