### PR TITLE
Forkchoice on attestation tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ Teku is an open-source Ethereum consensus client written in Java, implementing a
 # Run reference tests (consensus spec tests)
 ./gradlew referenceTest
 
+# Run one reference suite manually
+ENV_TEST_TYPE=fork_choice/on_attestation ENV_SPEC=minimal ENV_MILESTONE=gloas ./gradlew --no-daemon :eth-reference-tests:referenceTest --tests tech.pegasys.teku.reference.ManualReferenceTestRunner -x generateReferenceTestClasses
+
 # Run acceptance tests
 ./gradlew acceptanceTest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Teku is an open-source Ethereum consensus client written in Java, implementing a
 # Run reference tests (consensus spec tests)
 ./gradlew referenceTest
 
-# Run one reference suite manually
+# Run one reference suite manually (example)
 ENV_TEST_TYPE=fork_choice/on_attestation ENV_SPEC=minimal ENV_MILESTONE=gloas ./gradlew --no-daemon :eth-reference-tests:referenceTest --tests tech.pegasys.teku.reference.ManualReferenceTestRunner -x generateReferenceTestClasses
 
 # Run acceptance tests

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -228,8 +228,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
                     signatureVerifier,
                     gossipValidationHelper,
                     invalidBlockRoots,
-                    blockRootsWithInvalidExecutionPayload,
-                    recentChainData::containsExecutionPayload))
+                    blockRootsWithInvalidExecutionPayload))
             : Optional.empty();
 
     try {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -85,6 +85,7 @@ import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.ExecutionPayloadImportResult;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
 import tech.pegasys.teku.statetransition.datacolumns.DasCustodyStand;
@@ -217,14 +218,15 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
     final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
     final Set<Bytes32> blockRootsWithInvalidExecutionPayload = new HashSet<>();
+    final GossipValidationHelper gossipValidationHelper =
+        new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem());
     final Optional<AttestationValidator> maybeAttestationValidator =
         testDefinition.getTestType().equals("fork_choice/on_attestation")
             ? Optional.of(
                 new AttestationValidator(
                     spec,
                     signatureVerifier,
-                    new GossipValidationHelper(
-                        spec, recentChainData, storageSystem.getMetricsSystem()),
+                    gossipValidationHelper,
                     invalidBlockRoots,
                     blockRootsWithInvalidExecutionPayload,
                     recentChainData::containsExecutionPayload))
@@ -240,6 +242,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           forkChoice,
           executionLayer,
           maybeAttestationValidator,
+          gossipValidationHelper,
           invalidBlockRoots,
           blockRootsWithInvalidExecutionPayload);
     } catch (final AssertionError e) {
@@ -285,6 +288,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final ForkChoice forkChoice,
       final ExecutionLayerChannelStub executionLayer,
       final Optional<AttestationValidator> maybeAttestationValidator,
+      final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final Set<Bytes32> blockRootsWithInvalidExecutionPayload)
       throws IOException {
@@ -311,7 +315,14 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             invalidBlockRoots);
 
       } else if (step.containsKey("attestation")) {
-        applyAttestation(testDefinition, forkChoice, step, maybeAttestationValidator);
+        applyAttestation(
+            testDefinition,
+            recentChainData,
+            forkChoice,
+            step,
+            maybeAttestationValidator,
+            gossipValidationHelper,
+            blockRootsWithInvalidExecutionPayload);
 
       } else if (step.containsKey("pow_block")) {
         applyPowBlock(testDefinition, step, executionLayer);
@@ -383,9 +394,12 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
   private void applyAttestation(
       final TestDefinition testDefinition,
+      final RecentChainData recentChainData,
       final ForkChoice forkChoice,
       final Map<String, Object> step,
-      final Optional<AttestationValidator> maybeAttestationValidator) {
+      final Optional<AttestationValidator> maybeAttestationValidator,
+      final GossipValidationHelper gossipValidationHelper,
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload) {
     final String attestationName = get(step, "attestation");
     final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
     final Attestation attestation =
@@ -403,13 +417,35 @@ public class ForkChoiceTestExecutor implements TestExecutor {
               .validateSingleOrAggregateAttestation(validatableAttestation);
       assertThat(validationResult).isCompleted();
       final InternalValidationResult internalValidationResult = safeJoin(validationResult);
-      if (!internalValidationResult.isAccept()) {
+      // Reject/ignore gossip validation results do not reach fork choice in production.
+      if (internalValidationResult.isNotProcessable()) {
         assertThat(valid)
             .withFailMessage(
                 "Expected attestation to be valid but gossip validation returned %s",
                 internalValidationResult)
             .isFalse();
         return;
+      }
+      // SAVE_FOR_FUTURE normally still reaches fork choice. Re-check just the shared payload-status
+      // validation to identify Gloas payload-status failures that should stop before fork choice.
+      if (internalValidationResult.isSaveForFuture()) {
+        final AttestationUtil attestationUtil =
+            spec.atSlot(attestation.getData().getSlot()).getAttestationUtil();
+        final InternalValidationResult payloadStatusValidationResult =
+            gossipValidationHelper.validatePayloadStatus(
+                attestationUtil,
+                attestation.getData(),
+                blockRootsWithInvalidExecutionPayload,
+                recentChainData::containsExecutionPayload);
+        // A payload-status failure means the fixture's attestation is invalid before fork choice.
+        if (!payloadStatusValidationResult.isAccept()) {
+          assertThat(valid)
+              .withFailMessage(
+                  "Expected attestation to be valid but payload status validation returned %s",
+                  payloadStatusValidationResult)
+              .isFalse();
+          return;
+        }
       }
     }
     final SafeFuture<AttestationProcessingResult> result =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -27,9 +27,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -96,7 +99,9 @@ import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
 import tech.pegasys.teku.statetransition.payloadattestation.ValidatablePayloadAttestationMessage;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.util.RPCFetchDelayProvider;
+import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
 import tech.pegasys.teku.storage.client.ChainHead;
@@ -115,9 +120,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/ex_ante", new ForkChoiceTestExecutor())
           .put("fork_choice/reorg", new ForkChoiceTestExecutor())
           .put("fork_choice/on_block", new ForkChoiceTestExecutor())
-          .put(
-              "fork_choice/on_attestation",
-              IGNORE_TESTS) // TODO: https://github.com/Consensys/teku/issues/10773
+          .put("fork_choice/on_attestation", new ForkChoiceTestExecutor())
           .put("fork_choice/on_merge_block", IGNORE_TESTS) // TTD Logic is deprecated
           .put("fork_choice/withholding", new ForkChoiceTestExecutor())
           .put("sync/optimistic", new ForkChoiceTestExecutor())
@@ -192,6 +195,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     final StubDataColumnSidecarManager dataColumnSidecarManager =
         new StubDataColumnSidecarManager(spec, recentChainData, dasSampler);
     spec.reinitializeForTesting(blobSidecarManager, dataColumnSidecarManager, kzg);
+    final AsyncBLSSignatureVerifier signatureVerifier =
+        AsyncBLSSignatureVerifier.wrap(
+            blsDisabled ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE);
     final ForkChoice forkChoice =
         new ForkChoice(
             spec,
@@ -207,9 +213,22 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             LateBlockReorgPreparationHandler.NOOP,
             DebugDataDumper.NOOP,
             storageSystem.getMetricsSystem(),
-            AsyncBLSSignatureVerifier.wrap(
-                blsDisabled ? BLSSignatureVerifier.NOOP : BLSSignatureVerifier.SIMPLE));
+            signatureVerifier);
     final ExecutionLayerChannelStub executionLayer = new ExecutionLayerChannelStub(spec, false);
+    final Map<Bytes32, BlockImportResult> invalidBlockRoots = new HashMap<>();
+    final Set<Bytes32> blockRootsWithInvalidExecutionPayload = new HashSet<>();
+    final Optional<AttestationValidator> maybeAttestationValidator =
+        testDefinition.getTestType().equals("fork_choice/on_attestation")
+            ? Optional.of(
+                new AttestationValidator(
+                    spec,
+                    signatureVerifier,
+                    new GossipValidationHelper(
+                        spec, recentChainData, storageSystem.getMetricsSystem()),
+                    invalidBlockRoots,
+                    blockRootsWithInvalidExecutionPayload,
+                    recentChainData::containsExecutionPayload))
+            : Optional.empty();
 
     try {
       runSteps(
@@ -219,7 +238,10 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           blobSidecarManager,
           dataColumnSidecarManager,
           forkChoice,
-          executionLayer);
+          executionLayer,
+          maybeAttestationValidator,
+          invalidBlockRoots,
+          blockRootsWithInvalidExecutionPayload);
     } catch (final AssertionError e) {
       final String protoArrayData =
           recentChainData.getForkChoiceStrategy().orElseThrow().getBlockData().stream()
@@ -261,7 +283,10 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final StubBlobSidecarManager blobSidecarManager,
       final StubDataColumnSidecarManager dataColumnSidecarManager,
       final ForkChoice forkChoice,
-      final ExecutionLayerChannelStub executionLayer)
+      final ExecutionLayerChannelStub executionLayer,
+      final Optional<AttestationValidator> maybeAttestationValidator,
+      final Map<Bytes32, BlockImportResult> invalidBlockRoots,
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload)
       throws IOException {
     final List<Map<String, Object>> steps = loadSteps(testDefinition);
     for (Map<String, Object> step : steps) {
@@ -282,10 +307,11 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             dataColumnSidecarManager,
             forkChoice,
             step,
-            executionLayer);
+            executionLayer,
+            invalidBlockRoots);
 
       } else if (step.containsKey("attestation")) {
-        applyAttestation(testDefinition, forkChoice, step);
+        applyAttestation(testDefinition, forkChoice, step, maybeAttestationValidator);
 
       } else if (step.containsKey("pow_block")) {
         applyPowBlock(testDefinition, step, executionLayer);
@@ -301,7 +327,12 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         applyPayloadAttestation(testDefinition, spec, recentChainData, forkChoice, step);
 
       } else if (step.containsKey("execution_payload")) {
-        applyExecutionPayloadEnvelope(testDefinition, forkChoice, executionLayer, step);
+        applyExecutionPayloadEnvelope(
+            testDefinition,
+            forkChoice,
+            executionLayer,
+            step,
+            blockRootsWithInvalidExecutionPayload);
 
       } else {
         throw new UnsupportedOperationException("Unsupported step: " + step);
@@ -353,7 +384,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
   private void applyAttestation(
       final TestDefinition testDefinition,
       final ForkChoice forkChoice,
-      final Map<String, Object> step) {
+      final Map<String, Object> step,
+      final Optional<AttestationValidator> maybeAttestationValidator) {
     final String attestationName = get(step, "attestation");
     final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
     final Attestation attestation =
@@ -362,8 +394,26 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             attestationName + SSZ_SNAPPY_EXTENSION,
             testDefinition.getSpec().getGenesisSchemaDefinitions().getAttestationSchema());
     final Spec spec = testDefinition.getSpec();
+    final ValidatableAttestation validatableAttestation =
+        ValidatableAttestation.from(spec, attestation);
+    if (maybeAttestationValidator.isPresent()) {
+      final SafeFuture<InternalValidationResult> validationResult =
+          maybeAttestationValidator
+              .get()
+              .validateSingleOrAggregateAttestation(validatableAttestation);
+      assertThat(validationResult).isCompleted();
+      final InternalValidationResult internalValidationResult = safeJoin(validationResult);
+      if (!internalValidationResult.isAccept()) {
+        assertThat(valid)
+            .withFailMessage(
+                "Expected attestation to be valid but gossip validation returned %s",
+                internalValidationResult)
+            .isFalse();
+        return;
+      }
+    }
     final SafeFuture<AttestationProcessingResult> result =
-        forkChoice.onAttestation(ValidatableAttestation.from(spec, attestation));
+        forkChoice.onAttestation(validatableAttestation);
     assertThat(result).isCompleted();
     AttestationProcessingResult processingResult = safeJoin(result);
     assertThat(processingResult.isSuccessful())
@@ -433,7 +483,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final TestDefinition testDefinition,
       final ForkChoice forkChoice,
       final ExecutionLayerChannelStub executionLayer,
-      final Map<String, Object> step) {
+      final Map<String, Object> step,
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload) {
     final String envelopeName = get(step, "execution_payload");
     final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
     final SignedExecutionPayloadEnvelope envelope =
@@ -446,6 +497,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         forkChoice.onExecutionPayloadEnvelope(envelope, executionLayer);
     assertThat(result).isCompleted();
     final ExecutionPayloadImportResult importResult = safeJoin(result);
+    if (!importResult.isSuccessful() && isInvalidExecutionPayload(importResult)) {
+      blockRootsWithInvalidExecutionPayload.add(envelope.getBeaconBlockRoot());
+    }
     assertThat(importResult.isSuccessful())
         .withFailMessage(
             "Expected valid=%s but got isSuccessful=%s (reason: %s)",
@@ -461,7 +515,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final StubDataColumnSidecarManager dataColumnSidecarManager,
       final ForkChoice forkChoice,
       final Map<String, Object> step,
-      final ExecutionLayerChannelStub executionLayer) {
+      final ExecutionLayerChannelStub executionLayer,
+      final Map<Bytes32, BlockImportResult> invalidBlockRoots) {
     final String blockName = get(step, "block");
     final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
     final SignedBeaconBlock block =
@@ -520,6 +575,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         forkChoice.onBlock(block, Optional.empty(), BlockBroadcastValidator.NOOP, executionLayer);
     assertThat(result).isCompleted();
     final BlockImportResult importResult = safeJoin(result);
+    if (!importResult.isSuccessful()) {
+      invalidBlockRoots.put(block.getRoot(), importResult);
+    }
     assertThat(importResult)
         .describedAs("Incorrect block import result for block %s", block)
         .has(new Condition<>(r -> r.isSuccessful() == valid, "isSuccessful matching " + valid));
@@ -769,6 +827,17 @@ public class ForkChoiceTestExecutor implements TestExecutor {
   private static Optional<Bytes32> getOptionallyBytes32(
       final Map<String, Object> yamlData, final String key) {
     return ForkChoiceTestExecutor.<String>getOptionally(yamlData, key).map(Bytes32::fromHexString);
+  }
+
+  private static boolean isInvalidExecutionPayload(final ExecutionPayloadImportResult result) {
+    return switch (result.getFailureReason()) {
+      case FAILED_VERIFICATION, FAILED_DATA_AVAILABILITY_CHECK_INVALID -> true;
+      case UNKNOWN_BEACON_BLOCK_ROOT,
+          FAILED_EXECUTION,
+          FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
+          INTERNAL_ERROR ->
+          false;
+    };
   }
 
   private static ForkChoiceMetaData getMetaData(final TestDefinition testDefinition)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -316,7 +316,6 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       } else if (step.containsKey("attestation")) {
         applyAttestation(
             testDefinition,
-            recentChainData,
             forkChoice,
             step,
             maybeAttestationValidator,
@@ -393,7 +392,6 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
   private void applyAttestation(
       final TestDefinition testDefinition,
-      final RecentChainData recentChainData,
       final ForkChoice forkChoice,
       final Map<String, Object> step,
       final Optional<AttestationValidator> maybeAttestationValidator,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -52,7 +52,22 @@ public class AttestationValidator {
       final AsyncBLSSignatureVerifier signatureVerifier,
       final GossipValidationHelper gossipValidationHelper,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots) {
-    this(spec, signatureVerifier, gossipValidationHelper, invalidBlockRoots, Set.of(), __ -> true);
+    this(spec, signatureVerifier, gossipValidationHelper, invalidBlockRoots, Set.of());
+  }
+
+  public AttestationValidator(
+      final Spec spec,
+      final AsyncBLSSignatureVerifier signatureVerifier,
+      final GossipValidationHelper gossipValidationHelper,
+      final Map<Bytes32, BlockImportResult> invalidBlockRoots,
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload) {
+    this(
+        spec,
+        signatureVerifier,
+        gossipValidationHelper,
+        invalidBlockRoots,
+        blockRootsWithInvalidExecutionPayload,
+        gossipValidationHelper::containsExecutionPayload);
   }
 
   public AttestationValidator(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -143,7 +143,6 @@ public class AttestationValidator {
     }
 
     final AttestationUtil attestationUtil = spec.atSlot(data.getSlot()).getAttestationUtil();
-
     final AttestationValidationResult attestationIndexValidationResult =
         attestationUtil.validateCommitteeIndexValue(attestation.getData().getIndex());
     if (!attestationIndexValidationResult.isValid()) {
@@ -152,23 +151,26 @@ public class AttestationValidator {
               attestationIndexValidationResult.getReason().orElse("Invalid attestation data")));
     }
 
-    final AttestationValidationResult payloadStatusValidationResult =
-        attestationUtil.validatePayloadStatus(
+    final InternalValidationResult payloadStatusValidationResult =
+        gossipValidationHelper.validatePayloadStatus(
+            attestationUtil,
             attestation.getData(),
-            gossipValidationHelper.getSlotForBlockRoot(attestation.getData().getBeaconBlockRoot()));
-    if (!payloadStatusValidationResult.isValid()) {
+            blockRootsWithInvalidExecutionPayload,
+            executionPayloadSeenForFullPayloadAttestation);
+    if (payloadStatusValidationResult.isReject()) {
       return SafeFuture.completedFuture(
           InternalValidationResultWithState.reject(
-              payloadStatusValidationResult.getReason().orElse("Invalid payload status")));
+              payloadStatusValidationResult.getDescription().orElse("Invalid payload status")));
+    }
+    if (payloadStatusValidationResult.isSaveForFuture()) {
+      return completedFuture(InternalValidationResultWithState.saveForFuture());
     }
 
     final Optional<SlotInclusionGossipValidationResult> slotInclusionGossipValidationResult =
-        spec.atSlot(data.getSlot())
-            .getAttestationUtil()
-            .performSlotInclusionGossipValidation(
-                attestation,
-                gossipValidationHelper.getGenesisTime(),
-                gossipValidationHelper.getCurrentTimeMillis());
+        attestationUtil.performSlotInclusionGossipValidation(
+            attestation,
+            gossipValidationHelper.getGenesisTime(),
+            gossipValidationHelper.getCurrentTimeMillis());
 
     if (slotInclusionGossipValidationResult.isPresent()) {
       return switch (slotInclusionGossipValidationResult.get()) {
@@ -191,20 +193,6 @@ public class AttestationValidator {
     // If it's not in the store, it may not have been processed yet so save for future.
     if (!gossipValidationHelper.isBlockAvailable(data.getBeaconBlockRoot())) {
       return completedFuture(InternalValidationResultWithState.saveForFuture());
-    }
-
-    final Bytes32 blockRoot = data.getBeaconBlockRoot();
-    if (spec.atSlot(data.getSlot()).getForkChoiceUtil().getFullPayloadVoteHint(data.getIndex())) {
-      // [REJECT] If index == 1, the execution payload for block passes validation.
-      if (blockRootsWithInvalidExecutionPayload.contains(blockRoot)) {
-        return completedFuture(
-            InternalValidationResultWithState.reject(
-                "Execution payload for full payload attestation is invalid"));
-      }
-      // [IGNORE] If index == 1, the execution payload for block has been seen.
-      if (!executionPayloadSeenForFullPayloadAttestation.test(blockRoot)) {
-        return completedFuture(InternalValidationResultWithState.saveForFuture());
-      }
     }
 
     return gossipValidationHelper

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -82,6 +82,15 @@ public class AttestationValidator {
       return completedFuture(internalValidationResult);
     }
 
+    return validateSingleOrAggregateAttestation(validatableAttestation);
+  }
+
+  /** Runs checks shared by unaggregated and aggregate attestations, excluding envelope checks. */
+  public SafeFuture<InternalValidationResult> validateSingleOrAggregateAttestation(
+      final ValidatableAttestation validatableAttestation) {
+    if (validatableAttestation.isAcceptedAsGossip()) {
+      return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
+    }
     return singleOrAggregateAttestationChecks(
             signatureVerifier, validatableAttestation, validatableAttestation.getReceivedSubnetId())
         .thenApply(InternalValidationResultWithState::getResult)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -220,6 +220,10 @@ public class GossipValidationHelper {
     return recentChainData.containsBlock(blockRoot);
   }
 
+  public boolean containsExecutionPayload(final Bytes32 blockRoot) {
+    return recentChainData.containsExecutionPayload(blockRoot);
+  }
+
   int getMaxOffsetTimeInMillis() {
     return maxOffsetTimeInMillis;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -17,6 +17,8 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -33,6 +35,8 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
@@ -179,6 +183,39 @@ public class GossipValidationHelper {
     return recentChainData.getSlotForBlockRoot(blockRoot);
   }
 
+  public InternalValidationResult validatePayloadStatus(
+      final AttestationUtil attestationUtil,
+      final AttestationData attestationData,
+      final Set<Bytes32> blockRootsWithInvalidExecutionPayload,
+      final Predicate<Bytes32> executionPayloadSeenForFullPayloadAttestation) {
+    final AttestationValidationResult payloadStatusValidationResult =
+        attestationUtil.validatePayloadStatus(
+            attestationData, getSlotForBlockRoot(attestationData.getBeaconBlockRoot()));
+    // [REJECT] attestation.data.index == 0 if block.slot == attestation.data.slot.
+    if (!payloadStatusValidationResult.isValid()) {
+      return reject(payloadStatusValidationResult.getReason().orElse("Invalid payload status"));
+    }
+
+    final Bytes32 blockRoot = attestationData.getBeaconBlockRoot();
+    if (spec.atSlot(attestationData.getSlot())
+        .getForkChoiceUtil()
+        .getFullPayloadVoteHint(attestationData.getIndex())) {
+      // [REJECT] If attestation.data.index == 1 (payload present for a past block), the execution
+      // payload for block passes validation.
+      if (blockRootsWithInvalidExecutionPayload.contains(blockRoot)) {
+        return InternalValidationResult.reject(
+            "Execution payload for full payload attestation is invalid");
+      }
+      // [IGNORE] When attestation.data.index == 1 (payload present for a past block), the execution
+      // payload for block has been seen.
+      if (!executionPayloadSeenForFullPayloadAttestation.test(blockRoot)) {
+        return InternalValidationResult.SAVE_FOR_FUTURE;
+      }
+    }
+
+    return InternalValidationResult.ACCEPT;
+  }
+
   public boolean isBlockAvailable(final Bytes32 blockRoot) {
     return recentChainData.containsBlock(blockRoot);
   }
@@ -259,5 +296,9 @@ public class GossipValidationHelper {
         .getExecutionPayloadIfAvailable(blockRoot)
         .map(SignedExecutionPayloadEnvelope::getMessage)
         .map(envelope -> envelope.getPayload().getGasLimit());
+  }
+
+  private static InternalValidationResult reject(final String reason) {
+    return InternalValidationResult.create(ValidationResultCode.REJECT, reason);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GloasAttestationValidatorTest.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.statetransition.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
@@ -27,6 +27,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -236,12 +237,14 @@ public class GloasAttestationValidatorTest extends ElectraAttestationValidatorTe
 
   private GossipValidationHelper mockGossipValidationForFullPayloadRule(
       final Attestation attestation, final Bytes32 blockRoot) {
-    final GossipValidationHelper gossipValidationHelper = mock(GossipValidationHelper.class);
-    when(gossipValidationHelper.getSlotForBlockRoot(blockRoot)).thenReturn(Optional.of(ZERO));
-    when(gossipValidationHelper.getGenesisTime()).thenReturn(ZERO);
-    when(gossipValidationHelper.getCurrentTimeMillis())
-        .thenReturn(spec.computeTimeMillisAtSlot(attestation.getData().getSlot(), ZERO));
-    when(gossipValidationHelper.isBlockAvailable(blockRoot)).thenReturn(true);
+    final GossipValidationHelper gossipValidationHelper =
+        spy(new GossipValidationHelper(spec, recentChainData, new StubMetricsSystem()));
+    doReturn(Optional.of(ZERO)).when(gossipValidationHelper).getSlotForBlockRoot(blockRoot);
+    doReturn(ZERO).when(gossipValidationHelper).getGenesisTime();
+    doReturn(spec.computeTimeMillisAtSlot(attestation.getData().getSlot(), ZERO))
+        .when(gossipValidationHelper)
+        .getCurrentTimeMillis();
+    doReturn(true).when(gossipValidationHelper).isBlockAvailable(blockRoot);
     return gossipValidationHelper;
   }
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -16297,7 +16297,9 @@
 - name: verify_data_column_sidecar_kzg_proofs#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
-      search: public boolean verifyDataColumnSidecarKzgProofs(
+      search: |-
+        public boolean verifyDataColumnSidecarKzgProofs(
+              final DataColumnSidecar dataColumnSidecar, final SszList<SszKZGCommitment> kzgCommitments)
   spec: |
     <spec fn="verify_data_column_sidecar_kzg_proofs" fork="fulu" hash="1cd21395">
     def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -16297,9 +16297,8 @@
 - name: verify_data_column_sidecar_kzg_proofs#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
-      search: |-
-        public boolean verifyDataColumnSidecarKzgProofs(
-              final DataColumnSidecar dataColumnSidecar, final SszList<SszKZGCommitment> kzgCommitments)
+      search: public boolean verifyDataColumnSidecarKzgProofs\(\s*final DataColumnSidecar dataColumnSidecar, final SszList<SszKZGCommitment> kzgCommitments\) \{
+      regex: true
   spec: |
     <spec fn="verify_data_column_sidecar_kzg_proofs" fork="fulu" hash="1cd21395">
     def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -15401,6 +15401,8 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public AttestationProcessingResult validateOnAttestation(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+      search: public InternalValidationResult validatePayloadStatus(
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
       search: public AttestationValidationResult validateCommitteeIndexValue(
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Part of alpha.9 #10773
https://github.com/ethereum/consensus-specs/pull/5275

Though we have double check for `isAcceptedAsGossip()` in prod, it's cheap boolean check or it will be completely gone on compilation (i bet 99.9% on this). Everything else looks ok to me.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to reference test wiring and a small refactor that exposes existing validation logic; production `validate()` behavior is unchanged.
> 
> **Overview**
> Enables **`fork_choice/on_attestation`** Ethereum reference tests in `ForkChoiceTestExecutor` (they were previously ignored) and drives attestation steps through production-style gossip validation before `forkChoice.onAttestation`.
> 
> For **`fork_choice/on_attestation`** only, the executor builds an `AttestationValidator` with shared state: failed block imports are recorded in `invalidBlockRoots`, and execution payload import failures classified as invalid are tracked in `blockRootsWithInvalidExecutionPayload`. Attestation steps call **`validateSingleOrAggregateAttestation`** first; rejections must align with the step’s `valid` flag, and fork choice is skipped when gossip validation does not accept.
> 
> `AttestationValidator` exposes **`validateSingleOrAggregateAttestation`** as a public entry point (shared single/aggregate checks without the single-attestation envelope path); **`validate()`** delegates to it after `singleAttestationChecks`, preserving existing production flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5b1481cab07dc349d0d2efb7ba5426407a3b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->