### PR TITLE
Update GetBlockV3Test to include appropriate HTTP status codes

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v3_validator_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v3_validator_blocks_{slot}.json
@@ -128,6 +128,16 @@
         "description" : "Data is unavailable because the chain has not yet reached genesis",
         "content" : { }
       },
+      "406" : {
+        "description" : "Not acceptable",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
       "400" : {
         "description" : "The request could not be processed, check the response for more information.",
         "content" : {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostStateBuilders.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostStateBuilders.java
@@ -86,7 +86,7 @@ public class PostStateBuilders extends RestApiEndpoint {
             .tags(TAG_BEACON)
             .response(SC_OK, "Request successful", RESPONSE_TYPE, EthereumTypes.sszResponseType())
             .withNotFoundResponse()
-            .withNotAcceptedResponse()
+            .withNotAcceptableResponse()
             .withChainDataResponses()
             .build());
     this.chainDataProvider = chainDataProvider;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostStateValidatorIdentities.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostStateValidatorIdentities.java
@@ -69,7 +69,7 @@ public class PostStateValidatorIdentities extends RestApiEndpoint {
             .requestBodyType(BODY_STRING_LIST)
             .response(SC_OK, "Request successful", RESPONSE_TYPE, EthereumTypes.sszResponseType())
             .withNotFoundResponse()
-            .withNotAcceptedResponse()
+            .withNotAcceptableResponse()
             .withChainDataResponses()
             .build());
     this.chainDataProvider = chainDataProvider;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientBootstrap.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientBootstrap.java
@@ -67,7 +67,7 @@ public class GetLightClientBootstrap extends RestApiEndpoint {
                 getResponseType(schemaDefinitionCache),
                 sszResponseType())
             .withNotFoundResponse()
-            .withNotAcceptedResponse()
+            .withNotAcceptableResponse()
             .withNotImplementedResponse()
             .withChainDataResponses()
             .build());

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientUpdatesByRange.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientUpdatesByRange.java
@@ -54,7 +54,7 @@ public class GetLightClientUpdatesByRange extends RestApiEndpoint {
                 SC_OK,
                 "Request successful",
                 List.of(getJsonResponseType(schemaDefinitionCache), getSszResponseType()))
-            .withNotAcceptedResponse()
+            .withNotAcceptableResponse()
             .withNotImplementedResponse()
             .build());
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetDataColumnSidecars.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetDataColumnSidecars.java
@@ -86,7 +86,7 @@ public class GetDataColumnSidecars extends RestApiEndpoint {
             ETH_CONSENSUS_HEADER_TYPE)
         .withNotFoundResponse()
         .withInternalErrorResponse()
-        .withNotAcceptedResponse()
+        .withNotAcceptableResponse()
         .build();
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -89,7 +89,7 @@ public class GetAttestationData extends RestApiEndpoint {
                 EthereumTypes.sszResponseType(
                     attestationData -> spec.atSlot(attestationData.getSlot()).getMilestone()))
             .withNotFoundResponse()
-            .withNotAcceptedResponse()
+            .withNotAcceptableResponse()
             .withChainDataResponses()
             .build());
     this.provider = provider;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetPayloadAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetPayloadAttestationData.java
@@ -88,7 +88,7 @@ public class GetPayloadAttestationData extends RestApiEndpoint {
                 SC_NOT_FOUND,
                 "No canonical block has been seen for the requested slot.",
                 HTTP_ERROR_RESPONSE_TYPE)
-            .withNotAcceptedResponse()
+            .withNotAcceptableResponse()
             .withInternalErrorResponse()
             .withChainDataResponses()
             .build());

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
@@ -109,6 +109,7 @@ public class GetNewBlockV3 extends RestApiEndpoint {
             blockContainerAndMetaDataSszResponseType(),
             getHeaders())
         .withChainDataResponses()
+        .withNotAcceptableResponse()
         .build();
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
@@ -17,7 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_ACCEPTABLE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_BLOCK_VALUE;
@@ -151,6 +153,21 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
   @TestTemplate
   void metadata_shouldHandle204() {
     verifyMetadataEmptyResponse(handler, SC_NO_CONTENT);
+  }
+
+  @TestTemplate
+  void metadata_shouldHandle400() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_BAD_REQUEST);
+  }
+
+  @TestTemplate
+  void metadata_shouldHandle406() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_NOT_ACCEPTABLE);
+  }
+
+  @TestTemplate
+  void metadata_shouldHandle500() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
   }
 
   @TestTemplate

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -724,7 +724,7 @@ public class EndpointMetadata {
       return response(SC_NOT_FOUND, "Not found", HTTP_ERROR_RESPONSE_TYPE);
     }
 
-    public EndpointMetaDataBuilder withNotAcceptedResponse() {
+    public EndpointMetaDataBuilder withNotAcceptableResponse() {
       return response(SC_NOT_ACCEPTABLE, "Not acceptable", HTTP_ERROR_RESPONSE_TYPE);
     }
 


### PR DESCRIPTION
## PR Description
Add missing GetNewBlockV3 unit tests and rename EndpointMetaDataBuilder.withNotAcceptedResponse to withNotAcceptableResponse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename plus OpenAPI metadata and unit tests; no request-handling logic changes beyond documenting 406 on GetNewBlockV3.
> 
> **Overview**
> Renames the REST API metadata helper **`withNotAcceptedResponse`** to **`withNotAcceptableResponse`** so the name matches HTTP **406 Not Acceptable** (`SC_NOT_ACCEPTABLE`). All existing beacon/validator/debug handlers that already declared that response are updated to the new method name only; behavior is unchanged.
> 
> **`GetNewBlockV3`** now registers **406** in its endpoint metadata (previously missing), and the integration OpenAPI fixture for **`/eth/v3/validator/blocks/{slot}`** gains a **406** response entry. **`GetNewBlockV3Test`** adds metadata coverage for **400**, **406**, and **500** alongside existing status tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa65e6e05d88304fa2ffaa452cd1e9cb5f33217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->