### PR TITLE
Avoid sublist allocation in TreeUtil.createTree

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/DataColumnSidecarDeserializationBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/DataColumnSidecarDeserializationBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.benchmarks.ssz;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.fulu.DataColumn;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class DataColumnSidecarDeserializationBenchmark {
+
+  private static final UInt64 SLOT = UInt64.ONE;
+
+  @Param({"1", "72"})
+  public int blobCount;
+
+  private DataColumnSidecarSchema<DataColumnSidecar> schema;
+  private Bytes serializedSidecar;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    final Spec spec = TestSpecFactory.createMainnetFulu();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(1, spec);
+    schema =
+        SchemaDefinitionsFulu.required(spec.atSlot(SLOT).getSchemaDefinitions())
+            .getDataColumnSidecarSchema()
+            .toBaseSchema();
+
+    final SignedBeaconBlockHeader signedBeaconBlockHeader =
+        dataStructureUtil.randomSignedBeaconBlockHeader(SLOT);
+    final DataColumn dataColumn = dataStructureUtil.randomDataColumn(SLOT, blobCount);
+    final DataColumnSidecar sidecar =
+        dataStructureUtil.new RandomDataColumnSidecarBuilder()
+            .slot(SLOT)
+            .index(UInt64.ZERO)
+            .signedBeaconBlockHeader(signedBeaconBlockHeader)
+            .kzgCommitments(dataStructureUtil.randomKZGCommitments(blobCount))
+            .kzgProofs(dataStructureUtil.randomKZGProofs(blobCount))
+            .dataColumn(dataColumn)
+            .build();
+
+    serializedSidecar = sidecar.sszSerialize();
+  }
+
+  @Benchmark
+  public DataColumnSidecar deserializeDataColumnSidecar() {
+    return schema.sszDeserialize(serializedSidecar);
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeUtil.java
@@ -113,43 +113,54 @@ public class TreeUtil {
   }
 
   public static TreeNode createTree(final List<? extends TreeNode> leafNodes, final int depth) {
-    if (leafNodes.isEmpty()) {
+    return createTree(leafNodes, 0, leafNodes.size(), depth);
+  }
+
+  private static TreeNode createTree(
+      final List<? extends TreeNode> leafNodes, final int from, final int to, final int depth) {
+    if (from == to) {
       return ZERO_TREES[depth];
     } else if (depth == 0) {
-      checkArgument(leafNodes.size() == 1);
-      return leafNodes.get(0);
+      checkArgument(to - from == 1);
+      return leafNodes.get(from);
     } else {
       long index = 1L << (depth - 1);
-      int iIndex = index > leafNodes.size() ? leafNodes.size() : (int) index;
+      int iIndex = index > to - from ? to : from + (int) index;
 
-      List<? extends TreeNode> leftSublist = leafNodes.subList(0, iIndex);
-      List<? extends TreeNode> rightSublist = leafNodes.subList(iIndex, leafNodes.size());
       return BranchNode.create(
-          createTree(leftSublist, depth - 1), createTree(rightSublist, depth - 1));
+          createTree(leafNodes, from, iIndex, depth - 1),
+          createTree(leafNodes, iIndex, to, depth - 1));
     }
   }
 
   public static TreeNode createTree(
       final List<? extends TreeNode> leafNodes, final TreeNode defaultNode, final int depth) {
-    if (leafNodes.isEmpty()) {
+    return createTree(leafNodes, defaultNode, 0, leafNodes.size(), depth);
+  }
+
+  private static TreeNode createTree(
+      final List<? extends TreeNode> leafNodes,
+      final TreeNode defaultNode,
+      final int from,
+      final int to,
+      final int depth) {
+    if (from == to) {
       if (depth > 0) {
-        TreeNode defaultChild = createTree(leafNodes, defaultNode, depth - 1);
+        TreeNode defaultChild = createTree(leafNodes, defaultNode, from, to, depth - 1);
         return BranchNode.create(defaultChild, defaultChild);
       } else {
         return defaultNode;
       }
     } else if (depth == 0) {
-      checkArgument(leafNodes.size() == 1);
-      return leafNodes.get(0);
+      checkArgument(to - from == 1);
+      return leafNodes.get(from);
     } else {
       long index = 1L << (depth - 1);
-      int iIndex = index > leafNodes.size() ? leafNodes.size() : (int) index;
+      int iIndex = index > to - from ? to : from + (int) index;
 
-      List<? extends TreeNode> leftSublist = leafNodes.subList(0, iIndex);
-      List<? extends TreeNode> rightSublist = leafNodes.subList(iIndex, leafNodes.size());
       return BranchNode.create(
-          createTree(leftSublist, defaultNode, depth - 1),
-          createTree(rightSublist, defaultNode, depth - 1));
+          createTree(leafNodes, defaultNode, from, iIndex, depth - 1),
+          createTree(leafNodes, defaultNode, iIndex, to, depth - 1));
     }
   }
 

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeTest.java
@@ -70,6 +70,33 @@ public class TreeTest {
   }
 
   @Test
+  public void testCreateTreeWithDefaultNode() {
+    final TreeNode defaultLeaf = newTestLeaf(111);
+    BranchNode n1 =
+        (BranchNode)
+            TreeUtil.createTree(
+                IntStream.range(0, 5).mapToObj(TreeTest::newTestLeaf).collect(Collectors.toList()),
+                defaultLeaf,
+                3);
+
+    BranchNode n10 = (BranchNode) n1.left();
+    BranchNode n11 = (BranchNode) n1.right();
+    BranchNode n100 = (BranchNode) n10.left();
+    BranchNode n101 = (BranchNode) n10.right();
+    BranchNode n110 = (BranchNode) n11.left();
+    BranchNode n111 = (BranchNode) n11.right();
+
+    assertThat(n100.left()).isEqualTo(newTestLeaf(0));
+    assertThat(n100.right()).isEqualTo(newTestLeaf(1));
+    assertThat(n101.left()).isEqualTo(newTestLeaf(2));
+    assertThat(n101.right()).isEqualTo(newTestLeaf(3));
+    assertThat(n110.left()).isEqualTo(newTestLeaf(4));
+    assertThat(n110.right()).isSameAs(defaultLeaf);
+    assertThat(n111.left()).isSameAs(defaultLeaf);
+    assertThat(n111.right()).isSameAs(defaultLeaf);
+  }
+
+  @Test
   public void testZeroLeafDefaultTree() {
     TreeNode n1 = TreeUtil.createDefaultTree(5, LeafNode.EMPTY_LEAF);
     assertThat(n1.get(0b1000)).isSameAs(LeafNode.EMPTY_LEAF);


### PR DESCRIPTION
I noticed this last time I run a allocation perf analysis with claude skill.

This is most relevant during column backfilling

<img width="779" height="479" alt="image" src="https://github.com/user-attachments/assets/e5b38ebd-ab75-4440-9672-e2155383c92f" />



--------- 

# DataColumnSidecar Deserialization Allocation Savings

Benchmark case:

- `DataColumnSidecar`
- `blobCount = 72`
- One benchmark operation is one `schema.sszDeserialize(serializedSidecar)` call.

Measured allocation:

| Version | Allocation |
| --- | ---: |
| Before `TreeUtil.createTree` range recursion | `1,207,425 B/op` |
| After `TreeUtil.createTree` range recursion | `891,521 B/op` |
| Saved | `315,904 B/op` |

The saved allocation is almost exactly explained by removed `ArrayList$SubList` objects:

```text
315,904 B / 32 B per ArrayList$SubList = 9,872 removed SubList objects
```

## Where The 9,872 SubLists Came From

Before the optimization, `TreeUtil.createTree(...)` recursively split lists with:

```java
leafNodes.subList(...)
leafNodes.subList(...)
```

That created two `ArrayList$SubList` objects for every internal tree node.

For a tree with `N` leaves:

```text
internal nodes = N - 1
SubList allocations = 2 * (N - 1)
```

## Per-Sidecar Breakdown

| Source | Reason | SubLists |
| --- | --- | ---: |
| 72 `Cell`s | each cell is `2048 B = 64 SSZ chunks`; `2 * (64 - 1) = 126` SubLists per cell | `72 * 126 = 9,072` |
| `DataColumn` list backing tree | 72 cells in max-length 4096 list tree | `158` |
| 72 KZG commitments | each commitment is `Bytes48 = 2 chunks`; `2` SubLists each | `144` |
| 72 KZG proofs | each proof is `Bytes48 = 2 chunks`; `2` SubLists each | `144` |
| KZG commitments list tree | list backing tree for 72 commitments | `158` |
| KZG proofs list tree | list backing tree for 72 proofs | `158` |
| Signed block header nested trees | small nested container/vector trees | `20` |
| Inclusion proof vector | `Vector[Bytes32, 4]`; `2 * (4 - 1)` | `6` |
| Top-level sidecar container | 6-field container tree; `2 * (6 - 1)` rounded via tree shape | `12` |
| **Total** |  | **`9,872`** |

## Key Takeaway

The saving is not from avoiding large retained structures. Each `ArrayList$SubList` is small, around `32 B`.

The win comes from volume:

```text
9,872 SubLists * 32 B = 315,904 B
```

So for a 72-blob `DataColumnSidecar`, the `createTree` optimization saves about:

```text
315,904 B/op ~= 308.5 KiB/op
```




## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
