### PR TITLE
Add containers for Staked Builder API

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
@@ -23,6 +23,9 @@ public interface SpecConfigGloas extends SpecConfigFulu, NetworkingSpecConfigGlo
   UInt64 BUILDER_INDEX_SELF_BUILD = UInt64.MAX_VALUE;
   UInt64 BUILDER_PAYMENT_THRESHOLD_NUMERATOR = UInt64.valueOf(6);
   UInt64 BUILDER_PAYMENT_THRESHOLD_DENOMINATOR = UInt64.valueOf(10);
+  // builder-specs
+  UInt64 MAX_EXECUTION_PAYMENT = UInt64.MAX_VALUE; // 2**64 - 1
+  long MAX_DATA_SIZE = 4096;
 
   static SpecConfigGloas required(final SpecConfig specConfig) {
     return specConfig

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -41,4 +41,7 @@ public class Domain {
 
   // Heze
   public static final Bytes4 INCLUSION_LIST_COMMITTEE = Bytes4.fromHexString("0x0E000000");
+
+  // builder-specs
+  public static final Bytes4 REQUEST_AUTH = Bytes4.fromHexString("0x0B000001");
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistration.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistration.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 
 public class ValidatorRegistration
     extends Container4<ValidatorRegistration, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
-  public static final ValidatorRegistrationSchema SSZ_SCHEMA = new ValidatorRegistrationSchema();
 
   protected ValidatorRegistration(
       final ValidatorRegistrationSchema schema, final TreeNode backingNode) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferences.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferences.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container1;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class BuilderPreferences extends Container1<BuilderPreferences, SszUInt64> {
+
+  protected BuilderPreferences(
+      final BuilderPreferencesSchema schema, final UInt64 maxExecutionPayment) {
+    super(schema, SszUInt64.of(maxExecutionPayment));
+  }
+
+  protected BuilderPreferences(final BuilderPreferencesSchema schema, final TreeNode backingTree) {
+    super(schema, backingTree);
+  }
+
+  public UInt64 getMaxExecutionPayment() {
+    return getField0().get();
+  }
+
+  @Override
+  public BuilderPreferencesSchema getSchema() {
+    return (BuilderPreferencesSchema) super.getSchema();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class BuilderPreferencesRequest
+    extends Container2<BuilderPreferencesRequest, BuilderPreferences, SignedRequestAuth> {
+
+  BuilderPreferencesRequest(
+      final BuilderPreferencesRequestSchema schema,
+      final BuilderPreferences preferences,
+      final SignedRequestAuth auth) {
+    super(schema, preferences, auth);
+  }
+
+  BuilderPreferencesRequest(
+      final BuilderPreferencesRequestSchema schema, final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  public BuilderPreferences getPreferences() {
+    return getField0();
+  }
+
+  public SignedRequestAuth getAuth() {
+    return getField1();
+  }
+
+  @Override
+  public BuilderPreferencesRequestSchema getSchema() {
+    return (BuilderPreferencesRequestSchema) super.getSchema();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestSchema.java
@@ -23,7 +23,7 @@ public class BuilderPreferencesRequestSchema
       final BuilderPreferencesSchema builderPreferencesSchema,
       final SignedRequestAuthSchema signedRequestAuthSchema) {
     super(
-        "BuilderPreferencesRequest",
+        "BuilderPreferencesRequestV1",
         namedSchema("preferences", builderPreferencesSchema),
         namedSchema("auth", signedRequestAuthSchema));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestSchema.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class BuilderPreferencesRequestSchema
+    extends ContainerSchema2<BuilderPreferencesRequest, BuilderPreferences, SignedRequestAuth> {
+
+  public BuilderPreferencesRequestSchema(
+      final BuilderPreferencesSchema builderPreferencesSchema,
+      final SignedRequestAuthSchema signedRequestAuthSchema) {
+    super(
+        "BuilderPreferencesRequest",
+        namedSchema("preferences", builderPreferencesSchema),
+        namedSchema("auth", signedRequestAuthSchema));
+  }
+
+  public BuilderPreferencesRequest create(
+      final BuilderPreferences preferences, final SignedRequestAuth auth) {
+    return new BuilderPreferencesRequest(this, preferences, auth);
+  }
+
+  @Override
+  public BuilderPreferencesRequest createFromBackingNode(final TreeNode node) {
+    return new BuilderPreferencesRequest(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesSchema.java
@@ -23,7 +23,7 @@ public class BuilderPreferencesSchema extends ContainerSchema1<BuilderPreference
 
   public BuilderPreferencesSchema() {
     super(
-        "BuilderPreferences",
+        "BuilderPreferencesV1",
         namedSchema("max_execution_payment", SszPrimitiveSchemas.UINT64_SCHEMA));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesSchema.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema1;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class BuilderPreferencesSchema extends ContainerSchema1<BuilderPreferences, SszUInt64> {
+
+  public BuilderPreferencesSchema() {
+    super(
+        "BuilderPreferences",
+        namedSchema("max_execution_payment", SszPrimitiveSchemas.UINT64_SCHEMA));
+  }
+
+  public BuilderPreferences create(final UInt64 maxExecutionPayment) {
+    return new BuilderPreferences(this, maxExecutionPayment);
+  }
+
+  @Override
+  public BuilderPreferences createFromBackingNode(final TreeNode node) {
+    return new BuilderPreferences(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuth.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuth.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class RequestAuth extends Container2<RequestAuth, SszByteList, SszUInt64> {
+
+  protected RequestAuth(final RequestAuthSchema schema, final SszByteList data, final UInt64 slot) {
+    super(schema, data, SszUInt64.of(slot));
+  }
+
+  protected RequestAuth(final RequestAuthSchema schema, final TreeNode backingTree) {
+    super(schema, backingTree);
+  }
+
+  public SszByteList getData() {
+    return getField0();
+  }
+
+  public UInt64 getSlot() {
+    return getField1().get();
+  }
+
+  @Override
+  public RequestAuthSchema getSchema() {
+    return (RequestAuthSchema) super.getSchema();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuthSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuthSchema.java
@@ -26,7 +26,7 @@ public class RequestAuthSchema extends ContainerSchema2<RequestAuth, SszByteList
 
   public RequestAuthSchema(final long maxDataSize) {
     super(
-        "RequestAuth",
+        "RequestAuthV1",
         namedSchema("data", SszByteListSchema.create(maxDataSize)),
         namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuthSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuthSchema.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class RequestAuthSchema extends ContainerSchema2<RequestAuth, SszByteList, SszUInt64> {
+
+  public RequestAuthSchema(final long maxDataSize) {
+    super(
+        "RequestAuth",
+        namedSchema("data", SszByteListSchema.create(maxDataSize)),
+        namedSchema("slot", SszPrimitiveSchemas.UINT64_SCHEMA));
+  }
+
+  public RequestAuth create(final Bytes data, final UInt64 slot) {
+    return new RequestAuth(this, getDataSchema().fromBytes(data), slot);
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszByteListSchema<?> getDataSchema() {
+    return (SszByteListSchema<?>) getFieldSchema0();
+  }
+
+  @Override
+  public RequestAuth createFromBackingNode(final TreeNode node) {
+    return new RequestAuth(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuth.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuth.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class SignedRequestAuth extends Container2<SignedRequestAuth, RequestAuth, SszSignature> {
+
+  SignedRequestAuth(
+      final SignedRequestAuthSchema schema,
+      final RequestAuth message,
+      final BLSSignature signature) {
+    super(schema, message, new SszSignature(signature));
+  }
+
+  SignedRequestAuth(final SignedRequestAuthSchema schema, final TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  public RequestAuth getMessage() {
+    return getField0();
+  }
+
+  public BLSSignature getSignature() {
+    return getField1().getSignature();
+  }
+
+  @Override
+  public SignedRequestAuthSchema getSchema() {
+    return (SignedRequestAuthSchema) super.getSchema();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuthSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuthSchema.java
@@ -24,7 +24,7 @@ public class SignedRequestAuthSchema
 
   public SignedRequestAuthSchema(final RequestAuthSchema requestAuthSchema) {
     super(
-        "SignedRequestAuth",
+        "SignedRequestAuthV1",
         namedSchema("message", requestAuthSchema),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuthSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuthSchema.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+
+public class SignedRequestAuthSchema
+    extends ContainerSchema2<SignedRequestAuth, RequestAuth, SszSignature> {
+
+  public SignedRequestAuthSchema(final RequestAuthSchema requestAuthSchema) {
+    super(
+        "SignedRequestAuth",
+        namedSchema("message", requestAuthSchema),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  public SignedRequestAuth create(final RequestAuth message, final BLSSignature signature) {
+    return new SignedRequestAuth(this, message, signature);
+  }
+
+  @Override
+  public SignedRequestAuth createFromBackingNode(final TreeNode node) {
+    return new SignedRequestAuth(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
@@ -13,9 +13,14 @@
 
 package tech.pegasys.teku.spec.schemas;
 
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistrationsSchema;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferencesRequestSchema;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferencesSchema;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.RequestAuthSchema;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedRequestAuthSchema;
 
 public class ApiSchemas {
 
@@ -30,4 +35,17 @@ public class ApiSchemas {
   public static final SignedValidatorRegistrationsSchema SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA =
       new SignedValidatorRegistrationsSchema(
           SIGNED_VALIDATOR_REGISTRATION_SCHEMA, MAX_VALIDATOR_REGISTRATIONS_SIZE);
+
+  // https://github.com/ethereum/builder-specs/blob/main/specs/gloas/validator.md#new-containers
+  public static final RequestAuthSchema REQUEST_AUTH_SCHEMA =
+      new RequestAuthSchema(SpecConfigGloas.MAX_DATA_SIZE);
+
+  public static final SignedRequestAuthSchema SIGNED_REQUEST_AUTH_SCHEMA =
+      new SignedRequestAuthSchema(REQUEST_AUTH_SCHEMA);
+
+  public static final BuilderPreferencesSchema BUILDER_PREFERENCES_SCHEMA =
+      new BuilderPreferencesSchema();
+
+  public static final BuilderPreferencesRequestSchema BUILDER_PREFERENCES_REQUEST_SCHEMA =
+      new BuilderPreferencesRequestSchema(BUILDER_PREFERENCES_SCHEMA, SIGNED_REQUEST_AUTH_SCHEMA);
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesPropertyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.BuilderPreferencesSupplier;
+
+public class BuilderPreferencesPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll(supplier = BuilderPreferencesSupplier.class)
+          final BuilderPreferences builderPreferences)
+      throws JsonProcessingException {
+    assertRoundTrip(builderPreferences);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BuilderPreferencesSupplier.class)
+          final BuilderPreferences builderPreferences,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(builderPreferences, seed);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/BuilderPreferencesRequestPropertyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.BuilderPreferencesRequestSupplier;
+
+public class BuilderPreferencesRequestPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll(supplier = BuilderPreferencesRequestSupplier.class)
+          final BuilderPreferencesRequest builderPreferencesRequest)
+      throws JsonProcessingException {
+    assertRoundTrip(builderPreferencesRequest);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BuilderPreferencesRequestSupplier.class)
+          final BuilderPreferencesRequest builderPreferencesRequest,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(builderPreferencesRequest, seed);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuthPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/RequestAuthPropertyTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.RequestAuthSupplier;
+
+public class RequestAuthPropertyTest {
+  @Property
+  void roundTrip(@ForAll(supplier = RequestAuthSupplier.class) final RequestAuth requestAuth)
+      throws JsonProcessingException {
+    assertRoundTrip(requestAuth);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = RequestAuthSupplier.class) final RequestAuth requestAuth,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(requestAuth, seed);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuthPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/versions/gloas/SignedRequestAuthPropertyTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder.versions.gloas;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas.SignedRequestAuthSupplier;
+
+public class SignedRequestAuthPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll(supplier = SignedRequestAuthSupplier.class) final SignedRequestAuth signedRequestAuth)
+      throws JsonProcessingException {
+    assertRoundTrip(signedRequestAuth);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedRequestAuthSupplier.class) final SignedRequestAuth signedRequestAuth,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedRequestAuth, seed);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/BuilderPreferencesRequestSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/BuilderPreferencesRequestSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferencesRequest;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BuilderPreferencesRequestSupplier
+    extends DataStructureUtilSupplier<BuilderPreferencesRequest> {
+  public BuilderPreferencesRequestSupplier() {
+    super(DataStructureUtil::randomBuilderPreferencesRequest, SpecMilestone.GLOAS);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/BuilderPreferencesSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/BuilderPreferencesSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferences;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BuilderPreferencesSupplier extends DataStructureUtilSupplier<BuilderPreferences> {
+  public BuilderPreferencesSupplier() {
+    super(DataStructureUtil::randomBuilderPreferences, SpecMilestone.GLOAS);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/RequestAuthSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/RequestAuthSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.RequestAuth;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class RequestAuthSupplier extends DataStructureUtilSupplier<RequestAuth> {
+  public RequestAuthSupplier() {
+    super(DataStructureUtil::randomRequestAuth, SpecMilestone.GLOAS);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/SignedRequestAuthSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/builder/versions/gloas/SignedRequestAuthSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.builder.versions.gloas;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedRequestAuth;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedRequestAuthSupplier extends DataStructureUtilSupplier<SignedRequestAuth> {
+  public SignedRequestAuthSupplier() {
+    super(DataStructureUtil::randomSignedRequestAuth, SpecMilestone.GLOAS);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -20,6 +20,10 @@ import static tech.pegasys.teku.ethereum.pow.api.DepositConstants.DEPOSIT_CONTRA
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.kzg.KZG.CELLS_PER_EXT_BLOB;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_PREFERENCES_REQUEST_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.BUILDER_PREFERENCES_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.REQUEST_AUTH_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_REQUEST_AUTH_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA;
@@ -136,6 +140,10 @@ import tech.pegasys.teku.spec.datastructures.builder.ExecutionPayloadAndBlobsBun
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferences;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.BuilderPreferencesRequest;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.RequestAuth;
+import tech.pegasys.teku.spec.datastructures.builder.versions.gloas.SignedRequestAuth;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
@@ -2045,6 +2053,24 @@ public final class DataStructureUtil {
   public SszList<SignedValidatorRegistration> randomSignedValidatorRegistrations(final int size) {
     return SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.createFromElements(
         IntStream.range(0, size).mapToObj(__ -> randomSignedValidatorRegistration()).toList());
+  }
+
+  public RequestAuth randomRequestAuth() {
+    return REQUEST_AUTH_SCHEMA.create(
+        randomBytes(randomPositiveInt((int) SpecConfigGloas.MAX_DATA_SIZE)), randomSlot());
+  }
+
+  public SignedRequestAuth randomSignedRequestAuth() {
+    return SIGNED_REQUEST_AUTH_SCHEMA.create(randomRequestAuth(), randomSignature());
+  }
+
+  public BuilderPreferences randomBuilderPreferences() {
+    return BUILDER_PREFERENCES_SCHEMA.create(randomUInt64());
+  }
+
+  public BuilderPreferencesRequest randomBuilderPreferencesRequest() {
+    return BUILDER_PREFERENCES_REQUEST_SCHEMA.create(
+        randomBuilderPreferences(), randomSignedRequestAuth());
   }
 
   public ForkChoiceState randomForkChoiceState(final boolean optimisticHead) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SigningRequestBody.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SigningRequestBody.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.schemas.ApiSchemas;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.validator.api.signer.AggregationSlotWrapper;
 import tech.pegasys.teku.validator.api.signer.BlockWrapper;
@@ -78,7 +79,7 @@ public record SigningRequestBody(Bytes signingRoot, SignType type, Map<String, O
             SigningRequestBody::getBlockWrapper)
         .withOptionalField(
             SignType.VALIDATOR_REGISTRATION.getName(),
-            ValidatorRegistration.SSZ_SCHEMA.getJsonTypeDefinition(),
+            ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA.getJsonTypeDefinition(),
             SigningRequestBody::getValidatorRegistration)
         .withOptionalField(
             SignType.CONTRIBUTION_AND_PROOF.getName(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/builder-specs/blob/main/specs/gloas/validator.md#new-containers

## Fixed Issue(s)
related to https://github.com/Consensys/teku/issues/10822

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive spec and test-only data structures with no consensus or networking behavior changes; the validator client change is a schema reference swap only.
> 
> **Overview**
> Adds **Gloas staked builder API** SSZ types from [builder-specs](https://github.com/ethereum/builder-specs/blob/main/specs/gloas/validator.md): `RequestAuth` / `SignedRequestAuth`, `BuilderPreferences`, and `BuilderPreferencesRequest` (preferences plus signed auth), with matching schemas under `builder/versions/gloas`.
> 
> **Spec wiring:** `SpecConfigGloas` gains `MAX_EXECUTION_PAYMENT` and `MAX_DATA_SIZE` (4096); `Domain` gains `REQUEST_AUTH` (`0x0B000001`). Shared instances are registered on `ApiSchemas` and used from `DataStructureUtil` for random test data.
> 
> **Tests / cleanup:** jqwik round-trip and mutation property tests with suppliers; `ValidatorRegistration` drops its inline `SSZ_SCHEMA` constant; external signer JSON for validator registration now uses `ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA` instead of the removed static schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5a50b03a26cbe554986c78e4c48e35949b2f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->