### PR TITLE
Update dependencies and handle Guava JRE versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 }
 
 plugins {
-	id 'com.diffplug.spotless' version '8.5.1'
+	id 'com.diffplug.spotless' version '8.7.0'
 	id 'com.github.ben-manes.versions' version '0.54.0'
 	id 'com.github.jk1.dependency-license-report' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.7'
@@ -172,7 +172,7 @@ dependencyRules {
 
 def isNonStable = { String version ->
 	def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { keyword -> version.toUpperCase().contains(keyword) }
-	def regex = /^[0-9,.v-]+(-r)?$/
+	def regex = /^[0-9,.v-]+(-r|-jre)?$/
 	return !stableKeyword && !(version ==~ regex)
 }
 
@@ -186,27 +186,27 @@ def isWeb3jMajorUpgrade = { candidate ->
 
 def isRejectedDependencyUpdate = { candidate ->
 	candidate.group == 'org.xerial.snappy' &&
-			candidate.module == 'snappy-java' &&
-			candidate.version == '1.1.10.8'
+	candidate.module == 'snappy-java' &&
+	candidate.version == '1.1.10.8'
 }
 
 // reject all non stable versions and selected major upgrades
 tasks.named("dependencyUpdates").configure {
 	rejectVersionIf {
 		isNonStable(it.candidate.version) ||
-				isWeb3jMajorUpgrade(it.candidate) ||
-				isRejectedDependencyUpdate(it.candidate)
+		isWeb3jMajorUpgrade(it.candidate) ||
+		isRejectedDependencyUpdate(it.candidate)
 	}
 }
 
 spotless {
 	groovyGradle {
 		target files(
-				fileTree(rootDir) {
-					include '*.gradle'
-					include 'gradle/*.gradle'
-				},
-				allprojects.collect { project -> project.file('build.gradle') }.findAll { it.isFile() })
+		fileTree(rootDir) {
+			include '*.gradle'
+			include 'gradle/*.gradle'
+		},
+		allprojects.collect { project -> project.file('build.gradle') }.findAll { it.isFile() })
 		trimTrailingWhitespace()
 		endWithNewline()
 		greclipse()
@@ -684,7 +684,7 @@ def getManagedDependencyVersion = { String group, String artifact ->
 
 def getBesuPrometheusMetricsBomVersion = { String besuVersion ->
 	def besuBom = configurations.detachedConfiguration(
-			dependencies.create("org.hyperledger.besu:bom:${besuVersion}@pom"))
+	dependencies.create("org.hyperledger.besu:bom:${besuVersion}@pom"))
 	besuBom.transitive = false
 	def pom = new XmlSlurper(false, false).parse(besuBom.singleFile)
 	def dependency = pom.dependencyManagement.dependencies.dependency.find {
@@ -1230,11 +1230,11 @@ subprojects {
 		archiveBaseName = jarName
 		manifest {
 			attributes(
-					'Specification-Title': jarName,
-					'Specification-Version': project.version,
-					'Implementation-Title': jarName,
-					'Implementation-Version': specificVersion
-					)
+			'Specification-Title': jarName,
+			'Specification-Version': project.version,
+			'Implementation-Title': jarName,
+			'Implementation-Version': specificVersion
+			)
 		}
 		reproducibleFileOrder = true
 		preserveFileTimestamps = false

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -3,8 +3,8 @@ dependencyManagement {
 		mavenBom 'io.netty:netty-bom:4.2.14.Final'
 	}
 	dependencies {
-		dependency 'com.fasterxml.jackson.core:jackson-databind:2.21.2'
-		dependencySet(group: 'com.fasterxml.jackson.dataformat', version: '2.21.2') {
+		dependency 'com.fasterxml.jackson.core:jackson-databind:2.22.0'
+		dependencySet(group: 'com.fasterxml.jackson.dataformat', version: '2.22.0') {
 			entry 'jackson-dataformat-yaml'
 			entry 'jackson-dataformat-toml'
 		}
@@ -48,12 +48,12 @@ dependencyManagement {
 
 		dependency 'org.mock-server:mockserver-junit-jupiter:5.15.0'
 
-		dependencySet(group: 'io.swagger.core.v3', version: '2.2.48') {
+		dependencySet(group: 'io.swagger.core.v3', version: '2.2.51') {
 			entry 'swagger-annotations'
 		}
 
 		// On update don't forget to change version in tech.pegasys.teku.infrastructure.restapi.SwaggerUIBuilder
-		dependency 'org.webjars:swagger-ui:5.32.4'
+		dependency 'org.webjars:swagger-ui:5.32.6'
 
 		dependency 'org.thymeleaf:thymeleaf:3.1.4.RELEASE'
 		dependencySet(group: 'com.github.oshi', version: '6.12.0') {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/SwaggerUIBuilder.java
@@ -42,7 +42,7 @@ import tech.pegasys.teku.infrastructure.restapi.openapi.OpenApiDocBuilder;
 
 public class SwaggerUIBuilder {
   // Version here MUST match `swagger-ui` library version
-  private static final String SWAGGER_UI_VERSION = "5.32.4";
+  private static final String SWAGGER_UI_VERSION = "5.32.6";
 
   private static final String SWAGGER_UI_PATH = "/swagger-ui";
   private static final String SWAGGER_HOSTED_PATH = "/webjars/swagger-ui/" + SWAGGER_UI_VERSION;


### PR DESCRIPTION
Summary
Bump selected dependency versions, including Spotless, Jackson, Swagger annotations, and Swagger UI. Update SwaggerUIBuilder so its hardcoded Swagger UI version matches the webjar dependency. Treat -jre dependency versions as stable in the dependencyUpdates filter so Guava is reported correctly.

Testing
./gradlew dependencyUpdates --no-parallel -q
./gradlew spotlessGroovyGradleCheck -q

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
