### PR TITLE
Specrefs capella, deneb, electra + last fulu batch

### DIFF
--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -254,11 +254,6 @@ specrefs:
       - get_safe_execution_block_hash#gloas
 
       # Not implemented: fulu
-      - compute_matrix#fulu
-      - get_data_column_sidecars#fulu
-      - get_data_column_sidecars_from_block#fulu
-      - get_data_column_sidecars_from_column_sidecar#fulu
-      - recover_matrix#fulu
       - verify_partial_data_column_header_inclusion_proof#fulu
       - verify_partial_data_column_sidecar_kzg_proofs#fulu
       - validate_beacon_block_gossip#fulu

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -252,12 +252,6 @@ specrefs:
       - get_safe_execution_block_hash#bellatrix
       - get_safe_execution_block_hash#gloas
 
-      # Not implemented: capella
-      - prepare_execution_payload#capella
-      - process_execution_payload#capella
-      - validate_beacon_block_gossip#capella
-      - validate_bls_to_execution_change_gossip#capella
-
       # Not implemented: deneb
       - compute_signed_block_header#deneb
       - get_blob_sidecars#deneb

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -182,6 +182,7 @@ specrefs:
       - is_sync_committee_update
       - is_valid_light_client_header
       - is_valid_normalized_merkle_branch
+      - normalize_merkle_branch#electra
       - next_sync_committee_gindex_at_slot
       - process_light_client_finality_update
       - process_light_client_optimistic_update
@@ -253,12 +254,6 @@ specrefs:
       - get_safe_execution_block_hash#gloas
 
       # Not implemented: electra
-      - add_validator_to_registry#electra
-      - compute_on_chain_aggregate#electra
-      - get_committee_indices#electra
-      - get_eth1_pending_deposit_count#electra
-      - is_within_weak_subjectivity_period#electra
-      - normalize_merkle_branch#electra
       - prepare_execution_payload#electra
       - process_execution_payload#electra
       - process_voluntary_exit#electra

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -256,8 +256,6 @@ specrefs:
       # Not implemented: fulu
       - verify_partial_data_column_header_inclusion_proof#fulu
       - verify_partial_data_column_sidecar_kzg_proofs#fulu
-      - validate_beacon_block_gossip#fulu
-      - validate_data_column_sidecar_gossip#fulu
       - validate_partial_data_column_sidecar_gossip#fulu
 
       # Not implemented: gloas

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -252,13 +252,6 @@ specrefs:
       - get_safe_execution_block_hash#bellatrix
       - get_safe_execution_block_hash#gloas
 
-      # Not implemented: deneb
-      - compute_signed_block_header#deneb
-      - get_blob_sidecars#deneb
-      - prepare_execution_payload#deneb
-      - process_registry_updates#deneb
-      - process_voluntary_exit#deneb
-
       # Not implemented: electra
       - add_validator_to_registry#electra
       - compute_on_chain_aggregate#electra

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -253,13 +253,6 @@ specrefs:
       - get_safe_execution_block_hash#bellatrix
       - get_safe_execution_block_hash#gloas
 
-      # Not implemented: electra
-      - prepare_execution_payload#electra
-      - process_execution_payload#electra
-      - process_voluntary_exit#electra
-      - is_eligible_for_partial_withdrawals#electra
-      - get_validators_sweep_withdrawals#electra
-
       # Not implemented: fulu
       - compute_matrix#fulu
       - get_data_column_sidecars#fulu

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -9025,7 +9025,13 @@
     </spec>
 
 - name: prepare_execution_payload#capella
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+      search: executionLayer.engineForkChoiceUpdated(forkChoiceState, payloadBuildingAttributes)
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+      search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+      search: return getPayloadAttributeWithdrawals(currentHeadBlock, state)
   spec: |
     <spec fn="prepare_execution_payload" fork="capella" style="diff" hash="bdb15c3f">
     --- bellatrix
@@ -10215,7 +10221,11 @@
     </spec>
 
 - name: process_execution_payload#capella
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
+      search: public void processExecutionPayload(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
+      search: public void validateExecutionPayloadHeader(
   spec: |
     <spec fn="process_execution_payload" fork="capella" style="diff" hash="8da02dfc">
     --- bellatrix
@@ -14456,7 +14466,9 @@
     </spec>
 
 - name: validate_beacon_block_gossip#capella
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_block_gossip" fork="capella" hash="18ed1bc4">
     def validate_beacon_block_gossip(
@@ -15049,7 +15061,11 @@
     </spec>
 
 - name: validate_bls_to_execution_change_gossip#capella
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/SignedBlsToExecutionChangeValidator.java
+      search: public SafeFuture<InternalValidationResult> validateForGossip(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/BlsToExecutionChangesValidator.java
+      search: public Optional<OperationInvalidReason> validate(
   spec: |
     <spec fn="validate_bls_to_execution_change_gossip" fork="capella" hash="dc7d042d">
     def validate_bls_to_execution_change_gossip(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -6497,7 +6497,13 @@
     </spec>
 
 - name: get_validators_sweep_withdrawals#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+      search: new WithdrawalsHelpersElectra(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
+      search: protected int processValidatorsSweepWithdrawals(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
+      search: public UInt64 getMaxEffectiveBalance(
   spec: |
     <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="034093ad">
     def get_validators_sweep_withdrawals(
@@ -7335,7 +7341,9 @@
     </spec>
 
 - name: is_eligible_for_partial_withdrawals#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
+      search: protected int processPendingPartialWithdrawals(
   spec: |
     <spec fn="is_eligible_for_partial_withdrawals" fork="electra" hash="c8d29720">
     def is_eligible_for_partial_withdrawals(validator: Validator, balance: Gwei) -> bool:
@@ -9122,7 +9130,13 @@
     </spec>
 
 - name: prepare_execution_payload#electra
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+      search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
+    - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
+      search: public static Optional<PayloadAttributesV3> fromInternalPayloadBuildingAttributesV3(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+      search: executionLayer.engineForkChoiceUpdated(forkChoiceState, payloadBuildingAttributes)
   spec: |
     <spec fn="prepare_execution_payload" fork="electra" style="diff" hash="c617aa1b">
     --- capella
@@ -10348,7 +10362,11 @@
     </spec>
 
 - name: process_execution_payload#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDeneb.java
+      search: public void validateExecutionPayload(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+      search: public NewPayloadRequest computeNewPayloadRequest(
   spec: |
     <spec fn="process_execution_payload" fork="electra" style="diff" hash="078e4a6c">
     --- deneb
@@ -11734,7 +11752,15 @@
     </spec>
 
 - name: process_voluntary_exit#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+      search: public void processVoluntaryExits(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectra.java
+      search: public Optional<OperationInvalidReason> validate(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectra.java
+      search: Optional<OperationInvalidReason> validateElectraConditions(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+      search: public boolean verifyVoluntaryExitSignature(
   spec: |
     <spec fn="process_voluntary_exit" fork="electra" style="diff" hash="51b07d36">
     --- deneb

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1379,7 +1379,11 @@
     </spec>
 
 - name: compute_matrix#fulu
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+      search: public List<List<MatrixEntry>> computeExtendedMatrixAndProofs(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+      search: public List<List<MatrixEntry>> computeExtendedMatrix(
   spec: |
     <spec fn="compute_matrix" fork="fulu" hash="87e3f29c">
     def compute_matrix(blobs: Sequence[Blob]) -> Sequence[MatrixEntry]:
@@ -4127,7 +4131,9 @@
     </spec>
 
 - name: get_data_column_sidecars#fulu
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+      search: protected List<DataColumnSidecar> constructDataColumnSidecarsInternal(
   spec: |
     <spec fn="get_data_column_sidecars" fork="fulu" hash="317fc596">
     def get_data_column_sidecars(
@@ -4212,7 +4218,9 @@
     </spec>
 
 - name: get_data_column_sidecars_from_block#fulu
-  sources: []
+  sources:
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+      search: createDataColumnSidecarsSelector()
   spec: |
     <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="02ffae23">
     def get_data_column_sidecars_from_block(
@@ -4264,7 +4272,11 @@
     </spec>
 
 - name: get_data_column_sidecars_from_column_sidecar#fulu
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImpl.java
+      search: private RecoveryTask createRecoveryTask(final DataColumnSidecar dataColumnSidecar)
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/util/DataColumnSidecarELManagerImpl.java
+      search: private void publishRecoveredDataColumnSidecars(
   spec: |
     <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4877148a">
     def get_data_column_sidecars_from_column_sidecar(
@@ -12083,7 +12095,11 @@
     </spec>
 
 - name: recover_matrix#fulu
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+      search: public List<DataColumnSidecar> reconstructAllDataColumnSidecars(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
+      search: public List<List<MatrixEntry>> recoverMatrix(
   spec: |
     <spec fn="recover_matrix" fork="fulu" hash="d21e29e7">
     def recover_matrix(

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1811,7 +1811,9 @@
     </spec>
 
 - name: compute_signed_block_header#deneb
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
+      search: public SignedBeaconBlockHeader asHeader()
   spec: |
     <spec fn="compute_signed_block_header" fork="deneb" hash="552442e1">
     def compute_signed_block_header(signed_block: SignedBeaconBlock) -> SignedBeaconBlockHeader:
@@ -3562,7 +3564,15 @@
     </spec>
 
 - name: get_blob_sidecars#deneb
-  sources: []
+  sources:
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+      search: public List<BlobSidecar> createBlobSidecars(
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+      search: public Function<SignedBlockContainer, List<BlobSidecar>> createBlobSidecarsSelector()
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+      search: public BlobSidecar constructBlobSidecar(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+      search: public List<Bytes32> computeBlobKzgCommitmentInclusionProof(
   spec: |
     <spec fn="get_blob_sidecars" fork="deneb" hash="0206e9a5">
     def get_blob_sidecars(
@@ -9070,7 +9080,13 @@
     </spec>
 
 - name: prepare_execution_payload#deneb
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+      search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
+    - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
+      search: public static Optional<PayloadAttributesV3> fromInternalPayloadBuildingAttributesV3(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+      search: executionLayer.engineForkChoiceUpdated(forkChoiceState, payloadBuildingAttributes)
   spec: |
     <spec fn="prepare_execution_payload" fork="deneb" style="diff" hash="c617aa1b">
     --- capella
@@ -11294,7 +11310,9 @@
     </spec>
 
 - name: process_registry_updates#deneb
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+      search: public void processRegistryUpdates(
   spec: |
     <spec fn="process_registry_updates" fork="deneb" style="diff" hash="71a6a2d9">
     --- phase0
@@ -11675,7 +11693,9 @@
     </spec>
 
 - name: process_voluntary_exit#deneb
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+      search: public void processVoluntaryExits(
   spec: |
     <spec fn="process_voluntary_exit" fork="deneb" style="diff" hash="f97fd167">
     --- phase0

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -106,7 +106,11 @@
     </spec>
 
 - name: add_validator_to_registry#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
+      search: public void addValidatorToRegistry(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
+      search: public Validator getValidatorFromDeposit(
   spec: |
     <spec fn="add_validator_to_registry" fork="electra" style="diff" hash="7970ce24">
 
@@ -1497,7 +1501,13 @@
     </spec>
 
 - name: compute_on_chain_aggregate#electra
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolV2.java
+      search: public SszList<Attestation> getAttestationsForBlock(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/MatchingDataAttestationGroupV2.java
+      search: public PooledAttestationWithData fillUpAggregation(
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestationWithData.java
+      search: public Attestation toAttestation(
   spec: |
     <spec fn="compute_on_chain_aggregate" fork="electra" hash="3aa56e8f">
     def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
@@ -3895,7 +3905,9 @@
     </spec>
 
 - name: get_committee_indices#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
+      search: public Optional<List<UInt64>> getCommitteeIndices()
   spec: |
     <spec fn="get_committee_indices" fork="electra" hash="fa701795">
     def get_committee_indices(committee_bits: Bitvector) -> Sequence[CommitteeIndex]:
@@ -4431,7 +4443,11 @@
     </spec>
 
 - name: get_eth1_pending_deposit_count#electra
-  sources: []
+  sources:
+    - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+      search: final UInt64 eth1PendingDepositCount =
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+      search: protected void verifyOutstandingDepositsAreProcessed(
   spec: |
     <spec fn="get_eth1_pending_deposit_count" fork="electra" hash="5dc54930">
     def get_eth1_pending_deposit_count(state: BeaconState) -> uint64:
@@ -8213,7 +8229,11 @@
     </spec>
 
 - name: is_within_weak_subjectivity_period#electra
-  sources: []
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/weaksubjectivity/WeakSubjectivityCalculator.java
+      search: public boolean isWithinWeakSubjectivityPeriod(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/weaksubjectivity/WeakSubjectivityCalculatorElectra.java
+      search: public UInt64 computeWeakSubjectivityPeriod(
   spec: |
     <spec fn="is_within_weak_subjectivity_period" fork="electra" style="diff" hash="d05d230d">
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -14846,7 +14846,9 @@
     </spec>
 
 - name: validate_beacon_block_gossip#fulu
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(
   spec: |
     <spec fn="validate_beacon_block_gossip" fork="fulu" hash="58934408">
     def validate_beacon_block_gossip(
@@ -15206,7 +15208,13 @@
     </spec>
 
 - name: validate_data_column_sidecar_gossip#fulu
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+      search: public SafeFuture<InternalValidationResult> validate(final DataColumnSidecar dataColumnSidecar)
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
+      search: public SafeFuture<Optional<DataColumnSidecarValidationError>> validateAndVerifyKzgProofs(
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
+      search: public SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(
   spec: |
     <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="57a6f229">
     def validate_data_column_sidecar_gossip(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Last batch of specrefs linking
The remaining is really not done in Teku
What is linked is linked for all milestones.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Closes #10580 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only YAML updates to spec reference mappings; no consensus or networking behavior changes in the diff.
> 
> **Overview**
> This PR completes a large **specrefs** batch: fork-specific consensus helpers that previously had empty `sources` in `specrefs/functions.yml` now point at concrete Teku classes and method search strings (e.g. Electra registry/withdrawals/attestation aggregation, Deneb blob sidecars and signed block headers, Capella/Deneb/Electra execution payload prepare/process paths, Fulu matrix/data-column/recovery helpers, and gossip validators).
> 
> **`.ethspecify.yml`** is updated to match: `normalize_merkle_branch#electra` is treated as implemented, and long “not implemented” lists for Capella, Deneb, and Electra are removed because those items are now linked. The Fulu not-implemented section is narrowed to the few helpers still without Teku mappings (partial data-column verify/gossip paths).
> 
> No application/runtime Java changes appear in this diff—only spec-to-code traceability metadata for reviewers and spec compliance work (closes #10580).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f996341d3c495af2fde8c41b7f20fb88dc8cccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->