### PR TITLE
rename LRU based set method

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/ColumnIdCachingDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/ColumnIdCachingDasDb.java
@@ -44,7 +44,7 @@ class ColumnIdCachingDasDb implements DataColumnSidecarDB {
     this.delegateDb = delegateDb;
     this.slotToNumberOfColumns = slotToNumberOfColumns;
     this.readSlotCaches = LimitedMap.createSynchronizedLRU(slotReadCacheSize);
-    this.latestAdded = LimitedSet.createSynchronized(sidecarsWriteCacheSize);
+    this.latestAdded = LimitedSet.createSynchronizedLRU(sidecarsWriteCacheSize);
   }
 
   private SlotCache getOrCreateSlotCache(final UInt64 slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/payloadattestation/PayloadAttestationMessageGossipValidator.java
@@ -51,7 +51,7 @@ public class PayloadAttestationMessageGossipValidator {
   private final SigningRootUtil signingRootUtil;
 
   private final Set<ValidatorIndexAndSlot> seenPayloadAttestations =
-      LimitedSet.createSynchronized(VALID_PAYLOAD_ATTESTATION_SET_SIZE);
+      LimitedSet.createSynchronizedLRU(VALID_PAYLOAD_ATTESTATION_SET_SIZE);
 
   public PayloadAttestationMessageGossipValidator(
       final Spec spec,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -54,7 +54,7 @@ public class SignedContributionAndProofValidator {
   private static final Logger LOG = LogManager.getLogger();
   private final Spec spec;
   private final Set<SourceUniquenessKey> seenIndices =
-      LimitedSet.createSynchronized(VALID_CONTRIBUTION_AND_PROOF_SET_SIZE);
+      LimitedSet.createSynchronizedLRU(VALID_CONTRIBUTION_AND_PROOF_SET_SIZE);
   private final SeenAggregatesCache<TargetUniquenessKey> seenAggregatesCache =
       new SeenAggregatesCache<>(VALID_CONTRIBUTION_AND_PROOF_SET_SIZE);
   private final SyncCommitteeStateUtils syncCommitteeStateUtils;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/FutureItems.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/FutureItems.java
@@ -117,6 +117,6 @@ public class FutureItems<T> implements SlotEventsChannel {
   }
 
   private Set<T> createNewSet() {
-    return LimitedSet.createSynchronized(MAX_ITEMS_PER_SLOT);
+    return LimitedSet.createSynchronizedLRU(MAX_ITEMS_PER_SLOT);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.statetransition.util.SeenAggregatesCache;
 public class AggregateAttestationValidator {
   private static final Logger LOG = LogManager.getLogger();
   private final Set<AggregatorIndexAndEpoch> receivedAggregatorIndexAndEpochs =
-      LimitedSet.createSynchronized(VALID_AGGREGATE_SET_SIZE);
+      LimitedSet.createSynchronizedLRU(VALID_AGGREGATE_SET_SIZE);
   private final SeenAggregatesCache<DataHashAndCommitteeIndex> seenAggregationBits =
       new SeenAggregatesCache<>(VALID_ATTESTATION_DATA_SET_SIZE);
   private final AttestationValidator attestationValidator;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidator.java
@@ -33,7 +33,8 @@ public class AttesterSlashingValidator implements OperationValidator<AttesterSla
   private static final Logger LOG = LogManager.getLogger();
 
   private final RecentChainData recentChainData;
-  private final Set<UInt64> seenIndices = LimitedSet.createSynchronized(VALID_VALIDATOR_SET_SIZE);
+  private final Set<UInt64> seenIndices =
+      LimitedSet.createSynchronizedLRU(VALID_VALIDATOR_SET_SIZE);
   private final Spec spec;
 
   public AttesterSlashingValidator(final RecentChainData recentChainData, final Spec spec) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -72,8 +72,8 @@ public class BlobSidecarGossipValidator {
         invalidBlockRoots,
         validationHelper,
         miscHelpersDeneb,
-        LimitedSet.createSynchronized(validInfoSize),
-        LimitedSet.createSynchronized(validSignedBlockHeadersSize));
+        LimitedSet.createSynchronizedLRU(validInfoSize),
+        LimitedSet.createSynchronizedLRU(validSignedBlockHeadersSize));
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -145,9 +145,9 @@ public class DataColumnSidecarGossipValidator {
         gossipValidationHelper,
         metricsSystem,
         timeProvider,
-        LimitedSet.createSynchronized(validInfoSize),
-        LimitedSet.createSynchronized(validSignedBlockHeadersSize),
-        LimitedSet.createSynchronized(validSignedBlockHeadersSize));
+        LimitedSet.createSynchronizedLRU(validInfoSize),
+        LimitedSet.createSynchronizedLRU(validSignedBlockHeadersSize),
+        LimitedSet.createSynchronizedLRU(validSignedBlockHeadersSize));
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -49,7 +49,7 @@ public class ExecutionPayloadGossipValidator {
   private final SigningRootUtil signingRootUtil;
 
   private final Set<BlockRootAndBuilderIndex> seenPayloads =
-      LimitedSet.createSynchronized(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
+      LimitedSet.createSynchronizedLRU(RECENT_SEEN_EXECUTION_PAYLOADS_CACHE_SIZE);
 
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionProofGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionProofGossipValidator.java
@@ -32,7 +32,7 @@ public class ExecutionProofGossipValidator {
   public static ExecutionProofGossipValidator create() {
     return new ExecutionProofGossipValidator(
         // max subnets * 2 epochs * slots per epoch 32 based on mainnet for now
-        LimitedSet.createSynchronized((int) MAX_EXECUTION_PROOF_SUBNETS * 64));
+        LimitedSet.createSynchronizedLRU((int) MAX_EXECUTION_PROOF_SUBNETS * 64));
   }
 
   public ExecutionProofGossipValidator(final Set<ExecutionProof> receivedValidExecutionProofSet) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -48,7 +48,7 @@ public class ProposerPreferencesGossipValidator {
   private final RecentChainData recentChainData;
 
   private final Set<DedupKey> seenProposerPreferences =
-      LimitedSet.createSynchronized(RECENT_SEEN_PROPOSER_PREFERENCES_CACHE_SIZE);
+      LimitedSet.createSynchronizedLRU(RECENT_SEEN_PROPOSER_PREFERENCES_CACHE_SIZE);
 
   public ProposerPreferencesGossipValidator(
       final Spec spec,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidator.java
@@ -36,7 +36,7 @@ public class ProposerSlashingValidator implements OperationValidator<ProposerSla
   private final Spec spec;
   private final RecentChainData recentChainData;
   private final Set<UInt64> receivedValidSlashingForProposerSet =
-      LimitedSet.createSynchronized(VALID_VALIDATOR_SET_SIZE);
+      LimitedSet.createSynchronizedLRU(VALID_VALIDATOR_SET_SIZE);
 
   public ProposerSlashingValidator(final Spec spec, final RecentChainData recentChainData) {
     this.spec = spec;

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedSet.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedSet.java
@@ -33,7 +33,7 @@ public final class LimitedSet {
    * @param <T> The type of object held in the set.
    * @return A set that will evict elements when the max size is exceeded.
    */
-  public static <T> Set<T> createSynchronized(final int maxSize) {
+  public static <T> Set<T> createSynchronizedLRU(final int maxSize) {
     return Collections.newSetFromMap(LimitedMap.createSynchronizedLRU(maxSize));
   }
 

--- a/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedSetTest.java
+++ b/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedSetTest.java
@@ -22,7 +22,7 @@ public class LimitedSetTest {
 
   @Test
   public void create_evictLeastRecentlyAccessed() {
-    final Set<Integer> set = LimitedSet.createSynchronized(2);
+    final Set<Integer> set = LimitedSet.createSynchronizedLRU(2);
     set.add(1);
     assertThat(set.size()).isEqualTo(1);
     set.add(2);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
@@ -45,7 +45,7 @@ public class V4FinalizedStateTreeStorageLogic
   public V4FinalizedStateTreeStorageLogic(
       final MetricsSystem metricsSystem, final Spec spec, final int maxKnownNodeCacheSize) {
     this.spec = spec;
-    this.knownStoredBranchesCache = LimitedSet.createSynchronized(maxKnownNodeCacheSize);
+    this.knownStoredBranchesCache = LimitedSet.createSynchronizedLRU(maxKnownNodeCacheSize);
     this.branchNodeStoredCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.STORAGE_FINALIZED_DB,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Rename `LimitedSet::createSynchronized` to `LimitedSet::createSynchronizedLRU` for clarity

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Raised in https://github.com/Consensys/teku/pull/10804

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename with no logic changes; eviction behavior stays the same.
> 
> **Overview**
> Renames **`LimitedSet.createSynchronized`** to **`LimitedSet.createSynchronizedLRU`** so the factory name matches LRU eviction (via `LimitedMap.createSynchronizedLRU`).
> 
> All call sites are updated across gossip dedup caches (attestations, aggregates, slashings, blob/data column sidecars, execution payloads, sync committee contributions, etc.), `FutureItems`, data column DB caching, and finalized state tree branch caching. **`LimitedSetTest`** uses the new name; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 140e7132e726d9ae26431aed6951ff17075835ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->