### PR TITLE
Disconnect bad inbound connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@
 ### Additions and Improvements
 
 ### Bug Fixes
+
+- Prevent RPC rate-limited peers from immediately reconnecting inbound.

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -292,7 +292,7 @@ public class LibP2PPeer implements Peer {
   public void adjustReputation(final ReputationAdjustment adjustment) {
     final boolean shouldDisconnect = reputationManager.adjustReputation(getAddress(), adjustment);
     if (shouldDisconnect) {
-      disconnectCleanly(DisconnectReason.REMOTE_FAULT).finishError(LOG);
+      disconnectCleanly(DisconnectReason.BAD_SCORE).finishError(LOG);
     }
   }
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
@@ -167,10 +167,14 @@ public class PeerManager implements ConnectionHandler {
     final boolean wasAdded = connectedPeerMap.putIfAbsent(peer.getId(), peer) == null;
     if (wasAdded) {
       LOG.debug("onConnectedPeer() {}", peer.getId());
-      peerHandlers.forEach(h -> h.onConnect(peer));
-      connectSubscribers.forEach(c -> c.onConnected(peer));
       peer.subscribeDisconnect(
           (reason, locallyInitiated) -> onDisconnectedPeer(peer, reason, locallyInitiated));
+      // Eth2PeerManager installs the clean-disconnect handler used to send goodbye messages.
+      peerHandlers.forEach(h -> h.onConnect(peer));
+      if (rejectUnsuitableInboundConnection(peer)) {
+        return;
+      }
+      connectSubscribers.forEach(c -> c.onConnected(peer));
     } else {
       LOG.trace("Disconnecting duplicate connection to {}", peer::getId);
       peer.disconnectImmediately(Optional.of(DisconnectReason.DUPLICATE_CONNECTION), true);
@@ -186,6 +190,21 @@ public class PeerManager implements ConnectionHandler {
       reputationManager.reportDisconnection(peer.getAddress(), reason, locallyInitiated);
       peerHandlers.forEach(h -> h.onDisconnect(peer));
     }
+  }
+
+  private boolean rejectUnsuitableInboundConnection(final Peer peer) {
+    if (peer.connectionInitiatedLocally()) {
+      return false;
+    }
+    return reputationManager
+        .getInboundConnectionRejectionReason(peer.getAddress())
+        .map(
+            reason -> {
+              LOG.debug("Rejecting inbound connection from {} because {}", peer.getId(), reason);
+              peer.disconnectCleanly(reason).finishTrace(LOG);
+              return true;
+            })
+        .orElse(false);
   }
 
   public Stream<Peer> streamPeers() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
@@ -145,6 +145,8 @@ public class DefaultReputationManager implements ReputationManager {
             DisconnectReason.UNABLE_TO_VERIFY_NETWORK,
             DisconnectReason.BAD_SCORE,
             DisconnectReason.REMOTE_FAULT);
+    private static final EnumSet<DisconnectReason> INBOUND_REJECTION_DURING_COOLDOWN_REASONS =
+        EnumSet.of(DisconnectReason.RATE_LIMITING);
 
     private volatile Optional<UInt64> suitableAfter = Optional.empty();
     private volatile Optional<DisconnectReason> inboundConnectionRejectionReason = Optional.empty();
@@ -179,13 +181,22 @@ public class DefaultReputationManager implements ReputationManager {
         score.set(DEFAULT_SCORE);
       } else if (suitableAfter.isEmpty()) {
         suitableAfter = Optional.of(disconnectTime.plus(COOLDOWN_PERIOD));
-        inboundConnectionRejectionReason = Optional.empty();
+        inboundConnectionRejectionReason =
+            isLocallyConsideredUnsuitableDuringCooldown(reason, locallyInitiated)
+                ? reason
+                : Optional.empty();
       }
     }
 
     private static boolean isLocallyConsideredUnsuitable(
         final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
       return locallyInitiated && reason.map(BAN_REASONS::contains).orElse(false);
+    }
+
+    private static boolean isLocallyConsideredUnsuitableDuringCooldown(
+        final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
+      return locallyInitiated
+          && reason.map(INBOUND_REJECTION_DURING_COOLDOWN_REASONS::contains).orElse(false);
     }
 
     public boolean adjustReputation(final ReputationAdjustment effect, final UInt64 currentTime) {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
@@ -76,6 +76,19 @@ public class DefaultReputationManager implements ReputationManager {
   }
 
   @Override
+  public Optional<DisconnectReason> getInboundConnectionRejectionReason(
+      final PeerAddress peerAddress) {
+    if (isStaticPeer(peerAddress)) {
+      return Optional.empty();
+    }
+    return peerReputations
+        .getCached(peerAddress.getId())
+        .flatMap(
+            reputation ->
+                reputation.getInboundConnectionRejectionReason(timeProvider.getTimeInSeconds()));
+  }
+
+  @Override
   public void reportInitiatedConnectionSuccessful(final PeerAddress peerAddress) {
     getOrCreateReputation(peerAddress).reportInitiatedConnectionSuccessful();
   }
@@ -130,13 +143,16 @@ public class DefaultReputationManager implements ReputationManager {
         EnumSet.of(
             DisconnectReason.IRRELEVANT_NETWORK,
             DisconnectReason.UNABLE_TO_VERIFY_NETWORK,
+            DisconnectReason.BAD_SCORE,
             DisconnectReason.REMOTE_FAULT);
 
     private volatile Optional<UInt64> suitableAfter = Optional.empty();
+    private volatile Optional<DisconnectReason> inboundConnectionRejectionReason = Optional.empty();
     private final AtomicInteger score = new AtomicInteger(DEFAULT_SCORE);
 
     public void reportInitiatedConnectionFailed(final UInt64 failureTime) {
       suitableAfter = Optional.of(failureTime.plus(COOLDOWN_PERIOD));
+      inboundConnectionRejectionReason = Optional.empty();
     }
 
     public boolean shouldInitiateConnection(final UInt64 currentTime) {
@@ -149,6 +165,7 @@ public class DefaultReputationManager implements ReputationManager {
 
     public void reportInitiatedConnectionSuccessful() {
       suitableAfter = Optional.empty();
+      inboundConnectionRejectionReason = Optional.empty();
     }
 
     public void reportDisconnection(
@@ -158,9 +175,11 @@ public class DefaultReputationManager implements ReputationManager {
       if (isLocallyConsideredUnsuitable(reason, locallyInitiated)
           || reason.map(DisconnectReason::isPermanent).orElse(false)) {
         suitableAfter = Optional.of(disconnectTime.plus(BAN_PERIOD));
+        inboundConnectionRejectionReason = reason;
         score.set(DEFAULT_SCORE);
       } else if (suitableAfter.isEmpty()) {
         suitableAfter = Optional.of(disconnectTime.plus(COOLDOWN_PERIOD));
+        inboundConnectionRejectionReason = Optional.empty();
       }
     }
 
@@ -181,9 +200,18 @@ public class DefaultReputationManager implements ReputationManager {
       if (shouldDisconnect) {
         // Prevent our node from connecting out to the remote peer for a long time
         suitableAfter = Optional.of(currentTime.plus(BAN_PERIOD));
+        inboundConnectionRejectionReason = Optional.of(DisconnectReason.BAD_SCORE);
         score.set(DEFAULT_SCORE);
       }
       return shouldDisconnect;
+    }
+
+    public Optional<DisconnectReason> getInboundConnectionRejectionReason(
+        final UInt64 currentTime) {
+      if (isSuitableAt(currentTime)) {
+        return Optional.empty();
+      }
+      return inboundConnectionRejectionReason;
     }
 
     @Override
@@ -204,6 +232,12 @@ public class DefaultReputationManager implements ReputationManager {
     @Override
     public boolean adjustReputation(final ReputationAdjustment effect, final UInt64 currentTime) {
       return false;
+    }
+
+    @Override
+    public Optional<DisconnectReason> getInboundConnectionRejectionReason(
+        final UInt64 currentTime) {
+      return Optional.empty();
     }
 
     @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManager.java
@@ -174,23 +174,33 @@ public class DefaultReputationManager implements ReputationManager {
         final UInt64 disconnectTime,
         final Optional<DisconnectReason> reason,
         final boolean locallyInitiated) {
-      if (isLocallyConsideredUnsuitable(reason, locallyInitiated)
-          || reason.map(DisconnectReason::isPermanent).orElse(false)) {
+      if (shouldBan(reason, locallyInitiated)) {
         suitableAfter = Optional.of(disconnectTime.plus(BAN_PERIOD));
         inboundConnectionRejectionReason = reason;
         score.set(DEFAULT_SCORE);
+      } else if (isLocallyConsideredUnsuitableDuringCooldown(reason, locallyInitiated)) {
+        suitableAfter = Optional.of(disconnectTime.plus(COOLDOWN_PERIOD));
+        inboundConnectionRejectionReason = reason;
       } else if (suitableAfter.isEmpty()) {
         suitableAfter = Optional.of(disconnectTime.plus(COOLDOWN_PERIOD));
-        inboundConnectionRejectionReason =
-            isLocallyConsideredUnsuitableDuringCooldown(reason, locallyInitiated)
-                ? reason
-                : Optional.empty();
+        inboundConnectionRejectionReason = Optional.empty();
       }
     }
 
-    private static boolean isLocallyConsideredUnsuitable(
+    private static boolean shouldBan(
         final Optional<DisconnectReason> reason, final boolean locallyInitiated) {
-      return locallyInitiated && reason.map(BAN_REASONS::contains).orElse(false);
+      return reason
+          .map(
+              disconnectReason -> {
+                if (disconnectReason.isPermanent()) {
+                  return true;
+                }
+                if (!locallyInitiated) {
+                  return false;
+                }
+                return BAN_REASONS.contains(disconnectReason);
+              })
+          .orElse(false);
     }
 
     private static boolean isLocallyConsideredUnsuitableDuringCooldown(

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/ReputationManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/reputation/ReputationManager.java
@@ -29,6 +29,12 @@ public interface ReputationManager {
         }
 
         @Override
+        public Optional<DisconnectReason> getInboundConnectionRejectionReason(
+            final PeerAddress peerAddress) {
+          return Optional.empty();
+        }
+
+        @Override
         public void reportInitiatedConnectionSuccessful(PeerAddress peerAddress) {}
 
         @Override
@@ -44,6 +50,12 @@ public interface ReputationManager {
   void reportInitiatedConnectionFailed(final PeerAddress peerAddress);
 
   boolean isConnectionInitiationAllowed(final PeerAddress peerAddress);
+
+  /**
+   * Returns the reason to use when rejecting an inbound connection from this peer, or empty when
+   * the peer should not be rejected. This excludes temporary outbound dial cooldowns.
+   */
+  Optional<DisconnectReason> getInboundConnectionRejectionReason(final PeerAddress peerAddress);
 
   void reportInitiatedConnectionSuccessful(final PeerAddress peerAddress);
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment.LARGE_PENALTY;
 
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler;
+import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
@@ -161,5 +163,24 @@ public class LibP2PPeerTest {
     assertThat(disconnectionReason.get()).contains(DisconnectReason.IRRELEVANT_NETWORK);
     assertThat(disconnectionLocallyInitiated.get()).isTrue();
     assertThat(disconnectionCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void adjustReputation_shouldDisconnectWithBadScoreWhenThresholdIsReached() {
+    final ReputationManager reputationManager = mock(ReputationManager.class);
+    final LibP2PPeer peer =
+        new LibP2PPeer(connection, List.of(rpcHandler), reputationManager, p -> 0.0);
+    final AtomicReference<DisconnectReason> disconnectReason = new AtomicReference<>();
+    peer.setDisconnectRequestHandler(
+        reason -> {
+          disconnectReason.set(reason);
+          return SafeFuture.COMPLETE;
+        });
+    when(reputationManager.adjustReputation(any(PeerAddress.class), eq(LARGE_PENALTY)))
+        .thenReturn(true);
+
+    peer.adjustReputation(LARGE_PENALTY);
+
+    assertThat(disconnectReason).hasValue(DisconnectReason.BAD_SCORE);
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManagerTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.p2p.libp2p;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -36,11 +37,15 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
+import tech.pegasys.teku.networking.p2p.network.PeerAddress;
+import tech.pegasys.teku.networking.p2p.network.PeerHandler;
+import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 
@@ -134,6 +139,57 @@ public class PeerManagerTest {
     Assertions.assertThrows(
         PeerAlreadyConnectedException.class, () -> peerManager.onConnectedPeer(peer));
 
+    assertThat(connectedPeers).containsExactly(peer);
+  }
+
+  @Test
+  public void subscribeConnect_shouldRejectInboundConnectionWithBadReputation() {
+    final PeerHandler peerHandler = mock(PeerHandler.class);
+    final PeerManager peerManager =
+        new PeerManager(
+            new StubMetricsSystem(),
+            reputationManager,
+            List.of(peerHandler),
+            Collections.emptyList(),
+            peerId -> 0.0);
+    final List<Peer> connectedPeers = new ArrayList<>();
+    peerManager.subscribeConnect(connectedPeers::add);
+
+    final Peer peer = mock(Peer.class);
+    final MockNodeId nodeId = new MockNodeId(1);
+    final PeerAddress peerAddress = new PeerAddress(nodeId);
+    when(peer.getId()).thenReturn(nodeId);
+    when(peer.getAddress()).thenReturn(peerAddress);
+    when(peer.connectionInitiatedLocally()).thenReturn(false);
+    when(peer.disconnectCleanly(DisconnectReason.BAD_SCORE)).thenReturn(SafeFuture.COMPLETE);
+    when(reputationManager.getInboundConnectionRejectionReason(peerAddress))
+        .thenReturn(Optional.of(DisconnectReason.BAD_SCORE));
+
+    peerManager.onConnectedPeer(peer);
+
+    final InOrder inOrder = inOrder(peerHandler, peer);
+    inOrder.verify(peerHandler).onConnect(peer);
+    inOrder.verify(peer).disconnectCleanly(DisconnectReason.BAD_SCORE);
+    assertThat(connectedPeers).isEmpty();
+  }
+
+  @Test
+  public void subscribeConnect_shouldNotRejectOutboundConnectionWithBadReputation() {
+    final List<Peer> connectedPeers = new ArrayList<>();
+    peerManager.subscribeConnect(connectedPeers::add);
+
+    final Peer peer = mock(Peer.class);
+    final MockNodeId nodeId = new MockNodeId(1);
+    final PeerAddress peerAddress = new PeerAddress(nodeId);
+    when(peer.getId()).thenReturn(nodeId);
+    when(peer.getAddress()).thenReturn(peerAddress);
+    when(peer.connectionInitiatedLocally()).thenReturn(true);
+    when(reputationManager.getInboundConnectionRejectionReason(peerAddress))
+        .thenReturn(Optional.of(DisconnectReason.BAD_SCORE));
+
+    peerManager.onConnectedPeer(peer);
+
+    verify(peer, never()).disconnectCleanly(DisconnectReason.BAD_SCORE);
     assertThat(connectedPeers).containsExactly(peer);
   }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManagerTest.java
@@ -114,6 +114,25 @@ class DefaultReputationManagerTest {
   }
 
   @Test
+  void shouldRejectInboundConnectionAfterRateLimitDisconnect() {
+    reputationManager.reportDisconnection(
+        peerAddress, Optional.of(DisconnectReason.RATE_LIMITING), true);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress))
+        .contains(DisconnectReason.RATE_LIMITING);
+  }
+
+  @Test
+  void shouldStopRejectingInboundConnectionAfterRateLimitCooldownExpires() {
+    reputationManager.reportDisconnection(
+        peerAddress, Optional.of(DisconnectReason.RATE_LIMITING), true);
+
+    timeProvider.advanceTimeBySeconds(MORE_THAN_COOLDOWN_PERIOD);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress)).isEmpty();
+  }
+
+  @Test
   void shouldAllowConnectionAfterDisconnectAfterTimePasses() {
     reputationManager.reportDisconnection(peerAddress, Optional.empty(), true);
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManagerTest.java
@@ -55,6 +55,13 @@ class DefaultReputationManagerTest {
   }
 
   @Test
+  public void shouldNotRejectInboundConnectionWhenConnectionHasFailedRecently() {
+    reputationManager.reportInitiatedConnectionFailed(peerAddress);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress)).isEmpty();
+  }
+
+  @Test
   public void shouldAllowConnectionInitiationToUnknownPeers() {
     assertThat(reputationManager.isConnectionInitiationAllowed(peerAddress)).isTrue();
   }
@@ -97,6 +104,13 @@ class DefaultReputationManagerTest {
 
     assertThat(reputationManager.isConnectionInitiationAllowed(new PeerAddress(new MockNodeId(1))))
         .isFalse();
+  }
+
+  @Test
+  void shouldNotRejectInboundConnectionAfterDisconnect() {
+    reputationManager.reportDisconnection(peerAddress, Optional.empty(), true);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress)).isEmpty();
   }
 
   @Test
@@ -154,6 +168,7 @@ class DefaultReputationManagerTest {
     return Stream.of(
         DisconnectReason.IRRELEVANT_NETWORK,
         DisconnectReason.UNABLE_TO_VERIFY_NETWORK,
+        DisconnectReason.BAD_SCORE,
         DisconnectReason.REMOTE_FAULT);
   }
 
@@ -170,6 +185,23 @@ class DefaultReputationManagerTest {
 
     timeProvider.advanceTimeBySeconds(MORE_THAN_BAN_PERIOD);
     assertThat(reputationManager.isConnectionInitiationAllowed(peerAddress)).isTrue();
+  }
+
+  @Test
+  void shouldRejectInboundConnectionAfterScoreDropsBelowThreshold() {
+    reputationManager.adjustReputation(peerAddress, LARGE_PENALTY);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress))
+        .contains(DisconnectReason.BAD_SCORE);
+  }
+
+  @Test
+  void shouldStopRejectingInboundConnectionAfterBanExpires() {
+    reputationManager.adjustReputation(peerAddress, LARGE_PENALTY);
+
+    timeProvider.advanceTimeBySeconds(MORE_THAN_BAN_PERIOD);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress)).isEmpty();
   }
 
   @Test

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/reputation/DefaultReputationManagerTest.java
@@ -123,6 +123,28 @@ class DefaultReputationManagerTest {
   }
 
   @Test
+  void shouldRejectInboundConnectionAfterRateLimitDisconnectDuringExistingCooldown() {
+    reputationManager.reportInitiatedConnectionFailed(peerAddress);
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress)).isEmpty();
+
+    reputationManager.reportDisconnection(
+        peerAddress, Optional.of(DisconnectReason.RATE_LIMITING), true);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress))
+        .contains(DisconnectReason.RATE_LIMITING);
+  }
+
+  @Test
+  void shouldNotRejectInboundConnectionForStaticPeerAfterRateLimitDisconnect() {
+    peerPools.addPeerToPool(peerAddress.getId(), PeerConnectionType.STATIC);
+
+    reputationManager.reportDisconnection(
+        peerAddress, Optional.of(DisconnectReason.RATE_LIMITING), true);
+
+    assertThat(reputationManager.getInboundConnectionRejectionReason(peerAddress)).isEmpty();
+  }
+
+  @Test
   void shouldStopRejectingInboundConnectionAfterRateLimitCooldownExpires() {
     reputationManager.reportDisconnection(
         peerAddress, Optional.of(DisconnectReason.RATE_LIMITING), true);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Previously, reputation bans only affected outbound peer selection: Teku checked isConnectionInitiationAllowed before dialing discovered peers.

  A banned peer could still reconnect inbound because the p2p accept path did not consult reputation.

  This adds an inbound rejection check for reputation-banned peers and sends a clean BAD_SCORE goodbye before exposing the peer as connected.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #9924 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
