### PR TITLE
handle proposer preference with dependant root is new for checkpoint boundary

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -121,6 +121,12 @@ public class ProposerPreferencesGossipValidator {
     final int minSeedLookahead = spec.atSlot(proposalSlot).getConfig().getMinSeedLookahead();
     final UInt64 checkpointEpoch =
         spec.computeEpochAtSlot(proposalSlot).minusMinZero(minSeedLookahead);
+
+    /*
+     * Pre-flight the checkpoint-state precondition for the [REJECT] is_valid_proposal_slot rule below.
+     * A dependent root at or after the checkpoint boundary cannot be the root of the checkpoint state
+     * required by that rule.
+     */
     final UInt64 checkpointBoundarySlot = spec.computeStartSlotAtEpoch(checkpointEpoch);
     final Optional<UInt64> maybeDependentRootSlot =
         recentChainData.getSlotForBlockRoot(dependentRoot);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
+import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -120,6 +121,23 @@ public class ProposerPreferencesGossipValidator {
     final int minSeedLookahead = spec.atSlot(proposalSlot).getConfig().getMinSeedLookahead();
     final UInt64 checkpointEpoch =
         spec.computeEpochAtSlot(proposalSlot).minusMinZero(minSeedLookahead);
+    final UInt64 checkpointBoundarySlot = spec.computeStartSlotAtEpoch(checkpointEpoch);
+    final Optional<UInt64> maybeDependentRootSlot =
+        recentChainData.getSlotForBlockRoot(dependentRoot);
+    if (maybeDependentRootSlot.isPresent()) {
+      final UInt64 dependentRootSlot = maybeDependentRootSlot.get();
+      if (!dependentRootSlot.isLessThan(checkpointBoundarySlot)) {
+        LOG.trace(
+            "Proposer preferences dependent root {} is at slot {}, but must be before checkpoint boundary slot {}",
+            dependentRoot,
+            dependentRootSlot,
+            checkpointBoundarySlot);
+        return completedFuture(
+            reject(
+                "Proposer preferences dependent root %s is at slot %s, but must be before checkpoint boundary slot %s",
+                dependentRoot, dependentRootSlot, checkpointBoundarySlot));
+      }
+    }
     return recentChainData
         .retrieveCheckpointState(new Checkpoint(checkpointEpoch, dependentRoot))
         .thenApply(
@@ -134,7 +152,9 @@ public class ProposerPreferencesGossipValidator {
               final BeaconState state = maybeState.get();
 
               /*
-               * [REJECT] is_valid_proposal_slot(state, preferences) returns True
+               * [REJECT] is_valid_proposal_slot(state, preferences) returns True, where state is the checkpoint state
+               * at the epoch compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD
+               * and the root preferences.dependent_root.
                */
               final int slotsPerEpoch = spec.atSlot(proposalSlot).getConfig().getSlotsPerEpoch();
               final int lookaheadIndex =
@@ -166,6 +186,17 @@ public class ProposerPreferencesGossipValidator {
               }
 
               return ACCEPT;
+            })
+        .exceptionally(
+            error -> {
+              LOG.trace(
+                  "Unable to generate proposer preferences checkpoint state for checkpoint epoch {} and dependent root {}",
+                  checkpointEpoch,
+                  dependentRoot,
+                  error);
+              return reject(
+                  "Unable to generate proposer preferences checkpoint state for checkpoint epoch %s and dependent root %s",
+                  checkpointEpoch, dependentRoot);
             });
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
@@ -125,6 +125,45 @@ public class ProposerPreferencesGossipValidatorTest {
   }
 
   @TestTemplate
+  void shouldReject_whenDependentRootBlockIsNotBeforeCheckpointBoundary() {
+    final UInt64 checkpointBoundarySlot = getCheckpointBoundarySlot();
+    when(recentChainData.getSlotForBlockRoot(dependentRoot))
+        .thenReturn(Optional.of(checkpointBoundarySlot));
+
+    assertThatSafeFuture(validator.validate(signedProposerPreferences))
+        .isCompletedWithValueMatching(
+            result ->
+                result.isReject()
+                    && result
+                        .getDescription()
+                        .filter(
+                            description ->
+                                description.contains("but must be before checkpoint boundary slot"))
+                        .isPresent());
+    verify(recentChainData, never()).retrieveCheckpointState(any(Checkpoint.class));
+  }
+
+  @TestTemplate
+  void shouldReject_whenCheckpointStateRetrievalFails() {
+    when(recentChainData.retrieveCheckpointState(any(Checkpoint.class)))
+        .thenReturn(SafeFuture.failedFuture(new IllegalStateException("checkpoint state failed")));
+
+    assertThatSafeFuture(validator.validate(signedProposerPreferences))
+        .isCompletedWithValueMatching(
+            result ->
+                result.isReject()
+                    && result
+                        .getDescription()
+                        .filter(
+                            description ->
+                                description.contains(
+                                    "Unable to generate proposer preferences checkpoint state"))
+                        .isPresent());
+    verify(gossipValidationHelper, never())
+        .isSignatureValidWithRespectToProposerIndex(any(), any(), any(), any());
+  }
+
+  @TestTemplate
   void shouldIgnore_whenAlreadySeen() {
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
         .isCompletedWithValue(ACCEPT);
@@ -220,5 +259,11 @@ public class ProposerPreferencesGossipValidatorTest {
 
     return signedProposerPreferencesSchema.create(
         proposerPreferences, dataStructureUtil.randomSignature());
+  }
+
+  private UInt64 getCheckpointBoundarySlot() {
+    return spec.computeStartSlotAtEpoch(
+        spec.computeEpochAtSlot(proposalSlot)
+            .minusMinZero(spec.atSlot(proposalSlot).getConfig().getMinSeedLookahead()));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
@@ -126,7 +126,10 @@ public class ProposerPreferencesGossipValidatorTest {
 
   @TestTemplate
   void shouldReject_whenDependentRootBlockIsNotBeforeCheckpointBoundary() {
-    final UInt64 checkpointBoundarySlot = getCheckpointBoundarySlot();
+    final UInt64 checkpointBoundarySlot =
+        spec.computeStartSlotAtEpoch(
+            spec.computeEpochAtSlot(proposalSlot)
+                .minusMinZero(spec.atSlot(proposalSlot).getConfig().getMinSeedLookahead()));
     when(recentChainData.getSlotForBlockRoot(dependentRoot))
         .thenReturn(Optional.of(checkpointBoundarySlot));
 
@@ -259,11 +262,5 @@ public class ProposerPreferencesGossipValidatorTest {
 
     return signedProposerPreferencesSchema.create(
         proposerPreferences, dataStructureUtil.randomSignature());
-  }
-
-  private UInt64 getCheckpointBoundarySlot() {
-    return spec.computeStartSlotAtEpoch(
-        spec.computeEpochAtSlot(proposalSlot)
-            .minusMinZero(spec.atSlot(proposalSlot).getConfig().getMinSeedLookahead()));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Add  a check that rejects `ProposerPreference`s with `dependent_root` whose block slot is not before the computed checkpoint boundary slot.
This should prevent the original checkpoint state generation error. Any other checkpoint state retrieval failure is now rejected via `exceptionally`.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #10798 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which proposer preference gossip messages are accepted vs rejected on the network; incorrect boundary logic could drop valid messages or still admit invalid ones.
> 
> **Overview**
> Tightens **gossip validation** for signed **proposer preferences** so invalid `dependent_root` choices are rejected before checkpoint state work, and checkpoint retrieval failures are handled explicitly.
> 
> Before calling `retrieveCheckpointState`, the validator now checks whether the block for `dependent_root` sits **strictly before** the checkpoint boundary slot for `proposal_slot - MIN_SEED_LOOKAHEAD`. If the root is at or after that boundary, validation **rejects** immediately instead of attempting checkpoint state generation that could error (#10798).
> 
> Failures from `retrieveCheckpointState` are mapped via **`exceptionally`** to a **reject** (with trace logging) rather than leaving the future failed. Tests cover the boundary rejection path (no checkpoint lookup) and checkpoint retrieval failure (no signature check).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c89904c4e0db40263448de4e4bd02601c11c55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->