### PR TITLE
Improve dependency update checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import groovy.json.JsonSlurper
+import groovy.xml.XmlSlurper
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import io.consensys.protocols.license.reporter.GroupedLicenseHtmlRenderer
 import tech.pegasys.teku.depcheck.DepCheckPlugin
@@ -19,7 +20,7 @@ buildscript {
 
 plugins {
 	id 'com.diffplug.spotless' version '8.5.1'
-	id 'com.github.ben-manes.versions' version '0.53.0'
+	id 'com.github.ben-manes.versions' version '0.54.0'
 	id 'com.github.jk1.dependency-license-report' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'net.ltgt.errorprone' version '4.3.0' apply false
@@ -175,10 +176,26 @@ def isNonStable = { String version ->
 	return !stableKeyword && !(version ==~ regex)
 }
 
-// reject all non stable versions
+def isWeb3jMajorUpgrade = { candidate ->
+	if (candidate.group != 'org.web3j') {
+		return false
+	}
+	def majorVersion = candidate.version.tokenize('.')[0]
+	return majorVersion.isInteger() && majorVersion.toInteger() >= 5
+}
+
+def isRejectedDependencyUpdate = { candidate ->
+	candidate.group == 'org.xerial.snappy' &&
+			candidate.module == 'snappy-java' &&
+			candidate.version == '1.1.10.8'
+}
+
+// reject all non stable versions and selected major upgrades
 tasks.named("dependencyUpdates").configure {
 	rejectVersionIf {
-		isNonStable(it.candidate.version)
+		isNonStable(it.candidate.version) ||
+				isWeb3jMajorUpgrade(it.candidate) ||
+				isRejectedDependencyUpdate(it.candidate)
 	}
 }
 
@@ -657,7 +674,63 @@ tasks.register('checkMavenCoordinateCollisions') {
 	}
 }
 
+def getManagedDependencyVersion = { String group, String artifact ->
+	def version = dependencyManagement.managedVersions["${group}:${artifact}"]
+	if (version == null) {
+		throw new GradleException("Managed dependency ${group}:${artifact} not found")
+	}
+	return version
+}
+
+def getBesuPrometheusMetricsBomVersion = { String besuVersion ->
+	def besuBom = configurations.detachedConfiguration(
+			dependencies.create("org.hyperledger.besu:bom:${besuVersion}@pom"))
+	besuBom.transitive = false
+	def pom = new XmlSlurper(false, false).parse(besuBom.singleFile)
+	def dependency = pom.dependencyManagement.dependencies.dependency.find {
+		it.groupId.text() == 'io.prometheus' && it.artifactId.text() == 'prometheus-metrics-bom'
+	}
+	if (dependency == null) {
+		throw new GradleException("Besu ${besuVersion} BOM does not import io.prometheus:prometheus-metrics-bom")
+	}
+	return dependency.version.text()
+}
+
+def majorMinorVersion = { String version ->
+	def parts = version.tokenize('.')
+	if (parts.size() < 2) {
+		throw new GradleException("Version ${version} must include major and minor components")
+	}
+	return parts.take(2).join('.')
+}
+
+tasks.register('checkBesuPrometheusVersionCompatibility') {
+	doLast {
+		def besuVersion = getManagedDependencyVersion('org.hyperledger.besu.internal', 'besu-metrics-core')
+		def tekuPrometheusVersion = getManagedDependencyVersion('io.prometheus', 'prometheus-metrics-bom')
+		def besuPrometheusVersion = getBesuPrometheusMetricsBomVersion(besuVersion)
+
+		if (majorMinorVersion(tekuPrometheusVersion) != majorMinorVersion(besuPrometheusVersion)) {
+			throw new GradleException("Teku manages io.prometheus:prometheus-metrics-bom:${tekuPrometheusVersion}, " +
+			"but org.hyperledger.besu:bom:${besuVersion} imports ${besuPrometheusVersion}. " +
+			"The Prometheus BOM must stay on the same major.minor version line as Besu.")
+		}
+	}
+}
+
+tasks.register('dependencyUpdateChecks', Exec) {
+	group = 'verification'
+	description = 'Runs the dependency update report and dependency compatibility checks.'
+	workingDir rootDir
+	commandLine gradlewCommand,
+			'dependencyUpdates',
+			'checkBesuPrometheusVersionCompatibility',
+			'checkMavenCoordinateCollisions',
+			'--no-parallel'
+}
+
 check.dependsOn('checkMavenCoordinateCollisions')
+check.dependsOn('checkBesuPrometheusVersionCompatibility')
 
 application {
 	applicationName = "teku"

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/SwaggerWebjarIntegrityTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/SwaggerWebjarIntegrityTest.java
@@ -35,6 +35,13 @@ import org.junit.jupiter.api.Test;
 class SwaggerWebjarIntegrityTest {
   private static final String VENDOR_COPY_PATH = "/swagger-ui/vendor";
 
+  @Test
+  public void swaggerUiBuilderShouldReferenceAvailableSwaggerUiWebjarVersion() {
+    assertThat(SwaggerUIBuilder.class.getResource(RESOURCES_WEBJARS_SWAGGER_UI + "swagger-ui.css"))
+        .as("SwaggerUIBuilder swagger-ui version should match org.webjars:swagger-ui")
+        .isNotNull();
+  }
+
   /**
    * `infrastructure/restapi/src/main/resources/swagger-ui/vendor` contains several files which
    * should match files with the same names in 'org.webjars:swagger-ui'.
@@ -58,7 +65,9 @@ class SwaggerWebjarIntegrityTest {
   }
 
   private byte[] getClasspathFile(final String path) throws IOException {
-    try (InputStream in = getClass().getResourceAsStream(path)) {
+    final InputStream in = getClass().getResourceAsStream(path);
+    assertThat(in).as("Classpath resource %s", path).isNotNull();
+    try (in) {
       return in.readAllBytes();
     }
   }


### PR DESCRIPTION
Summary

Update the Ben Manes versions plugin to 0.54.0.
Restrict dependencyUpdates so it does not suggest org.web3j major upgrades to 5.x or later. Explicitly reject org.xerial.snappy:snappy-java:1.1.10.8 due to xerial/snappy-java#692. Add checkBesuPrometheusVersionCompatibility to keep Teku’s Prometheus BOM on the same major/minor line as the Besu BOM. Add dependencyUpdateChecks as a one-command dependency update workflow that runs dependencyUpdates with --no-parallel plus the compatibility checks. Add coverage to ensure SwaggerUIBuilder references an available org.webjars:swagger-ui classpath resource.

Testing

./gradlew dependencyUpdateChecks
./gradlew spotlessGroovyGradleCheck --no-parallel
./gradlew :infrastructure:restapi:test --tests tech.pegasys.teku.infrastructure.restapi.SwaggerWebjarIntegrityTest --no-parallel

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
