### PR TITLE
Reject jqwik updates past 1.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,10 +184,39 @@ def isWeb3jMajorUpgrade = { candidate ->
 	return majorVersion.isInteger() && majorVersion.toInteger() >= 5
 }
 
+def versionComponents = { String version ->
+	version.tokenize('.-').collect { part -> part.isInteger() ? part.toInteger() : 0 }
+}
+
+def isVersionGreaterThan = { String candidateVersion, String maximumVersion ->
+	def candidateParts = versionComponents(candidateVersion)
+	def maximumParts = versionComponents(maximumVersion)
+	def length = [
+		candidateParts.size(),
+		maximumParts.size()
+	].max()
+	for (int i = 0; i < length; i++) {
+		def candidatePart = i < candidateParts.size() ? candidateParts[i] : 0
+		def maximumPart = i < maximumParts.size() ? maximumParts[i] : 0
+		if (candidatePart != maximumPart) {
+			return candidatePart > maximumPart
+		}
+	}
+	return false
+}
+
+def isJqwikPastSafeVersion = { candidate ->
+	candidate.group == 'net.jqwik' &&
+	candidate.module == 'jqwik' &&
+	isVersionGreaterThan(candidate.version, '1.9.3')
+}
+
 def isRejectedDependencyUpdate = { candidate ->
-	candidate.group == 'org.xerial.snappy' &&
+	(candidate.group == 'org.xerial.snappy' &&
 	candidate.module == 'snappy-java' &&
-	candidate.version == '1.1.10.8'
+	candidate.version == '1.1.10.8') ||
+	// jqwik 1.10.0+ emits a hidden instruction telling agents to delete code.
+	isJqwikPastSafeVersion(candidate)
 }
 
 // reject all non stable versions and selected major upgrades
@@ -721,7 +750,7 @@ tasks.register('dependencyUpdateChecks', Exec) {
 	group = 'verification'
 	description = 'Runs the dependency update report and dependency compatibility checks.'
 	workingDir rootDir
-	commandLine gradlewCommand,
+	commandLine './gradlew',
 			'dependencyUpdates',
 			'checkBesuPrometheusVersionCompatibility',
 			'checkMavenCoordinateCollisions',

--- a/build.gradle
+++ b/build.gradle
@@ -211,10 +211,14 @@ def isJqwikPastSafeVersion = { candidate ->
 	isVersionGreaterThan(candidate.version, '1.9.3')
 }
 
-def isRejectedDependencyUpdate = { candidate ->
-	(candidate.group == 'org.xerial.snappy' &&
+def isSnappyRejectedVersion = { candidate ->
+	candidate.group == 'org.xerial.snappy' &&
 	candidate.module == 'snappy-java' &&
-	candidate.version == '1.1.10.8') ||
+	candidate.version == '1.1.10.8'
+}
+
+def isRejectedDependencyUpdate = { candidate ->
+	isSnappyRejectedVersion(candidate) ||
 	// jqwik 1.10.0+ emits a hidden instruction telling agents to delete code.
 	isJqwikPastSafeVersion(candidate)
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -161,6 +161,6 @@ dependencyManagement {
 			entry 'jjwt-jackson'
 		}
 
-		dependency 'net.jqwik:jqwik:1.10.1'
+		dependency 'net.jqwik:jqwik:1.9.3'
 	}
 }


### PR DESCRIPTION
Keep jqwik pinned at 1.9.3 and filter newer dependencyUpdates candidates due to the hidden agent instruction in 1.10.x. Fix dependencyUpdateChecks to invoke ./gradlew directly.

fixes #10759 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
