### PR TITLE
Upgrade jvm-libp2p to 1.3.2

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -37,7 +37,7 @@ dependencyManagement {
 			entry 'javalin-rendering-thymeleaf'
 		}
 
-		dependency 'io.libp2p:jvm-libp2p:1.3.1-RELEASE'
+		dependency 'io.libp2p:jvm-libp2p:1.3.2-RELEASE'
 		dependency 'tech.pegasys:jblst:0.3.15'
 		dependency 'io.consensys.protocols:jc-kzg-4844:2.1.6'
 		dependency 'io.github.crate-crypto:java-eth-kzg:0.10.0'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fixing QUIC issues

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> P2P networking depends on jvm-libp2p for peer connectivity and gossip; a patch release for QUIC fixes can still affect connection behavior across the beacon network.
> 
> **Overview**
> Bumps the centralized **`io.libp2p:jvm-libp2p`** dependency from **1.3.1-RELEASE** to **1.3.2-RELEASE** in `gradle/versions.gradle`, so all modules that consume libp2p (P2P networking, sync, acceptance tests, etc.) pick up the newer release.
> 
> The upgrade is intended to address **QUIC** problems in the underlying JVM libp2p stack; there are no Teku source changes in this PR—only the version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938f5fd927ad6cb1ea65c7465044829da5ccd78c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->