### PR TITLE
Split new builder deposits signature verification into batches

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -26,7 +26,7 @@ public class Constants {
   public static final int VALID_PAYLOAD_ATTESTATION_SET_SIZE = 512 * 2;
   // The cache is used for the `payload_present` voting, gossip and RPC fetch de-duplication, so no
   // need for a long term caching (1 epoch)
-  public static final int VALID_EXECUTION_PAYLOADS_SET_SIZE = 32;
+  public static final int VALID_EXECUTION_PAYLOAD_SET_SIZE = 32;
   // Target holding two slots worth of aggregators (16 aggregators, 64 committees and 2 slots)
   public static final int VALID_AGGREGATE_SET_SIZE = 16 * 64 * 2;
   // Tracking 10 slots worth of bids

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -47,7 +47,7 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorF
   // a single bad signature forces a fallback to verify every signature in the batch one by one.
   // Capping the batch at this size bounds that cost: a bad signature only triggers individual
   // re-verification within its own sub-batch rather than across all new builder deposits.
-  private static final int NEW_BUILDER_DEPOSIT_SIGNATURE_VALIDATION_BATCH_SIZE = 256;
+  private static final int NEW_BUILDER_DEPOSIT_SIGNATURE_VERIFICATION_BATCH_SIZE = 256;
 
   private final MiscHelpersGloas miscHelpersGloas;
   private final PredicatesGloas predicatesGloas;
@@ -125,7 +125,7 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorF
       }
     }
 
-    Lists.partition(newBuilderDeposits, NEW_BUILDER_DEPOSIT_SIGNATURE_VALIDATION_BATCH_SIZE)
+    Lists.partition(newBuilderDeposits, NEW_BUILDER_DEPOSIT_SIGNATURE_VERIFICATION_BATCH_SIZE)
         .forEach(
             newBuilderDepositsBatch -> {
               final boolean newBuilderDepositSignaturesAreAllGood =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.execution;
 
+import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -40,6 +41,13 @@ import tech.pegasys.teku.spec.logic.versions.gloas.util.ValidatorsUtilGloas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorFulu {
+
+  // New builder deposit signatures are checked with BLS batch verification, which only returns a
+  // single pass/fail for the whole batch. A failure does not reveal which signature is invalid, so
+  // a single bad signature forces a fallback to verify every signature in the batch one by one.
+  // Capping the batch at this size bounds that cost: a bad signature only triggers individual
+  // re-verification within its own sub-batch rather than across all new builder deposits.
+  private static final int NEW_BUILDER_DEPOSIT_SIGNATURE_VALIDATION_BATCH_SIZE = 256;
 
   private final MiscHelpersGloas miscHelpersGloas;
   private final PredicatesGloas predicatesGloas;
@@ -117,12 +125,16 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorF
       }
     }
 
-    final boolean newBuilderDepositSignaturesAreAllGood =
-        batchVerifyNewBuilderDepositSignatures(newBuilderDeposits);
-
-    for (final DepositRequest newBuilderDeposit : newBuilderDeposits) {
-      applyDepositForBuilder(state, newBuilderDeposit, newBuilderDepositSignaturesAreAllGood);
-    }
+    Lists.partition(newBuilderDeposits, NEW_BUILDER_DEPOSIT_SIGNATURE_VALIDATION_BATCH_SIZE)
+        .forEach(
+            newBuilderDepositsBatch -> {
+              final boolean newBuilderDepositSignaturesAreAllGood =
+                  batchVerifyNewBuilderDepositSignatures(newBuilderDepositsBatch);
+              for (final DepositRequest newBuilderDeposit : newBuilderDepositsBatch) {
+                applyDepositForBuilder(
+                    state, newBuilderDeposit, newBuilderDepositSignaturesAreAllGood);
+              }
+            });
   }
 
   // Apply builder deposits immediately

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultExecutionPayloadManager.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import static tech.pegasys.teku.spec.config.Constants.VALID_EXECUTION_PAYLOADS_SET_SIZE;
+import static tech.pegasys.teku.spec.config.Constants.VALID_EXECUTION_PAYLOAD_SET_SIZE;
 
 import java.time.Duration;
 import java.util.Map;
@@ -51,11 +51,13 @@ public class DefaultExecutionPayloadManager
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final int PENDING_EXECUTION_PAYLOADS_CACHE_SIZE =
-      VALID_EXECUTION_PAYLOADS_SET_SIZE * 2;
+  // A payload is kept pending while its beacon block is still missing. Payloads from before the
+  // finalized slot are never queued, so the cache only needs to span the non-finalized window.
+  // Under healthy finality that window is ~2 epochs (2 * SLOTS_PER_EPOCH = 64 slots on mainnet)
+  private static final int PENDING_EXECUTION_PAYLOADS_CACHE_SIZE = 64;
 
   private final Set<Bytes32> executionPayloadsSeenBeforePayloadDue =
-      LimitedSet.createSynchronizedNatural(VALID_EXECUTION_PAYLOADS_SET_SIZE);
+      LimitedSet.createSynchronizedNatural(VALID_EXECUTION_PAYLOAD_SET_SIZE);
 
   // pending pool
   private final Map<BlockRootAndBuilderIndex, PendingExecutionPayload> pendingExecutionPayloads =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadGossipValidator.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.statetransition.validation;
 
-import static tech.pegasys.teku.spec.config.Constants.VALID_EXECUTION_PAYLOADS_SET_SIZE;
+import static tech.pegasys.teku.spec.config.Constants.VALID_EXECUTION_PAYLOAD_SET_SIZE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.SAVE_FOR_FUTURE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
@@ -49,7 +49,7 @@ public class ExecutionPayloadGossipValidator {
   private final SigningRootUtil signingRootUtil;
 
   private final Set<BlockRootAndBuilderIndex> seenPayloads =
-      LimitedSet.createSynchronizedLRU(VALID_EXECUTION_PAYLOADS_SET_SIZE);
+      LimitedSet.createSynchronizedLRU(VALID_EXECUTION_PAYLOAD_SET_SIZE);
 
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per discussion on Discord, if there is a single invalid signature when verifying new builder deposits, the whole batch verification would fail (let's say 8192 new builder deposits and only 1 invalid one would fail the whole batch). It's smarter to split into smaller sub-batches to handle this case better.

Also added small comments to `DefaultExecutionPayloadManager` regarding the pending pool with a reasoning.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus deposit processing for Gloas builder deposits and adjusts execution-payload pending cache sizing, which could affect block processing cost and memory under edge loads.
> 
> **Overview**
> **Gloas new builder deposits** are no longer BLS batch-verified in one shot. They are split into sub-batches of **256** (`Lists.partition`); each sub-batch is verified and applied separately so a single bad signature only forces per-signature fallback within that sub-batch, not across thousands of deposits.
> 
> **Execution payload caching** renames `VALID_EXECUTION_PAYLOADS_SET_SIZE` → `VALID_EXECUTION_PAYLOAD_SET_SIZE` and updates imports. `DefaultExecutionPayloadManager` sets the pending-payload map size to a fixed **64** (with comments that it matches the non-finalized slot window under healthy finality) instead of deriving it as `VALID_EXECUTION_PAYLOAD_SET_SIZE * 2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c0dd598a807dad75e99fad85529e64fcc2c3cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->