### PR TITLE
SSE Event proposer_preferences

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -292,6 +292,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             .rewardCalculator(rewardCalculator)
             .dataColumnSidecarManager(dataColumnSidecarManager)
             .payloadAttestationPool(payloadAttestationPool)
+            .proposerPreferencesManager(proposerPreferencesManager)
             .build();
 
     beaconRestApi =

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_events.json
@@ -9,7 +9,7 @@
       "in" : "query",
       "schema" : {
         "type" : "string",
-        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `execution_payload_available`, `execution_payload_bid`, `execution_payload_gossip`, `execution_payload`, `finalized_checkpoint`, `head`, `payload_attestation_message`, `payload_attributes`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
+        "description" : "Event types to subscribe to. Supported event types: [`attestation`, `attester_slashing`, `blob_sidecar`, `block_gossip`, `block`, `bls_to_execution_change`, `chain_reorg`, `contribution_and_proof`, `data_column_sidecar`, `execution_payload_available`, `execution_payload_bid`, `execution_payload_gossip`, `execution_payload`, `finalized_checkpoint`, `head`, `payload_attestation_message`, `payload_attributes`, `proposer_preferences`, `proposer_slashing`, `single_attestation`, `sync_state`, `voluntary_exit`]",
         "example" : "head"
       }
     } ],

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -114,6 +115,7 @@ public class EventSubscriptionManager
     nodeDataProvider.subscribeToValidDataColumnSidecars(
         (dataColumnSidecar, remoteOrigin) -> onNewDataColumnSidecar(dataColumnSidecar));
     nodeDataProvider.subscribeToPayloadAttestationMessages(this::onNewPayloadAttestationMessage);
+    nodeDataProvider.subscribeToProposerPreferences(this::onNewProposerPreferences);
   }
 
   public void registerClient(final SseClient sseClient) {
@@ -354,6 +356,16 @@ public class EventSubscriptionManager
       notifySubscribersOfEvent(
           EventType.payload_attestation_message,
           new PayloadAttestationMessageEvent(payloadAttestationMessage));
+    }
+  }
+
+  protected void onNewProposerPreferences(
+      final SignedProposerPreferences proposerPreferences,
+      final InternalValidationResult result,
+      final boolean fromNetwork) {
+    if (result.isAccept()) {
+      notifySubscribersOfEvent(
+          EventType.proposer_preferences, new ProposerPreferencesEvent(proposerPreferences));
     }
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ProposerPreferencesEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ProposerPreferencesEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.MILESTONE_TYPE;
+
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
+
+public class ProposerPreferencesEvent
+    extends Event<ProposerPreferencesEvent.VersionedProposerPreferences> {
+
+  record VersionedProposerPreferences(SpecMilestone version, SignedProposerPreferences data) {}
+
+  private static SerializableTypeDefinition<VersionedProposerPreferences> buildTypeDef(
+      final SignedProposerPreferences proposerPreferences) {
+    return SerializableTypeDefinition.object(VersionedProposerPreferences.class)
+        .name("VersionedProposerPreferences")
+        .withField("version", MILESTONE_TYPE, VersionedProposerPreferences::version)
+        .withField(
+            "data",
+            proposerPreferences.getSchema().getJsonTypeDefinition(),
+            VersionedProposerPreferences::data)
+        .build();
+  }
+
+  public ProposerPreferencesEvent(final SignedProposerPreferences proposerPreferences) {
+    super(
+        buildTypeDef(proposerPreferences),
+        new VersionedProposerPreferences(SpecMilestone.GLOAS, proposerPreferences));
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -162,6 +163,8 @@ public class EventSubscriptionManagerTest {
       data.randomSignedExecutionPayloadBid();
   private final PayloadAttestationMessage samplePayloadAttestationMessage =
       data.randomPayloadAttestationMessage();
+  private final SignedProposerPreferences sampleProposerPreferences =
+      data.randomSignedProposerPreferences();
 
   private final AsyncContext async = mock(AsyncContext.class);
   private final EventChannels channels = mock(EventChannels.class);
@@ -507,6 +510,16 @@ public class EventSubscriptionManagerTest {
     assertThat(outputStream.getString()).contains("\"version\":\"gloas\"");
   }
 
+  @Test
+  void shouldPropagateProposerPreferences() throws IOException {
+    when(req.getQueryString()).thenReturn("&topics=proposer_preferences");
+    manager.registerClient(client1);
+
+    triggerProposerPreferencesEvent();
+    checkEvent("proposer_preferences", new ProposerPreferencesEvent(sampleProposerPreferences));
+    assertThat(outputStream.getString()).contains("\"version\":\"gloas\"");
+  }
+
   private void triggerVoluntaryExitEvent() {
     manager.onNewVoluntaryExit(sampleVoluntaryExit, InternalValidationResult.ACCEPT, false);
     asyncRunner.executeQueuedActions();
@@ -635,6 +648,12 @@ public class EventSubscriptionManagerTest {
   private void triggerPayloadAttestationMessageEvent() {
     manager.onNewPayloadAttestationMessage(
         samplePayloadAttestationMessage, InternalValidationResult.ACCEPT, true);
+    asyncRunner.executeQueuedActions();
+  }
+
+  private void triggerProposerPreferencesEvent() {
+    manager.onNewProposerPreferences(
+        sampleProposerPreferences, InternalValidationResult.ACCEPT, true);
     asyncRunner.executeQueuedActions();
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
+import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
@@ -126,6 +127,7 @@ public class DataProvider {
     private DataColumnSidecarManager dataColumnSidecarManager;
     private CustodyGroupCountManager custodyGroupCountManager;
     private PayloadAttestationPool payloadAttestationPool;
+    private ProposerPreferencesManager proposerPreferencesManager = ProposerPreferencesManager.NOOP;
 
     public Builder recentChainData(final RecentChainData recentChainData) {
       this.recentChainData = recentChainData;
@@ -266,6 +268,7 @@ public class DataProvider {
               dataColumnSidecarManager,
               custodyGroupCountManager,
               payloadAttestationPool,
+              proposerPreferencesManager,
               spec);
       final ChainDataProvider chainDataProvider =
           new ChainDataProvider(
@@ -311,6 +314,12 @@ public class DataProvider {
 
     public Builder payloadAttestationPool(final PayloadAttestationPool payloadAttestationPool) {
       this.payloadAttestationPool = payloadAttestationPool;
+      return this;
+    }
+
+    public Builder proposerPreferencesManager(
+        final ProposerPreferencesManager proposerPreferencesManager) {
+      this.proposerPreferencesManager = proposerPreferencesManager;
       return this;
     }
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedProposerPreferences;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -56,6 +57,7 @@ import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool.New
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
 import tech.pegasys.teku.statetransition.datacolumns.ValidDataColumnSidecarsListener;
+import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber;
 import tech.pegasys.teku.statetransition.forkchoice.PreparedProposerInfo;
@@ -86,6 +88,7 @@ public class NodeDataProvider {
   private final DataColumnSidecarManager dataColumnSidecarManager;
   private final CustodyGroupCountManager custodyGroupCountManager;
   private final PayloadAttestationPool payloadAttestationPool;
+  private final ProposerPreferencesManager proposerPreferencesManager;
   private final Spec spec;
 
   public NodeDataProvider(
@@ -105,6 +108,7 @@ public class NodeDataProvider {
       final DataColumnSidecarManager dataColumnSidecarManager,
       final CustodyGroupCountManager custodyGroupCountManager,
       final PayloadAttestationPool payloadAttestationPool,
+      final ProposerPreferencesManager proposerPreferencesManager,
       final Spec spec) {
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingsPool;
@@ -122,6 +126,7 @@ public class NodeDataProvider {
     this.dataColumnSidecarManager = dataColumnSidecarManager;
     this.custodyGroupCountManager = custodyGroupCountManager;
     this.payloadAttestationPool = payloadAttestationPool;
+    this.proposerPreferencesManager = proposerPreferencesManager;
     this.spec = spec;
   }
 
@@ -352,6 +357,11 @@ public class NodeDataProvider {
   public void subscribeToPayloadAttestationMessages(
       final OperationAddedSubscriber<PayloadAttestationMessage> listener) {
     payloadAttestationPool.subscribeOperationAdded(listener);
+  }
+
+  public void subscribeToProposerPreferences(
+      final OperationAddedSubscriber<SignedProposerPreferences> listener) {
+    proposerPreferencesManager.subscribeOperationAdded(listener);
   }
 
   public SafeFuture<Optional<List<ValidatorLivenessAtEpoch>>> getValidatorLiveness(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/NodeDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/NodeDataProviderTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
+import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
@@ -72,6 +73,8 @@ public class NodeDataProviderTest {
   private final CustodyGroupCountManager custodyGroupCountManager =
       mock(CustodyGroupCountManager.class);
   private final PayloadAttestationPool payloadAttestationPool = mock(PayloadAttestationPool.class);
+  private final ProposerPreferencesManager proposerPreferencesManager =
+      mock(ProposerPreferencesManager.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
 
   private final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
@@ -107,6 +110,7 @@ public class NodeDataProviderTest {
             dataColumnSidecarManager,
             custodyGroupCountManager,
             payloadAttestationPool,
+            proposerPreferencesManager,
             spec);
   }
 
@@ -257,6 +261,7 @@ public class NodeDataProviderTest {
             dataColumnSidecarManager,
             custodyGroupCountManager,
             payloadAttestationPool,
+            proposerPreferencesManager,
             specMock);
     return specMock;
   }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/EventType.java
@@ -37,7 +37,8 @@ public enum EventType {
   execution_payload_gossip,
   execution_payload_available,
   execution_payload_bid,
-  payload_attestation_message;
+  payload_attestation_message,
+  proposer_preferences;
 
   public static List<EventType> getTopics(final List<String> topics) {
     return topics.stream().map(EventType::valueOf).toList();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1590,6 +1590,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .custodyGroupCountManager(custodyGroupCountManager)
             .dataColumnSidecarManager(dataColumnSidecarManager)
             .payloadAttestationPool(payloadAttestationPool)
+            .proposerPreferencesManager(proposerPreferencesManager)
             .build();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Part of #10819 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SSE and provider wiring mirroring existing Gloas event types; no changes to validation or consensus logic beyond broadcasting accepted preferences.
> 
> **Overview**
> Adds a new **`proposer_preferences`** Server-Sent Events topic on `/eth/v1/events` so clients can subscribe to validated Gloas **`SignedProposerPreferences`** as they are accepted.
> 
> **`ProposerPreferencesManager`** is threaded through **`DataProvider`** / **`NodeDataProvider`** (with a **`subscribeToProposerPreferences`** hook), **`BeaconChainController`**, and integration test wiring. **`EventSubscriptionManager`** listens on that subscription and emits **`ProposerPreferencesEvent`** (versioned JSON with milestone `gloas`) only when validation accepts the message—same gating as other pool-backed SSE events.
> 
> **`EventType`** and the OpenAPI events spec list **`proposer_preferences`** among supported topics; unit tests cover SSE propagation and JSON shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4333d4cfd9c409a9a60b498197c579a3cc40a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->