### PR TITLE
Update Teku third-party dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 plugins {
 	id 'com.diffplug.spotless' version '8.7.0'
 	id 'com.github.ben-manes.versions' version '0.54.0'
-	id 'com.github.jk1.dependency-license-report' version '3.1.4'
+	id 'com.github.jk1.dependency-license-report' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'net.ltgt.errorprone' version '4.3.0' apply false
 	id 'de.undercouch.download' version '5.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 plugins {
 	id 'com.diffplug.spotless' version '8.7.0'
 	id 'com.github.ben-manes.versions' version '0.54.0'
-	id 'com.github.jk1.dependency-license-report' version '3.1.2'
+	id 'com.github.jk1.dependency-license-report' version '3.1.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'net.ltgt.errorprone' version '4.3.0' apply false
 	id 'de.undercouch.download' version '5.6.0'
@@ -1241,6 +1241,7 @@ subprojects {
 	}
 
 	dependencies {
+		compileOnlyApi 'com.google.code.findbugs:jsr305'
 		implementation 'com.google.guava:guava'
 		implementation 'org.apache.commons:commons-lang3'
 		implementation 'org.apache.logging.log4j:log4j-api'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,6 +1,6 @@
 dependencyManagement {
 	imports {
-		mavenBom 'io.netty:netty-bom:4.2.14.Final'
+		mavenBom 'io.netty:netty-bom:4.2.15.Final'
 	}
 	dependencies {
 		dependency 'com.fasterxml.jackson.core:jackson-databind:2.22.0'
@@ -8,7 +8,7 @@ dependencyManagement {
 			entry 'jackson-dataformat-yaml'
 			entry 'jackson-dataformat-toml'
 		}
-		dependency 'com.fasterxml.jackson.module:jackson-module-blackbird:2.21.2'
+		dependency 'com.fasterxml.jackson.module:jackson-module-blackbird:2.22.0'
 
 		dependencySet(group: 'com.google.errorprone', version: '2.45.0') {
 			entry 'error_prone_check_api'
@@ -17,7 +17,10 @@ dependencyManagement {
 
 		dependency 'tech.pegasys.tools.epchecks:errorprone-checks:1.1.1'
 
-		dependency 'com.google.guava:guava:33.1.0-jre'
+		dependencySet(group: 'com.google.code.findbugs', version: '3.0.2') {
+			entry 'jsr305'
+		}
+		dependency 'com.google.guava:guava:33.6.0-jre'
 
 		dependency 'org.yaml:snakeyaml:2.6'
 
@@ -32,7 +35,7 @@ dependencyManagement {
 
 		dependency 'info.picocli:picocli:4.7.7'
 
-		dependencySet(group: 'io.javalin', version: '7.2.0') {
+		dependencySet(group: 'io.javalin', version: '7.2.2') {
 			entry 'javalin'
 			entry 'javalin-rendering-thymeleaf'
 		}
@@ -44,7 +47,7 @@ dependencyManagement {
 
 		dependency 'org.hdrhistogram:HdrHistogram:2.2.2'
 
-		dependency 'org.jetbrains.kotlin:kotlin-stdlib:2.3.20'
+		dependency 'org.jetbrains.kotlin:kotlin-stdlib:2.4.0'
 
 		dependency 'org.mock-server:mockserver-junit-jupiter:5.15.0'
 
@@ -55,7 +58,7 @@ dependencyManagement {
 		// On update don't forget to change version in tech.pegasys.teku.infrastructure.restapi.SwaggerUIBuilder
 		dependency 'org.webjars:swagger-ui:5.32.6'
 
-		dependency 'org.thymeleaf:thymeleaf:3.1.4.RELEASE'
+		dependency 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
 		dependencySet(group: 'com.github.oshi', version: '6.12.0') {
 			entry 'oshi-core'
 			entry 'oshi-core-java11'
@@ -72,10 +75,10 @@ dependencyManagement {
 
 		dependency 'org.apache.commons:commons-text:1.15.0'
 		dependency 'org.apache.commons:commons-lang3:3.20.0'
-		dependency 'commons-io:commons-io:2.21.0'
+		dependency 'commons-io:commons-io:2.22.0'
 		dependency 'org.commonjava.mimeparse:mimeparse:0.1.3.3'
 
-		dependencySet(group: 'org.apache.logging.log4j', version: '2.25.4') {
+		dependencySet(group: 'org.apache.logging.log4j', version: '2.26.0') {
 			entry 'log4j-api'
 			entry 'log4j-core'
 			entry 'log4j-slf4j-impl'
@@ -94,14 +97,15 @@ dependencyManagement {
 			entry 'bcutil-jdk18on' // already used by dependencies, fixes offline building
 		}
 
-		dependencySet(group: 'org.junit.jupiter', version: '5.13.4') {
+		dependencySet(group: 'org.junit.jupiter', version: '5.14.4') {
 			entry 'junit-jupiter-api'
 			entry 'junit-jupiter-engine'
 			entry 'junit-jupiter-params'
 		}
-		dependency 'org.junit.platform:junit-platform-launcher:1.13.4'
+		dependency 'org.junit:junit-bom:5.14.4'
+		dependency 'org.junit.platform:junit-platform-launcher:1.14.4'
 
-		dependency 'net.java.dev.jna:jna:5.18.1'
+		dependency 'net.java.dev.jna:jna:5.19.1'
 
 		dependencySet(group: 'org.mockito', version: '5.23.0') {
 			entry 'mockito-core'
@@ -145,7 +149,7 @@ dependencyManagement {
 			entry "junit-jupiter"
 		}
 
-		dependency 'io.consensys.protocols:discovery:26.4.1'
+		dependency 'io.consensys.protocols:discovery:26.6.0'
 
 		dependencySet(group: 'org.jupnp', version: '3.0.4') {
 			entry "org.jupnp"
@@ -158,6 +162,6 @@ dependencyManagement {
 			entry 'jjwt-jackson'
 		}
 
-		dependency 'net.jqwik:jqwik:1.9.3'
+		dependency 'net.jqwik:jqwik:1.10.1'
 	}
 }

--- a/services/bootnode/build.gradle
+++ b/services/bootnode/build.gradle
@@ -13,6 +13,6 @@ dependencies {
 	implementation project(':storage')
 	implementation project(':storage:api')
 
-	testImplementation platform('org.junit:junit-bom:5.13.3')
+	testImplementation platform('org.junit:junit-bom')
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -774,10 +774,11 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     assertThat(actual.eth2NetworkConfiguration().getSpec())
         .isEqualTo(expected.eth2NetworkConfiguration().getSpec());
 
-    // Ignore any Spec assertion on recursion
+    // Ignore Spec recursion and synchronization locks from lazy suppliers.
     assertThat(actual)
         .usingRecursiveComparison()
         .ignoringFieldsOfTypes(Spec.class)
+        .ignoringFieldsMatchingRegexes(".*\\.lock")
         .isEqualTo(expected);
   }
 


### PR DESCRIPTION
 using `dependencyUpdateChecks`, excluding the Prometheus metrics BOM as requested.

## Highlights:
- Bumped Netty, Jackson Blackbird, Guava, Javalin, Kotlin stdlib, Thymeleaf, commons-io, Log4j, JUnit/JUnit Platform, JNA, Besu/discovery, and jqwik.
- Kept `io.prometheus:prometheus-metrics-bom` at `1.5.1`.
- Added explicit `jsr305` management because newer Guava no longer brings it transitively.
- Centralized `org.junit:junit-bom` and `com.google.code.findbugs:jsr305` versions in `gradle/versions.gradle`.
- Updated the CLI config recursive comparison to ignore internal lazy-supplier lock objects exposed by the Guava bump.

## Testing

- `./gradlew dependencyUpdateChecks`
- `./gradlew spotlessApply`
- `./gradlew clean build`
- `./gradlew :ethereum:json-types:test`
- `./gradlew :services:bootnode:build`
- `./gradlew :infrastructure:ssz:compileJava`
- `./gradlew :services:bootnode:dependencyInsight --configuration testRuntimeClasspath --dependency org.junit:junit-bom`
- `./gradlew :infrastructure:ssz:dependencyInsight --configuration compileClasspath --dependency com.google.code.findbugs:jsr305`
- `git diff --check`

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
