### PR TITLE
statically cache SszByte values

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszByte.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszByte.java
@@ -21,27 +21,37 @@ import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszPrimitiveSche
 
 public class SszByte extends AbstractSszPrimitive<Byte> {
 
-  public static final SszByte ZERO = SszByte.of(0);
+  // There are only 256 possible byte values and SszByte is immutable (see AbstractSszPrimitive),
+  // so all instances are interned. This removes the per-element SszByte (and boxed Byte) allocation
+  // that dominated SSZ deserialization of byte collections. Two caches are needed because a SszByte
+  // carries its schema: of(..) uses BYTE_SCHEMA, asUInt8(..) uses UINT8_SCHEMA.
+  private static final SszByte[] BYTE_CACHE = new SszByte[256];
+  private static final SszByte[] UINT8_CACHE = new SszByte[256];
+
+  static {
+    for (int i = 0; i < 256; i++) {
+      BYTE_CACHE[i] = new SszByte((byte) i, SszPrimitiveSchemas.BYTE_SCHEMA);
+      UINT8_CACHE[i] = new SszByte((byte) i, SszPrimitiveSchemas.UINT8_SCHEMA);
+    }
+  }
+
+  public static final SszByte ZERO = BYTE_CACHE[0];
 
   public static SszByte of(final int value) {
-    return new SszByte((byte) value);
+    return BYTE_CACHE[value & 0xFF];
   }
 
   public static SszByte asUInt8(final byte value) {
-    return new SszByte(value, SszPrimitiveSchemas.UINT8_SCHEMA);
+    return UINT8_CACHE[value & 0xFF];
   }
 
   public static SszByte asUInt8(final int value) {
     checkArgument(value >= 0 && value <= 255, "value must be in uint8 range (0–255)");
-    return new SszByte((byte) value, SszPrimitiveSchemas.UINT8_SCHEMA);
+    return UINT8_CACHE[value];
   }
 
   public static SszByte of(final byte value) {
-    return new SszByte(value);
-  }
-
-  private SszByte(final Byte value) {
-    this(value, SszPrimitiveSchemas.BYTE_SCHEMA);
+    return BYTE_CACHE[value & 0xFF];
   }
 
   private SszByte(final Byte value, final AbstractSszPrimitiveSchema<Byte, SszByte> schema) {

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszByteTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszByteTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.primitive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+
+class SszByteTest {
+
+  @Test
+  void of_returnsCorrectValueForAllBytes() {
+    for (int i = -128; i <= 127; i++) {
+      final byte value = (byte) i;
+      assertThat(SszByte.of(value).get()).isEqualTo(value);
+      assertThat(SszByte.of(value).getSchema()).isEqualTo(SszPrimitiveSchemas.BYTE_SCHEMA);
+    }
+  }
+
+  @Test
+  void asUInt8_returnsCorrectValueForAllUnsignedBytes() {
+    for (int i = 0; i <= 255; i++) {
+      assertThat(SszByte.asUInt8(i).get()).isEqualTo((byte) i);
+      assertThat(SszByte.asUInt8(i).getSchema()).isEqualTo(SszPrimitiveSchemas.UINT8_SCHEMA);
+    }
+  }
+
+  @Test
+  void asUInt8_rejectsValuesOutsideUnsignedByteRange() {
+    assertThatThrownBy(() -> SszByte.asUInt8(-1)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> SszByte.asUInt8(256)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void of_internsInstancesAcrossAllValues() {
+    for (int i = -128; i <= 127; i++) {
+      final byte value = (byte) i;
+      assertThat(SszByte.of(value)).isSameAs(SszByte.of(value));
+      // int and byte overloads must resolve to the same interned instance
+      assertThat(SszByte.of((int) value)).isSameAs(SszByte.of(value));
+    }
+  }
+
+  @Test
+  void asUInt8_internsInstancesAcrossAllValues() {
+    for (int i = 0; i <= 255; i++) {
+      assertThat(SszByte.asUInt8(i)).isSameAs(SszByte.asUInt8(i));
+      assertThat(SszByte.asUInt8((byte) i)).isSameAs(SszByte.asUInt8(i));
+    }
+  }
+
+  @Test
+  void of_intOverloadTruncatesConsistentlyWithByteOverload() {
+    // values outside the signed byte range must truncate to the same interned instance
+    assertThat(SszByte.of(256)).isSameAs(SszByte.of((byte) 0));
+    assertThat(SszByte.of(-1)).isSameAs(SszByte.of((byte) -1));
+    assertThat(SszByte.of(255)).isSameAs(SszByte.of((byte) -1));
+  }
+
+  @Test
+  void zero_isTheInternedZeroInstance() {
+    assertThat(SszByte.ZERO).isSameAs(SszByte.of((byte) 0));
+    assertThat(SszByte.ZERO.get()).isEqualTo((byte) 0);
+  }
+
+  @Test
+  void byteAndUInt8InstancesAreDistinctButValueEqual() {
+    // different schemas -> different interned instances ...
+    assertThat(SszByte.of((byte) 5)).isNotSameAs(SszByte.asUInt8(5));
+    // ... but equality is value-based (schema-independent), preserving existing semantics
+    assertThat(SszByte.of((byte) 5)).isEqualTo(SszByte.asUInt8(5));
+  }
+}


### PR DESCRIPTION
# Allocation Optimization — `SszByte` Interning

A steady-state allocation hotspot found via `async-profiler` (`-e alloc`), its root cause,
the exact call path, and the allocation numbers before/after the fix.

- **Date:** 2026-06-18
- **Target:** Teku beacon node, `master` (+ this change)
- **Run context:** mainnet checkpoint-synced to head (Fulu/PeerDAS era), profiled in
  steady state over **~2 epochs** (65 slots). Weight = allocation **sample count**
  (TLAB-based sampling, ~one event per few-hundred-KB allocated).

---

## 1. Reason

`SszByte` allocated a **new immutable object on every factory call**, even though only
**256 distinct byte values exist**:

```java
// before
public static SszByte asUInt8(final byte value) {
  return new SszByte(value, SszPrimitiveSchemas.UINT8_SCHEMA);
}
public static SszByte of(final int value) {
  return new SszByte((byte) value);
}
```

`SszByte` is fully immutable — `AbstractSszPrimitive` holds only `final` fields and
recomputes its backing node on demand — so distinct instances per value carry no benefit
and every call is pure garbage.

---

## 2. Code path

99.4% of all `SszByte` allocations came through a single path:

```
BeaconChainMetrics.onSlot(slot)                          // EVERY slot, unconditional
  └─ updateMetrics(head)
       ├─ state.getValidatorStatsCurrentEpoch(...)        // ValidatorStatsAltair
       └─ state.getValidatorStatsPreviousEpoch(...)
            └─ getValidatorStats(SszList<SszByte> participationFlags)
                 └─ for (SszByte flag : participationFlags)        // one boxed SszByte per element
                      SszPrimitiveListImpl.getImpl
                        → SszPrimitiveSchema.createFromPackedNode
                          → UINT8_SCHEMA.boxed
                            → SszByte.asUInt8        // ← allocation
```

| Business caller | SszByte samples | share |
|---|---|---|
| `ValidatorStatsAltair.getValidatorStats` | 13,711 | 97.5% |
| `ValidatorStatusFactoryAltair.processParticipation` | 177 | 1.3% |
| `BlockProcessorAltair.processAttestation` | 171 | 1.2% |

**The data structure** is `previous/current_epoch_participation`:

```
List[ParticipationFlags (uint8), VALIDATOR_REGISTRY_LIMIT]   // one byte per validator
```

It is stored **packed as raw bytes** in the SSZ backing tree. The `for-each` materializes a
fresh `SszByte` for **every element** because the element-index cache on that path is a
`NoopIntCache` (no element caching). Source
`ethereum/spec/.../versions/altair/ValidatorStatsAltair.java:32-45`:

```java
private CorrectAndLiveValidators getValidatorStats(final SszList<SszByte> participationFlags) {
  int numberOfCorrectValidators = 0;
  int numberOfLiveValidators = 0;
  for (SszByte participationFlag : participationFlags) {   // <-- boxes every validator's flag
    final byte flag = participationFlag.get();
    ...
  }
}
```

**Trigger frequency:** `BeaconChainMetrics implements SlotEventsChannel`; `onSlot()` calls
`updateMetrics()` **unconditionally every slot**
(`services/beaconchain/.../BeaconChainMetrics.java:217`), and `updateMetrics` walks
**both** the current and previous participation lists.

---

## 3. Numbers

The "13,711 samples" is **not** an allocation count — async-profiler samples roughly one
event per few-hundred-KB allocated, so each sample stands in for thousands of real (24-byte)
objects. The reliable count is deterministic, from the call structure.

Let **V** = validator-registry size (mainnet ≈ **1M+**, one entry per validator). Each
`updateMetrics` walks both lists, once per slot:

| Scope | `SszByte` objects allocated (before) → after |
|---|---|
| per slot (2 lists) | **2 × V** ≈ ~2M → **0** |
| per epoch (32 slots) | **64 × V** ≈ ~64M → **0** |
| profiling window (~65 slots) | **130 × V** ≈ **~130 million** → **0** |

At ~24 bytes each (object header + `Byte` ref + schema ref; the `Byte` itself was already
free via the JDK `Byte` cache), that is **~3 GB of short-lived garbage in ~13 minutes
(~4 MB/s, ~1.5 GB/epoch)** from this one per-slot loop — now **zero** allocation
(512-entry array lookups instead).

**Cross-check (sampled ↔ deterministic):** 130M objects ÷ 13,711 samples
≈ **1 sample per ~9,500 objects** ≈ ~227 KB/sample — squarely in the TLAB-sampling-interval
range, so the two independent views agree and the 2.56% figure is real, not a sampling
artifact.

### Before / after (identical config, re-profiled over another ~2 epochs)

| Leaf type | Before | After |
|---|---|---|
| **`SszByte`** | **2.56%** (14,059 samples) | **0.000%** (0) ✅ |

`SszByte` dropped out of the profile entirely (it had been the #10 allocator). All other
buckets stayed within run-to-run variance — the ~2.56% was eliminated with **no allocation
pushed elsewhere** and no regression.

---

## 4. The fix

`infrastructure/ssz/.../primitive/SszByte.java` — intern all instances. Two 256-entry caches
are needed because a `SszByte` carries its schema (`of()` → `BYTE_SCHEMA`,
`asUInt8()` → `UINT8_SCHEMA`). Interning is thread-safe given the type's immutability.

```java
private static final SszByte[] BYTE_CACHE = new SszByte[256];
private static final SszByte[] UINT8_CACHE = new SszByte[256];

static {
  for (int i = 0; i < 256; i++) {
    BYTE_CACHE[i]  = new SszByte((byte) i, SszPrimitiveSchemas.BYTE_SCHEMA);
    UINT8_CACHE[i] = new SszByte((byte) i, SszPrimitiveSchemas.UINT8_SCHEMA);
  }
}
public static final SszByte ZERO = BYTE_CACHE[0];

public static SszByte of(final int value)       { return BYTE_CACHE[value & 0xFF]; }
public static SszByte of(final byte value)      { return BYTE_CACHE[value & 0xFF]; }
public static SszByte asUInt8(final byte value) { return UINT8_CACHE[value & 0xFF]; }
public static SszByte asUInt8(final int value)  {
  checkArgument(value >= 0 && value <= 255, "value must be in uint8 range (0–255)");
  return UINT8_CACHE[value];
}
```

`value & 0xFF` maps the signed `byte` (−128..127) to its unsigned 0..255 cache index
(avoids negative array indices and matches how the caches were populated).

Test `infrastructure/ssz/.../primitive/SszByteTest.java` (new) covers value/schema
correctness across all 256 values, range validation, int↔byte truncation consistency,
`ZERO` identity, value-based equality preserved across schemas, and the interning identity
guarantees. Written test-first (4 interning assertions failed on the old code, all pass now);
full `:infrastructure:ssz:test` suite green.

---

## Artifacts

- `./tmp/profile_alloc.html` / `.collapsed` — baseline flame graph + raw stacks
- `./tmp/profile_alloc_after.html` / `.collapsed` — post-change flame graph + raw stacks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SSZ primitive change with preserved value equality and broad tests; only reference identity changes for repeated factory calls.
> 
> **Overview**
> **`SszByte` factory methods no longer allocate** on each call. `of` / `asUInt8` now return pre-built entries from two 256-element static caches (`BYTE_SCHEMA` vs `UINT8_SCHEMA`), with `value & 0xFF` for signed-byte indexing. `SszByte.ZERO` points at `BYTE_CACHE[0]`; the package-private `of(Byte)` constructor path was removed in favor of cache lookups.
> 
> Adds **`SszByteTest`** to lock in values/schemas for all bytes, uint8 range checks, int truncation behavior, interning identity, distinct schema instances, and unchanged value-based equality across schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb7ffefa53325efeef5fe6a233da688ae746d43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->