### PR TITLE
Add jdk.management module to Docker runtime for process_cpu_seconds_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 ### Bug Fixes
 
 - Prevent RPC rate-limited peers from immediately reconnecting inbound.
+- Fixed missing `process_cpu_seconds_total` metric in the Docker images by adding the `jdk.management` module to the custom Java runtime.

--- a/docker/jdk25/Dockerfile
+++ b/docker/jdk25/Dockerfile
@@ -6,6 +6,7 @@ RUN $JAVA_HOME/bin/jlink \
          --add-modules java.se \
          --add-modules java.management \
          --add-modules java.prefs \
+         --add-modules jdk.management \
          --add-modules jdk.httpserver \
          --add-modules jdk.unsupported \
          --add-modules jdk.jdwp.agent \

--- a/docker/jdk26/Dockerfile
+++ b/docker/jdk26/Dockerfile
@@ -6,6 +6,7 @@ RUN $JAVA_HOME/bin/jlink \
          --add-modules java.se \
          --add-modules java.management \
          --add-modules java.prefs \
+         --add-modules jdk.management \
          --add-modules jdk.httpserver \
          --add-modules jdk.unsupported \
          --add-modules jdk.jdwp.agent \


### PR DESCRIPTION
## Summary

Fixes #10838.

After moving the Docker images to a custom `jlink`-built Java runtime, the `process_cpu_seconds_total` Prometheus metric stopped being emitted from the `/metrics` endpoint (other `process_*` metrics were unaffected).

**Root cause:** the `jlink` module list in `docker/jdk25/Dockerfile` and `docker/jdk26/Dockerfile` omitted the `jdk.management` module, which is the module that exports `com.sun.management`. Prometheus' `ProcessMetrics` CPU collector reads CPU time via `com.sun.management.OperatingSystemMXBean.getProcessCpuTime()`; without `jdk.management` the class cannot be resolved at runtime (`NoClassDefFoundError: com/sun/management/OperatingSystemMXBean`), so the collector silently drops the metric. Note `java.se` does not pull in any `jdk.*` modules, so it does not cover this.

## Change

Add `--add-modules jdk.management` to both Dockerfiles' `jlink` invocation.

## Testing

Reproduced and verified locally using the same JDK 25 + `jlink` setup the images use, with a small probe calling `getProcessCpuTime()`:

| Runtime | `jdk.management` present | `getProcessCpuTime()` |
|---------|--------------------------|------------------------|
| Current module list | absent | ❌ `NoClassDefFoundError: com/sun/management/OperatingSystemMXBean` |
| With `jdk.management` | present | ✅ returns CPU time |

Thanks to @yohamta0 for the detailed report and diagnosis.