### PR TITLE
never fallback to base in resolveVoteNode

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -381,7 +381,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
     if (payloadPresent) {
       return blockNodeIndex.getFullNode(voteRoot);
     }
-    return blockNodeIndex.getEmptyNode(voteRoot).or(() -> maybeBaseNode);
+    return blockNodeIndex.getEmptyNode(voteRoot);
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how validator vote weight is applied in Gloas fork choice when EMPTY nodes are missing, which can affect head selection and scoring.
> 
> **Overview**
> In **Gloas fork choice**, `resolveVoteNode` no longer falls back to the **BASE** node when resolving a vote without a payload hint and the **EMPTY** variant is missing.
> 
> Previously, `getEmptyNode(voteRoot).or(() -> maybeBaseNode)` could attach attestations to the structural BASE node after the vote slot had moved past the block slot. The method now returns only `getEmptyNode(voteRoot)`, so an unresolved EMPTY yields **no** node instead of crediting BASE. Votes that still qualify via `voteSlot <= blockSlot` continue to resolve to BASE unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d986d2b92ec7955ee295bf894caf59b34c176241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->