### PR TITLE
Gloas sync fix

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/DataColumnSidecarUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/DataColumnSidecarUtil.java
@@ -77,6 +77,13 @@ public interface DataColumnSidecarUtil {
       DataColumnSidecar dataColumnSidecar,
       Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot);
 
+  default SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
+      final DataColumnSidecar dataColumnSidecar,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments,
+      final Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot) {
+    return validateAndVerifyKzgProofsWithBlock(dataColumnSidecar, retrieveSignedBlockByRoot);
+  }
+
   SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(
       DataColumnSidecar dataColumnSidecar,
       Spec spec,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
@@ -265,6 +265,24 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
   }
 
   @Override
+  public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
+      final DataColumnSidecar dataColumnSidecar,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments,
+      final Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot) {
+    return blobKzgCommitments
+        .map(
+            commitments ->
+                SafeFuture.completedFuture(
+                    verifyDataColumnSidecar(dataColumnSidecar, commitments)
+                        .or(
+                            () ->
+                                verifyDataColumnSidecarKzgProofs(dataColumnSidecar, commitments))))
+        .orElseGet(
+            () ->
+                validateAndVerifyKzgProofsWithBlock(dataColumnSidecar, retrieveSignedBlockByRoot));
+  }
+
+  @Override
   public SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(
       final DataColumnSidecar dataColumnSidecar,
       final Spec spec,
@@ -297,6 +315,12 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
     final SszList<SszKZGCommitment> bidKzgCommitments =
         BeaconBlockBodyGloas.required(signedBeaconBlock.getMessage().getBody())
             .getBlobKzgCommitments();
+    return verifyDataColumnSidecar(dataColumnSidecar, bidKzgCommitments);
+  }
+
+  private Optional<DataColumnSidecarValidationError> verifyDataColumnSidecar(
+      final DataColumnSidecar dataColumnSidecar,
+      final SszList<SszKZGCommitment> bidKzgCommitments) {
     final boolean validDataColumnSidecar =
         miscHelpersGloas.verifyDataColumnSidecarWithCommitments(
             dataColumnSidecar, bidKzgCommitments);
@@ -312,6 +336,12 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
     final SszList<SszKZGCommitment> bidKzgCommitments =
         BeaconBlockBodyGloas.required(signedBeaconBlock.getMessage().getBody())
             .getBlobKzgCommitments();
+    return verifyDataColumnSidecarKzgProofs(dataColumnSidecar, bidKzgCommitments);
+  }
+
+  private Optional<DataColumnSidecarValidationError> verifyDataColumnSidecarKzgProofs(
+      final DataColumnSidecar dataColumnSidecar,
+      final SszList<SszKZGCommitment> bidKzgCommitments) {
     final boolean validDataColumnSidecar =
         miscHelpersGloas.verifyDataColumnSidecarKzgProofs(dataColumnSidecar, bidKzgCommitments);
     if (!validDataColumnSidecar) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfiller.java
@@ -482,7 +482,7 @@ public class DasCustodyBackfiller extends Service
 
     LOG.debug("DasCustodyBackfiller: Retrieving missing column {} to custody", colId);
 
-    final SafeFuture<DataColumnSidecar> req = retriever.retrieve(colId);
+    final SafeFuture<DataColumnSidecar> req = retriever.retrieve(colId, Optional.empty());
     pendingRequests.put(colId, req);
 
     return req.thenPeek(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
@@ -24,8 +24,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.util.StringifyUtil;
@@ -85,8 +88,7 @@ public class DasPreSampler {
                         sampler.onNewValidatedDataColumnSidecar(columnId, RemoteOrigin.CUSTODY)))
         .always(
             () ->
-                sampler
-                    .checkDataAvailability(block.getSlot(), block.getRoot())
+                checkDataAvailability(block)
                     .finish(
                         succ ->
                             LOG.debug(
@@ -99,6 +101,22 @@ public class DasPreSampler {
                                 block.getSlot(),
                                 block.getRoot(),
                                 err)));
+  }
+
+  private SafeFuture<List<UInt64>> checkDataAvailability(final SignedBeaconBlock block) {
+    final Optional<SszList<SszKZGCommitment>> blobKzgCommitments = getBlobKzgCommitments(block);
+    if (blobKzgCommitments.isPresent()) {
+      return sampler.checkDataAvailability(block.getSlot(), block.getRoot(), blobKzgCommitments);
+    }
+    return sampler.checkDataAvailability(block.getSlot(), block.getRoot());
+  }
+
+  private Optional<SszList<SszKZGCommitment>> getBlobKzgCommitments(final SignedBeaconBlock block) {
+    return block
+        .getMessage()
+        .getBody()
+        .toVersionGloas()
+        .map(BeaconBlockBodyGloas::getBlobKzgCommitments);
   }
 
   private List<DataColumnSlotAndIdentifier> calculateSamplingColumnIds(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -120,6 +120,7 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
       final Bytes32 blockRoot,
       final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     final DataColumnSamplingTracker tracker = getOrCreateTracker(slot, blockRoot);
+    tracker.updateBlobKzgCommitments(blobKzgCommitments);
 
     if (tracker.completionFuture().isDone()) {
       return tracker.completionFuture();
@@ -145,7 +146,10 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
     tracker.rpcFetchInProgress().set(true);
     asyncRunner
         .getDelayedFuture(delay)
-        .always(() -> fetchMissingColumnsViaRPC(slot, blockRoot, tracker, Optional.empty()));
+        .always(
+            () ->
+                fetchMissingColumnsViaRPC(
+                    slot, blockRoot, tracker, tracker.getBlobKzgCommitments()));
   }
 
   private void fetchMissingColumnsViaRPC(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
@@ -110,6 +111,14 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
   @Override
   public SafeFuture<List<UInt64>> checkDataAvailability(
       final UInt64 slot, final Bytes32 blockRoot) {
+    return checkDataAvailability(slot, blockRoot, Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<List<UInt64>> checkDataAvailability(
+      final UInt64 slot,
+      final Bytes32 blockRoot,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     final DataColumnSamplingTracker tracker = getOrCreateTracker(slot, blockRoot);
 
     if (tracker.completionFuture().isDone()) {
@@ -117,7 +126,7 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
     }
 
     if (tracker.rpcFetchInProgress().compareAndSet(false, true)) {
-      fetchMissingColumnsViaRPC(slot, blockRoot, tracker);
+      fetchMissingColumnsViaRPC(slot, blockRoot, tracker, blobKzgCommitments);
     }
 
     return tracker.completionFuture();
@@ -136,11 +145,14 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
     tracker.rpcFetchInProgress().set(true);
     asyncRunner
         .getDelayedFuture(delay)
-        .always(() -> fetchMissingColumnsViaRPC(slot, blockRoot, tracker));
+        .always(() -> fetchMissingColumnsViaRPC(slot, blockRoot, tracker, Optional.empty()));
   }
 
   private void fetchMissingColumnsViaRPC(
-      final UInt64 slot, final Bytes32 blockRoot, final DataColumnSamplingTracker tracker) {
+      final UInt64 slot,
+      final Bytes32 blockRoot,
+      final DataColumnSamplingTracker tracker,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     // Delayed fetch callbacks can outlive the tracker they were scheduled for.
     // Only the currently installed tracker may issue RPC requests.
     if (isStaledTracker(blockRoot, tracker)) {
@@ -158,7 +170,8 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
         missingColumns.size());
 
     SafeFuture.collectAll(
-            missingColumns.stream().map(id -> retrieveColumnWithSamplingAndCustody(id, tracker)))
+            missingColumns.stream()
+                .map(id -> retrieveColumnWithSamplingAndCustody(id, tracker, blobKzgCommitments)))
         .thenAccept(
             retrievedColumns -> {
               if (retrievedColumns.size() == missingColumns.size()) {
@@ -223,9 +236,11 @@ public class DasSamplerBasic implements DataAvailabilitySampler, SlotEventsChann
   }
 
   private SafeFuture<DataColumnSidecar> retrieveColumnWithSamplingAndCustody(
-      final DataColumnSlotAndIdentifier id, final DataColumnSamplingTracker tracker) {
+      final DataColumnSlotAndIdentifier id,
+      final DataColumnSamplingTracker tracker,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     return retriever
-        .retrieve(id)
+        .retrieve(id, blobKzgCommitments)
         .thenPeek(
             sidecar -> {
               if (tracker.add(id, RemoteOrigin.RPC)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
@@ -17,11 +17,13 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.BlockEventsListener;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
@@ -75,6 +77,13 @@ public interface DataAvailabilitySampler
    * the {@link #flush()} method
    */
   SafeFuture<List<UInt64>> checkDataAvailability(UInt64 slot, Bytes32 blockRoot);
+
+  default SafeFuture<List<UInt64>> checkDataAvailability(
+      final UInt64 slot,
+      final Bytes32 blockRoot,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    return checkDataAvailability(slot, blockRoot);
+  }
 
   /**
    * Immediately initiates sampling. When doing batch sampling it would be more effective to invoke

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSamplingTracker.java
@@ -18,11 +18,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 
@@ -35,6 +38,7 @@ record DataColumnSamplingTracker(
     SafeFuture<List<UInt64>> completionFuture,
     AtomicBoolean fullySampled,
     AtomicBoolean blockImportOnCompletionEnabled,
+    AtomicReference<Optional<SszList<SszKZGCommitment>>> blobKzgCommitments,
     Optional<Integer> earlyCompletionRequirementCount) {
   private static final Logger LOG = LogManager.getLogger();
 
@@ -56,7 +60,30 @@ record DataColumnSamplingTracker(
         completionFuture,
         new AtomicBoolean(false),
         new AtomicBoolean(false),
+        new AtomicReference<>(Optional.empty()),
         completionColumnCount);
+  }
+
+  void updateBlobKzgCommitments(final Optional<SszList<SszKZGCommitment>> maybeBlobKzgCommitments) {
+    maybeBlobKzgCommitments.ifPresent(
+        newBlobKzgCommitments -> {
+          final Optional<SszList<SszKZGCommitment>> newValue = Optional.of(newBlobKzgCommitments);
+          blobKzgCommitments.updateAndGet(
+              currentValue -> {
+                if (currentValue.isEmpty()) {
+                  return newValue;
+                }
+                if (!currentValue.get().equals(newBlobKzgCommitments)) {
+                  throw new IllegalArgumentException(
+                      "Conflicting blob KZG commitments for " + blockRoot);
+                }
+                return currentValue;
+              });
+        });
+  }
+
+  Optional<SszList<SszKZGCommitment>> getBlobKzgCommitments() {
+    return blobKzgCommitments.get();
   }
 
   boolean enableBlockImportOnCompletion() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/log/rpc/LoggingBatchDataColumnsByRootReqResp.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/log/rpc/LoggingBatchDataColumnsByRootReqResp.java
@@ -14,10 +14,14 @@
 package tech.pegasys.teku.statetransition.datacolumns.log.rpc;
 
 import java.util.List;
+import java.util.Map;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.BatchDataColumnsByRootReqResp;
 
 public class LoggingBatchDataColumnsByRootReqResp implements BatchDataColumnsByRootReqResp {
@@ -32,13 +36,15 @@ public class LoggingBatchDataColumnsByRootReqResp implements BatchDataColumnsByR
 
   @Override
   public AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRoot(
-      final UInt256 nodeId, final List<DataColumnsByRootIdentifier> columnIdentifiers) {
+      final UInt256 nodeId,
+      final List<DataColumnsByRootIdentifier> columnIdentifiers,
+      final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot) {
     final ReqRespResponseLogger<DataColumnSidecar> responseLogger =
         logger
             .getDataColumnSidecarsByRootLogger()
             .onOutboundRequest(LoggingPeerId.fromNodeId(nodeId), columnIdentifiers);
     return delegate
-        .requestDataColumnSidecarsByRoot(nodeId, columnIdentifiers)
+        .requestDataColumnSidecarsByRoot(nodeId, columnIdentifiers, blobKzgCommitmentsByRoot)
         .peek(responseLogger.asAsyncStreamVisitor());
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRootReqResp.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRootReqResp.java
@@ -14,15 +14,21 @@
 package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.util.List;
+import java.util.Map;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 
 public interface BatchDataColumnsByRootReqResp {
 
   AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRoot(
-      UInt256 nodeId, List<DataColumnsByRootIdentifier> byRootIdentifiers);
+      UInt256 nodeId,
+      List<DataColumnsByRootIdentifier> byRootIdentifiers,
+      Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot);
 
   int getCurrentRequestLimit(UInt256 nodeId);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqResp.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqResp.java
@@ -13,15 +13,25 @@
 
 package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
+import java.util.Optional;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 
 public interface DataColumnReqResp {
 
   SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
       UInt256 nodeId, DataColumnSlotAndIdentifier columnIdentifier);
+
+  default SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
+      final UInt256 nodeId,
+      final DataColumnSlotAndIdentifier columnIdentifier,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    return requestDataColumnSidecar(nodeId, columnIdentifier);
+  }
 
   void flush();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
@@ -34,6 +34,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStreamHandler;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -43,6 +44,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifierSchema;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 
 public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
@@ -69,6 +71,7 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
   private record RequestEntry(
       UInt256 nodeId,
       DataColumnSlotAndIdentifier columnIdentifier,
+      Optional<SszList<SszKZGCommitment>> blobKzgCommitments,
       SafeFuture<DataColumnSidecar> promise) {}
 
   private final ConcurrentLinkedQueue<RequestEntry> bufferedRequests =
@@ -77,7 +80,16 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
   @Override
   public SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
       final UInt256 nodeId, final DataColumnSlotAndIdentifier columnIdentifier) {
-    final RequestEntry entry = new RequestEntry(nodeId, columnIdentifier, new SafeFuture<>());
+    return requestDataColumnSidecar(nodeId, columnIdentifier, Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
+      final UInt256 nodeId,
+      final DataColumnSlotAndIdentifier columnIdentifier,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    final RequestEntry entry =
+        new RequestEntry(nodeId, columnIdentifier, blobKzgCommitments, new SafeFuture<>());
     bufferedRequests.add(entry);
     return entry.promise();
   }
@@ -94,7 +106,8 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
     }
   }
 
-  private record ByRootRequest(Bytes32 root, Set<UInt64> columns) {}
+  private record ByRootRequest(
+      Bytes32 root, Set<UInt64> columns, Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {}
 
   private void flushForNode(final UInt256 nodeId, final List<RequestEntry> nodeRequests) {
     LOG.debug("Flushing requests for node {}: {} total", nodeId, nodeRequests.size());
@@ -102,7 +115,13 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
       return;
     }
 
-    final List<ByRootRequest> byRootRequests = groupByRootRequests(nodeRequests);
+    final List<ByRootRequest> byRootRequests;
+    try {
+      byRootRequests = groupByRootRequests(nodeRequests);
+    } catch (final RuntimeException error) {
+      nodeRequests.forEach(nodeRequest -> nodeRequest.promise().completeExceptionally(error));
+      return;
+    }
     LOG.trace("Processing prepared requests for node {}: byRoot({})", nodeId, byRootRequests);
 
     final List<DataColumnsByRootIdentifier> byRootIdentifiers =
@@ -122,7 +141,13 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
 
     final AsyncStream<DataColumnSidecar> byRootStream =
         AsyncStream.createUnsafe(byRootBatches.iterator())
-            .flatMap(byRootBatch -> byRootRpc.requestDataColumnSidecarsByRoot(nodeId, byRootBatch));
+            .flatMap(
+                byRootBatch -> {
+                  final Map<Bytes32, SszList<SszKZGCommitment>> batchCommitmentsByRoot =
+                      getBlobKzgCommitmentsByRoot(byRootBatch, byRootRequests);
+                  return byRootRpc.requestDataColumnSidecarsByRoot(
+                      nodeId, byRootBatch, batchCommitmentsByRoot);
+                });
 
     byRootStream.consume(createResponseHandler(nodeRequests));
   }
@@ -171,11 +196,18 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
 
   private List<ByRootRequest> groupByRootRequests(final List<RequestEntry> nodeRequests) {
     final NavigableMap<SlotAndBlockRoot, Set<UInt64>> bySlotAndBlockRootMap = new TreeMap<>();
+    final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot = new HashMap<>();
     nodeRequests.forEach(
         nodeRequest -> {
           final UInt64 column = nodeRequest.columnIdentifier.columnIndex();
           final SlotAndBlockRoot key = nodeRequest.columnIdentifier().getSlotAndBlockRoot();
           bySlotAndBlockRootMap.computeIfAbsent(key, k -> new HashSet<>()).add(column);
+          nodeRequest
+              .blobKzgCommitments()
+              .ifPresent(
+                  blobKzgCommitments ->
+                      addBlobKzgCommitments(
+                          blobKzgCommitmentsByRoot, key.getBlockRoot(), blobKzgCommitments));
         });
 
     if (bySlotAndBlockRootMap.isEmpty()) {
@@ -186,10 +218,42 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
     while (!bySlotAndBlockRootMap.isEmpty()) {
       final Map.Entry<SlotAndBlockRoot, Set<UInt64>> current =
           bySlotAndBlockRootMap.pollFirstEntry();
-      byRootRequests.add(new ByRootRequest(current.getKey().getBlockRoot(), current.getValue()));
+      final Bytes32 blockRoot = current.getKey().getBlockRoot();
+      byRootRequests.add(
+          new ByRootRequest(
+              blockRoot,
+              current.getValue(),
+              Optional.ofNullable(blobKzgCommitmentsByRoot.get(blockRoot))));
     }
 
     return Collections.unmodifiableList(byRootRequests);
+  }
+
+  private void addBlobKzgCommitments(
+      final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot,
+      final Bytes32 root,
+      final SszList<SszKZGCommitment> blobKzgCommitments) {
+    final SszList<SszKZGCommitment> previous =
+        blobKzgCommitmentsByRoot.putIfAbsent(root, blobKzgCommitments);
+    if (previous != null && !previous.equals(blobKzgCommitments)) {
+      throw new IllegalArgumentException("Conflicting blob KZG commitments for " + root);
+    }
+  }
+
+  private Map<Bytes32, SszList<SszKZGCommitment>> getBlobKzgCommitmentsByRoot(
+      final List<DataColumnsByRootIdentifier> byRootBatch,
+      final List<ByRootRequest> byRootRequests) {
+    final Set<Bytes32> rootsInBatch =
+        byRootBatch.stream()
+            .map(DataColumnsByRootIdentifier::getBlockRoot)
+            .collect(Collectors.toUnmodifiableSet());
+    return byRootRequests.stream()
+        .filter(request -> rootsInBatch.contains(request.root()))
+        .flatMap(
+            request ->
+                request.blobKzgCommitments().stream()
+                    .map(blobKzgCommitments -> Map.entry(request.root(), blobKzgCommitments)))
+        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   private AsyncStreamHandler<DataColumnSidecar> createResponseHandler(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
@@ -15,8 +15,10 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 
@@ -30,6 +32,12 @@ public interface DataColumnSidecarRetriever {
    *     complete exceptionally when cancelled or with {@link NotOnCanonicalChainException}
    */
   SafeFuture<DataColumnSidecar> retrieve(DataColumnSlotAndIdentifier columnId);
+
+  default SafeFuture<DataColumnSidecar> retrieve(
+      final DataColumnSlotAndIdentifier columnId,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    return retrieve(columnId);
+  }
 
   /**
    * The {@link #retrieve(DataColumnSlotAndIdentifier)} method may buffer requests and delay

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetriever.java
@@ -31,18 +31,13 @@ public interface DataColumnSidecarRetriever {
    * @return a future which may run indefinitely until finds a requested data or cancelled or may
    *     complete exceptionally when cancelled or with {@link NotOnCanonicalChainException}
    */
-  SafeFuture<DataColumnSidecar> retrieve(DataColumnSlotAndIdentifier columnId);
-
-  default SafeFuture<DataColumnSidecar> retrieve(
-      final DataColumnSlotAndIdentifier columnId,
-      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
-    return retrieve(columnId);
-  }
+  SafeFuture<DataColumnSidecar> retrieve(
+      DataColumnSlotAndIdentifier columnId, Optional<SszList<SszKZGCommitment>> blobKzgCommitments);
 
   /**
-   * The {@link #retrieve(DataColumnSlotAndIdentifier)} method may buffer requests and delay
-   * processing them till the next occasion. This method forces all the queued requests to be
-   * processed. However, requests could still be queued in a downstream component if there is a
+   * The {@link #retrieve(DataColumnSlotAndIdentifier, Optional)} method may buffer requests and
+   * delay processing them till the next occasion. This method forces all the queued requests to be
+   * processed. However, requests could still be queued in a downstream component if there is
    * congestion.
    */
   void flush();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -37,12 +37,14 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.cache.Cache;
 import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
@@ -97,8 +99,16 @@ public class SimpleSidecarRetriever
 
   @Override
   public SafeFuture<DataColumnSidecar> retrieve(final DataColumnSlotAndIdentifier columnId) {
+    return retrieve(columnId, Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<DataColumnSidecar> retrieve(
+      final DataColumnSlotAndIdentifier columnId,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     final RetrieveRequest request =
-        pendingRequests.computeIfAbsent(columnId, __ -> new RetrieveRequest(columnId));
+        pendingRequests.computeIfAbsent(
+            columnId, __ -> new RetrieveRequest(columnId, blobKzgCommitments));
     startIfNecessary();
     return request.result;
   }
@@ -146,7 +156,8 @@ public class SimpleSidecarRetriever
     }
 
     final SafeFuture<DataColumnSidecar> reqRespPromise =
-        reqResp.requestDataColumnSidecar(match.peer.nodeId, match.request.columnId);
+        reqResp.requestDataColumnSidecar(
+            match.peer.nodeId, match.request.columnId, match.request.blobKzgCommitments);
     match.peer.countSidecarRequest();
 
     final SafeFuture<Void> activeRpcRequest =
@@ -306,10 +317,14 @@ public class SimpleSidecarRetriever
     final DataColumnSlotAndIdentifier columnId;
     final SafeFuture<DataColumnSidecar> result = new SafeFuture<>();
     final AtomicBoolean activeRpcRequestSet = new AtomicBoolean(false);
+    final Optional<SszList<SszKZGCommitment>> blobKzgCommitments;
     volatile ActiveRequest activeRpcRequest = null;
 
-    private RetrieveRequest(final DataColumnSlotAndIdentifier columnId) {
+    private RetrieveRequest(
+        final DataColumnSlotAndIdentifier columnId,
+        final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
       this.columnId = columnId;
+      this.blobKzgCommitments = blobKzgCommitments;
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -98,17 +98,12 @@ public class SimpleSidecarRetriever
   }
 
   @Override
-  public SafeFuture<DataColumnSidecar> retrieve(final DataColumnSlotAndIdentifier columnId) {
-    return retrieve(columnId, Optional.empty());
-  }
-
-  @Override
   public SafeFuture<DataColumnSidecar> retrieve(
       final DataColumnSlotAndIdentifier columnId,
       final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     final RetrieveRequest request =
-        pendingRequests.computeIfAbsent(
-            columnId, __ -> new RetrieveRequest(columnId, blobKzgCommitments));
+        pendingRequests.computeIfAbsent(columnId, __ -> new RetrieveRequest(columnId));
+    request.updateBlobKzgCommitments(blobKzgCommitments);
     startIfNecessary();
     return request.result;
   }
@@ -157,7 +152,7 @@ public class SimpleSidecarRetriever
 
     final SafeFuture<DataColumnSidecar> reqRespPromise =
         reqResp.requestDataColumnSidecar(
-            match.peer.nodeId, match.request.columnId, match.request.blobKzgCommitments);
+            match.peer.nodeId, match.request.columnId, match.request.getBlobKzgCommitments());
     match.peer.countSidecarRequest();
 
     final SafeFuture<Void> activeRpcRequest =
@@ -317,14 +312,30 @@ public class SimpleSidecarRetriever
     final DataColumnSlotAndIdentifier columnId;
     final SafeFuture<DataColumnSidecar> result = new SafeFuture<>();
     final AtomicBoolean activeRpcRequestSet = new AtomicBoolean(false);
-    final Optional<SszList<SszKZGCommitment>> blobKzgCommitments;
+    private volatile Optional<SszList<SszKZGCommitment>> blobKzgCommitments = Optional.empty();
     volatile ActiveRequest activeRpcRequest = null;
 
-    private RetrieveRequest(
-        final DataColumnSlotAndIdentifier columnId,
-        final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    private RetrieveRequest(final DataColumnSlotAndIdentifier columnId) {
       this.columnId = columnId;
-      this.blobKzgCommitments = blobKzgCommitments;
+    }
+
+    private synchronized void updateBlobKzgCommitments(
+        final Optional<SszList<SszKZGCommitment>> maybeBlobKzgCommitments) {
+      maybeBlobKzgCommitments.ifPresent(
+          newBlobKzgCommitments -> {
+            blobKzgCommitments.ifPresent(
+                existingBlobKzgCommitments -> {
+                  if (!existingBlobKzgCommitments.equals(newBlobKzgCommitments)) {
+                    throw new IllegalArgumentException(
+                        "Conflicting blob KZG commitments for " + columnId);
+                  }
+                });
+            blobKzgCommitments = Optional.of(newBlobKzgCommitments);
+          });
+    }
+
+    private Optional<SszList<SszKZGCommitment>> getBlobKzgCommitments() {
+      return blobKzgCommitments;
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetriever.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,10 +30,12 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.Cancellable;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
@@ -138,19 +141,27 @@ public class SidecarRetriever implements DataColumnSidecarRetriever {
 
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
-  public SafeFuture<DataColumnSidecar> retrieve(final DataColumnSlotAndIdentifier columnId) {
+  public SafeFuture<DataColumnSidecar> retrieve(
+      final DataColumnSlotAndIdentifier columnId,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     final PendingRecoveryRequest pendingRecoveryRequest =
-        requests.computeIfAbsent(
+        requests.compute(
             columnId,
-            __ ->
-                new PendingRecoveryRequest(
-                    columnId,
-                    delegate.retrieve(columnId),
-                    timeProvider.getTimeInMillis(),
-                    recoveryTimeout,
-                    downloadTimeout,
-                    sidecarRecoveryMetric,
-                    () -> requests.remove(columnId)));
+            (__, existingRequest) -> {
+              if (existingRequest != null) {
+                blobKzgCommitments.ifPresent(
+                    ignored -> delegate.retrieve(columnId, blobKzgCommitments));
+                return existingRequest;
+              }
+              return new PendingRecoveryRequest(
+                  columnId,
+                  delegate.retrieve(columnId, blobKzgCommitments),
+                  timeProvider.getTimeInMillis(),
+                  recoveryTimeout,
+                  downloadTimeout,
+                  sidecarRecoveryMetric,
+                  () -> requests.remove(columnId));
+            });
     pendingRecoveryRequest.start();
     return pendingRecoveryRequest.getFuture();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfillerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyBackfillerTest.java
@@ -212,7 +212,8 @@ class DasCustodyBackfillerTest {
     when(recentChainData.retrieveSignedBlockByRoot(block2.getRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(block2)));
 
-    when(retriever.retrieve(any())).thenReturn(completedFuture(mock(DataColumnSidecar.class)));
+    when(retriever.retrieve(any(), eq(Optional.empty())))
+        .thenReturn(completedFuture(mock(DataColumnSidecar.class)));
     when(dataColumnSidecarCustody.onNewValidatedDataColumnSidecar(any(), any()))
         .thenReturn(SafeFuture.COMPLETE);
 
@@ -226,7 +227,7 @@ class DasCustodyBackfillerTest {
         .getDataColumnIdentifiers(eq(UInt64.valueOf(193)), eq(UInt64.valueOf(202)), any());
 
     // we expect 4 columns to be retrieved and stored
-    verify(retriever, times(4)).retrieve(any());
+    verify(retriever, times(4)).retrieve(any(), eq(Optional.empty()));
     verify(dataColumnSidecarCustody, times(4)).onNewValidatedDataColumnSidecar(any(), any());
 
     // no change in earliest available slot
@@ -318,7 +319,7 @@ class DasCustodyBackfillerTest {
 
     // Mock retrieval
     SafeFuture<DataColumnSidecar> retrievalFuture = completedFuture(mock(DataColumnSidecar.class));
-    when(retriever.retrieve(any())).thenReturn(retrievalFuture);
+    when(retriever.retrieve(any(), eq(Optional.empty()))).thenReturn(retrievalFuture);
     when(dataColumnSidecarCustody.onNewValidatedDataColumnSidecar(any(), any()))
         .thenReturn(SafeFuture.COMPLETE);
 
@@ -336,10 +337,10 @@ class DasCustodyBackfillerTest {
     DataColumnSlotAndIdentifier expectedHot2Missing2 =
         new DataColumnSlotAndIdentifier(hotBlocksSlot, hotBlock2Root, UInt64.ONE);
 
-    verify(retriever).retrieve(expectedFinalizedMissing);
-    verify(retriever).retrieve(expectedHot1Missing);
-    verify(retriever).retrieve(expectedHot2Missing1);
-    verify(retriever).retrieve(expectedHot2Missing2);
+    verify(retriever).retrieve(expectedFinalizedMissing, Optional.empty());
+    verify(retriever).retrieve(expectedHot1Missing, Optional.empty());
+    verify(retriever).retrieve(expectedHot2Missing1, Optional.empty());
+    verify(retriever).retrieve(expectedHot2Missing2, Optional.empty());
     verify(dataColumnSidecarCustody, times(4))
         .onNewValidatedDataColumnSidecar(any(), eq(RemoteOrigin.RPC));
 
@@ -366,7 +367,7 @@ class DasCustodyBackfillerTest {
     asyncRunner.executeQueuedActions();
 
     // Verify NO retrieval attempted because block has no blobs
-    verify(retriever, never()).retrieve(any());
+    verify(retriever, never()).retrieve(any(), any());
 
     // Cursor should move past the block (to 95)
     assertThat(earliestAvailableColumnSlotStore.get()).isPresent().hasValue(blockSlot);
@@ -450,9 +451,11 @@ class DasCustodyBackfillerTest {
     final SafeFuture<DataColumnSidecar> pendingFutureFork = new SafeFuture<>();
 
     // argThatMatch ignores column index, so this stub applies to any column request for that block
-    when(retriever.retrieve(columnIdArgThatMatch(blockSlot, canonicalBlock.getRoot())))
+    when(retriever.retrieve(
+            columnIdArgThatMatch(blockSlot, canonicalBlock.getRoot()), eq(Optional.empty())))
         .thenReturn(pendingFutureCanonical);
-    when(retriever.retrieve(columnIdArgThatMatch(blockSlot, forkBlock.getRoot())))
+    when(retriever.retrieve(
+            columnIdArgThatMatch(blockSlot, forkBlock.getRoot()), eq(Optional.empty())))
         .thenReturn(pendingFutureFork);
 
     // Start backfill
@@ -460,8 +463,10 @@ class DasCustodyBackfillerTest {
     asyncRunner.executeQueuedActions();
 
     // Verify both were requested (Now strictly 1 time each because we restricted custody to [0])
-    verify(retriever).retrieve(columnIdArgThatMatch(blockSlot, canonicalBlock.getRoot()));
-    verify(retriever).retrieve(columnIdArgThatMatch(blockSlot, forkBlock.getRoot()));
+    verify(retriever)
+        .retrieve(columnIdArgThatMatch(blockSlot, canonicalBlock.getRoot()), eq(Optional.empty()));
+    verify(retriever)
+        .retrieve(columnIdArgThatMatch(blockSlot, forkBlock.getRoot()), eq(Optional.empty()));
 
     // 2. Setup Finalization triggers
 
@@ -501,7 +506,8 @@ class DasCustodyBackfillerTest {
     when(combinedChainDataClient.getFinalizedBlockAtSlotExact(minCustodySlot))
         .thenReturn(completedFuture(Optional.of(block)));
 
-    when(retriever.retrieve(any())).thenReturn(completedFuture(mock(DataColumnSidecar.class)));
+    when(retriever.retrieve(any(), eq(Optional.empty())))
+        .thenReturn(completedFuture(mock(DataColumnSidecar.class)));
     when(dataColumnSidecarCustody.onNewValidatedDataColumnSidecar(any(), any()))
         .thenReturn(SafeFuture.COMPLETE);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
@@ -27,14 +27,18 @@ import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySamp
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
@@ -123,6 +127,29 @@ public class DasPreSamplerTest {
     verify(sampler, never())
         .onNewValidatedDataColumnSidecar(any(DataColumnSlotAndIdentifier.class), any());
     verify(sampler).checkDataAvailability(block.getSlot(), block.getRoot());
+    verify(sampler).flush();
+  }
+
+  @Test
+  void shouldPreSampleGloasBlockWithBlobKzgCommitments() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasDataStructureUtil = new DataStructureUtil(gloasSpec);
+    final SignedBeaconBlock block =
+        gloasDataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 1);
+    final SszList<SszKZGCommitment> blobKzgCommitments =
+        BeaconBlockBodyGloas.required(block.getMessage().getBody()).getBlobKzgCommitments();
+
+    when(sampler.checkSamplingEligibility(block.getMessage())).thenReturn(REQUIRED);
+    when(custodyGroupCountManager.getSamplingColumnIndices()).thenReturn(Set.of());
+    when(sampler.checkDataAvailability(
+            block.getSlot(), block.getRoot(), Optional.of(blobKzgCommitments)))
+        .thenReturn(SafeFuture.completedFuture(null));
+
+    dasPreSampler.onNewPreImportBlocks(List.of(block));
+
+    verify(sampler)
+        .checkDataAvailability(block.getSlot(), block.getRoot(), Optional.of(blobKzgCommitments));
+    verify(sampler, never()).checkDataAvailability(block.getSlot(), block.getRoot());
     verify(sampler).flush();
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -274,6 +274,37 @@ public class DasSamplerBasicTest {
   }
 
   @Test
+  @SuppressWarnings({"FutureReturnValueIgnored", "unchecked"})
+  void checkDataAvailability_shouldForwardBlobKzgCommitmentsToDelayedRetriever() {
+    final SlotAndBlockRoot slotAndBlockRoot =
+        new SlotAndBlockRoot(dataStructureUtil.randomSlot(), dataStructureUtil.randomBytes32());
+    final SszList<SszKZGCommitment> blobKzgCommitments = mock(SszList.class);
+
+    when(rpcFetchDelayProvider.calculate(slotAndBlockRoot.getSlot()))
+        .thenReturn(Duration.ofSeconds(1));
+    when(retriever.retrieve(any(), eq(Optional.of(blobKzgCommitments))))
+        .thenReturn(new SafeFuture<>());
+
+    sampler.checkDataAvailability(
+        slotAndBlockRoot.getSlot(),
+        slotAndBlockRoot.getBlockRoot(),
+        Optional.of(blobKzgCommitments));
+
+    assertSamplerTrackerHasRPCFetchScheduled(slotAndBlockRoot.getBlockRoot(), true);
+
+    stubTimeProvider.advanceTimeByMillis(1_000);
+    asyncRunner.executeDueActions();
+
+    for (final UInt64 missingColumn : SAMPLING_INDICES) {
+      verify(retriever)
+          .retrieve(
+              new DataColumnSlotAndIdentifier(
+                  slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot(), missingColumn),
+              Optional.of(blobKzgCommitments));
+    }
+  }
+
+  @Test
   @SuppressWarnings("FutureReturnValueIgnored")
   void checkDataAvailability_shouldSetRPCFetchedToFalseOnFailureAndRPCFetchesAgain() {
     final SlotAndBlockRoot slotAndBlockRoot =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -49,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -93,7 +95,7 @@ public class DasSamplerBasicTest {
     currentSlotProvider = mock(CurrentSlotProvider.class);
     blockImportChannel = mock(BlockImportChannel.class);
 
-    when(retriever.retrieve(any()))
+    when(retriever.retrieve(any(), any()))
         .thenReturn(SafeFuture.completedFuture(mock(DataColumnSidecar.class)));
 
     when(currentSlotProvider.getCurrentSlot()).thenReturn(UInt64.ZERO);
@@ -164,7 +166,7 @@ public class DasSamplerBasicTest {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(dataStructureUtil.randomSlot(), dataStructureUtil.randomBytes32());
 
-    when(retriever.retrieve(any())).thenReturn(new SafeFuture<>());
+    when(retriever.retrieve(any(), eq(Optional.empty()))).thenReturn(new SafeFuture<>());
 
     final SafeFuture<List<UInt64>> completionFuture =
         sampler.checkDataAvailability(slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot());
@@ -209,7 +211,7 @@ public class DasSamplerBasicTest {
               return futureSidecarsByIndex.get(id.columnIndex());
             })
         .when(retriever)
-        .retrieve(any());
+        .retrieve(any(), eq(Optional.empty()));
 
     when(rpcFetchDelayProvider.calculate(slotAndBlockRoot.getSlot()))
         .thenReturn(Duration.ofSeconds(1));
@@ -247,12 +249,37 @@ public class DasSamplerBasicTest {
   }
 
   @Test
+  @SuppressWarnings({"FutureReturnValueIgnored", "unchecked"})
+  void checkDataAvailability_shouldForwardBlobKzgCommitmentsToRetriever() {
+    final SlotAndBlockRoot slotAndBlockRoot =
+        new SlotAndBlockRoot(dataStructureUtil.randomSlot(), dataStructureUtil.randomBytes32());
+    final SszList<SszKZGCommitment> blobKzgCommitments = mock(SszList.class);
+
+    when(rpcFetchDelayProvider.calculate(slotAndBlockRoot.getSlot())).thenReturn(Duration.ZERO);
+    when(retriever.retrieve(any(), eq(Optional.of(blobKzgCommitments))))
+        .thenReturn(new SafeFuture<>());
+
+    sampler.checkDataAvailability(
+        slotAndBlockRoot.getSlot(),
+        slotAndBlockRoot.getBlockRoot(),
+        Optional.of(blobKzgCommitments));
+
+    for (final UInt64 missingColumn : SAMPLING_INDICES) {
+      verify(retriever)
+          .retrieve(
+              new DataColumnSlotAndIdentifier(
+                  slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot(), missingColumn),
+              Optional.of(blobKzgCommitments));
+    }
+  }
+
+  @Test
   @SuppressWarnings("FutureReturnValueIgnored")
   void checkDataAvailability_shouldSetRPCFetchedToFalseOnFailureAndRPCFetchesAgain() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(dataStructureUtil.randomSlot(), dataStructureUtil.randomBytes32());
 
-    when(retriever.retrieve(any()))
+    when(retriever.retrieve(any(), eq(Optional.empty())))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("error")));
 
     final SafeFuture<List<UInt64>> completionFuture =
@@ -269,9 +296,9 @@ public class DasSamplerBasicTest {
         .isSameAs(completionFuture);
     assertSamplerTrackerHasRPCFetchScheduled(slotAndBlockRoot.getBlockRoot(), false);
 
-    verify(retriever, times(SAMPLING_INDICES.size())).retrieve(any());
+    verify(retriever, times(SAMPLING_INDICES.size())).retrieve(any(), eq(Optional.empty()));
 
-    when(retriever.retrieve(any())).thenReturn(new SafeFuture<>());
+    when(retriever.retrieve(any(), eq(Optional.empty()))).thenReturn(new SafeFuture<>());
 
     final SafeFuture<List<UInt64>> secondCompletionFuture =
         sampler.checkDataAvailability(slotAndBlockRoot.getSlot(), slotAndBlockRoot.getBlockRoot());
@@ -279,7 +306,7 @@ public class DasSamplerBasicTest {
     assertSamplerTracker(
         slotAndBlockRoot.getBlockRoot(), slotAndBlockRoot.getSlot(), SAMPLING_INDICES);
 
-    verify(retriever, times(SAMPLING_INDICES.size() * 2)).retrieve(any());
+    verify(retriever, times(SAMPLING_INDICES.size() * 2)).retrieve(any(), eq(Optional.empty()));
 
     assertThat(secondCompletionFuture).isSameAs(completionFuture);
     assertSamplerTrackerHasRPCFetchScheduled(slotAndBlockRoot.getBlockRoot(), true);
@@ -291,7 +318,7 @@ public class DasSamplerBasicTest {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(dataStructureUtil.randomSlot(), dataStructureUtil.randomBytes32());
 
-    when(retriever.retrieve(any())).thenReturn(new SafeFuture<>());
+    when(retriever.retrieve(any(), eq(Optional.empty()))).thenReturn(new SafeFuture<>());
 
     when(rpcFetchDelayProvider.calculate(slotAndBlockRoot.getSlot())).thenReturn(Duration.ZERO);
 
@@ -740,7 +767,9 @@ public class DasSamplerBasicTest {
 
     // verify we call retrieve for all missing columns
     for (final UInt64 missingColumn : missingColumns) {
-      verify(retriever).retrieve(new DataColumnSlotAndIdentifier(slot, blockRoot, missingColumn));
+      verify(retriever)
+          .retrieve(
+              new DataColumnSlotAndIdentifier(slot, blockRoot, missingColumn), Optional.empty());
     }
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -538,7 +538,7 @@ public class DasSamplerBasicTest {
     assertThat(sampler.getRecentlySampledColumnsByRoot())
         .doesNotContainKey(blockWithoutBlobs.getRoot());
     assertThat(asyncRunner.countDelayedActions()).isZero();
-    verify(retriever, never()).retrieve(any());
+    verify(retriever, never()).retrieve(any(), any());
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
@@ -693,7 +694,7 @@ public class DasSamplerBasicTest {
     asyncRunner.executeDueActions();
 
     assertThat(asyncRunner.countDelayedActions()).isZero();
-    verify(retriever, never()).retrieve(any());
+    verify(retriever, never()).retrieve(any(), any());
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicTest.java
@@ -49,7 +49,6 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImplTest.java
@@ -16,18 +16,22 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -35,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifierSchema;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -67,13 +72,15 @@ public class DataColumnReqRespBatchingImplTest {
     final DataColumnSidecar sidecar11_0 =
         dataStructureUtil.randomDataColumnSidecar(blockHeader11, ZERO);
     when(byRootRpc.requestDataColumnSidecarsByRoot(
-            UInt256.ZERO, List.of(byRootSchema.create(blockRoot1, List.of(ZERO, ONE)))))
+            UInt256.ZERO, List.of(byRootSchema.create(blockRoot1, List.of(ZERO, ONE))), Map.of()))
         .thenReturn(AsyncStream.of(sidecar10_0, sidecar10_1));
     when(byRootRpc.requestDataColumnSidecarsByRoot(
-            UInt256.ONE, List.of(byRootSchema.create(blockRoot1, List.of(UInt64.valueOf(3))))))
+            UInt256.ONE,
+            List.of(byRootSchema.create(blockRoot1, List.of(UInt64.valueOf(3)))),
+            Map.of()))
         .thenReturn(AsyncStream.of(sidecar10_3));
     when(byRootRpc.requestDataColumnSidecarsByRoot(
-            UInt256.valueOf(2), List.of(byRootSchema.create(blockRoot2, List.of(ZERO)))))
+            UInt256.valueOf(2), List.of(byRootSchema.create(blockRoot2, List.of(ZERO))), Map.of()))
         .thenReturn(AsyncStream.of(sidecar11_0));
     final SafeFuture<DataColumnSidecar> dataColumnSidecar10_0_Future =
         dataColumnReqResp.requestDataColumnSidecar(
@@ -102,13 +109,73 @@ public class DataColumnReqRespBatchingImplTest {
     assertThat(dataColumnSidecar11_0_Future).isCompletedWithValue(sidecar11_0);
     verify(byRootRpc)
         .requestDataColumnSidecarsByRoot(
-            UInt256.ZERO, List.of(byRootSchema.create(blockRoot1, List.of(ZERO, ONE))));
+            UInt256.ZERO, List.of(byRootSchema.create(blockRoot1, List.of(ZERO, ONE))), Map.of());
     verify(byRootRpc)
         .requestDataColumnSidecarsByRoot(
-            UInt256.ONE, List.of(byRootSchema.create(blockRoot1, List.of(UInt64.valueOf(3)))));
+            UInt256.ONE,
+            List.of(byRootSchema.create(blockRoot1, List.of(UInt64.valueOf(3)))),
+            Map.of());
     verify(byRootRpc)
         .requestDataColumnSidecarsByRoot(
-            UInt256.valueOf(2), List.of(byRootSchema.create(blockRoot2, List.of(ZERO))));
+            UInt256.valueOf(2), List.of(byRootSchema.create(blockRoot2, List.of(ZERO))), Map.of());
+  }
+
+  @Test
+  @SuppressWarnings({"JavaCase", "unchecked"})
+  public void shouldPassBlobKzgCommitmentsByRootToByRootRpc() {
+    final SignedBeaconBlockHeader blockHeader10 =
+        dataStructureUtil.randomSignedBeaconBlockHeader(UInt64.valueOf(10));
+    final Bytes32 blockRoot1 = blockHeader10.getMessage().getRoot();
+    final DataColumnSidecar sidecar10_0 =
+        dataStructureUtil.randomDataColumnSidecar(blockHeader10, ZERO);
+    final SszList<SszKZGCommitment> blobKzgCommitments = mock(SszList.class);
+    final List<DataColumnsByRootIdentifier> expectedIdentifiers =
+        List.of(byRootSchema.create(blockRoot1, List.of(ZERO)));
+    final Map<Bytes32, SszList<SszKZGCommitment>> expectedCommitments =
+        Map.of(blockRoot1, blobKzgCommitments);
+
+    when(byRootRpc.requestDataColumnSidecarsByRoot(
+            UInt256.ZERO, expectedIdentifiers, expectedCommitments))
+        .thenReturn(AsyncStream.of(sidecar10_0));
+
+    final SafeFuture<DataColumnSidecar> dataColumnSidecar10_0_Future =
+        dataColumnReqResp.requestDataColumnSidecar(
+            UInt256.ZERO,
+            new DataColumnSlotAndIdentifier(blockHeader10.getMessage().getSlot(), blockRoot1, ZERO),
+            Optional.of(blobKzgCommitments));
+
+    dataColumnReqResp.flush();
+
+    assertThat(dataColumnSidecar10_0_Future).isCompletedWithValue(sidecar10_0);
+    verify(byRootRpc)
+        .requestDataColumnSidecarsByRoot(UInt256.ZERO, expectedIdentifiers, expectedCommitments);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldFailRequestsWhenSameRootHasConflictingBlobKzgCommitments() {
+    final SignedBeaconBlockHeader blockHeader10 =
+        dataStructureUtil.randomSignedBeaconBlockHeader(UInt64.valueOf(10));
+    final Bytes32 blockRoot1 = blockHeader10.getMessage().getRoot();
+    final SszList<SszKZGCommitment> blobKzgCommitments1 = mock(SszList.class);
+    final SszList<SszKZGCommitment> blobKzgCommitments2 = mock(SszList.class);
+
+    final SafeFuture<DataColumnSidecar> dataColumnSidecar100Future =
+        dataColumnReqResp.requestDataColumnSidecar(
+            UInt256.ZERO,
+            new DataColumnSlotAndIdentifier(blockHeader10.getMessage().getSlot(), blockRoot1, ZERO),
+            Optional.of(blobKzgCommitments1));
+    final SafeFuture<DataColumnSidecar> dataColumnSidecar101Future =
+        dataColumnReqResp.requestDataColumnSidecar(
+            UInt256.ZERO,
+            new DataColumnSlotAndIdentifier(blockHeader10.getMessage().getSlot(), blockRoot1, ONE),
+            Optional.of(blobKzgCommitments2));
+
+    dataColumnReqResp.flush();
+
+    assertThat(dataColumnSidecar100Future).isCompletedExceptionally();
+    assertThat(dataColumnSidecar101Future).isCompletedExceptionally();
+    verifyNoInteractions(byRootRpc);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -153,7 +153,8 @@ public class SimpleSidecarRetrieverTest {
                 .getResponseScore())
         .isEqualTo(10);
 
-    final SafeFuture<DataColumnSidecar> resp0 = simpleSidecarRetriever.retrieve(id0);
+    final SafeFuture<DataColumnSidecar> resp0 =
+        simpleSidecarRetriever.retrieve(id0, Optional.empty());
 
     advanceTimeGradually(retrieverRound.multipliedBy(2));
 
@@ -201,6 +202,26 @@ public class SimpleSidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void shouldUpgradePendingRequestWithBlobKzgCommitmentsBeforeReqResp() {
+    final TestPeer custodyPeer = createCustodyPeer();
+    final SszList<SszKZGCommitment> blobKzgCommitments = mock(SszList.class);
+    final DataColumnSlotAndIdentifier columnId =
+        new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnIndex);
+    testPeerManager.connectPeer(custodyPeer);
+
+    simpleSidecarRetriever
+        .retrieve(columnId, Optional.empty())
+        .finish(err -> LOG.error("Error retrieving sidecar", err));
+    simpleSidecarRetriever
+        .retrieve(columnId, Optional.of(blobKzgCommitments))
+        .finish(err -> LOG.error("Error retrieving sidecar", err));
+    advanceTimeGradually(retrieverRound);
+
+    assertThat(testPeerManager.getLastBlobKzgCommitments()).contains(blobKzgCommitments);
+  }
+
+  @Test
   void selectingBestPeerShouldRespectRequestLimits() {
     final TestPeer nonCustodyPeer = createNonCustodyPeer();
     final TestPeer overloadedCustodyPeer = createCustodyPeer(0);
@@ -212,7 +233,9 @@ public class SimpleSidecarRetrieverTest {
 
     final DataColumnSlotAndIdentifier id0 =
         new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnIndex);
-    simpleSidecarRetriever.retrieve(id0).finish(err -> LOG.error("Error retrieving sidecar", err));
+    simpleSidecarRetriever
+        .retrieve(id0, Optional.empty())
+        .finish(err -> LOG.error("Error retrieving sidecar", err));
 
     advanceTimeGradually(retrieverRound);
     assertThat(allRequestCountsFunc.get()).isEqualTo(List.of(0, 0, 0, 1));
@@ -249,7 +272,7 @@ public class SimpleSidecarRetrieverTest {
     final DataColumnSidecar sidecar0 =
         createSidecarAndAddToAllPeers(0, peerWithEarliestSlotAvailableZero);
     simpleSidecarRetriever
-        .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar0))
+        .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar0), Optional.empty())
         .finish(err -> LOG.error("Error retrieving sidecar", err));
     advanceTimeGradually(retrieverRound);
     assertThat(allRequestCountsFunc.get()).isEqualTo(List.of(0, 1, 0, 0));
@@ -258,7 +281,7 @@ public class SimpleSidecarRetrieverTest {
         createSidecarAndAddToAllPeers(
             1, peerWithEarliestSlotAvailableZero, peerWithEarliestSlotAvailableOne);
     simpleSidecarRetriever
-        .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar1))
+        .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar1), Optional.empty())
         .finish(err -> LOG.error("Error retrieving sidecar", err));
     advanceTimeGradually(retrieverRound);
     assertThat(allRequestCountsFunc.get()).isEqualTo(List.of(0, 1, 1, 0));
@@ -270,7 +293,7 @@ public class SimpleSidecarRetrieverTest {
             peerWithEarliestSlotAvailableOne,
             peerWithEarliestSlotAvailableTwo);
     simpleSidecarRetriever
-        .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar2))
+        .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar2), Optional.empty())
         .finish(err -> LOG.error("Error retrieving sidecar", err));
     advanceTimeGradually(retrieverRound);
     assertThat(allRequestCountsFunc.get()).isEqualTo(List.of(0, 1, 1, 1));
@@ -296,7 +319,7 @@ public class SimpleSidecarRetrieverTest {
           createSidecarAndAddToAllPeers(
               i, goodScoreCustodyPeer, medianScoreCustodyPeer, badScoreCustodyPeer);
       simpleSidecarRetriever
-          .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar))
+          .retrieve(DataColumnSlotAndIdentifier.fromDataColumn(sidecar), Optional.empty())
           .finish(err -> LOG.error("Error retrieving sidecar", err));
     }
 
@@ -311,7 +334,7 @@ public class SimpleSidecarRetrieverTest {
 
     final DataColumnSlotAndIdentifier id0 =
         new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnIndex);
-    SafeFuture<DataColumnSidecar> resp0_0 = simpleSidecarRetriever.retrieve(id0);
+    SafeFuture<DataColumnSidecar> resp0_0 = simpleSidecarRetriever.retrieve(id0, Optional.empty());
 
     advanceTimeGradually(retrieverRound);
     assertThat(custodyPeer.getRequests()).hasSize(1);
@@ -352,7 +375,8 @@ public class SimpleSidecarRetrieverTest {
             .limit(20_000)
             .toList();
 
-    columnIds.forEach(columnId -> simpleSidecarRetriever.retrieve(columnId).finishDebug(LOG));
+    columnIds.forEach(
+        columnId -> simpleSidecarRetriever.retrieve(columnId, Optional.empty()).finishDebug(LOG));
 
     Assertions.assertTimeout(Duration.ofSeconds(10), () -> advanceTimeGradually(retrieverRound));
   }
@@ -373,7 +397,7 @@ public class SimpleSidecarRetrieverTest {
             .map(colIdx -> new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, colIdx))
             .toList();
 
-    colIds.forEach(simpleSidecarRetriever::retrieve);
+    colIds.forEach(columnId -> simpleSidecarRetriever.retrieve(columnId, Optional.empty()));
 
     final int peerCustodyCount = custodyCountSupplier.getCustodyGroupCountForPeer(peer.getNodeId());
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
@@ -48,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -178,6 +181,23 @@ public class SimpleSidecarRetrieverTest {
     assertThat(nonCustodyPeer.getRequests()).isEmpty();
     assertThat(custodyPeerHavingData.getRequests()).hasSize(1);
     assertThat(custodyPeerMissingData.getRequests()).hasSize(2);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldForwardBlobKzgCommitmentsToReqResp() {
+    final TestPeer custodyPeer = createCustodyPeer();
+    final SszList<SszKZGCommitment> blobKzgCommitments = mock(SszList.class);
+    final DataColumnSlotAndIdentifier columnId =
+        new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnIndex);
+    testPeerManager.connectPeer(custodyPeer);
+
+    simpleSidecarRetriever
+        .retrieve(columnId, Optional.of(blobKzgCommitments))
+        .finish(err -> LOG.error("Error retrieving sidecar", err));
+    advanceTimeGradually(retrieverRound);
+
+    assertThat(testPeerManager.getLastBlobKzgCommitments()).contains(blobKzgCommitments);
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/recovering/SidecarRetrieverTest.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever.recovering;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.statetransition.datacolumns.retriever.recovering.SidecarRetriever.CANCELLED;
 import static tech.pegasys.teku.statetransition.datacolumns.retriever.recovering.SidecarRetriever.DOWNLOADED;
@@ -23,6 +25,7 @@ import static tech.pegasys.teku.statetransition.datacolumns.retriever.recovering
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +34,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -39,6 +43,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -48,6 +53,7 @@ import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
+import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecarRetriever;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecarRetrieverStub;
 
 public class SidecarRetrieverTest {
@@ -117,7 +123,7 @@ public class SidecarRetrieverTest {
     when(custodyManager.getCustodyGroupCount()).thenReturn(8);
     final BeaconBlock block = blockResolver.addBlock(10, 10);
     final DataColumnSlotAndIdentifier id = createId(block, 0);
-    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id);
+    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id, Optional.empty());
     timeProvider.advanceTimeBy(RECOVERY_TIMEOUT.dividedBy(2));
     stubAsyncRunner.executeQueuedActions();
     assertThat(response.isDone()).isTrue();
@@ -128,7 +134,7 @@ public class SidecarRetrieverTest {
     when(custodyManager.getCustodyGroupCount()).thenReturn(128);
     final BeaconBlock block = blockResolver.addBlock(10, 10);
     final DataColumnSlotAndIdentifier id = createId(block, 0);
-    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id);
+    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id, Optional.empty());
     timeProvider.advanceTimeBy(RECOVERY_TIMEOUT.dividedBy(2));
     stubAsyncRunner.executeQueuedActions();
     assertThat(response.isDone()).isFalse();
@@ -158,6 +164,47 @@ public class SidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void shouldForwardBlobKzgCommitmentsToDelegateRetriever() {
+    final DataColumnSidecarRetriever delegateRetriever = mock(DataColumnSidecarRetriever.class);
+    final SidecarRetriever retriever = createRetriever(delegateRetriever);
+    final BeaconBlock block = blockResolver.addBlock(10, 1);
+    final DataColumnSlotAndIdentifier id = createId(block, 0);
+    final SszList<SszKZGCommitment> blobKzgCommitments = mock(SszList.class);
+    when(delegateRetriever.retrieve(id, Optional.of(blobKzgCommitments)))
+        .thenReturn(new SafeFuture<>());
+
+    final SafeFuture<DataColumnSidecar> response =
+        retriever.retrieve(id, Optional.of(blobKzgCommitments));
+
+    assertThat(response).isNotDone();
+    verify(delegateRetriever).retrieve(id, Optional.of(blobKzgCommitments));
+    verify(delegateRetriever, never()).retrieve(id, Optional.empty());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldForwardBlobKzgCommitmentsToDelegateForExistingRequest() {
+    final DataColumnSidecarRetriever delegateRetriever = mock(DataColumnSidecarRetriever.class);
+    final SidecarRetriever retriever = createRetriever(delegateRetriever);
+    final BeaconBlock block = blockResolver.addBlock(10, 1);
+    final DataColumnSlotAndIdentifier id = createId(block, 0);
+    final SszList<SszKZGCommitment> blobKzgCommitments = mock(SszList.class);
+    final SafeFuture<DataColumnSidecar> delegateResponse = new SafeFuture<>();
+    when(delegateRetriever.retrieve(id, Optional.empty())).thenReturn(delegateResponse);
+    when(delegateRetriever.retrieve(id, Optional.of(blobKzgCommitments)))
+        .thenReturn(delegateResponse);
+
+    final SafeFuture<DataColumnSidecar> firstResponse = retriever.retrieve(id, Optional.empty());
+    final SafeFuture<DataColumnSidecar> secondResponse =
+        retriever.retrieve(id, Optional.of(blobKzgCommitments));
+
+    assertThat(secondResponse).isSameAs(firstResponse);
+    verify(delegateRetriever).retrieve(id, Optional.empty());
+    verify(delegateRetriever).retrieve(id, Optional.of(blobKzgCommitments));
+  }
+
+  @Test
   void successfulRetrievalShouldRemoveFromPendingRequests() {
     final int blobCount = 1;
     final int columnsInDbCount = 1;
@@ -169,7 +216,8 @@ public class SidecarRetrieverTest {
         IntStream.range(10, Integer.MAX_VALUE).limit(columnsInDbCount).boxed().toList();
     dbColumnIndices.forEach(idx -> assertThat(db.addSidecar(sidecars.get(idx))).isDone());
 
-    final SafeFuture<DataColumnSidecar> res0 = retriever.retrieve(createId(block, 0));
+    final SafeFuture<DataColumnSidecar> res0 =
+        retriever.retrieve(createId(block, 0), Optional.empty());
 
     // this will add the file to the delegate, which will finish the download task
     delegateRetriever.addReadyColumnSidecar(sidecars.get(0));
@@ -182,7 +230,8 @@ public class SidecarRetrieverTest {
   @Test
   void cancelledRetrievalShouldRemoveFromPendingRequests() {
     final BeaconBlock block = blockResolver.addBlock(10, 1);
-    final SafeFuture<DataColumnSidecar> res0 = retriever.retrieve(createId(block, 0));
+    final SafeFuture<DataColumnSidecar> res0 =
+        retriever.retrieve(createId(block, 0), Optional.empty());
     res0.completeExceptionally(new RuntimeException("ERR"));
     assertThat(retriever.pendingRequestCount()).isZero();
     stubAsyncRunner.executeQueuedActions();
@@ -193,7 +242,7 @@ public class SidecarRetrieverTest {
   void stopClearsPendingRequests() {
     final BeaconBlock block = blockResolver.addBlock(10, 10);
     final DataColumnSlotAndIdentifier id = createId(block, 0);
-    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id);
+    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id, Optional.empty());
     retriever.stop();
     assertThat(retriever.getPendingRequestsChecker()).isNull();
     assertThat(retriever.getPendingRequests()).isEmpty();
@@ -205,7 +254,7 @@ public class SidecarRetrieverTest {
   void shouldCheckPendingRequestsOnTimer() {
     final BeaconBlock block = blockResolver.addBlock(10, 10);
     final DataColumnSlotAndIdentifier id = createId(block, 0);
-    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id);
+    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id, Optional.empty());
     timeProvider.advanceTimeBy(CHECK_INTERVAL);
     stubAsyncRunner.executeQueuedActions();
     assertThat(retriever.pendingRequestCount()).isEqualTo(1);
@@ -221,7 +270,7 @@ public class SidecarRetrieverTest {
   void createDoesNotIncrementMetrics() {
     final BeaconBlock block = blockResolver.addBlock(10, 10);
     final DataColumnSlotAndIdentifier id = createId(block, 0);
-    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id);
+    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id, Optional.empty());
     assertThat(response).isNotDone();
     verifyMetrics(0, 0, 0);
   }
@@ -230,7 +279,7 @@ public class SidecarRetrieverTest {
   void shouldTimeoutAfterExpiryTime() {
     final BeaconBlock block = blockResolver.addBlock(10, 10);
     final DataColumnSlotAndIdentifier id = createId(block, 0);
-    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id);
+    final SafeFuture<DataColumnSidecar> response = retriever.retrieve(id, Optional.empty());
 
     for (int i = 0; i < 10; i++) {
       timeProvider.advanceTimeBy(CHECK_INTERVAL);
@@ -243,6 +292,24 @@ public class SidecarRetrieverTest {
   static DataColumnSlotAndIdentifier createId(final BeaconBlock block, final int colIdx) {
     return new DataColumnSlotAndIdentifier(
         block.getSlot(), block.getRoot(), UInt64.valueOf(colIdx));
+  }
+
+  private SidecarRetriever createRetriever(final DataColumnSidecarRetriever delegateRetriever) {
+    final SidecarRetriever retriever =
+        new SidecarRetriever(
+            delegateRetriever,
+            spec,
+            dbAccessor,
+            stubAsyncRunner,
+            RECOVERY_TIMEOUT,
+            RECOVERY_TIMEOUT.dividedBy(2),
+            CHECK_INTERVAL,
+            timeProvider,
+            columnCount,
+            custodyManager,
+            metricsSystem);
+    retriever.start();
+    return retriever;
   }
 
   private void verifyMetrics(

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetrieverStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnSidecarRetrieverStub.java
@@ -17,10 +17,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 
@@ -28,7 +31,9 @@ public class DataColumnSidecarRetrieverStub implements DataColumnSidecarRetrieve
   private static final Logger LOG = LogManager.getLogger();
 
   public record RetrieveRequest(
-      DataColumnSlotAndIdentifier columnId, SafeFuture<DataColumnSidecar> future) {}
+      DataColumnSlotAndIdentifier columnId,
+      Optional<SszList<SszKZGCommitment>> blobKzgCommitments,
+      SafeFuture<DataColumnSidecar> future) {}
 
   public List<RetrieveRequest> requests = new ArrayList<>();
   private final Map<DataColumnSlotAndIdentifier, DataColumnSidecar> readySidecars = new HashMap<>();
@@ -40,20 +45,23 @@ public class DataColumnSidecarRetrieverStub implements DataColumnSidecarRetrieve
     LOG.debug("ADD sidecar {}", colId);
     readySidecars.put(colId, sidecar);
     requests.stream()
-        .filter(req -> req.columnId.equals(colId))
-        .forEach(req -> req.future.complete(sidecar));
+        .filter(req -> req.columnId().equals(colId))
+        .forEach(req -> req.future().complete(sidecar));
   }
 
   @Override
-  public SafeFuture<DataColumnSidecar> retrieve(final DataColumnSlotAndIdentifier columnId) {
-    final RetrieveRequest request = new RetrieveRequest(columnId, new SafeFuture<>());
+  public SafeFuture<DataColumnSidecar> retrieve(
+      final DataColumnSlotAndIdentifier columnId,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    final RetrieveRequest request =
+        new RetrieveRequest(columnId, blobKzgCommitments, new SafeFuture<>());
     LOG.debug("RETRIEVE sidecar {}", columnId);
     requests.add(request);
     final DataColumnSidecar maybeSidecar = readySidecars.get(columnId);
     if (maybeSidecar != null) {
-      request.future.complete(maybeSidecar);
+      request.future().complete(maybeSidecar);
     }
-    return request.future;
+    return request.future();
   }
 
   @Override

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
@@ -14,10 +14,13 @@
 package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.blobs.RemoteOrigin;
 import tech.pegasys.teku.statetransition.datacolumns.util.CancelableFuture;
@@ -46,8 +49,10 @@ public class DelayedDataColumnSidecarRetriever implements DataColumnSidecarRetri
   }
 
   @Override
-  public SafeFuture<DataColumnSidecar> retrieve(final DataColumnSlotAndIdentifier columnId) {
-    return delay(() -> delegate.retrieve(columnId));
+  public SafeFuture<DataColumnSidecar> retrieve(
+      final DataColumnSlotAndIdentifier columnId,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    return delay(() -> delegate.retrieve(columnId, blobKzgCommitments));
   }
 
   @Override

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeerManager.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeerManager.java
@@ -15,9 +15,12 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 
 public class TestPeerManager implements DataColumnPeerManager, DataColumnReqResp {
@@ -25,6 +28,7 @@ public class TestPeerManager implements DataColumnPeerManager, DataColumnReqResp
       new DataColumnPeerManagerStub();
 
   private final Map<UInt256, TestPeer> connectedPeers = new HashMap<>();
+  private Optional<SszList<SszKZGCommitment>> lastBlobKzgCommitments = Optional.empty();
 
   public void connectPeer(final TestPeer peer) {
     dataColumnPeerManagerStub.addPeer(peer);
@@ -40,6 +44,19 @@ public class TestPeerManager implements DataColumnPeerManager, DataColumnReqResp
     } else {
       return peer.requestSidecar(columnIdentifier.toDataColumnIdentifier());
     }
+  }
+
+  @Override
+  public SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
+      final UInt256 nodeId,
+      final DataColumnSlotAndIdentifier columnIdentifier,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
+    lastBlobKzgCommitments = blobKzgCommitments;
+    return requestDataColumnSidecar(nodeId, columnIdentifier);
+  }
+
+  public Optional<SszList<SszKZGCommitment>> getLastBlobKzgCommitments() {
+    return lastBlobKzgCommitments;
   }
 
   @Override

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -323,7 +324,7 @@ public abstract class AbstractRpcMethodIntegrationTest {
     final List<DataColumnSidecar> dataColumnSidecars = new ArrayList<>();
     waitFor(
         peer.requestDataColumnSidecarsByRoot(
-            dataColumnIdentifiers, RpcResponseListener.from(dataColumnSidecars::add)));
+            dataColumnIdentifiers, RpcResponseListener.from(dataColumnSidecars::add), Map.of()));
     assertThat(peer.getOutstandingRequests()).isEqualTo(0);
     return dataColumnSidecars;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
@@ -16,14 +16,17 @@ package tech.pegasys.teku.networking.eth2.peers;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStreamPublisher;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.BatchDataColumnsByRangeReqResp;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.BatchDataColumnsByRootReqResp;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnPeerManager;
@@ -64,7 +67,9 @@ public class DataColumnPeerManagerImpl
 
   @Override
   public AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRoot(
-      final UInt256 nodeId, final List<DataColumnsByRootIdentifier> byRootIdentifiers) {
+      final UInt256 nodeId,
+      final List<DataColumnsByRootIdentifier> byRootIdentifiers,
+      final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot) {
     final Eth2Peer eth2Peer = connectedPeers.get(nodeId);
     final AsyncStreamPublisher<DataColumnSidecar> ret =
         AsyncStream.createPublisher(Integer.MAX_VALUE);
@@ -72,7 +77,7 @@ public class DataColumnPeerManagerImpl
       ret.onError(new DataColumnReqResp.DasPeerDisconnectedException());
     } else {
       eth2Peer
-          .requestDataColumnSidecarsByRoot(byRootIdentifiers, ret::onNext)
+          .requestDataColumnSidecarsByRoot(byRootIdentifiers, ret::onNext, blobKzgCommitmentsByRoot)
           .finish(__ -> ret.onComplete(), ret::onError);
     }
     return ret;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -22,6 +22,7 @@ import com.google.common.base.Suppliers;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,6 +34,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -85,6 +87,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.status.StatusMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
@@ -349,7 +352,8 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   @Override
   public SafeFuture<Void> requestDataColumnSidecarsByRoot(
       final List<DataColumnsByRootIdentifier> dataColumnIdentifiers,
-      final RpcResponseListener<DataColumnSidecar> listener) {
+      final RpcResponseListener<DataColumnSidecar> listener,
+      final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot) {
     return rpcMethods
         .dataColumnSidecarsByRoot()
         .map(
@@ -366,7 +370,8 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
                         timeProvider,
                         dataColumnSidecarSignatureValidator,
                         dataColumnIdentifiers,
-                        combinedChainDataClient)))
+                        combinedChainDataClient,
+                        blobKzgCommitmentsByRoot)))
         .orElse(failWithUnsupportedMethodException("DataColumnSidecarsByRoot"));
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -14,12 +14,14 @@
 package tech.pegasys.teku.networking.eth2.peers;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -43,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.SingleRpcRequestBodySelector;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public interface Eth2Peer extends Peer, SyncSource {
@@ -117,7 +120,8 @@ public interface Eth2Peer extends Peer, SyncSource {
 
   SafeFuture<Void> requestDataColumnSidecarsByRoot(
       List<DataColumnsByRootIdentifier> dataColumnIdentifiers,
-      RpcResponseListener<DataColumnSidecar> listener);
+      RpcResponseListener<DataColumnSidecar> listener,
+      Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot);
 
   SafeFuture<Void> requestExecutionPayloadEnvelopesByRoot(
       List<Bytes32> beaconBlockRoots, RpcResponseListener<SignedExecutionPayloadEnvelope> listener);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
@@ -17,10 +17,12 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.networking.eth2.peers.DataColumnSidecarSignatureValidator;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarValidationError;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -53,10 +55,16 @@ public abstract class AbstractDataColumnSidecarValidator {
 
   SafeFuture<Optional<DataColumnSidecarValidationError>> verifyKzgProofs(
       final DataColumnSidecar dataColumnSidecar) {
+    return verifyKzgProofs(dataColumnSidecar, Optional.empty());
+  }
+
+  SafeFuture<Optional<DataColumnSidecarValidationError>> verifyKzgProofs(
+      final DataColumnSidecar dataColumnSidecar,
+      final Optional<SszList<SszKZGCommitment>> blobKzgCommitments) {
     final DataColumnSidecarUtil dataColumnSidecarUtil =
         spec.getDataColumnSidecarUtil(dataColumnSidecar.getSlot());
-    return dataColumnSidecarUtil.validateAndVerifyKzgProofsWithBlock(
-        dataColumnSidecar, combinedChainDataClient::getBlockByBlockRoot);
+    return dataColumnSidecarUtil.validateAndVerifyKzgProofs(
+        dataColumnSidecar, blobKzgCommitments, combinedChainDataClient::getBlockByBlockRoot);
   }
 
   boolean verifyInclusionProof(final DataColumnSidecar dataColumnSidecar) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
@@ -14,8 +14,11 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import java.util.List;
+import java.util.Map;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.networking.eth2.peers.DataColumnSidecarSignatureValidator;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType;
@@ -24,6 +27,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
@@ -41,6 +45,28 @@ public class DataColumnSidecarsByRootListenerValidatingProxy
       final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
       final List<DataColumnsByRootIdentifier> expectedByRootIdentifiers,
       final CombinedChainDataClient combinedChainDataClient) {
+    this(
+        peer,
+        spec,
+        listener,
+        metricsSystem,
+        timeProvider,
+        dataColumnSidecarSignatureValidator,
+        expectedByRootIdentifiers,
+        combinedChainDataClient,
+        Map.of());
+  }
+
+  public DataColumnSidecarsByRootListenerValidatingProxy(
+      final Peer peer,
+      final Spec spec,
+      final RpcResponseListener<DataColumnSidecar> listener,
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider,
+      final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
+      final List<DataColumnsByRootIdentifier> expectedByRootIdentifiers,
+      final CombinedChainDataClient combinedChainDataClient,
+      final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot) {
     super(
         peer,
         spec,
@@ -55,7 +81,8 @@ public class DataColumnSidecarsByRootListenerValidatingProxy
                             column ->
                                 new DataColumnIdentifier(byRootIdentifier.getBlockRoot(), column)))
             .toList(),
-        combinedChainDataClient);
+        combinedChainDataClient,
+        blobKzgCommitmentsByRoot);
     this.listener = listener;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
@@ -19,21 +19,27 @@ import static tech.pegasys.teku.statetransition.validation.DataColumnSidecarGoss
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.networking.eth2.peers.DataColumnSidecarSignatureValidator;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecarValidator {
   private final Set<DataColumnIdentifier> expectedDataColumnIdentifiers;
+  private final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot;
   private final MetricsHistogram dataColumnSidecarInclusionProofVerificationTimeSeconds;
   private final MetricsHistogram dataColumnSidecarKzgBatchVerificationTimeSeconds;
 
@@ -45,9 +51,30 @@ public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecar
       final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
       final List<DataColumnIdentifier> expectedDataColumnIdentifiers,
       final CombinedChainDataClient combinedChainDataClient) {
+    this(
+        peer,
+        spec,
+        metricsSystem,
+        timeProvider,
+        dataColumnSidecarSignatureValidator,
+        expectedDataColumnIdentifiers,
+        combinedChainDataClient,
+        Map.of());
+  }
+
+  public DataColumnSidecarsByRootValidator(
+      final Peer peer,
+      final Spec spec,
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider,
+      final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
+      final List<DataColumnIdentifier> expectedDataColumnIdentifiers,
+      final CombinedChainDataClient combinedChainDataClient,
+      final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot) {
     super(peer, spec, dataColumnSidecarSignatureValidator, combinedChainDataClient);
     this.expectedDataColumnIdentifiers = ConcurrentHashMap.newKeySet();
     this.expectedDataColumnIdentifiers.addAll(expectedDataColumnIdentifiers);
+    this.blobKzgCommitmentsByRoot = Map.copyOf(blobKzgCommitmentsByRoot);
     this.dataColumnSidecarInclusionProofVerificationTimeSeconds =
         DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_HISTOGRAM.apply(
             metricsSystem, timeProvider);
@@ -89,7 +116,9 @@ public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecar
 
     final MetricsHistogram.Timer kzgVerificationTimer =
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer();
-    return verifyKzgProofs(dataColumnSidecar)
+    final Optional<SszList<SszKZGCommitment>> blobKzgCommitments =
+        Optional.ofNullable(blobKzgCommitmentsByRoot.get(dataColumnSidecar.getBeaconBlockRoot()));
+    return verifyKzgProofs(dataColumnSidecar, blobKzgCommitments)
         .alwaysRun(kzgVerificationTimer.closeUnchecked())
         .exceptionallyCompose(
             error ->

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
@@ -25,6 +27,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -32,6 +35,8 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumnSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.gloas.DataColumnSidecarSchemaGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
@@ -114,5 +119,65 @@ public class DataColumnSidecarsByRootValidatorGloasTest
                 .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
                 .describe())
         .hasMessageContaining("DataColumnSidecar's KZG proofs do not match the bid's KZG proofs");
+  }
+
+  @Test
+  void dataColumnSidecarUsesScopedBlobKzgCommitmentsWhenBlockIsUnknown() {
+    final SignedBeaconBlock block1 = createBlock(currentForkFirstSlot);
+    final DataColumnSidecar dataColumnSidecar1_0 =
+        dataStructureUtil.randomDataColumnSidecar(block1, UInt64.ZERO);
+    final SszList<SszKZGCommitment> blobKzgCommitments =
+        BeaconBlockBodyGloas.required(block1.getMessage().getBody()).getBlobKzgCommitments();
+    final DataColumnIdentifier sidecarIdentifier1_0 =
+        DataColumnIdentifier.createFromSidecar(dataColumnSidecar1_0);
+    blocksByRoot.remove(block1.getRoot());
+
+    validator =
+        new DataColumnSidecarsByRootValidator(
+            peer,
+            spec,
+            metricsSystem,
+            timeProvider,
+            dataColumnSidecarSignatureValidator,
+            List.of(sidecarIdentifier1_0),
+            combinedChainDataClient,
+            Map.of(block1.getRoot(), blobKzgCommitments));
+
+    assertThatSafeFuture(validator.validate(dataColumnSidecar1_0)).isCompleted();
+    verify(combinedChainDataClient, never()).getBlockByBlockRoot(block1.getRoot());
+  }
+
+  @Test
+  void dataColumnSidecarFailsKzgVerificationWithScopedBlobKzgCommitments() {
+    when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(false);
+
+    final SignedBeaconBlock block1 = createBlock(currentForkFirstSlot);
+    final DataColumnSidecar dataColumnSidecar1_0 =
+        dataStructureUtil.randomDataColumnSidecar(block1, UInt64.ZERO);
+    final SszList<SszKZGCommitment> blobKzgCommitments =
+        BeaconBlockBodyGloas.required(block1.getMessage().getBody()).getBlobKzgCommitments();
+    final DataColumnIdentifier sidecarIdentifier1_0 =
+        DataColumnIdentifier.createFromSidecar(dataColumnSidecar1_0);
+    blocksByRoot.remove(block1.getRoot());
+
+    validator =
+        new DataColumnSidecarsByRootValidator(
+            peer,
+            spec,
+            metricsSystem,
+            timeProvider,
+            dataColumnSidecarSignatureValidator,
+            List.of(sidecarIdentifier1_0),
+            combinedChainDataClient,
+            Map.of(block1.getRoot(), blobKzgCommitments));
+
+    assertThatSafeFuture(validator.validate(dataColumnSidecar1_0))
+        .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)
+        .hasMessageContaining(
+            DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
+                .DATA_COLUMN_SIDECAR_KZG_VERIFICATION_FAILED
+                .describe())
+        .hasMessageContaining("DataColumnSidecar's KZG proofs do not match the bid's KZG proofs");
+    verify(combinedChainDataClient, never()).getBlockByBlockRoot(block1.getRoot());
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -30,6 +31,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -62,6 +64,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.RpcRequestBodySelector;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 
 public class RespondingEth2Peer implements Eth2Peer {
@@ -275,7 +278,8 @@ public class RespondingEth2Peer implements Eth2Peer {
   @Override
   public SafeFuture<Void> requestDataColumnSidecarsByRoot(
       final List<DataColumnsByRootIdentifier> dataColumnIdentifiers,
-      final RpcResponseListener<DataColumnSidecar> listener) {
+      final RpcResponseListener<DataColumnSidecar> listener,
+      final Map<Bytes32, SszList<SszKZGCommitment>> blobKzgCommitmentsByRoot) {
     final PendingRequestHandler<Void, DataColumnSidecar> handler =
         PendingRequestHandler.createForBatchDataColumnSidecarRequest(
             listener,

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/DataColumnSidecarNetworkRetrieverImpl.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/DataColumnSidecarNetworkRetrieverImpl.java
@@ -17,25 +17,37 @@ import static java.util.Collections.emptyList;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.storage.api.DataColumnSidecarNetworkRetriever;
 
 public class DataColumnSidecarNetworkRetrieverImpl implements DataColumnSidecarNetworkRetriever {
   private static final Logger LOG = LogManager.getLogger();
 
-  final Function<DataColumnSlotAndIdentifier, SafeFuture<DataColumnSidecar>> retriever;
+  final BiFunction<
+          DataColumnSlotAndIdentifier,
+          Optional<SszList<SszKZGCommitment>>,
+          SafeFuture<DataColumnSidecar>>
+      retriever;
   final Runnable retrieverFlusher;
   final Function<DataColumnSidecar, SafeFuture<Void>> dbWriter;
   final Duration retrievalTimeout;
 
   public DataColumnSidecarNetworkRetrieverImpl(
-      final Function<DataColumnSlotAndIdentifier, SafeFuture<DataColumnSidecar>> retriever,
+      final BiFunction<
+              DataColumnSlotAndIdentifier,
+              Optional<SszList<SszKZGCommitment>>,
+              SafeFuture<DataColumnSidecar>>
+          retriever,
       final Runnable retrieverFlusher,
       final Function<DataColumnSidecar, SafeFuture<Void>> dbWriter,
       final Duration retrievalTimeout) {
@@ -53,7 +65,7 @@ public class DataColumnSidecarNetworkRetrieverImpl implements DataColumnSidecarN
         requiredIdentifiers.stream()
             .map(
                 columnId -> {
-                  var rpcRequest = retriever.apply(columnId);
+                  var rpcRequest = retriever.apply(columnId, Optional.empty());
                   rpcRequest
                       .thenCompose(dbWriter)
                       .finish(

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/DataColumnSidecarNetworkRetrieverImplTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/DataColumnSidecarNetworkRetrieverImplTest.java
@@ -23,19 +23,26 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.storage.api.DataColumnSidecarNetworkRetriever;
 
 public class DataColumnSidecarNetworkRetrieverImplTest {
 
   @SuppressWarnings("unchecked")
-  final Function<DataColumnSlotAndIdentifier, SafeFuture<DataColumnSidecar>> retriever =
-      mock(Function.class);
+  final BiFunction<
+          DataColumnSlotAndIdentifier,
+          Optional<SszList<SszKZGCommitment>>,
+          SafeFuture<DataColumnSidecar>>
+      retriever = mock(BiFunction.class);
 
   final Runnable retrieverFlusher = mock(Runnable.class);
 
@@ -56,8 +63,8 @@ public class DataColumnSidecarNetworkRetrieverImplTest {
   @Test
   void shouldReturnSidecarsWhenSuccessful() {
     var pendingSidecar2 = new SafeFuture<DataColumnSidecar>();
-    when(retriever.apply(id1)).thenReturn(SafeFuture.completedFuture(sidecar1));
-    when(retriever.apply(id2)).thenReturn(pendingSidecar2);
+    when(retriever.apply(id1, Optional.empty())).thenReturn(SafeFuture.completedFuture(sidecar1));
+    when(retriever.apply(id2, Optional.empty())).thenReturn(pendingSidecar2);
 
     final SafeFuture<List<DataColumnSidecar>> result =
         networkRetriever.retrieveDataColumnSidecars(List.of(id1, id2));
@@ -77,7 +84,7 @@ public class DataColumnSidecarNetworkRetrieverImplTest {
 
   @Test
   void shouldNotFailIfDbWriteFails() {
-    when(retriever.apply(id1)).thenReturn(SafeFuture.completedFuture(sidecar1));
+    when(retriever.apply(id1, Optional.empty())).thenReturn(SafeFuture.completedFuture(sidecar1));
     when(dbWriter.apply(sidecar1)).thenReturn(SafeFuture.failedFuture(new RuntimeException()));
 
     final SafeFuture<List<DataColumnSidecar>> result =
@@ -97,15 +104,15 @@ public class DataColumnSidecarNetworkRetrieverImplTest {
     assertThat(result).isCompleted();
     assertThat(result.join()).isEmpty();
 
-    verify(retriever, never()).apply(any());
+    verify(retriever, never()).apply(any(), any());
     verify(retrieverFlusher, never()).run();
   }
 
   @Test
   void shouldReturnEmptyListWhenOneRequestFails() {
     // One succeeds, one fails
-    when(retriever.apply(id1)).thenReturn(SafeFuture.completedFuture(sidecar1));
-    when(retriever.apply(id2))
+    when(retriever.apply(id1, Optional.empty())).thenReturn(SafeFuture.completedFuture(sidecar1));
+    when(retriever.apply(id2, Optional.empty()))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("Network Error")));
 
     final SafeFuture<List<DataColumnSidecar>> result =
@@ -128,7 +135,7 @@ public class DataColumnSidecarNetworkRetrieverImplTest {
             retriever, retrieverFlusher, dbWriter, shortTimeout);
 
     final SafeFuture<DataColumnSidecar> pendingFuture = new SafeFuture<>();
-    when(retriever.apply(id1)).thenReturn(pendingFuture);
+    when(retriever.apply(id1, Optional.empty())).thenReturn(pendingFuture);
 
     final SafeFuture<List<DataColumnSidecar>> result =
         timeoutRetriever.retrieveDataColumnSidecars(List.of(id1));


### PR DESCRIPTION
fixes #10797

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus data-availability validation and KZG proof paths; incorrect or conflicting commitments could reject valid sidecars or affect sync, though conflicts are explicitly guarded.
> 
> **Overview**
> Fixes **Gloas** data-availability sync by threading **blob KZG commitments** from the signed beacon block through sampling, retrieval, and Req/Resp so column sidecars can be validated **without loading the block from chain storage**.
> 
> **Gloas spec logic** adds `validateAndVerifyKzgProofs` with an optional commitments list: when present, sidecar structure and KZG checks run against those commitments synchronously; otherwise behavior falls back to fetching the block by root.
> 
> The **DAS pipeline** (`DasPreSampler`, `DasSamplerBasic`, trackers, backfiller) passes commitments into `checkDataAvailability` and `retrieve`, keeps them on the sampling tracker (with conflict detection), and forwards them through batched **DataColumnsByRoot** RPC (`DataColumnReqRespBatchingImpl`, logging wrapper, peer manager).
> 
> **Networking** extends `requestDataColumnSidecarsByRoot` with a per-root commitments map; **DataColumnSidecarsByRootValidator** uses scoped commitments for KZG verification when the block is unknown locally.
> 
> Call sites that lack commitments still pass `Optional.empty()`; defaults on interfaces preserve prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3ce81542afcb29fd82ad05679a8261eda81422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->