### PR TITLE
Alternative gloas sync fix

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubDataColumnSidecarManager.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubDataColumnSidecarManager.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.validation.DataColumnSidecarGossipValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
@@ -94,6 +95,8 @@ public class StubDataColumnSidecarManager implements AvailabilityCheckerFactory<
                     spec,
                     new ConcurrentHashMap<>(),
                     new GossipValidationHelper(spec, recentChainData, metricsSystem),
+                    new BlobKzgCommitmentsProvider(
+                        spec, recentChainData::retrieveSignedBlockByRoot, 128),
                     metricsSystem,
                     recentChainData.getStore());
             validationResult.complete(validateDataColumnSidecar());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/DataColumnSidecarUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/DataColumnSidecarUtil.java
@@ -77,6 +77,11 @@ public interface DataColumnSidecarUtil {
       DataColumnSidecar dataColumnSidecar,
       Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot);
 
+  SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
+      DataColumnSidecar dataColumnSidecar,
+      Function<Bytes32, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
+          retrieveBlobKzgCommitments);
+
   SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(
       DataColumnSidecar dataColumnSidecar,
       Spec spec,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/DataColumnSidecarUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/DataColumnSidecarUtil.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -73,13 +72,9 @@ public interface DataColumnSidecarUtil {
       Function<Bytes32, Optional<UInt64>> getBlockSlot,
       BiPredicate<UInt64, Bytes32> currentFinalizedCheckpointIsAncestorOfBlock);
 
-  SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofsWithBlock(
-      DataColumnSidecar dataColumnSidecar,
-      Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot);
-
   SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
       DataColumnSidecar dataColumnSidecar,
-      Function<Bytes32, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
+      Function<DataColumnSidecar, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
           retrieveBlobKzgCommitments);
 
   SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -289,7 +289,12 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
   }
 
   public boolean verifyDataColumnSidecarKzgProofs(final DataColumnSidecar dataColumnSidecar) {
+    return verifyDataColumnSidecarKzgProofs(
+        dataColumnSidecar, DataColumnSidecarFulu.required(dataColumnSidecar).getKzgCommitments());
+  }
 
+  public boolean verifyDataColumnSidecarKzgProofs(
+      final DataColumnSidecar dataColumnSidecar, final SszList<SszKZGCommitment> kzgCommitments) {
     final List<KZGCellWithColumnId> cellWithIds =
         IntStream.range(0, dataColumnSidecar.getColumn().size())
             .mapToObj(
@@ -300,9 +305,7 @@ public class MiscHelpersFulu extends MiscHelpersElectra {
             .collect(Collectors.toList());
     return getKzg()
         .verifyCellProofBatch(
-            DataColumnSidecarFulu.required(dataColumnSidecar).getKzgCommitments().stream()
-                .map(SszKZGCommitment::getKZGCommitment)
-                .toList(),
+            kzgCommitments.stream().map(SszKZGCommitment::getKZGCommitment).toList(),
             cellWithIds,
             dataColumnSidecar.getKzgProofs().stream().map(SszKZGProof::getKZGProof).toList());
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
@@ -354,6 +354,12 @@ public class DataColumnSidecarUtilFulu implements DataColumnSidecarUtil {
     }
   }
 
+  /**
+   * Fulu sidecars include the commitments and proofs required for KZG verification, so the external
+   * block-root commitments source is intentionally unused. This mirrors {@link
+   * #validateAndVerifyKzgProofsWithBlock(DataColumnSidecar, Function)}, where block retrieval is
+   * also unnecessary for Fulu KZG validation.
+   */
   @Override
   public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
       final DataColumnSidecar dataColumnSidecar,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
@@ -354,6 +354,15 @@ public class DataColumnSidecarUtilFulu implements DataColumnSidecarUtil {
     }
   }
 
+  @Override
+  public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
+      final DataColumnSidecar dataColumnSidecar,
+      final Function<Bytes32, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
+          retrieveBlobKzgCommitments) {
+    return validateAndVerifyKzgProofsWithBlock(
+        dataColumnSidecar, blockRoot -> SafeFuture.completedFuture(Optional.empty()));
+  }
+
   /**
    * Perform state-dependent validation for Fulu data column sidecars. Validates proposer
    * correctness and header signature by retrieving the parent block's post state. Implements the

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumnSidecarFulu;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -316,57 +315,28 @@ public class DataColumnSidecarUtilFulu implements DataColumnSidecarUtil {
     return Optional.of(proofInfo);
   }
 
-  /**
-   * Perform async KZG proof validation for Fulu data column sidecars.
-   *
-   * <p>Gossip rule:
-   *
-   * <ul>
-   *   <li>[REJECT] The sidecar's column data is valid as verified by
-   *       verify_data_column_sidecar_kzg_proofs(sidecar).
-   * </ul>
-   *
-   * <p>Note: In Fulu, the KZG commitments are embedded directly in the sidecar (via the inclusion
-   * proof), so block retrieval is not required. Structural verification of the sidecar (commitments
-   * count, cells count, etc.) is performed separately in {@link
-   * #verifyDataColumnSidecarStructure(DataColumnSidecar)}, which must be called before this method.
-   *
-   * @param dataColumnSidecar the data column sidecar to validate
-   * @param retrieveSignedBlockByRoot unused in Fulu — block retrieval is not needed since KZG
-   *     commitments are available directly from the sidecar
-   * @return SafeFuture with optional validation error. Empty means validation passed, present means
-   *     validation found an issue.
-   */
-  @Override
-  public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofsWithBlock(
-      final DataColumnSidecar dataColumnSidecar,
-      final Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot) {
-    try {
-      if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(dataColumnSidecar)) {
-        return SafeFuture.completedFuture(
-            Optional.of(
-                DataColumnSidecarValidationError.Critical.format(
-                    "Invalid DataColumnSidecar KZG Proofs")));
-      }
-      return SafeFuture.completedFuture(Optional.empty());
-    } catch (final Throwable t) {
-      return SafeFuture.failedFuture(t);
-    }
-  }
-
-  /**
-   * Fulu sidecars include the commitments and proofs required for KZG verification, so the external
-   * block-root commitments source is intentionally unused. This mirrors {@link
-   * #validateAndVerifyKzgProofsWithBlock(DataColumnSidecar, Function)}, where block retrieval is
-   * also unnecessary for Fulu KZG validation.
-   */
   @Override
   public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
       final DataColumnSidecar dataColumnSidecar,
-      final Function<Bytes32, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
+      final Function<DataColumnSidecar, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
           retrieveBlobKzgCommitments) {
-    return validateAndVerifyKzgProofsWithBlock(
-        dataColumnSidecar, blockRoot -> SafeFuture.completedFuture(Optional.empty()));
+    return retrieveBlobKzgCommitments
+        .apply(dataColumnSidecar)
+        .thenApply(
+            maybeBlobKzgCommitments -> {
+              if (maybeBlobKzgCommitments.isEmpty()) {
+                return Optional.of(
+                    DataColumnSidecarValidationError.BadTiming.format(
+                        "DataColumnSidecar's KZG commitments are unavailable"));
+              }
+              if (!miscHelpersFulu.verifyDataColumnSidecarKzgProofs(
+                  dataColumnSidecar, maybeBlobKzgCommitments.get())) {
+                return Optional.of(
+                    DataColumnSidecarValidationError.Critical.format(
+                        "Invalid DataColumnSidecar KZG Proofs"));
+              }
+              return Optional.empty();
+            });
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
@@ -348,6 +348,7 @@ public class MiscHelpersGloas extends MiscHelpersFulu {
    * @param kzgCommitments the KZG commitments from the execution payload bid
    * @return true if the KZG proofs are valid
    */
+  @Override
   public boolean verifyDataColumnSidecarKzgProofs(
       final DataColumnSidecar dataColumnSidecar, final SszList<SszKZGCommitment> kzgCommitments) {
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
@@ -243,24 +243,45 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
   public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofsWithBlock(
       final DataColumnSidecar dataColumnSidecar,
       final Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot) {
+    return validateAndVerifyKzgProofs(
+        dataColumnSidecar,
+        blockRoot ->
+            retrieveSignedBlockByRoot
+                .apply(blockRoot)
+                .thenApply(
+                    maybeSignedBeaconBlock ->
+                        maybeSignedBeaconBlock.flatMap(
+                            signedBeaconBlock ->
+                                signedBeaconBlock
+                                    .getMessage()
+                                    .getBody()
+                                    .getOptionalBlobKzgCommitments())));
+  }
+
+  @Override
+  public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
+      final DataColumnSidecar dataColumnSidecar,
+      final Function<Bytes32, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
+          retrieveBlobKzgCommitments) {
 
     final Bytes32 beaconBlockRoot = dataColumnSidecar.getBeaconBlockRoot();
 
-    return retrieveSignedBlockByRoot
+    return retrieveBlobKzgCommitments
         .apply(beaconBlockRoot)
         .thenApply(
-            maybeSignedBeaconBlock -> {
-              if (maybeSignedBeaconBlock.isEmpty()) {
+            maybeBlobKzgCommitments -> {
+              if (maybeBlobKzgCommitments.isEmpty()) {
                 return Optional.of(
                     DataColumnSidecarValidationError.BadTiming.format(
                         "DataColumnSidecar's beacon_block_root %s does not correspond to a known block",
                         beaconBlockRoot));
               }
-              final SignedBeaconBlock signedBeaconBlock = maybeSignedBeaconBlock.get();
+              final SszList<SszKZGCommitment> blobKzgCommitments =
+                  maybeBlobKzgCommitments.get();
               final Optional<DataColumnSidecarValidationError> maybeVerifyDataColumnSidecarResult =
-                  verifyDataColumnSidecar(dataColumnSidecar, signedBeaconBlock);
+                  verifyDataColumnSidecar(dataColumnSidecar, blobKzgCommitments);
               return maybeVerifyDataColumnSidecarResult.or(
-                  () -> verifyDataColumnSidecarKzgProofs(dataColumnSidecar, signedBeaconBlock));
+                  () -> verifyDataColumnSidecarKzgProofs(dataColumnSidecar, blobKzgCommitments));
             });
   }
 
@@ -293,13 +314,11 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
   }
 
   private Optional<DataColumnSidecarValidationError> verifyDataColumnSidecar(
-      final DataColumnSidecar dataColumnSidecar, final SignedBeaconBlock signedBeaconBlock) {
-    final SszList<SszKZGCommitment> bidKzgCommitments =
-        BeaconBlockBodyGloas.required(signedBeaconBlock.getMessage().getBody())
-            .getBlobKzgCommitments();
+      final DataColumnSidecar dataColumnSidecar,
+      final SszList<SszKZGCommitment> blobKzgCommitments) {
     final boolean validDataColumnSidecar =
         miscHelpersGloas.verifyDataColumnSidecarWithCommitments(
-            dataColumnSidecar, bidKzgCommitments);
+            dataColumnSidecar, blobKzgCommitments);
     if (!validDataColumnSidecar) {
       return Optional.of(
           DataColumnSidecarValidationError.Critical.format("Invalid DataColumnSidecar"));
@@ -308,12 +327,10 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
   }
 
   private Optional<DataColumnSidecarValidationError> verifyDataColumnSidecarKzgProofs(
-      final DataColumnSidecar dataColumnSidecar, final SignedBeaconBlock signedBeaconBlock) {
-    final SszList<SszKZGCommitment> bidKzgCommitments =
-        BeaconBlockBodyGloas.required(signedBeaconBlock.getMessage().getBody())
-            .getBlobKzgCommitments();
+      final DataColumnSidecar dataColumnSidecar,
+      final SszList<SszKZGCommitment> blobKzgCommitments) {
     final boolean validDataColumnSidecar =
-        miscHelpersGloas.verifyDataColumnSidecarKzgProofs(dataColumnSidecar, bidKzgCommitments);
+        miscHelpersGloas.verifyDataColumnSidecarKzgProofs(dataColumnSidecar, blobKzgCommitments);
     if (!validDataColumnSidecar) {
       return Optional.of(
           DataColumnSidecarValidationError.Critical.format(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -221,53 +220,16 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
     return Optional.empty();
   }
 
-  /**
-   * Perform async kzg commitments root validation for Gloas.
-   *
-   * <p>Gossip rules:
-   *
-   * <ul>
-   *   <li>[REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar,
-   *       bid.blob_kzg_commitments).
-   *   <li>[REJECT] The sidecar's column data is valid as verified by
-   *       verify_data_column_sidecar_kzg_proofs(sidecar, bid.blob_kzg_commitments).
-   * </ul>
-   *
-   * @param dataColumnSidecar the data column sidecar to validate
-   * @param retrieveSignedBlockByRoot function to retrieve full block by root (potentially
-   *     expensive)
-   * @return SafeFuture with optional validation result. Empty means validation passed, Present
-   *     means validation found an issue (invalid/save for future).
-   */
-  @Override
-  public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofsWithBlock(
-      final DataColumnSidecar dataColumnSidecar,
-      final Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveSignedBlockByRoot) {
-    return validateAndVerifyKzgProofs(
-        dataColumnSidecar,
-        blockRoot ->
-            retrieveSignedBlockByRoot
-                .apply(blockRoot)
-                .thenApply(
-                    maybeSignedBeaconBlock ->
-                        maybeSignedBeaconBlock.flatMap(
-                            signedBeaconBlock ->
-                                signedBeaconBlock
-                                    .getMessage()
-                                    .getBody()
-                                    .getOptionalBlobKzgCommitments())));
-  }
-
   @Override
   public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
       final DataColumnSidecar dataColumnSidecar,
-      final Function<Bytes32, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
+      final Function<DataColumnSidecar, SafeFuture<Optional<SszList<SszKZGCommitment>>>>
           retrieveBlobKzgCommitments) {
 
     final Bytes32 beaconBlockRoot = dataColumnSidecar.getBeaconBlockRoot();
 
     return retrieveBlobKzgCommitments
-        .apply(beaconBlockRoot)
+        .apply(dataColumnSidecar)
         .thenApply(
             maybeBlobKzgCommitments -> {
               if (maybeBlobKzgCommitments.isEmpty()) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/DataColumnSidecarUtilGloas.java
@@ -276,8 +276,7 @@ public class DataColumnSidecarUtilGloas implements DataColumnSidecarUtil {
                         "DataColumnSidecar's beacon_block_root %s does not correspond to a known block",
                         beaconBlockRoot));
               }
-              final SszList<SszKZGCommitment> blobKzgCommitments =
-                  maybeBlobKzgCommitments.get();
+              final SszList<SszKZGCommitment> blobKzgCommitments = maybeBlobKzgCommitments.get();
               final Optional<DataColumnSidecarValidationError> maybeVerifyDataColumnSidecarResult =
                   verifyDataColumnSidecar(dataColumnSidecar, blobKzgCommitments);
               return maybeVerifyDataColumnSidecarResult.or(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
@@ -117,6 +117,9 @@ public class BlobKzgCommitmentsProvider
   public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
     // Imported blocks may arrive from RPC or API outside DAS pre-sampling.
     onNewBlock(block);
+    // Keep this block's commitments for late-arriving sidecars. The parent root can be evicted
+    // once a child imports because its import-time data-column validation window has passed; store
+    // fallback still covers later historical/archive lookups.
     commitmentsByRoot.remove(block.getParentRoot());
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
@@ -82,6 +82,7 @@ public class BlobKzgCommitmentsProvider
 
   @Override
   public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
+    onNewBlock(block);
     commitmentsByRoot.remove(block.getParentRoot());
   }
 
@@ -96,6 +97,5 @@ public class BlobKzgCommitmentsProvider
     }
   }
 
-  private record BlobKzgCommitmentsEntry(
-      UInt64 slot, SszList<SszKZGCommitment> commitments) {}
+  private record BlobKzgCommitmentsEntry(UInt64 slot, SszList<SszKZGCommitment> commitments) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
@@ -30,6 +30,17 @@ import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
+/**
+ * Root-keyed source of blob KZG commitments for data column sidecar validation.
+ *
+ * <p>A beacon block root commits to the block body, and the body contains the {@code
+ * blob_kzg_commitments}; consequently a root to commitments entry is immutable and can be populated
+ * before full block import without conflict risk.
+ *
+ * <p>The cache is fed from DAS pre-sampling for forward sync batches, gossip block validation
+ * before import, RPC-fetched recent blocks before import, and successful block import for
+ * non-gossip/non-pre-sampled paths. Store lookup is retained as a fallback for cache misses.
+ */
 public class BlobKzgCommitmentsProvider
     implements ReceivedBlockEventsChannel, FinalizedCheckpointChannel {
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
@@ -15,14 +15,17 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
@@ -37,24 +40,32 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
  * blob_kzg_commitments}; consequently a root to commitments entry is immutable and can be populated
  * before full block import without conflict risk.
  *
- * <p>The cache is fed from DAS pre-sampling for forward sync batches, gossip block validation
- * before import, RPC-fetched recent blocks before import, and successful block import for
- * non-gossip/non-pre-sampled paths. Store lookup is retained as a fallback for cache misses.
+ * <p>When a data column sidecar already carries commitments, as in Fulu, those commitments are
+ * returned directly without caching. The cache is only a temporary pre-import source for forks
+ * where the sidecar omits commitments, as in Gloas. Store lookup is retained as a lazy fallback for
+ * cache misses.
  */
 public class BlobKzgCommitmentsProvider
     implements ReceivedBlockEventsChannel, FinalizedCheckpointChannel {
 
   private final Spec spec;
-  private final CombinedChainDataClient combinedChainDataClient;
+  private final Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveBlockByRoot;
   private final Map<Bytes32, BlobKzgCommitmentsEntry> commitmentsByRoot;
 
   public BlobKzgCommitmentsProvider(
       final Spec spec,
       final CombinedChainDataClient combinedChainDataClient,
       final int maxCacheSize) {
+    this(spec, combinedChainDataClient::getBlockByBlockRoot, maxCacheSize);
+  }
+
+  public BlobKzgCommitmentsProvider(
+      final Spec spec,
+      final Function<Bytes32, SafeFuture<Optional<SignedBeaconBlock>>> retrieveBlockByRoot,
+      final int maxCacheSize) {
     checkArgument(maxCacheSize > 0, "maxCacheSize must be positive");
     this.spec = spec;
-    this.combinedChainDataClient = combinedChainDataClient;
+    this.retrieveBlockByRoot = retrieveBlockByRoot;
     this.commitmentsByRoot = LimitedMap.createSynchronizedLRU(maxCacheSize);
   }
 
@@ -70,14 +81,23 @@ public class BlobKzgCommitmentsProvider
   }
 
   public SafeFuture<Optional<SszList<SszKZGCommitment>>> getBlobKzgCommitments(
+      final DataColumnSidecar dataColumnSidecar) {
+    return dataColumnSidecar
+        .getMaybeKzgCommitments()
+        .map(commitments -> SafeFuture.completedFuture(Optional.of(commitments)))
+        .orElseGet(() -> getBlobKzgCommitments(dataColumnSidecar.getBeaconBlockRoot()));
+  }
+
+  @VisibleForTesting
+  public SafeFuture<Optional<SszList<SszKZGCommitment>>> getBlobKzgCommitments(
       final Bytes32 blockRoot) {
     final BlobKzgCommitmentsEntry cachedEntry = commitmentsByRoot.get(blockRoot);
     if (cachedEntry != null) {
       return SafeFuture.completedFuture(Optional.of(cachedEntry.commitments()));
     }
 
-    return combinedChainDataClient
-        .getBlockByBlockRoot(blockRoot)
+    return retrieveBlockByRoot
+        .apply(blockRoot)
         .thenApply(
             maybeBlock -> {
               maybeBlock.ifPresent(this::onNewBlock);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProvider.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.LimitedMap;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
+import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class BlobKzgCommitmentsProvider
+    implements ReceivedBlockEventsChannel, FinalizedCheckpointChannel {
+
+  private final Spec spec;
+  private final CombinedChainDataClient combinedChainDataClient;
+  private final Map<Bytes32, BlobKzgCommitmentsEntry> commitmentsByRoot;
+
+  public BlobKzgCommitmentsProvider(
+      final Spec spec,
+      final CombinedChainDataClient combinedChainDataClient,
+      final int maxCacheSize) {
+    checkArgument(maxCacheSize > 0, "maxCacheSize must be positive");
+    this.spec = spec;
+    this.combinedChainDataClient = combinedChainDataClient;
+    this.commitmentsByRoot = LimitedMap.createSynchronizedLRU(maxCacheSize);
+  }
+
+  public void onNewBlock(final SignedBeaconBlock block) {
+    block
+        .getMessage()
+        .getBody()
+        .getOptionalBlobKzgCommitments()
+        .ifPresent(
+            commitments ->
+                commitmentsByRoot.put(
+                    block.getRoot(), new BlobKzgCommitmentsEntry(block.getSlot(), commitments)));
+  }
+
+  public SafeFuture<Optional<SszList<SszKZGCommitment>>> getBlobKzgCommitments(
+      final Bytes32 blockRoot) {
+    final BlobKzgCommitmentsEntry cachedEntry = commitmentsByRoot.get(blockRoot);
+    if (cachedEntry != null) {
+      return SafeFuture.completedFuture(Optional.of(cachedEntry.commitments()));
+    }
+
+    return combinedChainDataClient
+        .getBlockByBlockRoot(blockRoot)
+        .thenApply(
+            maybeBlock -> {
+              maybeBlock.ifPresent(this::onNewBlock);
+              return maybeBlock.flatMap(
+                  block -> block.getMessage().getBody().getOptionalBlobKzgCommitments());
+            });
+  }
+
+  @Override
+  public void onBlockValidated(final SignedBeaconBlock block) {
+    // Gossip validation does not guarantee that the block will become useful for DAS requests.
+  }
+
+  @Override
+  public void onBlockImported(final SignedBeaconBlock block, final boolean executionOptimistic) {
+    commitmentsByRoot.remove(block.getParentRoot());
+  }
+
+  @Override
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint checkpoint, final boolean fromOptimisticBlock) {
+    final UInt64 finalizedSlot = checkpoint.getEpochStartSlot(spec);
+    synchronized (commitmentsByRoot) {
+      commitmentsByRoot
+          .entrySet()
+          .removeIf(entry -> entry.getValue().slot().isLessThanOrEqualTo(finalizedSlot));
+    }
+  }
+
+  private record BlobKzgCommitmentsEntry(
+      UInt64 slot, SszList<SszKZGCommitment> commitments) {}
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySamp
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -51,25 +52,26 @@ public class DasPreSampler {
   }
 
   private boolean isSamplingRequired(final SignedBeaconBlock block) {
-    if (block == null) {
-      LOG.debug("SignedBeaconBlock was unexpectedly null");
-      return false;
-    }
     return sampler.checkSamplingEligibility(block.getMessage()) == REQUIRED;
   }
 
   public void onNewPreImportBlocks(final Collection<SignedBeaconBlock> blocks) {
-    blocks.stream().filter(block -> block != null).forEach(blobKzgCommitmentsProvider::onNewBlock);
+    final List<SignedBeaconBlock> nonNullBlocks = blocks.stream().filter(Objects::nonNull).toList();
+
+    // feed commitments provider first, including 0 blobs so that we can still check unexpected data
+    // columns for a 0 commitments block
+    nonNullBlocks.forEach(blobKzgCommitmentsProvider::onNewBlock);
 
     final List<SignedBeaconBlock> blocksToSample =
-        blocks.stream().filter(this::isSamplingRequired).toList();
+        nonNullBlocks.stream().filter(this::isSamplingRequired).toList();
 
     LOG.debug(
         "DasPreSampler: requesting pre-sample for {} (of {} received) blocks: {}",
-        blocksToSample.size(),
-        blocks.size(),
-        StringifyUtil.toIntRangeStringWithSize(
-            blocksToSample.stream().map(block -> block.getSlot().intValue()).toList()));
+        blocksToSample::size,
+        nonNullBlocks::size,
+        () ->
+            StringifyUtil.toIntRangeStringWithSize(
+                blocksToSample.stream().map(block -> block.getSlot().intValue()).toList()));
 
     blocksToSample.forEach(this::onNewPreImportBlock);
     sampler.flush();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
@@ -37,14 +37,17 @@ public class DasPreSampler {
   private final DataAvailabilitySampler sampler;
   private final DataColumnSidecarCustody custody;
   private final CustodyGroupCountManager custodyGroupCountManager;
+  private final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
 
   public DasPreSampler(
       final DataAvailabilitySampler sampler,
       final DataColumnSidecarCustody custody,
-      final CustodyGroupCountManager custodyGroupCountManager) {
+      final CustodyGroupCountManager custodyGroupCountManager,
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
     this.sampler = sampler;
     this.custody = custody;
     this.custodyGroupCountManager = custodyGroupCountManager;
+    this.blobKzgCommitmentsProvider = blobKzgCommitmentsProvider;
   }
 
   private boolean isSamplingRequired(final SignedBeaconBlock block) {
@@ -56,6 +59,8 @@ public class DasPreSampler {
   }
 
   public void onNewPreImportBlocks(final Collection<SignedBeaconBlock> blocks) {
+    blocks.stream().filter(block -> block != null).forEach(blobKzgCommitmentsProvider::onNewBlock);
+
     final List<SignedBeaconBlock> blocksToSample =
         blocks.stream().filter(this::isSamplingRequired).toList();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarTrackingKey;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil.InclusionProofInfo;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarValidationError;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 /**
  * Gossip validator for Data Column Sidecars supporting both Fulu and Gloas forks.
@@ -118,6 +119,7 @@ public class DataColumnSidecarGossipValidator {
   private final Set<InclusionProofInfo> validInclusionProofInfoSet;
   private final Set<Bytes32> validSignedBlockHeaders;
   private final GossipValidationHelper gossipValidationHelper;
+  private final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
   private final Counter totalDataColumnSidecarsProcessingRequestsCounter;
   private final Counter totalDataColumnSidecarsProcessingSuccessesCounter;
@@ -129,6 +131,7 @@ public class DataColumnSidecarGossipValidator {
       final Spec spec,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final GossipValidationHelper gossipValidationHelper,
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {
 
@@ -143,6 +146,7 @@ public class DataColumnSidecarGossipValidator {
         spec,
         invalidBlockRoots,
         gossipValidationHelper,
+        blobKzgCommitmentsProvider,
         metricsSystem,
         timeProvider,
         LimitedSet.createSynchronizedLRU(validInfoSize),
@@ -159,6 +163,7 @@ public class DataColumnSidecarGossipValidator {
       final Spec spec,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final GossipValidationHelper gossipValidationHelper,
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
       final Set<DataColumnSidecarTrackingKey> receivedValidDataColumnSidecarInfoSet,
@@ -167,6 +172,7 @@ public class DataColumnSidecarGossipValidator {
     this.spec = spec;
     this.invalidBlockRoots = invalidBlockRoots;
     this.gossipValidationHelper = gossipValidationHelper;
+    this.blobKzgCommitmentsProvider = blobKzgCommitmentsProvider;
     this.receivedValidDataColumnSidecarInfoSet = receivedValidDataColumnSidecarInfoSet;
     this.totalDataColumnSidecarsProcessingRequestsCounter =
         metricsSystem.createCounter(
@@ -321,8 +327,8 @@ public class DataColumnSidecarGossipValidator {
     final MetricsHistogram.Timer kzgVerificationTimer =
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer();
     return dataColumnSidecarUtil
-        .validateAndVerifyKzgProofsWithBlock(
-            dataColumnSidecar, gossipValidationHelper::retrieveSignedBlockByRoot)
+        .validateAndVerifyKzgProofs(
+            dataColumnSidecar, blobKzgCommitmentsProvider::getBlobKzgCommitments)
         .whenComplete((result, error) -> kzgVerificationTimer.closeUnchecked().run())
         .thenCompose(
             maybeKzgProofValidationResult -> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -119,7 +120,7 @@ public class DataColumnSidecarGossipValidator {
   private final Set<InclusionProofInfo> validInclusionProofInfoSet;
   private final Set<Bytes32> validSignedBlockHeaders;
   private final GossipValidationHelper gossipValidationHelper;
-  private final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
+  private final Supplier<BlobKzgCommitmentsProvider> blobKzgCommitmentsProviderSupplier;
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots;
   private final Counter totalDataColumnSidecarsProcessingRequestsCounter;
   private final Counter totalDataColumnSidecarsProcessingSuccessesCounter;
@@ -134,6 +135,22 @@ public class DataColumnSidecarGossipValidator {
       final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider) {
+    return create(
+        spec,
+        invalidBlockRoots,
+        gossipValidationHelper,
+        () -> blobKzgCommitmentsProvider,
+        metricsSystem,
+        timeProvider);
+  }
+
+  public static DataColumnSidecarGossipValidator create(
+      final Spec spec,
+      final Map<Bytes32, BlockImportResult> invalidBlockRoots,
+      final GossipValidationHelper gossipValidationHelper,
+      final Supplier<BlobKzgCommitmentsProvider> blobKzgCommitmentsProviderSupplier,
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider) {
 
     final Optional<Integer> maybeNumberOfColumns = spec.getNumberOfDataColumns();
 
@@ -146,7 +163,7 @@ public class DataColumnSidecarGossipValidator {
         spec,
         invalidBlockRoots,
         gossipValidationHelper,
-        blobKzgCommitmentsProvider,
+        blobKzgCommitmentsProviderSupplier,
         metricsSystem,
         timeProvider,
         LimitedSet.createSynchronizedLRU(validInfoSize),
@@ -163,7 +180,7 @@ public class DataColumnSidecarGossipValidator {
       final Spec spec,
       final Map<Bytes32, BlockImportResult> invalidBlockRoots,
       final GossipValidationHelper gossipValidationHelper,
-      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider,
+      final Supplier<BlobKzgCommitmentsProvider> blobKzgCommitmentsProviderSupplier,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
       final Set<DataColumnSidecarTrackingKey> receivedValidDataColumnSidecarInfoSet,
@@ -172,7 +189,7 @@ public class DataColumnSidecarGossipValidator {
     this.spec = spec;
     this.invalidBlockRoots = invalidBlockRoots;
     this.gossipValidationHelper = gossipValidationHelper;
-    this.blobKzgCommitmentsProvider = blobKzgCommitmentsProvider;
+    this.blobKzgCommitmentsProviderSupplier = blobKzgCommitmentsProviderSupplier;
     this.receivedValidDataColumnSidecarInfoSet = receivedValidDataColumnSidecarInfoSet;
     this.totalDataColumnSidecarsProcessingRequestsCounter =
         metricsSystem.createCounter(
@@ -328,7 +345,7 @@ public class DataColumnSidecarGossipValidator {
         dataColumnSidecarKzgBatchVerificationTimeSeconds.startTimer();
     return dataColumnSidecarUtil
         .validateAndVerifyKzgProofs(
-            dataColumnSidecar, blobKzgCommitmentsProvider::getBlobKzgCommitments)
+            dataColumnSidecar, blobKzgCommitmentsProviderSupplier.get()::getBlobKzgCommitments)
         .whenComplete((result, error) -> kzgVerificationTimer.closeUnchecked().run())
         .thenCompose(
             maybeKzgProofValidationResult -> {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProviderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProviderTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
@@ -108,17 +109,22 @@ class BlobKzgCommitmentsProviderTest {
   }
 
   @Test
-  void evictsParentRootWhenChildIsImported() {
+  void storesImportedBlockAndEvictsParentRoot() {
     final SignedBeaconBlock parent =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 1);
-    final SignedBeaconBlock importedChild = mock(SignedBeaconBlock.class);
-    when(importedChild.getParentRoot()).thenReturn(parent.getRoot());
+    final SignedBeaconBlock importedChild =
+        createBlockWithParentRoot(UInt64.valueOf(2), parent.getRoot(), 2);
+    final SszList<SszKZGCommitment> childCommitments =
+        importedChild.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
 
     provider.onNewBlock(parent);
     provider.onBlockImported(importedChild, false);
 
     assertThat(provider.getBlobKzgCommitments(parent.getRoot()).join()).isEmpty();
+    assertThat(provider.getBlobKzgCommitments(importedChild.getRoot()).join())
+        .contains(childCommitments);
     verify(combinedChainDataClient).getBlockByBlockRoot(parent.getRoot());
+    verify(combinedChainDataClient, never()).getBlockByBlockRoot(importedChild.getRoot());
   }
 
   @Test
@@ -168,5 +174,21 @@ class BlobKzgCommitmentsProviderTest {
     assertThat(provider.getBlobKzgCommitments(second.getRoot()).join()).isPresent();
     assertThat(provider.getBlobKzgCommitments(third.getRoot()).join()).isPresent();
     verify(combinedChainDataClient).getBlockByBlockRoot(first.getRoot());
+  }
+
+  private SignedBeaconBlock createBlockWithParentRoot(
+      final UInt64 slot, final Bytes32 parentRoot, final int commitmentCount) {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(slot, commitmentCount);
+    final BeaconBlock message = block.getMessage();
+    final BeaconBlock messageWithParentRoot =
+        new BeaconBlock(
+            message.getSchema(),
+            message.getSlot(),
+            message.getProposerIndex(),
+            parentRoot,
+            message.getStateRoot(),
+            message.getBody());
+    return SignedBeaconBlock.create(spec, messageWithParentRoot, block.getSignature());
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProviderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProviderTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -78,6 +79,23 @@ class BlobKzgCommitmentsProviderTest {
     assertThat(result).isPresent();
     assertThat(result.orElseThrow()).isEmpty();
     verify(combinedChainDataClient, never()).getBlockByBlockRoot(block.getRoot());
+  }
+
+  @Test
+  void returnsSidecarCommitmentsWithoutStoringThem() {
+    final Spec fuluSpec = TestSpecFactory.createMinimalFulu();
+    final DataStructureUtil fuluDataStructureUtil = new DataStructureUtil(fuluSpec);
+    final SignedBeaconBlock block =
+        fuluDataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 2);
+    final DataColumnSidecar dataColumnSidecar =
+        fuluDataStructureUtil.randomDataColumnSidecar(block, UInt64.ZERO);
+    final SszList<SszKZGCommitment> commitments =
+        dataColumnSidecar.getMaybeKzgCommitments().orElseThrow();
+
+    assertThat(provider.getBlobKzgCommitments(dataColumnSidecar).join()).contains(commitments);
+    assertThat(provider.getBlobKzgCommitments(dataColumnSidecar.getBeaconBlockRoot()).join())
+        .isEmpty();
+    verify(combinedChainDataClient).getBlockByBlockRoot(dataColumnSidecar.getBeaconBlockRoot());
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProviderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/BlobKzgCommitmentsProviderTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+class BlobKzgCommitmentsProviderTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalGloas();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final CombinedChainDataClient combinedChainDataClient =
+      mock(CombinedChainDataClient.class);
+
+  private BlobKzgCommitmentsProvider provider;
+
+  @BeforeEach
+  void setUp() {
+    provider = new BlobKzgCommitmentsProvider(spec, combinedChainDataClient, 2);
+    when(combinedChainDataClient.getBlockByBlockRoot(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  @Test
+  void returnsCommitmentsFedFromBlockWithoutQueryingStore() {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 3);
+    final SszList<SszKZGCommitment> commitments =
+        block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
+
+    provider.onNewBlock(block);
+
+    assertThat(provider.getBlobKzgCommitments(block.getRoot()).join()).contains(commitments);
+    verify(combinedChainDataClient, never()).getBlockByBlockRoot(block.getRoot());
+  }
+
+  @Test
+  void storesEmptyCommitmentsListAsKnownContext() {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 0);
+
+    provider.onNewBlock(block);
+
+    final Optional<SszList<SszKZGCommitment>> result =
+        provider.getBlobKzgCommitments(block.getRoot()).join();
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow()).isEmpty();
+    verify(combinedChainDataClient, never()).getBlockByBlockRoot(block.getRoot());
+  }
+
+  @Test
+  void ignoresBlocksWhoseBodyHasNoBlobCommitmentsField() {
+    final Spec phase0Spec = TestSpecFactory.createMinimalPhase0();
+    final SignedBeaconBlock blockWithoutBlobCommitments =
+        new DataStructureUtil(phase0Spec).randomSignedBeaconBlock(UInt64.ONE);
+
+    provider.onNewBlock(blockWithoutBlobCommitments);
+
+    assertThat(provider.getBlobKzgCommitments(blockWithoutBlobCommitments.getRoot()).join())
+        .isEmpty();
+    verify(combinedChainDataClient).getBlockByBlockRoot(blockWithoutBlobCommitments.getRoot());
+  }
+
+  @Test
+  void fallsBackToStoreOnMissAndCachesStoreResult() {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 2);
+    final SszList<SszKZGCommitment> commitments =
+        block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
+    when(combinedChainDataClient.getBlockByBlockRoot(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
+
+    assertThat(provider.getBlobKzgCommitments(block.getRoot()).join()).contains(commitments);
+    assertThat(provider.getBlobKzgCommitments(block.getRoot()).join()).contains(commitments);
+
+    verify(combinedChainDataClient, times(1)).getBlockByBlockRoot(block.getRoot());
+  }
+
+  @Test
+  void evictsParentRootWhenChildIsImported() {
+    final SignedBeaconBlock parent =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 1);
+    final SignedBeaconBlock importedChild = mock(SignedBeaconBlock.class);
+    when(importedChild.getParentRoot()).thenReturn(parent.getRoot());
+
+    provider.onNewBlock(parent);
+    provider.onBlockImported(importedChild, false);
+
+    assertThat(provider.getBlobKzgCommitments(parent.getRoot()).join()).isEmpty();
+    verify(combinedChainDataClient).getBlockByBlockRoot(parent.getRoot());
+  }
+
+  @Test
+  void ignoresValidatedBlockEvent() {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 1);
+
+    provider.onBlockValidated(block);
+
+    assertThat(provider.getBlobKzgCommitments(block.getRoot()).join()).isEmpty();
+    verify(combinedChainDataClient).getBlockByBlockRoot(block.getRoot());
+  }
+
+  @Test
+  void prunesEntriesAtOrBeforeFinalizedCheckpointStartSlot() {
+    final UInt64 finalizedEpoch = UInt64.ONE;
+    final UInt64 finalizedStartSlot = spec.computeStartSlotAtEpoch(finalizedEpoch);
+    final SignedBeaconBlock finalizedSlotBlock =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(finalizedStartSlot, 1);
+    final SignedBeaconBlock laterBlock =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(finalizedStartSlot.plus(1), 1);
+
+    provider.onNewBlock(finalizedSlotBlock);
+    provider.onNewBlock(laterBlock);
+    provider.onNewFinalizedCheckpoint(new Checkpoint(finalizedEpoch, Bytes32.ZERO), false);
+
+    assertThat(provider.getBlobKzgCommitments(finalizedSlotBlock.getRoot()).join()).isEmpty();
+    assertThat(provider.getBlobKzgCommitments(laterBlock.getRoot()).join()).isPresent();
+    verify(combinedChainDataClient).getBlockByBlockRoot(finalizedSlotBlock.getRoot());
+    verify(combinedChainDataClient, never()).getBlockByBlockRoot(laterBlock.getRoot());
+  }
+
+  @Test
+  void evictsLeastRecentlyUsedEntryWhenCapacityIsExceeded() {
+    final SignedBeaconBlock first =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.ONE, 1);
+    final SignedBeaconBlock second =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.valueOf(2), 1);
+    final SignedBeaconBlock third =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(UInt64.valueOf(3), 1);
+
+    provider.onNewBlock(first);
+    provider.onNewBlock(second);
+    provider.onNewBlock(third);
+
+    assertThat(provider.getBlobKzgCommitments(first.getRoot()).join()).isEmpty();
+    assertThat(provider.getBlobKzgCommitments(second.getRoot()).join()).isPresent();
+    assertThat(provider.getBlobKzgCommitments(third.getRoot()).join()).isPresent();
+    verify(combinedChainDataClient).getBlockByBlockRoot(first.getRoot());
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSamplerTest.java
@@ -48,9 +48,11 @@ public class DasPreSamplerTest {
   private final DataColumnSidecarCustody custody = mock(DataColumnSidecarCustody.class);
   private final CustodyGroupCountManager custodyGroupCountManager =
       mock(CustodyGroupCountManager.class);
+  private final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider =
+      mock(BlobKzgCommitmentsProvider.class);
 
   private final DasPreSampler dasPreSampler =
-      new DasPreSampler(sampler, custody, custodyGroupCountManager);
+      new DasPreSampler(sampler, custody, custodyGroupCountManager, blobKzgCommitmentsProvider);
 
   @Test
   void onNewPreImportBlocks_shouldNotSampleWhenEligibilityIsNotRequired() {
@@ -59,6 +61,7 @@ public class DasPreSamplerTest {
 
     dasPreSampler.onNewPreImportBlocks(List.of(block));
 
+    verify(blobKzgCommitmentsProvider).onNewBlock(block);
     verify(sampler).checkSamplingEligibility(block.getMessage());
     verify(sampler).flush();
     verifyNoMoreInteractions(sampler);
@@ -70,6 +73,7 @@ public class DasPreSamplerTest {
     final List<SignedBeaconBlock> blocks = new ArrayList<>();
     blocks.add(null);
     assertDoesNotThrow(() -> dasPreSampler.onNewPreImportBlocks(blocks));
+    verifyNoInteractions(blobKzgCommitmentsProvider);
   }
 
   @Test
@@ -91,6 +95,8 @@ public class DasPreSamplerTest {
     // Verify filtering
     verify(sampler).checkSamplingEligibility(blockToSample.getMessage());
     verify(sampler).checkSamplingEligibility(blockToSkip.getMessage());
+    verify(blobKzgCommitmentsProvider).onNewBlock(blockToSample);
+    verify(blobKzgCommitmentsProvider).onNewBlock(blockToSkip);
 
     // Verify processing for the required block
     verify(sampler).checkDataAvailability(blockToSample.getSlot(), blockToSample.getRoot());
@@ -118,6 +124,7 @@ public class DasPreSamplerTest {
 
     dasPreSampler.onNewPreImportBlocks(List.of(block));
 
+    verify(blobKzgCommitmentsProvider).onNewBlock(block);
     verify(custody).hasCustodyDataColumnSidecar(col1);
     verify(custody).hasCustodyDataColumnSidecar(col5);
     verify(sampler, never())
@@ -147,6 +154,7 @@ public class DasPreSamplerTest {
 
     dasPreSampler.onNewPreImportBlocks(List.of(block));
 
+    verify(blobKzgCommitmentsProvider).onNewBlock(block);
     // Verify sampler is notified about the column in custody
     verify(sampler).onNewValidatedDataColumnSidecar(col2, RemoteOrigin.CUSTODY);
     verify(sampler, never())

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractDataColumnSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AbstractDataColumnSidecarGossipValidatorTest.java
@@ -14,11 +14,16 @@
 package tech.pegasys.teku.statetransition.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
@@ -28,6 +33,7 @@ import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 /**
  * Abstract base class for testing DataColumnSidecarGossipValidator across different forks.
@@ -37,6 +43,8 @@ abstract class AbstractDataColumnSidecarGossipValidatorTest {
   protected final Map<Bytes32, BlockImportResult> invalidBlocks = new HashMap<>();
   protected final StubMetricsSystem metricsSystemStub = new StubMetricsSystem();
   protected final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(0);
+  protected final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider =
+      mock(BlobKzgCommitmentsProvider.class);
 
   protected DataStructureUtil dataStructureUtil;
   protected DataColumnSidecarGossipValidator dataColumnSidecarGossipValidator;
@@ -45,6 +53,16 @@ abstract class AbstractDataColumnSidecarGossipValidatorTest {
   protected DataColumnSidecar dataColumnSidecar;
 
   public abstract Spec createSpec(final Consumer<SpecConfigBuilder> configAdapter);
+
+  @BeforeEach
+  void setUpBlobKzgCommitmentsProvider() {
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any(DataColumnSidecar.class)))
+        .thenAnswer(
+            invocation -> {
+              final DataColumnSidecar sidecar = invocation.getArgument(0);
+              return SafeFuture.completedFuture(sidecar.getMaybeKzgCommitments());
+            });
+  }
 
   protected void assertValidationMetrics(final Map<ValidationResultCode, Integer> values) {
     assertThat(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorFuluTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorFuluTest.java
@@ -70,7 +70,12 @@ public class DataColumnSidecarGossipValidatorFuluTest
 
     this.dataColumnSidecarGossipValidator =
         DataColumnSidecarGossipValidator.create(
-            spec, invalidBlocks, gossipValidationHelper, metricsSystemStub, stubTimeProvider);
+            spec,
+            invalidBlocks,
+            gossipValidationHelper,
+            blobKzgCommitmentsProvider,
+            metricsSystemStub,
+            stubTimeProvider);
 
     parentSlot = UInt64.valueOf(1);
     slot = UInt64.valueOf(2);
@@ -148,7 +153,12 @@ public class DataColumnSidecarGossipValidatorFuluTest
 
     final DataColumnSidecarGossipValidator validatorWithMockedSpec =
         DataColumnSidecarGossipValidator.create(
-            mockSpec, invalidBlocks, gossipValidationHelper, metricsSystemStub, stubTimeProvider);
+            mockSpec,
+            invalidBlocks,
+            gossipValidationHelper,
+            blobKzgCommitmentsProvider,
+            metricsSystemStub,
+            stubTimeProvider);
 
     SafeFutureAssert.assertThatSafeFuture(validatorWithMockedSpec.validate(dataColumnSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
@@ -406,14 +416,19 @@ public class DataColumnSidecarGossipValidatorFuluTest
     when(mockDataColumnSidecarUtil.validateWithState(
             any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-    when(mockDataColumnSidecarUtil.validateAndVerifyKzgProofsWithBlock(any(), any()))
+    when(mockDataColumnSidecarUtil.validateAndVerifyKzgProofs(any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     when(mockDataColumnSidecarUtil.extractTrackingKey(any()))
         .thenReturn(new FuluTrackingKey(slot, UInt64.ZERO, index));
 
     final DataColumnSidecarGossipValidator validatorWithMockedSpec =
         DataColumnSidecarGossipValidator.create(
-            mockSpec, invalidBlocks, gossipValidationHelper, metricsSystemStub, stubTimeProvider);
+            mockSpec,
+            invalidBlocks,
+            gossipValidationHelper,
+            blobKzgCommitmentsProvider,
+            metricsSystemStub,
+            stubTimeProvider);
 
     SafeFutureAssert.assertThatSafeFuture(validatorWithMockedSpec.validate(dataColumnSidecar))
         .isCompletedWithValue(reject("DataColumnSidecar inclusion proof validation failed"));
@@ -451,7 +466,7 @@ public class DataColumnSidecarGossipValidatorFuluTest
             any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     // KZG proof validation fails
-    when(mockDataColumnSidecarUtil.validateAndVerifyKzgProofsWithBlock(any(), any()))
+    when(mockDataColumnSidecarUtil.validateAndVerifyKzgProofs(any(), any()))
         .thenReturn(
             SafeFuture.completedFuture(
                 Optional.of(
@@ -462,7 +477,12 @@ public class DataColumnSidecarGossipValidatorFuluTest
 
     final DataColumnSidecarGossipValidator validatorWithMockedSpec =
         DataColumnSidecarGossipValidator.create(
-            mockSpec, invalidBlocks, gossipValidationHelper, metricsSystemStub, stubTimeProvider);
+            mockSpec,
+            invalidBlocks,
+            gossipValidationHelper,
+            blobKzgCommitmentsProvider,
+            metricsSystemStub,
+            stubTimeProvider);
 
     SafeFutureAssert.assertThatSafeFuture(validatorWithMockedSpec.validate(dataColumnSidecar))
         .isCompletedWithValue(reject("Invalid DataColumnSidecar KZG Proofs"));
@@ -507,14 +527,19 @@ public class DataColumnSidecarGossipValidatorFuluTest
               proofInfoSet.add(inclusionProofInfo);
               return SafeFuture.completedFuture(Optional.empty());
             });
-    when(mockDataColumnSidecarUtil.validateAndVerifyKzgProofsWithBlock(any(), any()))
+    when(mockDataColumnSidecarUtil.validateAndVerifyKzgProofs(any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     when(mockDataColumnSidecarUtil.extractTrackingKey(any()))
         .thenReturn(new FuluTrackingKey(slot, UInt64.ZERO, index));
 
     final DataColumnSidecarGossipValidator validatorWithMockedSpec =
         DataColumnSidecarGossipValidator.create(
-            mockSpec, invalidBlocks, gossipValidationHelper, metricsSystemStub, stubTimeProvider);
+            mockSpec,
+            invalidBlocks,
+            gossipValidationHelper,
+            blobKzgCommitmentsProvider,
+            metricsSystemStub,
+            stubTimeProvider);
 
     // First validation, inclusion proof is verified and cached
     SafeFutureAssert.assertThatSafeFuture(validatorWithMockedSpec.validate(dataColumnSidecar))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorGloasTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -39,11 +41,13 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.util.GloasTrackingKey;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 public class DataColumnSidecarGossipValidatorGloasTest
     extends AbstractDataColumnSidecarGossipValidatorTest {
   private final GossipValidationHelper gossipValidationHelper = mock(GossipValidationHelper.class);
 
+  private Spec spec;
   private Bytes32 beaconBlockRoot;
 
   @Override
@@ -53,8 +57,7 @@ public class DataColumnSidecarGossipValidatorGloasTest
 
   @BeforeEach
   void setup() {
-    final Spec spec =
-        createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
+    spec = createSpec(builder -> builder.blsSignatureVerifier(BLSSignatureVerifier.NOOP));
     this.dataStructureUtil = new DataStructureUtil(spec);
 
     this.dataColumnSidecarGossipValidator =
@@ -107,6 +110,25 @@ public class DataColumnSidecarGossipValidatorGloasTest
   void shouldAcceptValidGloasDataColumnSidecar() {
     SafeFutureAssert.assertThatSafeFuture(
             dataColumnSidecarGossipValidator.validate(dataColumnSidecar))
+        .isCompletedWithValueMatching(InternalValidationResult::isAccept);
+  }
+
+  @Test
+  void shouldResolveBlobKzgCommitmentsProviderFromSupplierAtValidationTime() {
+    final AtomicReference<BlobKzgCommitmentsProvider> blobKzgCommitmentsProviderRef =
+        new AtomicReference<>();
+    final DataColumnSidecarGossipValidator validator =
+        DataColumnSidecarGossipValidator.create(
+            spec,
+            invalidBlocks,
+            gossipValidationHelper,
+            blobKzgCommitmentsProviderRef::get,
+            new StubMetricsSystem(),
+            stubTimeProvider);
+
+    blobKzgCommitmentsProviderRef.set(blobKzgCommitmentsProvider);
+
+    SafeFutureAssert.assertThatSafeFuture(validator.validate(dataColumnSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorGloasTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorGloasTest.java
@@ -30,13 +30,13 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.util.GloasTrackingKey;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -59,7 +59,12 @@ public class DataColumnSidecarGossipValidatorGloasTest
 
     this.dataColumnSidecarGossipValidator =
         DataColumnSidecarGossipValidator.create(
-            spec, invalidBlocks, gossipValidationHelper, metricsSystemStub, stubTimeProvider);
+            spec,
+            invalidBlocks,
+            gossipValidationHelper,
+            blobKzgCommitmentsProvider,
+            metricsSystemStub,
+            stubTimeProvider);
     slot = UInt64.valueOf(2);
     index = UInt64.valueOf(1);
     beaconBlockRoot = dataStructureUtil.randomBytes32();
@@ -82,15 +87,20 @@ public class DataColumnSidecarGossipValidatorGloasTest
         .thenReturn(Optional.of(slot));
     when(gossipValidationHelper.currentFinalizedCheckpointIsAncestorOfBlock(any(), any()))
         .thenReturn(true);
-    // for the default setup, return a block with matching KZG commitments
-    final BeaconBlock beaconBlock =
-        dataStructureUtil.randomBeaconBlock(
-            UInt64.ZERO,
-            dataStructureUtil.randomBeaconBlockBodyWithCommitments(
-                dataColumnSidecar.getColumn().size()));
-    final SignedBeaconBlock signedBeaconBlock = dataStructureUtil.signedBlock(beaconBlock);
-    when(gossipValidationHelper.retrieveSignedBlockByRoot(any(Bytes32.class)))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(signedBeaconBlock)));
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any(DataColumnSidecar.class)))
+        .thenAnswer(
+            invocation -> {
+              final DataColumnSidecar sidecar = invocation.getArgument(0);
+              return SafeFuture.completedFuture(
+                  Optional.of(createCommitments(sidecar.getColumn().size())));
+            });
+  }
+
+  private SszList<SszKZGCommitment> createCommitments(final int commitmentCount) {
+    return dataStructureUtil
+        .randomBeaconBlockBodyWithCommitments(commitmentCount)
+        .getOptionalBlobKzgCommitments()
+        .orElseThrow();
   }
 
   @Test
@@ -104,15 +114,10 @@ public class DataColumnSidecarGossipValidatorGloasTest
   void shouldRejectWhenDataColumnSidecarKzgCommitmentDoNotMatchBid() {
     // block with fewer commitments than the sidecar's column size
     final int insufficientCommitmentCount = dataColumnSidecar.getColumn().size() - 1;
-    final BeaconBlock blockWithInsufficientCommitments =
-        dataStructureUtil.randomBeaconBlock(
-            slot,
-            dataStructureUtil.randomBeaconBlockBodyWithCommitments(insufficientCommitmentCount));
-
-    when(gossipValidationHelper.retrieveSignedBlockByRoot(beaconBlockRoot))
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(dataColumnSidecar))
         .thenReturn(
             SafeFuture.completedFuture(
-                Optional.of(dataStructureUtil.signedBlock(blockWithInsufficientCommitments))));
+                Optional.of(createCommitments(insufficientCommitmentCount))));
 
     SafeFutureAssert.assertThatSafeFuture(
             dataColumnSidecarGossipValidator.validate(dataColumnSidecar))
@@ -188,17 +193,6 @@ public class DataColumnSidecarGossipValidatorGloasTest
             .beaconBlockRoot(beaconBlockRoot)
             .build();
 
-    // Update mock to return block with bid that has matching KZG commitments for the new sidecar
-    final BeaconBlock secondBeaconblock =
-        dataStructureUtil.randomBeaconBlock(
-            slot,
-            dataStructureUtil.randomBeaconBlockBodyWithCommitments(
-                sidecarDifferentIndex.getColumn().size()));
-    when(gossipValidationHelper.retrieveSignedBlockByRoot(beaconBlockRoot))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(dataStructureUtil.signedBlock(secondBeaconblock))));
-
     // Different column index, should accept
     SafeFutureAssert.assertThatSafeFuture(
             dataColumnSidecarGossipValidator.validate(sidecarDifferentIndex))
@@ -226,17 +220,6 @@ public class DataColumnSidecarGossipValidatorGloasTest
             .beaconBlockRoot(differentBlockRoot)
             .build();
 
-    // Mock block for the different block root
-    final BeaconBlock thirdBeaconblock =
-        dataStructureUtil.randomBeaconBlock(
-            slot,
-            dataStructureUtil.randomBeaconBlockBodyWithCommitments(
-                sidecarDifferentBlock.getColumn().size()));
-    when(gossipValidationHelper.retrieveSignedBlockByRoot(differentBlockRoot))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(dataStructureUtil.signedBlock(thirdBeaconblock))));
-
     // Should accept - different block root means different tracking key
     SafeFutureAssert.assertThatSafeFuture(
             dataColumnSidecarGossipValidator.validate(sidecarDifferentBlock))
@@ -250,7 +233,7 @@ public class DataColumnSidecarGossipValidatorGloasTest
 
   @Test
   void shouldRejectWhenBeaconBlockRootNotKnown() {
-    when(gossipValidationHelper.retrieveSignedBlockByRoot(beaconBlockRoot))
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(dataColumnSidecar))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     SafeFutureAssert.assertThatSafeFuture(
@@ -284,7 +267,7 @@ public class DataColumnSidecarGossipValidatorGloasTest
   @Test
   void shouldBeSavedForFutureWhenBlockUnavailable() {
     when(gossipValidationHelper.getSlotForBlockRoot(beaconBlockRoot)).thenReturn(Optional.of(slot));
-    when(gossipValidationHelper.retrieveSignedBlockByRoot(beaconBlockRoot))
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(dataColumnSidecar))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     SafeFutureAssert.assertThatSafeFuture(
@@ -295,15 +278,10 @@ public class DataColumnSidecarGossipValidatorGloasTest
   @Test
   void shouldRejectWhenKzgProofsDoNotMatch() {
     // block with bid that has a different number of commitments than the sidecar's column size
-    final BeaconBlock beaconBlock =
-        dataStructureUtil.randomBeaconBlock(
-            slot,
-            dataStructureUtil.randomBeaconBlockBodyWithCommitments(
-                dataColumnSidecar.getColumn().size() + 1));
-
-    when(gossipValidationHelper.retrieveSignedBlockByRoot(beaconBlockRoot))
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(dataColumnSidecar))
         .thenReturn(
-            SafeFuture.completedFuture(Optional.of(dataStructureUtil.signedBlock(beaconBlock))));
+            SafeFuture.completedFuture(
+                Optional.of(createCommitments(dataColumnSidecar.getColumn().size() + 1))));
 
     SafeFutureAssert.assertThatSafeFuture(
             dataColumnSidecarGossipValidator.validate(dataColumnSidecar))

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -100,6 +100,7 @@ import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 import tech.pegasys.teku.spec.logic.versions.fulu.helpers.BlobParameters;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 import tech.pegasys.teku.statetransition.CustodyGroupCountChannel;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarArchiveReconstructor;
 import tech.pegasys.teku.statetransition.datacolumns.log.gossip.DasGossipLogger;
@@ -121,6 +122,7 @@ public class Eth2P2PNetworkBuilder {
   protected P2PConfig config;
   protected EventChannels eventChannels;
   protected CombinedChainDataClient combinedChainDataClient;
+  protected BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
   protected Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier;
   protected MetadataMessagesFactory metadataMessagesFactory = new MetadataMessagesFactory();
   protected OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
@@ -191,6 +193,7 @@ public class Eth2P2PNetworkBuilder {
         Eth2PeerManager.create(
             asyncRunner,
             combinedChainDataClient,
+            blobKzgCommitmentsProvider,
             custodyGroupCountManagerSupplier,
             metadataMessagesFactory,
             metricsSystem,
@@ -617,6 +620,7 @@ public class Eth2P2PNetworkBuilder {
     assertNotNull("eventChannels", eventChannels);
     assertNotNull("metricsSystem", metricsSystem);
     assertNotNull("combinedChainDataClient", combinedChainDataClient);
+    assertNotNull("blobKzgCommitmentsProvider", blobKzgCommitmentsProvider);
     assertNotNull("custodyGroupCountManagerSupplier", custodyGroupCountManagerSupplier);
     assertNotNull("metadataMessagesFactory", metadataMessagesFactory);
     assertNotNull("keyValueStore", keyValueStore);
@@ -662,6 +666,13 @@ public class Eth2P2PNetworkBuilder {
       final CombinedChainDataClient combinedChainDataClient) {
     checkNotNull(combinedChainDataClient);
     this.combinedChainDataClient = combinedChainDataClient;
+    return this;
+  }
+
+  public Eth2P2PNetworkBuilder blobKzgCommitmentsProvider(
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
+    checkNotNull(blobKzgCommitmentsProvider);
+    this.blobKzgCommitmentsProvider = blobKzgCommitmentsProvider;
     return this;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -88,7 +88,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   private static final Logger LOG = LogManager.getLogger();
@@ -126,7 +126,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
           DataColumnSidecarsByRangeRequestMessage.DataColumnSidecarsByRangeRequestMessageSchema>
       dataColumnSidecarsByRangeRequestMessageSchema;
   private final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator;
-  private final CombinedChainDataClient combinedChainDataClient;
+  private final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
 
   DefaultEth2Peer(
       final Spec spec,
@@ -144,7 +144,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
       final RateTracker requestTracker,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
-      final CombinedChainDataClient combinedChainDataClient) {
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
     super(peer);
     this.spec = spec;
     this.discoveryNodeId = discoveryNodeId;
@@ -153,7 +153,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
     this.metadataMessagesFactory = metadataMessagesFactory;
     this.peerChainValidator = peerChainValidator;
     this.dataColumnSidecarSignatureValidator = dataColumnSidecarSignatureValidator;
-    this.combinedChainDataClient = combinedChainDataClient;
+    this.blobKzgCommitmentsProvider = blobKzgCommitmentsProvider;
     requestObjectsTrackers = new EnumMap<>(RequestObject.class);
     requestObjectsTrackers.put(RequestObject.BLOCK, blocksRequestTracker);
     requestObjectsTrackers.put(RequestObject.BLOB_SIDECAR, blobSidecarsRequestTracker);
@@ -366,7 +366,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
                         timeProvider,
                         dataColumnSidecarSignatureValidator,
                         dataColumnIdentifiers,
-                        combinedChainDataClient)))
+                        blobKzgCommitmentsProvider)))
         .orElse(failWithUnsupportedMethodException("DataColumnSidecarsByRoot"));
   }
 
@@ -551,7 +551,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
                       request.getStartSlot(),
                       request.getCount(),
                       request.getColumns(),
-                      combinedChainDataClient));
+                      blobKzgCommitmentsProvider));
             })
         .orElse(failWithUnsupportedMethodException("DataColumnSidecarsByRange"));
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.SingleRpcRequestBodySelector;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 public interface Eth2Peer extends Peer, SyncSource {
   static Eth2Peer create(
@@ -62,7 +62,7 @@ public interface Eth2Peer extends Peer, SyncSource {
       final RateTracker requestTracker,
       final MetricsSystem metricsSystem,
       final TimeProvider timeProvider,
-      final CombinedChainDataClient combinedChainDataClient) {
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
     return new DefaultEth2Peer(
         spec,
         peer,
@@ -79,7 +79,7 @@ public interface Eth2Peer extends Peer, SyncSource {
         requestTracker,
         metricsSystem,
         timeProvider,
-        combinedChainDataClient);
+        blobKzgCommitmentsProvider);
   }
 
   void updateStatus(PeerStatus status);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFa
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class Eth2PeerFactory {
@@ -32,6 +33,7 @@ public class Eth2PeerFactory {
   private final MetadataMessagesFactory metadataMessagesFactory;
   private final MetricsSystem metricsSystem;
   private final CombinedChainDataClient chainDataClient;
+  private final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
   private final TimeProvider timeProvider;
   private final Optional<Checkpoint> requiredCheckpoint;
   private final int peerBlocksRateLimit;
@@ -44,6 +46,7 @@ public class Eth2PeerFactory {
       final Spec spec,
       final MetricsSystem metricsSystem,
       final CombinedChainDataClient chainDataClient,
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider,
       final StatusMessageFactory statusMessageFactory,
       final MetadataMessagesFactory metadataMessagesFactory,
       final TimeProvider timeProvider,
@@ -55,6 +58,7 @@ public class Eth2PeerFactory {
     this.spec = spec;
     this.metricsSystem = metricsSystem;
     this.chainDataClient = chainDataClient;
+    this.blobKzgCommitmentsProvider = blobKzgCommitmentsProvider;
     this.timeProvider = timeProvider;
     this.statusMessageFactory = statusMessageFactory;
     this.metadataMessagesFactory = metadataMessagesFactory;
@@ -89,6 +93,6 @@ public class Eth2PeerFactory {
         RateTracker.create(peerRequestLimit, TIME_OUT, timeProvider, "request_tracker"),
         metricsSystem,
         timeProvider,
-        chainDataClient);
+        blobKzgCommitmentsProvider);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarArchiveReconstructor;
 import tech.pegasys.teku.statetransition.datacolumns.log.rpc.DasReqRespLogger;
@@ -113,6 +114,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
   public static Eth2PeerManager create(
       final AsyncRunner asyncRunner,
       final CombinedChainDataClient combinedChainDataClient,
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider,
       final Supplier<CustodyGroupCountManager> custodyGroupCountManagerSupplier,
       final MetadataMessagesFactory metadataMessagesFactory,
       final MetricsSystem metricsSystem,
@@ -148,6 +150,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
             spec,
             metricsSystem,
             combinedChainDataClient,
+            blobKzgCommitmentsProvider,
             statusMessageFactory,
             metadataMessagesFactory,
             timeProvider,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarValidator.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarValidationError;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 public abstract class AbstractDataColumnSidecarValidator {
 
@@ -32,17 +32,17 @@ public abstract class AbstractDataColumnSidecarValidator {
   private final Spec spec;
   private final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator;
   final Peer peer;
-  final CombinedChainDataClient combinedChainDataClient;
+  final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
 
   public AbstractDataColumnSidecarValidator(
       final Peer peer,
       final Spec spec,
       final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
-      final CombinedChainDataClient combinedChainDataClient) {
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
     this.peer = peer;
     this.spec = spec;
     this.dataColumnSidecarSignatureValidator = dataColumnSidecarSignatureValidator;
-    this.combinedChainDataClient = combinedChainDataClient;
+    this.blobKzgCommitmentsProvider = blobKzgCommitmentsProvider;
   }
 
   boolean verifyValidity(final DataColumnSidecar dataColumnSidecar) {
@@ -55,8 +55,8 @@ public abstract class AbstractDataColumnSidecarValidator {
       final DataColumnSidecar dataColumnSidecar) {
     final DataColumnSidecarUtil dataColumnSidecarUtil =
         spec.getDataColumnSidecarUtil(dataColumnSidecar.getSlot());
-    return dataColumnSidecarUtil.validateAndVerifyKzgProofsWithBlock(
-        dataColumnSidecar, combinedChainDataClient::getBlockByBlockRoot);
+    return dataColumnSidecarUtil.validateAndVerifyKzgProofs(
+        dataColumnSidecar, blobKzgCommitmentsProvider::getBlobKzgCommitments);
   }
 
   boolean verifyInclusionProof(final DataColumnSidecar dataColumnSidecar) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 public class DataColumnSidecarsByRangeListenerValidatingProxy
     extends AbstractDataColumnSidecarValidator implements RpcResponseListener<DataColumnSidecar> {
@@ -56,8 +56,8 @@ public class DataColumnSidecarsByRangeListenerValidatingProxy
       final UInt64 startSlot,
       final UInt64 count,
       final List<UInt64> columns,
-      final CombinedChainDataClient combinedChainDataClient) {
-    super(peer, spec, dataColumnSidecarSignatureValidator, combinedChainDataClient);
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
+    super(peer, spec, dataColumnSidecarSignatureValidator, blobKzgCommitmentsProvider);
     this.dataColumnSidecarResponseListener = dataColumnSidecarResponseListener;
     this.startSlot = startSlot;
     this.endSlot = startSlot.plus(count).minusMinZero(1);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
@@ -25,7 +25,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 public class DataColumnSidecarsByRootListenerValidatingProxy
     extends DataColumnSidecarsByRootValidator implements RpcResponseListener<DataColumnSidecar> {
@@ -40,7 +40,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxy
       final TimeProvider timeProvider,
       final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
       final List<DataColumnsByRootIdentifier> expectedByRootIdentifiers,
-      final CombinedChainDataClient combinedChainDataClient) {
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
     super(
         peer,
         spec,
@@ -55,7 +55,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxy
                             column ->
                                 new DataColumnIdentifier(byRootIdentifier.getBlockRoot(), column)))
             .toList(),
-        combinedChainDataClient);
+        blobKzgCommitmentsProvider);
     this.listener = listener;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecarValidator {
   private final Set<DataColumnIdentifier> expectedDataColumnIdentifiers;
@@ -44,8 +44,8 @@ public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecar
       final TimeProvider timeProvider,
       final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator,
       final List<DataColumnIdentifier> expectedDataColumnIdentifiers,
-      final CombinedChainDataClient combinedChainDataClient) {
-    super(peer, spec, dataColumnSidecarSignatureValidator, combinedChainDataClient);
+      final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider) {
+    super(peer, spec, dataColumnSidecarSignatureValidator, blobKzgCommitmentsProvider);
     this.expectedDataColumnIdentifiers = ConcurrentHashMap.newKeySet();
     this.expectedDataColumnIdentifiers.addAll(expectedDataColumnIdentifiers);
     this.dataColumnSidecarInclusionProofVerificationTimeSeconds =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -52,7 +52,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.RpcRequestBodySelector;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.SingleRpcRequestBodySelector;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 class Eth2PeerTest {
 
@@ -74,8 +74,8 @@ class Eth2PeerTest {
   private final TimeProvider timeProvider = mock(TimeProvider.class);
   private final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator =
       mock(DataColumnSidecarSignatureValidator.class);
-  private final CombinedChainDataClient combinedChainDataClient =
-      mock(CombinedChainDataClient.class);
+  private final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider =
+      mock(BlobKzgCommitmentsProvider.class);
 
   private final PeerStatus randomPeerStatus = randomPeerStatus();
 
@@ -96,7 +96,7 @@ class Eth2PeerTest {
           rateTracker,
           metricsSystem,
           timeProvider,
-          combinedChainDataClient);
+          blobKzgCommitmentsProvider);
 
   @Test
   void updateStatus_shouldNotUpdateUntilValidationPasses() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.List;
+import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 @SuppressWarnings("JavaCase")
 public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest {
@@ -60,8 +61,8 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
 
   protected final DataColumnSidecarSignatureValidator signatureValidator =
       mock(DataColumnSidecarSignatureValidator.class);
-  protected final CombinedChainDataClient combinedChainDataClient =
-      mock(CombinedChainDataClient.class);
+  protected final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider =
+      mock(BlobKzgCommitmentsProvider.class);
 
   protected abstract Spec createSpec();
 
@@ -82,6 +83,8 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
         kzg);
     when(listener.onResponse(any())).thenReturn(SafeFuture.completedFuture(null));
     when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(true);
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     when(signatureValidator.validateSignature(any())).thenReturn(SafeFuture.completedFuture(true));
   }
 
@@ -105,7 +108,7 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
             ONE,
             UInt64.valueOf(4),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -143,7 +146,7 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
             ONE,
             UInt64.valueOf(2),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar datColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -183,7 +186,7 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
             ONE,
             UInt64.valueOf(2),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar datColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -222,7 +225,7 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
             ONE,
             UInt64.valueOf(1),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -257,7 +260,7 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
             ONE,
             UInt64.valueOf(1),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -292,7 +295,7 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
             ONE,
             UInt64.valueOf(1),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -326,7 +329,7 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
             ONE,
             UInt64.valueOf(1),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest.java
@@ -23,7 +23,6 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.List;
-import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,8 +82,12 @@ public abstract class AbstractDataColumnSidecarsByRangeListenerValidatingProxyTe
         kzg);
     when(listener.onResponse(any())).thenReturn(SafeFuture.completedFuture(null));
     when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(true);
-    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any(DataColumnSidecar.class)))
+        .thenAnswer(
+            invocation -> {
+              final DataColumnSidecar sidecar = invocation.getArgument(0);
+              return SafeFuture.completedFuture(sidecar.getMaybeKzgCommitments());
+            });
     when(signatureValidator.validateSignature(any())).thenReturn(SafeFuture.completedFuture(true));
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootListenerValidatingProxyTest.java
@@ -23,7 +23,6 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.List;
-import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,8 +86,12 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
         kzg);
     when(listener.onResponse(any())).thenReturn(SafeFuture.completedFuture(null));
     when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(true);
-    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any(DataColumnSidecar.class)))
+        .thenAnswer(
+            invocation -> {
+              final DataColumnSidecar sidecar = invocation.getArgument(0);
+              return SafeFuture.completedFuture(sidecar.getMaybeKzgCommitments());
+            });
     when(signatureValidator.validateSignature(any())).thenReturn(SafeFuture.completedFuture(true));
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootListenerValidatingProxyTest.java
@@ -23,6 +23,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.List;
+import java.util.Optional;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 @SuppressWarnings("JavaCase")
 public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTest {
@@ -61,8 +62,8 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
 
   protected final DataColumnSidecarSignatureValidator signatureValidator =
       mock(DataColumnSidecarSignatureValidator.class);
-  protected final CombinedChainDataClient combinedChainDataClient =
-      mock(CombinedChainDataClient.class);
+  protected final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider =
+      mock(BlobKzgCommitmentsProvider.class);
 
   protected abstract Spec createSpec();
 
@@ -86,6 +87,8 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
         kzg);
     when(listener.onResponse(any())).thenReturn(SafeFuture.completedFuture(null));
     when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(true);
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     when(signatureValidator.validateSignature(any())).thenReturn(SafeFuture.completedFuture(true));
   }
 
@@ -115,7 +118,7 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
             timeProvider,
             signatureValidator,
             dataColumnIdentifiers,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -152,7 +155,7 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
             timeProvider,
             signatureValidator,
             dataColumnIdentifiers,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar datColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -188,7 +191,7 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
             timeProvider,
             signatureValidator,
             dataColumnIdentifiers,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -222,7 +225,7 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
             timeProvider,
             signatureValidator,
             dataColumnIdentifiers,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);
@@ -252,7 +255,7 @@ public abstract class AbstractDataColumnSidecarsByRootListenerValidatingProxyTes
             timeProvider,
             signatureValidator,
             dataColumnIdentifiers,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootValidatorTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import java.util.List;
-import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,8 +76,12 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
         kzg);
     when(dataColumnSidecarSignatureValidator.validateSignature(any()))
         .thenReturn(SafeFuture.completedFuture(true));
-    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any(DataColumnSidecar.class)))
+        .thenAnswer(
+            invocation -> {
+              final DataColumnSidecar sidecar = invocation.getArgument(0);
+              return SafeFuture.completedFuture(sidecar.getMaybeKzgCommitments());
+            });
     when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(true);
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractDataColumnSidecarsByRootValidatorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
 import java.util.List;
+import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 
 @SuppressWarnings("JavaCase")
 public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
@@ -54,8 +55,8 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
   protected final TimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
   protected final DataColumnSidecarSignatureValidator dataColumnSidecarSignatureValidator =
       mock(DataColumnSidecarSignatureValidator.class);
-  protected final CombinedChainDataClient combinedChainDataClient =
-      mock(CombinedChainDataClient.class);
+  protected final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider =
+      mock(BlobKzgCommitmentsProvider.class);
 
   protected abstract Spec createSpec();
 
@@ -76,6 +77,8 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
         kzg);
     when(dataColumnSidecarSignatureValidator.validateSignature(any()))
         .thenReturn(SafeFuture.completedFuture(true));
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     when(kzg.verifyCellProofBatch(any(), any(), any())).thenReturn(true);
   }
 
@@ -94,7 +97,7 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertDoesNotThrow(() -> validator.validate(dataColumnSidecar1_0));
   }
@@ -116,7 +119,7 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertThatSafeFuture(validator.validate(dataColumnSidecar2_0))
         .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)
@@ -142,7 +145,7 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertThatSafeFuture(validator.validate(dataColumnSidecar1_0))
         .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)
@@ -170,7 +173,7 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertThatSafeFuture(validator.validate(dataColumnSidecar1_0))
         .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)
@@ -196,7 +199,7 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertDoesNotThrow(() -> validator.validate(dataColumnSidecar1_0).join());
     assertThatSafeFuture(validator.validate(dataColumnSidecar1_0))
@@ -224,7 +227,7 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     // verifySignature is separate from validate
     assertThat(validator.verifySignature(dataColumnSidecar1_0)).isCompletedWithValue(false);
@@ -247,7 +250,7 @@ public abstract class AbstractDataColumnSidecarsByRootValidatorTest {
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertThatSafeFuture(validator.validate(dataColumnSidecar1_0_modified))
         .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyFuluTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyFuluTest.java
@@ -86,7 +86,7 @@ public class DataColumnSidecarsByRangeListenerValidatingProxyFuluTest
             ONE,
             UInt64.valueOf(1),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyGloasTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
@@ -49,7 +50,10 @@ public class DataColumnSidecarsByRangeListenerValidatingProxyGloasTest
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(slot, 3);
     final SszList<SszKZGCommitment> commitments =
         block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
-    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(block.getRoot()))
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(
+            argThat(
+                (DataColumnSidecar sidecar) ->
+                    sidecar != null && sidecar.getBeaconBlockRoot().equals(block.getRoot()))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(commitments)));
     return block;
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxyGloasTest.java
@@ -20,14 +20,11 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -35,26 +32,11 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumnSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.gloas.DataColumnSidecarSchemaGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 public class DataColumnSidecarsByRangeListenerValidatingProxyGloasTest
     extends AbstractDataColumnSidecarsByRangeListenerValidatingProxyTest {
-
-  private final Map<Bytes32, SignedBeaconBlock> blocksByRoot = new HashMap<>();
-
-  @BeforeEach
-  @Override
-  void setUp() {
-    super.setUp();
-    blocksByRoot.clear();
-    // For Gloas, set up mock to retrieve blocks by root
-    when(combinedChainDataClient.getBlockByBlockRoot(any()))
-        .thenAnswer(
-            invocation -> {
-              final Bytes32 root = invocation.getArgument(0);
-              return SafeFuture.completedFuture(Optional.ofNullable(blocksByRoot.get(root)));
-            });
-  }
 
   @Override
   protected Spec createSpec() {
@@ -65,7 +47,10 @@ public class DataColumnSidecarsByRangeListenerValidatingProxyGloasTest
   protected SignedBeaconBlock createBlock(final UInt64 slot) {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(slot, 3);
-    blocksByRoot.put(block.getRoot(), block);
+    final SszList<SszKZGCommitment> commitments =
+        block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(commitments)));
     return block;
   }
 
@@ -105,7 +90,7 @@ public class DataColumnSidecarsByRangeListenerValidatingProxyGloasTest
             ONE,
             UInt64.valueOf(1),
             columns,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyGloasTest.java
@@ -21,14 +21,11 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -39,27 +36,12 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.gloas.DataColumnSide
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifierSchema;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 @SuppressWarnings("JavaCase")
 public class DataColumnSidecarsByRootListenerValidatingProxyGloasTest
     extends AbstractDataColumnSidecarsByRootListenerValidatingProxyTest {
-
-  private final Map<Bytes32, SignedBeaconBlock> blocksByRoot = new HashMap<>();
-
-  @BeforeEach
-  @Override
-  void setUp() {
-    super.setUp();
-    blocksByRoot.clear();
-    // For Gloas, set up mock to retrieve blocks by root
-    when(combinedChainDataClient.getBlockByBlockRoot(any()))
-        .thenAnswer(
-            invocation -> {
-              final Bytes32 root = invocation.getArgument(0);
-              return SafeFuture.completedFuture(Optional.ofNullable(blocksByRoot.get(root)));
-            });
-  }
 
   @Override
   protected Spec createSpec() {
@@ -70,7 +52,10 @@ public class DataColumnSidecarsByRootListenerValidatingProxyGloasTest
   protected SignedBeaconBlock createBlock(final UInt64 slot) {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(slot, 3);
-    blocksByRoot.put(block.getRoot(), block);
+    final SszList<SszKZGCommitment> commitments =
+        block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(commitments)));
     return block;
   }
 
@@ -125,7 +110,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyGloasTest
             timeProvider,
             signatureValidator,
             dataColumnIdentifiers,
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecar(block1, ZERO);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyGloasTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
@@ -54,7 +55,10 @@ public class DataColumnSidecarsByRootListenerValidatingProxyGloasTest
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(slot, 3);
     final SszList<SszKZGCommitment> commitments =
         block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
-    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(block.getRoot()))
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(
+            argThat(
+                (DataColumnSidecar sidecar) ->
+                    sidecar != null && sidecar.getBeaconBlockRoot().equals(block.getRoot()))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(commitments)));
     return block;
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorFuluTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorFuluTest.java
@@ -59,7 +59,7 @@ public class DataColumnSidecarsByRootValidatorFuluTest
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertThatSafeFuture(validator.validate(dataColumnSidecar1_0_modified))
         .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
@@ -48,7 +49,10 @@ public class DataColumnSidecarsByRootValidatorGloasTest
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(slot, 3);
     final SszList<SszKZGCommitment> commitments =
         block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
-    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(block.getRoot()))
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(
+            argThat(
+                (DataColumnSidecar sidecar) ->
+                    sidecar != null && sidecar.getBeaconBlockRoot().equals(block.getRoot()))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(commitments)));
     return block;
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidatorGloasTest.java
@@ -17,14 +17,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -32,28 +29,13 @@ import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumnSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.gloas.DataColumnSidecarSchemaGloas;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnIdentifier;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 
 @SuppressWarnings("JavaCase")
 public class DataColumnSidecarsByRootValidatorGloasTest
     extends AbstractDataColumnSidecarsByRootValidatorTest {
-
-  private final Map<Bytes32, SignedBeaconBlock> blocksByRoot = new HashMap<>();
-
-  @BeforeEach
-  @Override
-  void setUp() {
-    super.setUp();
-    blocksByRoot.clear();
-    // For Gloas, validateWithBlock fetches the block to retrieve bid KZG commitments
-    when(combinedChainDataClient.getBlockByBlockRoot(any()))
-        .thenAnswer(
-            invocation -> {
-              final Bytes32 root = invocation.getArgument(0);
-              return SafeFuture.completedFuture(Optional.ofNullable(blocksByRoot.get(root)));
-            });
-  }
 
   @Override
   protected Spec createSpec() {
@@ -62,10 +44,12 @@ public class DataColumnSidecarsByRootValidatorGloasTest
 
   @Override
   protected SignedBeaconBlock createBlock(final UInt64 slot) {
-    // Create a block with commitments and register it so validateWithBlock can find it
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(slot, 3);
-    blocksByRoot.put(block.getRoot(), block);
+    final SszList<SszKZGCommitment> commitments =
+        block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
+    when(blobKzgCommitmentsProvider.getBlobKzgCommitments(block.getRoot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(commitments)));
     return block;
   }
 
@@ -105,7 +89,7 @@ public class DataColumnSidecarsByRootValidatorGloasTest
             timeProvider,
             dataColumnSidecarSignatureValidator,
             List.of(sidecarIdentifier1_0),
-            combinedChainDataClient);
+            blobKzgCommitmentsProvider);
 
     assertThatSafeFuture(validator.validate(dataColumnSidecar1_0))
         .isCompletedExceptionallyWith(DataColumnSidecarsResponseInvalidResponseException.class)

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -120,6 +120,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsSupplier;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.CustodyGroupCountChannel;
 import tech.pegasys.teku.statetransition.block.VerifiedBlockOperationsListener;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarArchiveReconstructor;
 import tech.pegasys.teku.statetransition.datacolumns.log.gossip.DasGossipLogger;
@@ -275,6 +276,8 @@ public class Eth2P2PNetworkFactory {
             new SubnetSubscriptionService();
         final CombinedChainDataClient combinedChainDataClient =
             new CombinedChainDataClient(recentChainData, historicalChainData, spec);
+        final BlobKzgCommitmentsProvider blobKzgCommitmentsProvider =
+            new BlobKzgCommitmentsProvider(spec, combinedChainDataClient, 128);
         final DataColumnSidecarSubnetTopicProvider dataColumnSidecarSubnetTopicProvider =
             new DataColumnSidecarSubnetTopicProvider(
                 combinedChainDataClient.getRecentChainData(), gossipEncoding);
@@ -321,6 +324,7 @@ public class Eth2P2PNetworkFactory {
             Eth2PeerManager.create(
                 asyncRunner,
                 combinedChainDataClient,
+                blobKzgCommitmentsProvider,
                 () -> custodyGroupCountManager,
                 metadataMessagesFactory,
                 METRICS_SYSTEM,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -931,7 +931,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
     if (spec.isMilestoneSupported(SpecMilestone.FULU)) {
       dataColumnSidecarGossipValidator =
           DataColumnSidecarGossipValidator.create(
-              spec, invalidBlockRoots, gossipValidationHelper, metricsSystem, timeProvider);
+              spec,
+              invalidBlockRoots,
+              gossipValidationHelper,
+              blobKzgCommitmentsProvider,
+              metricsSystem,
+              timeProvider);
       dataColumnSidecarManager =
           new DataColumnSidecarManagerImpl(
               dataColumnSidecarGossipValidator, dasGossipLogger, metricsSystem, timeProvider);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.api.RewardCalculator;
 import tech.pegasys.teku.beacon.sync.DefaultSyncServiceFactory;
+import tech.pegasys.teku.beacon.sync.SyncConfig;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.beacon.sync.SyncServiceFactory;
 import tech.pegasys.teku.beacon.sync.events.CoalescingChainHeadChannel;
@@ -169,6 +170,7 @@ import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.block.FailedExecutionPool;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
+import tech.pegasys.teku.statetransition.datacolumns.BlobKzgCommitmentsProvider;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolver;
 import tech.pegasys.teku.statetransition.datacolumns.CurrentSlotProvider;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
@@ -362,6 +364,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile AttestationManager attestationManager;
   protected volatile SignatureVerificationService signatureVerificationService;
   protected volatile CombinedChainDataClient combinedChainDataClient;
+  protected volatile BlobKzgCommitmentsProvider blobKzgCommitmentsProvider;
   protected volatile OperationsReOrgManager operationsReOrgManager;
   protected volatile Eth1DataCache eth1DataCache;
   protected volatile SlotProcessor slotProcessor;
@@ -709,6 +712,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     initForkChoice();
     initBlockImporter();
     initCombinedChainDataClient();
+    initBlobKzgCommitmentsProvider();
     initAttestationPool();
     initAttesterSlashingPool();
     initProposerSlashingPool();
@@ -1160,7 +1164,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
           new DasPreSampler(
               this.dataAvailabilitySampler,
               this.dataColumnSidecarCustodyRef.get(),
-              custodyGroupCountManager);
+              custodyGroupCountManager,
+              blobKzgCommitmentsProvider);
       eventChannels.subscribe(SyncPreImportBlockChannel.class, dasPreSampler::onNewPreImportBlocks);
     }
   }
@@ -1565,6 +1570,20 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.debug("BeaconChainController.initCombinedChainDataClient()");
     combinedChainDataClient =
         new CombinedChainDataClient(recentChainData, storageQueryChannel, spec);
+  }
+
+  protected void initBlobKzgCommitmentsProvider() {
+    LOG.debug("BeaconChainController.initBlobKzgCommitmentsProvider()");
+    final SyncConfig syncConfig = beaconConfig.syncConfig();
+    final int maxCacheSize =
+        Math.max(
+            128,
+            syncConfig.getForwardSyncBatchSize() * syncConfig.getForwardSyncMaxPendingBatches());
+    blobKzgCommitmentsProvider =
+        new BlobKzgCommitmentsProvider(spec, combinedChainDataClient, maxCacheSize);
+    eventChannels
+        .subscribe(ReceivedBlockEventsChannel.class, blobKzgCommitmentsProvider)
+        .subscribe(FinalizedCheckpointChannel.class, blobKzgCommitmentsProvider);
   }
 
   protected SafeFuture<Void> initWeakSubjectivity(
@@ -2006,6 +2025,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .eventChannels(eventChannels)
             .combinedChainDataClient(
                 throttlingCombinedChainDataClient.orElse(combinedChainDataClient))
+            .blobKzgCommitmentsProvider(blobKzgCommitmentsProvider)
             .custodyGroupCountManagerSupplier(() -> custodyGroupCountManager)
             .gossipedBlockProcessor(blockManager::validateAndImportBlock)
             .gossipedBlobSidecarProcessor(blobSidecarManager::validateAndPrepareForBlockImport)

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -501,11 +501,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected void startServices() {
     final RecentBlocksFetcher recentBlocksFetcher = syncService.getRecentBlocksFetcher();
     recentBlocksFetcher.subscribeBlockFetched(
-        block ->
-            blockManager
-                .importBlock(block, RemoteOrigin.RPC)
-                .thenCompose(BlockImportAndBroadcastValidationResults::blockImportResult)
-                .finish(err -> LOG.error("Failed to process recently fetched block.", err)));
+        block -> {
+          // Make RPC-fetched block commitments visible before import can trigger sidecar
+          // validation.
+          blobKzgCommitmentsProvider.onNewBlock(block);
+          blockManager
+              .importBlock(block, RemoteOrigin.RPC)
+              .thenCompose(BlockImportAndBroadcastValidationResults::blockImportResult)
+              .finish(err -> LOG.error("Failed to process recently fetched block.", err));
+        });
     eventChannels.subscribe(ReceivedBlockEventsChannel.class, recentBlocksFetcher);
     final RecentBlobSidecarsFetcher recentBlobSidecarsFetcher =
         syncService.getRecentBlobSidecarsFetcher();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -937,7 +937,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
               spec,
               invalidBlockRoots,
               gossipValidationHelper,
-              blobKzgCommitmentsProvider,
+              () -> blobKzgCommitmentsProvider,
               metricsSystem,
               timeProvider);
       dataColumnSidecarManager =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1592,10 +1592,13 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected void initBlobKzgCommitmentsProvider() {
     LOG.debug("BeaconChainController.initBlobKzgCommitmentsProvider()");
     final SyncConfig syncConfig = beaconConfig.syncConfig();
+    // Keep one extra batch for overlap between feeding a new forward-sync batch and validating data
+    // column responses for batches already in flight.
     final int maxCacheSize =
         Math.max(
             128,
-            syncConfig.getForwardSyncBatchSize() * syncConfig.getForwardSyncMaxPendingBatches());
+            syncConfig.getForwardSyncBatchSize()
+                * (syncConfig.getForwardSyncMaxPendingBatches() + 1));
     blobKzgCommitmentsProvider =
         new BlobKzgCommitmentsProvider(spec, combinedChainDataClient, maxCacheSize);
     eventChannels


### PR DESCRIPTION
fixes #10797

alternative to #10818

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how KZG commitments are resolved during gossip and sync validation; incorrect caching or timing could mis-validate or defer sidecars, though behavior is covered by new unit tests.
> 
> **Overview**
> Introduces **`BlobKzgCommitmentsProvider`** so data column sidecar validation can resolve **`blob_kzg_commitments` by beacon block root** before the block is fully imported, with an LRU cache fed from gossip validation, pre-import sync, RPC-fetched blocks, and import events (plus pruning on finalize and parent eviction on import).
> 
> **KZG validation** no longer loads a full **`SignedBeaconBlock`** via `validateAndVerifyKzgProofsWithBlock`; fork utils now take **`validateAndVerifyKzgProofs`** with `retrieveBlobKzgCommitments`. **Fulu** still verifies proofs against supplied commitments but goes through the provider (sidecar-embedded commitments when present). **Gloas** validates structure and KZG proofs from the commitment list only. Gossip, **DasPreSampler**, eth2 req/resp validators, and P2P wiring are updated to inject the provider instead of **`CombinedChainDataClient`** block lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29844dfadff00e27e2d655b63b2140951473d4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->