### PR TITLE
`PAYLOAD_BUILDER_VERSION` + v1.7.0-alpha.11 remaining changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,7 +424,7 @@ allprojects {
 }
 
 def nightly = System.getenv("NIGHTLY") != null
-def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.10"
+def refTestVersion = nightly ? "nightly" : "v1.7.0-alpha.11"
 def blsRefTestVersion = 'v0.1.2'
 def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-specs/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.Sy
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodySchemaGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
@@ -184,9 +185,10 @@ public class DefaultOperationProcessor implements OperationProcessor {
 
   @Override
   public void processExecutionPayloadBid(
-      final MutableBeaconState state, final BeaconBlock beaconBlock)
+      final MutableBeaconState state, final SignedExecutionPayloadBid signedBid)
       throws BlockProcessingException {
-    spec.getBlockProcessor(beaconBlock.getSlot()).processExecutionPayloadBid(state, beaconBlock);
+    spec.getBlockProcessor(signedBid.getMessage().getSlot())
+        .processExecutionPayloadBid(state, signedBid);
   }
 
   @Override

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
@@ -83,7 +84,8 @@ public interface OperationProcessor {
   void processParentExecutionPayload(MutableBeaconState state, BeaconBlock beaconBlock)
       throws BlockProcessingException;
 
-  void processExecutionPayloadBid(MutableBeaconState state, BeaconBlock beaconBlock)
+  void processExecutionPayloadBid(
+      MutableBeaconState state, SignedExecutionPayloadBid executionPayloadBid)
       throws BlockProcessingException;
 
   void processPayloadAttestation(MutableBeaconState state, PayloadAttestation payloadAttestation)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ConsolidationRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositRequest;
@@ -160,7 +161,8 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
               new OperationsTestExecutor<>("block.ssz_snappy", Operation.PARENT_EXECUTION_PAYLOAD))
           .put(
               "operations/execution_payload_bid",
-              new OperationsTestExecutor<>("block.ssz_snappy", Operation.EXECUTION_PAYLOAD_BID))
+              new OperationsTestExecutor<>(
+                  "execution_payload_bid.ssz_snappy", Operation.EXECUTION_PAYLOAD_BID))
           .put(
               "operations/payload_attestation",
               new OperationsTestExecutor<>(
@@ -385,12 +387,14 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
         processor.processParentExecutionPayload(state, beaconBlock);
       }
       case EXECUTION_PAYLOAD_BID -> {
-        final BeaconBlock beaconBlock =
+        final SignedExecutionPayloadBid signedBid =
             loadSsz(
                 testDefinition,
                 dataFileName,
-                testDefinition.getSpec().getGenesisSchemaDefinitions().getBeaconBlockSchema());
-        processor.processExecutionPayloadBid(state, beaconBlock);
+                SchemaDefinitionsGloas.required(
+                        testDefinition.getSpec().getGenesisSchemaDefinitions())
+                    .getSignedExecutionPayloadBidSchema());
+        processor.processExecutionPayloadBid(state, signedBid);
       }
       case PAYLOAD_ATTESTATION -> {
         final PayloadAttestation payloadAttestation =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -130,6 +130,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/get_parent_payload_status", new ForkChoiceTestExecutor())
           .put("fork_choice/on_execution_payload_envelope", new ForkChoiceTestExecutor())
           .put("fork_choice/on_payload_attestation_message", new ForkChoiceTestExecutor())
+          .put("fork_choice/payload_data_availability", new ForkChoiceTestExecutor())
+          .put("fork_choice/payload_timeliness", new ForkChoiceTestExecutor())
           // Fork choice generated test types
           .put("fork_choice_compliance/block_weight_test", new ForkChoiceTestExecutor())
           .put("fork_choice_compliance/block_tree_test", new ForkChoiceTestExecutor())

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -319,6 +319,16 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
                   schemas ->
                       SchemaDefinitionsGloas.required(schemas)
                           .getSignedProposerPreferencesSchema()))
+          .put(
+              "ssz_static/BuilderDepositRequest",
+              new SszTestExecutor<>(
+                  schemas ->
+                      SchemaDefinitionsGloas.required(schemas).getBuilderDepositRequestSchema()))
+          .put(
+              "ssz_static/BuilderExitRequest",
+              new SszTestExecutor<>(
+                  schemas ->
+                      SchemaDefinitionsGloas.required(schemas).getBuilderExitRequestSchema()))
           .put("ssz_static/ForkChoiceNode", IGNORE_TESTS)
 
           // Legacy Schemas (Not yet migrated to SchemaDefinitions)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
@@ -23,6 +23,7 @@ public interface SpecConfigGloas extends SpecConfigFulu, NetworkingSpecConfigGlo
   UInt64 BUILDER_INDEX_SELF_BUILD = UInt64.MAX_VALUE;
   UInt64 BUILDER_PAYMENT_THRESHOLD_NUMERATOR = UInt64.valueOf(6);
   UInt64 BUILDER_PAYMENT_THRESHOLD_DENOMINATOR = UInt64.valueOf(10);
+  int PAYLOAD_BUILDER_VERSION = 0;
   // builder-specs
   UInt64 MAX_EXECUTION_PAYMENT = UInt64.MAX_VALUE; // 2**64 - 1
   long MAX_DATA_SIZE = 4096;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -172,7 +173,7 @@ public interface BlockProcessor {
       MutableBeaconState state, Optional<ExecutionPayloadSummary> payloadSummary)
       throws BlockProcessingException;
 
-  void processExecutionPayloadBid(MutableBeaconState state, BeaconBlock beaconBlock)
+  void processExecutionPayloadBid(MutableBeaconState state, SignedExecutionPayloadBid signedBid)
       throws BlockProcessingException;
 
   void processPayloadAttestations(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -380,7 +381,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
 
   @Override
   public void processExecutionPayloadBid(
-      final MutableBeaconState state, final BeaconBlock beaconBlock)
+      final MutableBeaconState state, final SignedExecutionPayloadBid signedBid)
       throws BlockProcessingException {
     throw new UnsupportedOperationException("No process_execution_payload_bid until Gloas");
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.block;
 
 import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.PAYLOAD_BUILDER_VERSION;
 
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -127,7 +128,12 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
         () ->
             processParentExecutionPayload(genericState, beaconBlock, validatorExitContextSupplier));
     processWithdrawals(genericState, Optional.empty());
-    safelyProcess(() -> processExecutionPayloadBid(genericState, beaconBlock));
+    safelyProcess(
+        () ->
+            processExecutionPayloadBid(
+                genericState,
+                BeaconBlockBodyGloas.required(beaconBlock.getBody())
+                    .getSignedExecutionPayloadBid()));
   }
 
   // process_parent_execution_payload
@@ -230,22 +236,16 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
   // process_execution_payload_bid
   @Override
   public void processExecutionPayloadBid(
-      final MutableBeaconState state, final BeaconBlock beaconBlock)
+      final MutableBeaconState state, final SignedExecutionPayloadBid signedBid)
       throws BlockProcessingException {
-    final SignedExecutionPayloadBid signedBid =
-        beaconBlock
-            .getBody()
-            .getOptionalSignedExecutionPayloadBid()
-            .orElseThrow(
-                () ->
-                    new BlockProcessingException(
-                        "Signed Execution Payload Bid expected as part of body"));
 
     final ExecutionPayloadBid bid = signedBid.getMessage();
 
     final UInt64 builderIndex = bid.getBuilderIndex();
 
     final UInt64 amount = bid.getValue();
+
+    final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
 
     if (builderIndex.equals(BUILDER_INDEX_SELF_BUILD)) {
       // For self-builds, amount must be zero regardless of withdrawal credential prefix
@@ -260,6 +260,11 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       // Verify that the builder is active
       if (!predicatesGloas.isActiveBuilder(state, builderIndex)) {
         throw new BlockProcessingException("Builder is not active");
+      }
+      // Verify that the builder is a payload builder
+      if (stateGloas.getBuilders().get(builderIndex.intValue()).getVersion()
+          != PAYLOAD_BUILDER_VERSION) {
+        throw new BlockProcessingException("Builder is not a payload builder");
       }
       // Verify that the builder has funds to cover the bid
       if (!beaconStateAccessorsGloas.canBuilderCoverBid(state, builderIndex, amount)) {
@@ -281,15 +286,15 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
     }
 
     // Verify that the bid is for the current slot
-    if (!bid.getSlot().equals(beaconBlock.getSlot())) {
+    if (!bid.getSlot().equals(state.getSlot())) {
       throw new BlockProcessingException("Bid is not for the current slot");
     }
 
-    final MutableBeaconStateGloas stateGloas = MutableBeaconStateGloas.required(state);
-
     // Verify that the bid is for the right parent block
     if (!bid.getParentBlockHash().equals(stateGloas.getLatestBlockHash())
-        || !bid.getParentBlockRoot().equals(beaconBlock.getParentRoot())) {
+        || !bid.getParentBlockRoot()
+            .equals(
+                beaconStateAccessors.getBlockRootAtSlot(state, state.getSlot().minusMinZero(1)))) {
       throw new BlockProcessingException("Bid is not for the right parent block");
     }
     if (!bid.getPrevRandao()
@@ -309,7 +314,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
                   schemaDefinitionsGloas
                       .getBuilderPendingWithdrawalSchema()
                       .create(bid.getFeeRecipient(), amount, builderIndex),
-                  beaconBlock.getProposerIndex());
+                  UInt64.valueOf(beaconStateAccessors.getBeaconProposerIndex(state)));
 
       stateGloas
           .getBuilderPendingPayments()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.execution;
 
+import static tech.pegasys.teku.spec.logic.common.helpers.Predicates.getExecutionAddressUnchecked;
+
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -96,7 +98,8 @@ public class ExecutionRequestsProcessorGloas extends ExecutionRequestsProcessorF
                       beaconStateMutatorsGloas.addBuilderToRegistry(
                           state,
                           pubkey,
-                          request.getWithdrawalCredentials(),
+                          request.getWithdrawalCredentials().get(0),
+                          getExecutionAddressUnchecked(request.getWithdrawalCredentials()),
                           request.getAmount(),
                           state.getSlot());
                     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.forktransition;
 
+import static tech.pegasys.teku.spec.config.SpecConfigGloas.PAYLOAD_BUILDER_VERSION;
+import static tech.pegasys.teku.spec.logic.common.helpers.Predicates.getExecutionAddressUnchecked;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -231,7 +234,8 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
                 beaconStateMutators.addBuilderToRegistry(
                     state,
                     pubkey,
-                    deposit.getWithdrawalCredentials(),
+                    PAYLOAD_BUILDER_VERSION,
+                    getExecutionAddressUnchecked(deposit.getWithdrawalCredentials()),
                     deposit.getAmount(),
                     deposit.getSlot());
               });

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
@@ -15,12 +15,11 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
-import static tech.pegasys.teku.spec.logic.common.helpers.Predicates.getExecutionAddressUnchecked;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
@@ -132,16 +131,16 @@ public class BeaconStateMutatorsGloas extends BeaconStateMutatorsElectra {
   public void addBuilderToRegistry(
       final MutableBeaconState state,
       final BLSPublicKey pubkey,
-      final Bytes32 withdrawalCredentials,
+      final int version,
+      final Eth1Address executionAddress,
       final UInt64 amount,
       final UInt64 slot) {
     final UInt64 index = beaconStateAccessorsGloas.getIndexForNewBuilder(state);
-    final int version = withdrawalCredentials.get(0);
     final Builder builder =
         new Builder(
             pubkey,
             version,
-            getExecutionAddressUnchecked(withdrawalCredentials),
+            executionAddress,
             amount,
             miscHelpers.computeEpochAtSlot(slot),
             FAR_FUTURE_EPOCH);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -173,7 +174,7 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
 
   @Override
   public void processExecutionPayloadBid(
-      final MutableBeaconState state, final BeaconBlock beaconBlock) {
+      final MutableBeaconState state, final SignedExecutionPayloadBid signedBid) {
     throw new UnsupportedOperationException("No process_execution_payload_bid until Gloas");
   }
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.10
+version: v1.7.0-alpha.11
 style: full
 
 specrefs:
@@ -292,22 +292,22 @@ specrefs:
 
       # Not implemented: gloas
       - get_proposer_dependent_root#gloas
+      - get_proposer_head#gloas
 
       # Redesign fork choice abstractions https://github.com/Consensys/teku/issues/10773
       - get_supported_node#phase0
       - get_supported_node#gloas
       - is_ancestor#phase0
       - is_ancestor#gloas
+      - is_epoch_boundary#phase0
 
       # Not implemented: heze
       - get_forkchoice_store#heze
-      - get_inclusion_list_bits#heze
       - get_inclusion_list_committee#heze
       - get_inclusion_list_committee_assignment#heze
       - get_inclusion_list_signature#heze
       - get_inclusion_list_store#heze
       - get_inclusion_list_transactions#heze
-      - is_inclusion_list_bits_inclusive#heze
       - is_payload_inclusion_list_satisfied#heze
       - is_valid_inclusion_list_signature#heze
       - on_execution_payload_envelope#heze

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -39,6 +39,24 @@
     BLS_WITHDRAWAL_PREFIX: Bytes1 = '0x00'
     </spec>
 
+- name: BUILDER_DEPOSIT_REQUEST_TYPE#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/BuilderDepositRequest.java
+      search: REQUEST_TYPE =
+  spec: |
+    <spec constant_var="BUILDER_DEPOSIT_REQUEST_TYPE" fork="gloas" hash="08333b0e">
+    BUILDER_DEPOSIT_REQUEST_TYPE: Bytes1 = '0x03'
+    </spec>
+
+- name: BUILDER_EXIT_REQUEST_TYPE#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/BuilderExitRequest.java
+      search: REQUEST_TYPE =
+  spec: |
+    <spec constant_var="BUILDER_EXIT_REQUEST_TYPE" fork="gloas" hash="cf4cdfb6">
+    BUILDER_EXIT_REQUEST_TYPE: Bytes1 = '0x04'
+    </spec>
+
 - name: BUILDER_INDEX_FLAG#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
@@ -204,6 +222,15 @@
     DOMAIN_BLS_TO_EXECUTION_CHANGE: DomainType = '0x0A000000'
     </spec>
 
+- name: DOMAIN_BUILDER_DEPOSIT#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+      search: BUILDER_DEPOSIT =
+  spec: |
+    <spec constant_var="DOMAIN_BUILDER_DEPOSIT" fork="gloas" hash="e0a71135">
+    DOMAIN_BUILDER_DEPOSIT: DomainType = '0x0E000000'
+    </spec>
+
 - name: DOMAIN_CONTRIBUTION_AND_PROOF#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -216,7 +243,7 @@
 - name: DOMAIN_DEPOSIT#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
-      search: DEPOSIT =
+      search: Bytes4 DEPOSIT =
   spec: |
     <spec constant_var="DOMAIN_DEPOSIT" fork="phase0" hash="eab99f9f">
     DOMAIN_DEPOSIT: DomainType = '0x03000000'
@@ -227,8 +254,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
       search: INCLUSION_LIST_COMMITTEE =
   spec: |
-    <spec constant_var="DOMAIN_INCLUSION_LIST_COMMITTEE" fork="heze" hash="95ea05fa">
-    DOMAIN_INCLUSION_LIST_COMMITTEE: DomainType = '0x0E000000'
+    <spec constant_var="DOMAIN_INCLUSION_LIST_COMMITTEE" fork="heze" hash="01403930">
+    DOMAIN_INCLUSION_LIST_COMMITTEE: DomainType = '0x10000000'
     </spec>
 
 - name: DOMAIN_PROPOSER_PREFERENCES#gloas
@@ -452,6 +479,15 @@
   spec: |
     <spec constant_var="PARTICIPATION_FLAG_WEIGHTS" fork="altair" hash="0068cac2">
     PARTICIPATION_FLAG_WEIGHTS = [TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]
+    </spec>
+
+- name: PAYLOAD_BUILDER_VERSION#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
+      search: PAYLOAD_BUILDER_VERSION = 0
+  spec: |
+    <spec constant_var="PAYLOAD_BUILDER_VERSION" fork="gloas" hash="96275869">
+    PAYLOAD_BUILDER_VERSION: uint8 = 0
     </spec>
 
 - name: PAYLOAD_STATUS_EMPTY#gloas

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -717,15 +717,40 @@
         withdrawable_epoch: Epoch
     </spec>
 
+- name: BuilderDepositRequest#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/BuilderDepositRequest.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/BuilderDepositRequestSchema.java
+  spec: |
+    <spec container="BuilderDepositRequest" fork="gloas" hash="428c4c71">
+    class BuilderDepositRequest(Container):
+        pubkey: BLSPubkey
+        withdrawal_credentials: Bytes32
+        amount: Gwei
+        signature: BLSSignature
+    </spec>
+
+- name: BuilderExitRequest#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/BuilderExitRequest.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/BuilderExitRequestSchema.java
+  spec: |
+    <spec container="BuilderExitRequest" fork="gloas" hash="85c60f61">
+    class BuilderExitRequest(Container):
+        source_address: ExecutionAddress
+        pubkey: BLSPubkey
+    </spec>
+
 - name: BuilderPendingPayment#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingPayment.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/BuilderPendingPaymentSchema.java
   spec: |
-    <spec container="BuilderPendingPayment" fork="gloas" hash="73cf1649">
+    <spec container="BuilderPendingPayment" fork="gloas" hash="835a8ae6">
     class BuilderPendingPayment(Container):
         weight: Gwei
         withdrawal: BuilderPendingWithdrawal
+        proposer_index: ValidatorIndex
     </spec>
 
 - name: BuilderPendingWithdrawal#gloas
@@ -1120,9 +1145,9 @@
 
 - name: ExecutionRequests#electra
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequests.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsBuilderElectra.java
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsSchema.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsSchemaElectra.java
   spec: |
     <spec container="ExecutionRequests" fork="electra" hash="048c4a44">
     class ExecutionRequests(Container):
@@ -1132,6 +1157,23 @@
         withdrawals: List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]
         # [New in Electra:EIP7251]
         consolidations: List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
+    </spec>
+
+- name: ExecutionRequests#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionRequestsGloas.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionRequestsBuilderGloas.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionRequestsSchemaGloas.java
+  spec: |
+    <spec container="ExecutionRequests" fork="gloas" hash="977acaf4">
+    class ExecutionRequests(Container):
+        deposits: List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
+        withdrawals: List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]
+        consolidations: List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
+        # [New in Gloas:EIP8282]
+        builder_deposits: List[BuilderDepositRequest, MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD]
+        # [New in Gloas:EIP8282]
+        builder_exits: List[BuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD]
     </spec>
 
 - name: Fork#phase0

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -22,11 +22,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
       search: public void addBuilderToRegistry(
   spec: |
-    <spec fn="add_builder_to_registry" fork="gloas" hash="cd0414c9">
+    <spec fn="add_builder_to_registry" fork="gloas" hash="21ceace9">
     def add_builder_to_registry(
         state: BeaconState,
         pubkey: BLSPubkey,
-        withdrawal_credentials: Bytes32,
+        version: uint8,
+        execution_address: ExecutionAddress,
         amount: uint64,
         slot: Slot,
     ) -> None:
@@ -35,8 +36,8 @@
             get_index_for_new_builder(state),
             Builder(
                 pubkey=pubkey,
-                version=uint8(withdrawal_credentials[0]),
-                execution_address=ExecutionAddress(withdrawal_credentials[12:]),
+                version=version,
+                execution_address=execution_address,
                 balance=amount,
                 deposit_epoch=compute_epoch_at_slot(slot),
                 withdrawable_epoch=FAR_FUTURE_EPOCH,
@@ -192,31 +193,6 @@
         )
     </spec>
 
-- name: apply_deposit_for_builder#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
-      search: public void applyDepositForBuilder(
-  spec: |
-    <spec fn="apply_deposit_for_builder" fork="gloas" hash="e4bc98c7">
-    def apply_deposit_for_builder(
-        state: BeaconState,
-        pubkey: BLSPubkey,
-        withdrawal_credentials: Bytes32,
-        amount: uint64,
-        signature: BLSSignature,
-        slot: Slot,
-    ) -> None:
-        builder_pubkeys = [b.pubkey for b in state.builders]
-        if pubkey not in builder_pubkeys:
-            # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
-            if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
-                add_builder_to_registry(state, pubkey, withdrawal_credentials, amount, slot)
-        else:
-            # Increase balance by deposit amount
-            builder_index = builder_pubkeys.index(pubkey)
-            state.builders[builder_index].balance += amount
-    </spec>
-
 - name: apply_light_client_update#altair
   sources: []
   spec: |
@@ -245,7 +221,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void applyParentExecutionPayload(
   spec: |
-    <spec fn="apply_parent_execution_payload" fork="gloas" hash="44874701">
+    <spec fn="apply_parent_execution_payload" fork="gloas" hash="64e168db">
     def apply_parent_execution_payload(
         state: BeaconState,
         requests: ExecutionRequests,
@@ -263,6 +239,10 @@
         for_ops(requests.deposits, process_deposit_request)
         for_ops(requests.withdrawals, process_withdrawal_request)
         for_ops(requests.consolidations, process_consolidation_request)
+        # [New in Gloas:EIP8282]
+        for_ops(requests.builder_deposits, process_builder_deposit_request)
+        # [New in Gloas:EIP8282]
+        for_ops(requests.builder_exits, process_builder_exit_request)
 
         # Settle the builder payment
         if parent_epoch == get_current_epoch(state):
@@ -4565,7 +4545,7 @@
 
 - name: get_execution_requests#electra
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodec.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionRequestsDataCodec.java
       search: public ExecutionRequests decode(
   spec: |
     <spec fn="get_execution_requests" fork="electra" hash="2c0fb728">
@@ -4613,9 +4593,82 @@
         )
     </spec>
 
+- name: get_execution_requests#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionRequestsDataCodec.java
+      search: public List<Bytes> encode(
+  spec: |
+    <spec fn="get_execution_requests" fork="gloas" hash="7b351e91">
+    def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
+        deposits = []
+        withdrawals = []
+        consolidations = []
+        # [New in Gloas:EIP8282]
+        builder_deposits = []
+        # [New in Gloas:EIP8282]
+        builder_exits = []
+
+        request_types = [
+            DEPOSIT_REQUEST_TYPE,
+            WITHDRAWAL_REQUEST_TYPE,
+            CONSOLIDATION_REQUEST_TYPE,
+            # [New in Gloas:EIP8282]
+            BUILDER_DEPOSIT_REQUEST_TYPE,
+            # [New in Gloas:EIP8282]
+            BUILDER_EXIT_REQUEST_TYPE,
+        ]
+
+        prev_request_type = None
+        for request in execution_requests_list:
+            request_type, request_data = request[0:1], request[1:]
+
+            # Check that the request type is valid
+            assert request_type in request_types
+            # Check that the request data is not empty
+            assert len(request_data) != 0
+            # Check that requests are in strictly ascending order
+            # Each successive type must be greater than the last with no duplicates
+            assert prev_request_type is None or prev_request_type < request_type
+            prev_request_type = request_type
+
+            if request_type == DEPOSIT_REQUEST_TYPE:
+                deposits = ssz_deserialize(
+                    List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD], request_data
+                )
+            elif request_type == WITHDRAWAL_REQUEST_TYPE:
+                withdrawals = ssz_deserialize(
+                    List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD], request_data
+                )
+            elif request_type == CONSOLIDATION_REQUEST_TYPE:
+                consolidations = ssz_deserialize(
+                    List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD], request_data
+                )
+            # [New in Gloas:EIP8282]
+            elif request_type == BUILDER_DEPOSIT_REQUEST_TYPE:
+                builder_deposits = ssz_deserialize(
+                    List[BuilderDepositRequest, MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD],
+                    request_data,
+                )
+            # [New in Gloas:EIP8282]
+            elif request_type == BUILDER_EXIT_REQUEST_TYPE:
+                builder_exits = ssz_deserialize(
+                    List[BuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD], request_data
+                )
+
+        return ExecutionRequests(
+            deposits=deposits,
+            withdrawals=withdrawals,
+            consolidations=consolidations,
+            # [New in Gloas:EIP8282]
+            builder_deposits=builder_deposits,
+            # [New in Gloas:EIP8282]
+            builder_exits=builder_exits,
+        )
+    </spec>
+
 - name: get_execution_requests_list#electra
   sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionRequestsDataCodec.java
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionRequestsDataCodec.java
       search: public List<Bytes> encode(
   spec: |
     <spec fn="get_execution_requests_list" fork="electra" hash="0a0be93f">
@@ -4624,6 +4677,30 @@
             (DEPOSIT_REQUEST_TYPE, execution_requests.deposits),
             (WITHDRAWAL_REQUEST_TYPE, execution_requests.withdrawals),
             (CONSOLIDATION_REQUEST_TYPE, execution_requests.consolidations),
+        ]
+
+        return [
+            request_type + ssz_serialize(request_data)
+            for request_type, request_data in requests
+            if len(request_data) != 0
+        ]
+    </spec>
+
+- name: get_execution_requests_list#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionRequestsDataCodec.java
+      search: public List<Bytes> encode(
+  spec: |
+    <spec fn="get_execution_requests_list" fork="gloas" hash="a9021134">
+    def get_execution_requests_list(execution_requests: ExecutionRequests) -> Sequence[bytes]:
+        requests = [
+            (DEPOSIT_REQUEST_TYPE, execution_requests.deposits),
+            (WITHDRAWAL_REQUEST_TYPE, execution_requests.withdrawals),
+            (CONSOLIDATION_REQUEST_TYPE, execution_requests.consolidations),
+            # [New in Gloas:EIP8282]
+            (BUILDER_DEPOSIT_REQUEST_TYPE, execution_requests.builder_deposits),
+            # [New in Gloas:EIP8282]
+            (BUILDER_EXIT_REQUEST_TYPE, execution_requests.builder_exits),
         ]
 
         return [
@@ -5757,20 +5834,21 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public ForkChoiceNode getProposerHead(
   spec: |
-    <spec fn="get_proposer_head" fork="phase0" hash="0b2b3507">
-    def get_proposer_head(store: Store, head_root: Root, slot: Slot) -> Root:
-        head_block = store.blocks[head_root]
+    <spec fn="get_proposer_head" fork="phase0" hash="3558f2cc">
+    def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
+        head_block = store.blocks[head_node.root]
         parent_root = head_block.parent_root
         parent_block = store.blocks[parent_root]
+        parent_node = ForkChoiceNode(root=parent_root)
 
         # Only re-org the head block if it arrived later than the attestation deadline.
-        head_late = is_head_late(store, head_root)
+        head_late = is_head_late(store, head_node.root)
 
-        # Do not re-org on an epoch boundary where the proposer shuffling could change.
-        shuffling_stable = is_shuffling_stable(slot)
+        # Do not re-org on an epoch boundary.
+        epoch_boundary = is_epoch_boundary(slot)
 
         # Ensure that the FFG information of the new head will be competitive with the current head.
-        ffg_competitive = is_ffg_competitive(store, head_root, parent_root)
+        ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
 
         # Do not re-org if the chain is not finalizing with acceptable frequency.
         finalization_ok = is_finalization_ok(store, slot)
@@ -5784,18 +5862,18 @@
         single_slot_reorg = parent_slot_ok and current_time_ok
 
         # Check that the head has few enough votes to be overpowered by our proposer boost.
-        assert store.proposer_boost_root != head_root  # ensure boost has worn off
-        head_weak = is_head_weak(store, head_root)
+        assert store.proposer_boost_root != head_node.root  # ensure boost has worn off
+        head_weak = is_head_weak(store, head_node.root)
 
         # Check that the missing votes are assigned to the parent and not being hoarded.
-        parent_strong = is_parent_strong(store, head_root)
+        parent_strong = is_parent_strong(store, head_node.root)
 
         # Re-org more aggressively if there is a proposer equivocation in the previous slot.
-        proposer_equivocation = is_proposer_equivocation(store, head_root)
+        proposer_equivocation = is_proposer_equivocation(store, head_node.root)
 
         if all([
             head_late,
-            shuffling_stable,
+            epoch_boundary,
             ffg_competitive,
             finalization_ok,
             proposing_on_time,
@@ -5803,12 +5881,72 @@
             head_weak,
             parent_strong,
         ]):
-            # We can re-org the current head by building upon its parent block.
-            return parent_root
+            # We can re-org the current head by building upon its parent node.
+            return parent_node
         elif all([head_weak, current_time_ok, proposer_equivocation]):
-            return parent_root
+            return parent_node
         else:
-            return head_root
+            return head_node
+    </spec>
+
+- name: get_proposer_head#gloas
+  sources: []
+  spec: |
+    <spec fn="get_proposer_head" fork="gloas" hash="52ed6595">
+    def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
+        head_block = store.blocks[head_node.root]
+        parent_root = head_block.parent_root
+        parent_block = store.blocks[parent_root]
+        # [Modified in Gloas:EIP7732]
+        parent_payload_status = get_parent_payload_status(store, head_block)
+        parent_node = ForkChoiceNode(root=parent_root, payload_status=parent_payload_status)
+
+        # Only re-org the head block if it arrived later than the attestation deadline.
+        head_late = is_head_late(store, head_node.root)
+
+        # Do not re-org on an epoch boundary.
+        epoch_boundary = is_epoch_boundary(slot)
+
+        # Ensure that the FFG information of the new head will be competitive with the current head.
+        ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
+
+        # Do not re-org if the chain is not finalizing with acceptable frequency.
+        finalization_ok = is_finalization_ok(store, slot)
+
+        # Only re-org if we are proposing on-time.
+        proposing_on_time = is_proposing_on_time(store)
+
+        # Only re-org a single slot at most.
+        parent_slot_ok = parent_block.slot + 1 == head_block.slot
+        current_time_ok = head_block.slot + 1 == slot
+        single_slot_reorg = parent_slot_ok and current_time_ok
+
+        # Check that the head has few enough votes to be overpowered by our proposer boost.
+        assert store.proposer_boost_root != head_node.root  # ensure boost has worn off
+        head_weak = is_head_weak(store, head_node.root)
+
+        # Check that the missing votes are assigned to the parent and not being hoarded.
+        parent_strong = is_parent_strong(store, head_node.root)
+
+        # Re-org more aggressively if there is a proposer equivocation in the previous slot.
+        proposer_equivocation = is_proposer_equivocation(store, head_node.root)
+
+        if all([
+            head_late,
+            epoch_boundary,
+            ffg_competitive,
+            finalization_ok,
+            proposing_on_time,
+            single_slot_reorg,
+            head_weak,
+            parent_strong,
+        ]):
+            # We can re-org the current head by building upon its parent node.
+            return parent_node
+        elif all([head_weak, current_time_ok, proposer_equivocation]):
+            return parent_node
+        else:
+            return head_node
     </spec>
 
 - name: get_proposer_preferences_signature#gloas
@@ -7325,6 +7463,14 @@
         )
     </spec>
 
+- name: is_epoch_boundary#phase0
+  sources: []
+  spec: |
+    <spec fn="is_epoch_boundary" fork="phase0" hash="8900b82d">
+    def is_epoch_boundary(slot: Slot) -> bool:
+        return slot % SLOTS_PER_EPOCH != 0
+    </spec>
+
 - name: is_execution_block#bellatrix
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -7661,12 +7807,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public boolean isParentStrong(
   spec: |
-    <spec fn="is_parent_strong" fork="phase0" hash="24316fbe">
+    <spec fn="is_parent_strong" fork="phase0" hash="a23d498f">
     def is_parent_strong(store: Store, root: Root) -> bool:
         justified_state = store.checkpoint_states[store.justified_checkpoint]
         parent_threshold = calculate_committee_fraction(justified_state, REORG_PARENT_WEIGHT_THRESHOLD)
         parent_root = store.blocks[root].parent_root
-        parent_weight = get_weight(store, ForkChoiceNode(root=parent_root))
+        parent_node = ForkChoiceNode(root=parent_root)
+        parent_weight = get_weight(store, parent_node)
         return parent_weight > parent_threshold
     </spec>
 
@@ -7675,13 +7822,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
       search: public boolean isParentStrong(
   spec: |
-    <spec fn="is_parent_strong" fork="gloas" hash="37089462">
+    <spec fn="is_parent_strong" fork="gloas" hash="3177c56c">
     def is_parent_strong(store: Store, root: Root) -> bool:
         justified_state = store.checkpoint_states[store.justified_checkpoint]
         parent_threshold = calculate_committee_fraction(justified_state, REORG_PARENT_WEIGHT_THRESHOLD)
-        block = store.blocks[root]
-        parent_payload_status = get_parent_payload_status(store, block)
-        parent_node = ForkChoiceNode(root=block.parent_root, payload_status=parent_payload_status)
+        parent_root = store.blocks[root].parent_root
+        # [Modified in Gloas:EIP7732]
+        parent_node = ForkChoiceNode(root=parent_root, payload_status=PAYLOAD_STATUS_PENDING)
         parent_weight = get_attestation_score(store, parent_node, justified_state)
         return parent_weight > parent_threshold
     </spec>
@@ -7832,16 +7979,6 @@
         return time_into_slot_ms <= proposer_reorg_cutoff_ms
     </spec>
 
-- name: is_shuffling_stable#phase0
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
-      search: public boolean isShufflingStable(
-  spec: |
-    <spec fn="is_shuffling_stable" fork="phase0" hash="680f0aa0">
-    def is_shuffling_stable(slot: Slot) -> bool:
-        return slot % SLOTS_PER_EPOCH != 0
-    </spec>
-
 - name: is_slashable_attestation_data#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -7909,6 +8046,23 @@
     <spec fn="is_sync_committee_update" fork="altair" hash="af6f8cb0">
     def is_sync_committee_update(update: LightClientUpdate) -> bool:
         return update.next_sync_committee_branch != NextSyncCommitteeBranch()
+    </spec>
+
+- name: is_valid_builder_deposit_signature#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+      search: private boolean isValidBuilderDepositSignature(
+  spec: |
+    <spec fn="is_valid_builder_deposit_signature" fork="gloas" hash="a4b72f03">
+    def is_valid_builder_deposit_signature(request: BuilderDepositRequest) -> bool:
+        deposit_message = DepositMessage(
+            pubkey=request.pubkey,
+            withdrawal_credentials=request.withdrawal_credentials,
+            amount=request.amount,
+        )
+        domain = compute_domain(DOMAIN_BUILDER_DEPOSIT)
+        signing_root = compute_signing_root(deposit_message, domain)
+        return bls.Verify(request.pubkey, signing_root, request.signature)
     </spec>
 
 - name: is_valid_deposit_signature#electra
@@ -8864,7 +9018,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: private void onboardBuildersFromPendingDeposits(
   spec: |
-    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="6bb266a4">
+    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="2f9926a6">
     def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
         """
         Applies any pending deposit for builders, effectively
@@ -8879,9 +9033,9 @@
                 pending_deposits.append(deposit)
                 continue
 
-            # Note that the function apply_deposit_for_builder can mutate the
-            # state and may add a builder to the registry. For this reason, the
-            # list of builder pubkeys must be recomputed each iteration.
+            # Note that applying a deposit below can mutate the state and
+            # may add a builder to the registry. For this reason, the list
+            # of builder pubkeys must be recomputed each iteration.
             builder_pubkeys = [b.pubkey for b in state.builders]
 
             # Deposits for non-builders stay in the pending queue. If there is a
@@ -8894,15 +9048,25 @@
                 if is_pending_validator(pending_deposits, deposit.pubkey):
                     pending_deposits.append(deposit)
                     continue
+                if not is_valid_deposit_signature(
+                    deposit.pubkey,
+                    deposit.withdrawal_credentials,
+                    deposit.amount,
+                    deposit.signature,
+                ):
+                    continue
 
-            apply_deposit_for_builder(
-                state,
-                deposit.pubkey,
-                deposit.withdrawal_credentials,
-                deposit.amount,
-                deposit.signature,
-                deposit.slot,
-            )
+                add_builder_to_registry(
+                    state,
+                    deposit.pubkey,
+                    PAYLOAD_BUILDER_VERSION,
+                    ExecutionAddress(deposit.withdrawal_credentials[12:]),
+                    deposit.amount,
+                    deposit.slot,
+                )
+            else:
+                builder_index = BuilderIndex(builder_pubkeys.index(deposit.pubkey))
+                state.builders[builder_index].balance += deposit.amount
 
         state.pending_deposits = pending_deposits
     </spec>
@@ -8912,7 +9076,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: private boolean payloadDataAvailability(
   spec: |
-    <spec fn="payload_data_availability" fork="gloas" hash="9d298e0e">
+    <spec fn="payload_data_availability" fork="gloas" hash="19906223">
     def payload_data_availability(store: Store, root: Root, available: bool) -> bool:
         """
         Return whether the blob data for the beacon block with root ``root`` is
@@ -8928,7 +9092,7 @@
             return not available
 
         votes = store.payload_data_availability_vote[root]
-        return sum(vote is available for vote in votes) > DATA_AVAILABILITY_TIMELY_THRESHOLD
+        return sum(vote == available for vote in votes) > DATA_AVAILABILITY_TIMELY_THRESHOLD
     </spec>
 
 - name: payload_timeliness#gloas
@@ -8936,7 +9100,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: private boolean payloadTimeliness(
   spec: |
-    <spec fn="payload_timeliness" fork="gloas" hash="4490a649">
+    <spec fn="payload_timeliness" fork="gloas" hash="c8eb8248">
     def payload_timeliness(store: Store, root: Root, timely: bool) -> bool:
         """
         Return whether the execution payload for the beacon block with root ``root``
@@ -8952,7 +9116,7 @@
             return not timely
 
         votes = store.payload_timeliness_vote[root]
-        return sum(vote is timely for vote in votes) > PAYLOAD_TIMELY_THRESHOLD
+        return sum(vote == timely for vote in votes) > PAYLOAD_TIMELY_THRESHOLD
     </spec>
 
 - name: polynomial_eval_to_coeff#fulu
@@ -9570,7 +9734,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void executionProcessing(
   spec: |
-    <spec fn="process_block" fork="gloas" hash="a911a43e">
+    <spec fn="process_block" fork="gloas" hash="7d98b5a3">
     def process_block(state: BeaconState, block: BeaconBlock) -> None:
         # [New in Gloas:EIP7732]
         process_parent_execution_payload(state, block)
@@ -9580,7 +9744,7 @@
         # [Modified in Gloas:EIP7732]
         # Removed `process_execution_payload`
         # [New in Gloas:EIP7732]
-        process_execution_payload_bid(state, block)
+        process_execution_payload_bid(state, block.body.signed_execution_payload_bid)
         process_randao(state, block.body)
         process_eth1_data(state, block.body)
         # [Modified in Gloas:EIP7732]
@@ -9645,6 +9809,61 @@
         validator.withdrawal_credentials = (
             ETH1_ADDRESS_WITHDRAWAL_PREFIX + b"\x00" * 11 + address_change.to_execution_address
         )
+    </spec>
+
+- name: process_builder_deposit_request#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+      search: public void processBuilderDepositRequests(
+  spec: |
+    <spec fn="process_builder_deposit_request" fork="gloas" hash="c3ba5adf">
+    def process_builder_deposit_request(state: BeaconState, request: BuilderDepositRequest) -> None:
+        builder_pubkeys = [b.pubkey for b in state.builders]
+        if request.pubkey not in builder_pubkeys:
+            if is_valid_builder_deposit_signature(request):
+                add_builder_to_registry(
+                    state,
+                    request.pubkey,
+                    uint8(request.withdrawal_credentials[0]),
+                    ExecutionAddress(request.withdrawal_credentials[12:]),
+                    request.amount,
+                    state.slot,
+                )
+        else:
+            builder_index = BuilderIndex(builder_pubkeys.index(request.pubkey))
+            builder = state.builders[builder_index]
+
+            # Increase balance by deposit amount
+            builder.balance += request.amount
+
+            # If exited, reset the withdrawable epoch
+            if builder.withdrawable_epoch != FAR_FUTURE_EPOCH:
+                epoch = get_current_epoch(state)
+                builder.withdrawable_epoch = epoch + MIN_BUILDER_WITHDRAWABILITY_DELAY
+    </spec>
+
+- name: process_builder_exit_request#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
+      search: public void processBuilderExitRequests(
+  spec: |
+    <spec fn="process_builder_exit_request" fork="gloas" hash="144e9faf">
+    def process_builder_exit_request(state: BeaconState, request: BuilderExitRequest) -> None:
+        builder_pubkeys = [b.pubkey for b in state.builders]
+        if request.pubkey not in builder_pubkeys:
+            return
+
+        builder_index = BuilderIndex(builder_pubkeys.index(request.pubkey))
+        builder = state.builders[builder_index]
+
+        if not is_active_builder(state, builder_index):
+            return
+        if builder.execution_address != request.source_address:
+            return
+        if get_pending_balance_to_withdraw_for_builder(state, builder_index) != 0:
+            return
+
+        initiate_builder_exit(state, builder_index)
     </spec>
 
 - name: process_builder_pending_payments#gloas
@@ -9836,50 +10055,6 @@
   spec: |
     <spec fn="process_deposit_request" fork="fulu" hash="26509dcc">
     def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
-        state.pending_deposits.append(
-            PendingDeposit(
-                pubkey=deposit_request.pubkey,
-                withdrawal_credentials=deposit_request.withdrawal_credentials,
-                amount=deposit_request.amount,
-                signature=deposit_request.signature,
-                slot=state.slot,
-            )
-        )
-    </spec>
-
-- name: process_deposit_request#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/execution/ExecutionRequestsProcessorGloas.java
-      search: public void processDepositRequests(
-  spec: |
-    <spec fn="process_deposit_request" fork="gloas" hash="a6fff32f">
-    def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
-        # [New in Gloas:EIP7732]
-        builder_pubkeys = [b.pubkey for b in state.builders]
-        validator_pubkeys = [v.pubkey for v in state.validators]
-
-        # [New in Gloas:EIP7732]
-        # Regardless of the withdrawal credentials prefix, if a builder/validator
-        # already exists with this pubkey, apply the deposit to their balance
-        is_builder = deposit_request.pubkey in builder_pubkeys
-        is_validator = deposit_request.pubkey in validator_pubkeys
-        if is_builder or (
-            is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
-            and not is_validator
-            and not is_pending_validator(state.pending_deposits, deposit_request.pubkey)
-        ):
-            # Apply builder deposits immediately
-            apply_deposit_for_builder(
-                state,
-                deposit_request.pubkey,
-                deposit_request.withdrawal_credentials,
-                deposit_request.amount,
-                deposit_request.signature,
-                state.slot,
-            )
-            return
-
-        # Add validator deposits to the queue
         state.pending_deposits.append(
             PendingDeposit(
                 pubkey=deposit_request.pubkey,
@@ -10391,9 +10566,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public void processExecutionPayloadBid(
   spec: |
-    <spec fn="process_execution_payload_bid" fork="gloas" hash="823c9f3a">
-    def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> None:
-        signed_bid = block.body.signed_execution_payload_bid
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="ba18a784">
+    def process_execution_payload_bid(
+        state: BeaconState, signed_bid: SignedExecutionPayloadBid
+    ) -> None:
         bid = signed_bid.message
         builder_index = bid.builder_index
         amount = bid.value
@@ -10405,6 +10581,8 @@
         else:
             # Verify that the builder is active
             assert is_active_builder(state, builder_index)
+            # Verify that the builder is a payload builder
+            assert state.builders[builder_index].version == PAYLOAD_BUILDER_VERSION
             # Verify that the builder has funds to cover the bid
             assert can_builder_cover_bid(state, builder_index, amount)
             # Verify that the bid signature is valid
@@ -10417,10 +10595,11 @@
         )
 
         # Verify that the bid is for the current slot
-        assert bid.slot == block.slot
+        assert bid.slot == state.slot
+        assert state.slot > GENESIS_SLOT
         # Verify that the bid is for the right parent block
         assert bid.parent_block_hash == state.latest_block_hash
-        assert bid.parent_block_root == block.parent_root
+        assert bid.parent_block_root == get_block_root_at_slot(state, Slot(state.slot - 1))
         assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 
         # Record the pending payment if there is some payment
@@ -10432,6 +10611,7 @@
                     amount=amount,
                     builder_index=builder_index,
                 ),
+                proposer_index=get_beacon_proposer_index(state),
             )
             state.builder_pending_payments[SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH] = (
                 pending_payment
@@ -10785,7 +10965,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void processOperationsNoValidation(
   spec: |
-    <spec fn="process_operations" fork="gloas" hash="e0633745">
+    <spec fn="process_operations" fork="gloas" hash="4864d8ef">
     def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
         assert len(body.deposits) == 0
 
@@ -10798,7 +10978,6 @@
         for_ops(body.attester_slashings, process_attester_slashing)
         # [Modified in Gloas:EIP7732]
         for_ops(body.attestations, process_attestation)
-        # [Modified in Gloas:EIP7732]
         for_ops(body.voluntary_exits, process_voluntary_exit)
         for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
         # [Modified in Gloas:EIP7732]
@@ -11160,7 +11339,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void removeBuilderPendingPayment(
   spec: |
-    <spec fn="process_proposer_slashing" fork="gloas" hash="10bda1c5">
+    <spec fn="process_proposer_slashing" fork="gloas" hash="4e7f566d">
     def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSlashing) -> None:
         header_1 = proposer_slashing.signed_header_1.message
         header_2 = proposer_slashing.signed_header_2.message
@@ -11183,16 +11362,22 @@
             assert bls.Verify(proposer.pubkey, signing_root, signed_header.signature)
 
         # [New in Gloas:EIP7732]
-        # Remove the BuilderPendingPayment corresponding to
-        # this proposal if it is still in the 2-epoch window.
+        # Remove the BuilderPendingPayment corresponding to this proposal if it is
+        # still in the 2-epoch window. Only clear it when the slashed validator is
+        # the proposer associated with the payment; otherwise an unrelated same-slot
+        # equivocation could grief an honest proposer's payment.
         slot = header_1.slot
         proposal_epoch = compute_epoch_at_slot(slot)
         if proposal_epoch == get_current_epoch(state):
             payment_index = SLOTS_PER_EPOCH + slot % SLOTS_PER_EPOCH
-            state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+            payment = state.builder_pending_payments[payment_index]
+            if payment.proposer_index == header_1.proposer_index:
+                state.builder_pending_payments[payment_index] = BuilderPendingPayment()
         elif proposal_epoch == get_previous_epoch(state):
             payment_index = slot % SLOTS_PER_EPOCH
-            state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+            payment = state.builder_pending_payments[payment_index]
+            if payment.proposer_index == header_1.proposer_index:
+                state.builder_pending_payments[payment_index] = BuilderPendingPayment()
 
         slash_validator(state, header_1.proposer_index)
     </spec>
@@ -11699,55 +11884,6 @@
          )
     </spec>
 
-- name: process_voluntary_exit#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
-      search: public void processVoluntaryExits(
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/operations/validation/VoluntaryExitValidatorGloas.java
-      search: public Optional<OperationInvalidReason> validate(
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
-      search: protected void initiateExit(
-  spec: |
-    <spec fn="process_voluntary_exit" fork="gloas" hash="2a22a698">
-    def process_voluntary_exit(state: BeaconState, signed_voluntary_exit: SignedVoluntaryExit) -> None:
-        voluntary_exit = signed_voluntary_exit.message
-        domain = compute_domain(
-            DOMAIN_VOLUNTARY_EXIT, CAPELLA_FORK_VERSION, state.genesis_validators_root
-        )
-        signing_root = compute_signing_root(voluntary_exit, domain)
-
-        # Exits must specify an epoch when they become valid; they are not valid before then
-        assert get_current_epoch(state) >= voluntary_exit.epoch
-
-        # [New in Gloas:EIP7732]
-        if is_builder_index(voluntary_exit.validator_index):
-            builder_index = convert_validator_index_to_builder_index(voluntary_exit.validator_index)
-            # Verify the builder is active
-            assert is_active_builder(state, builder_index)
-            # Only exit builder if it has no pending withdrawals in the queue
-            assert get_pending_balance_to_withdraw_for_builder(state, builder_index) == 0
-            # Verify signature
-            pubkey = state.builders[builder_index].pubkey
-            assert bls.Verify(pubkey, signing_root, signed_voluntary_exit.signature)
-            # Initiate exit
-            initiate_builder_exit(state, builder_index)
-            return
-
-        validator = state.validators[voluntary_exit.validator_index]
-        # Verify the validator is active
-        assert is_active_validator(validator, get_current_epoch(state))
-        # Verify exit has not been initiated
-        assert validator.exit_epoch == FAR_FUTURE_EPOCH
-        # Verify the validator has been active long enough
-        assert get_current_epoch(state) >= validator.activation_epoch + SHARD_COMMITTEE_PERIOD
-        # Only exit validator if it has no pending withdrawals in the queue
-        assert get_pending_balance_to_withdraw(state, voluntary_exit.validator_index) == 0
-        # Verify signature
-        assert bls.Verify(validator.pubkey, signing_root, signed_voluntary_exit.signature)
-        # Initiate exit
-        initiate_validator_exit(state, voluntary_exit.validator_index)
-    </spec>
-
 - name: process_withdrawal_request#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/execution/ExecutionRequestsProcessorElectra.java
@@ -12213,16 +12349,16 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: public boolean shouldBuildOnFull(
   spec: |
-    <spec fn="should_build_on_full" fork="gloas" hash="40a75144">
+    <spec fn="should_build_on_full" fork="gloas" hash="c93c17f0">
     def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
         assert head.payload_status != PAYLOAD_STATUS_PENDING
+        if store.blocks[head.root].slot + 1 != get_current_slot(store):
+            return head.payload_status == PAYLOAD_STATUS_FULL
         if head.payload_status == PAYLOAD_STATUS_EMPTY:
             return False
-        if store.blocks[head.root].slot + 1 != get_current_slot(store):
-            return True
-        if payload_data_availability(store, head.root, available=False):
-            return False
         if payload_timeliness(store, head.root, timely=False):
+            return False
+        if payload_data_availability(store, head.root, available=False):
             return False
         return True
     </spec>
@@ -12232,8 +12368,9 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: private boolean shouldExtendPayload(
   spec: |
-    <spec fn="should_extend_payload" fork="gloas" hash="fd2b578c">
+    <spec fn="should_extend_payload" fork="gloas" hash="4c7f1056">
     def should_extend_payload(store: Store, root: Root) -> bool:
+        assert store.blocks[root].slot + 1 == get_current_slot(store)
         if not is_payload_verified(store, root):
             return False
         proposer_root = store.proposer_boost_root
@@ -13028,7 +13165,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
       search: public BeaconStateAltair upgrade(
   spec: |
-    <spec fn="upgrade_to_altair" fork="altair" hash="4f858ca3">
+    <spec fn="upgrade_to_altair" fork="altair" hash="45bb04f7">
     def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:
         epoch = phase0.get_current_epoch(pre)
         post = BeaconState(
@@ -13037,6 +13174,7 @@
             slot=pre.slot,
             fork=Fork(
                 previous_version=pre.fork.current_version,
+                # [New in Altair]
                 current_version=ALTAIR_FORK_VERSION,
                 epoch=epoch,
             ),
@@ -13078,7 +13216,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/forktransition/BellatrixStateUpgrade.java
       search: public BeaconStateBellatrix upgrade(
   spec: |
-    <spec fn="upgrade_to_bellatrix" fork="bellatrix" hash="73a0a7ba">
+    <spec fn="upgrade_to_bellatrix" fork="bellatrix" hash="378e5a8d">
     def upgrade_to_bellatrix(pre: altair.BeaconState) -> BeaconState:
         epoch = altair.get_current_epoch(pre)
         post = BeaconState(
@@ -13087,7 +13225,7 @@
             slot=pre.slot,
             fork=Fork(
                 previous_version=pre.fork.current_version,
-                # [New in Bellatrix]
+                # [Modified in Bellatrix]
                 current_version=BELLATRIX_FORK_VERSION,
                 epoch=epoch,
             ),
@@ -13123,7 +13261,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/forktransition/CapellaStateUpgrade.java
       search: public BeaconStateCapella upgrade(
   spec: |
-    <spec fn="upgrade_to_capella" fork="capella" hash="673c74f0">
+    <spec fn="upgrade_to_capella" fork="capella" hash="f1f20b37">
     def upgrade_to_capella(pre: bellatrix.BeaconState) -> BeaconState:
         epoch = bellatrix.get_current_epoch(pre)
         latest_execution_payload_header = ExecutionPayloadHeader(
@@ -13150,6 +13288,7 @@
             slot=pre.slot,
             fork=Fork(
                 previous_version=pre.fork.current_version,
+                # [Modified in Capella]
                 current_version=CAPELLA_FORK_VERSION,
                 epoch=epoch,
             ),
@@ -13426,7 +13565,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: public BeaconStateGloas upgrade(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="d9a22a92">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="c769e40a">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -13436,7 +13575,7 @@
             slot=pre.slot,
             fork=Fork(
                 previous_version=pre.fork.current_version,
-                # [Modified in Gloas:EIP7732]
+                # [Modified in Gloas]
                 current_version=GLOAS_FORK_VERSION,
                 epoch=epoch,
             ),

--- a/specrefs/presets.yml
+++ b/specrefs/presets.yml
@@ -268,6 +268,24 @@
     MAX_BUILDERS_PER_WITHDRAWALS_SWEEP = 16384
     </spec>
 
+- name: MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD#gloas
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
+      search: "MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD:"
+  spec: |
+    <spec preset_var="MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="81a08140">
+    MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD: uint64 = 256
+    </spec>
+
+- name: MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD#gloas
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
+      search: "MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD:"
+  spec: |
+    <spec preset_var="MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="d461f12d">
+    MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD: uint64 = 16
+    </spec>
+
 - name: MAX_BYTES_PER_TRANSACTION#bellatrix
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.11

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Gloas consensus block processing, builder economics, and fork-choice payload rules that must match the spec; risk is mitigated by reference-test version bump and targeted logic changes rather than broad refactors.
> 
> **Overview**
> Bumps Ethereum **consensus-specs** reference tests and **specrefs** to **v1.7.0-alpha.11**, with Gloas/EPBS behavior brought in line with that release.
> 
> **Execution payload bids** now take a **`SignedExecutionPayloadBid`** (not a full block): reference operation tests load `execution_payload_bid.ssz_snappy`, and Gloas validation checks **`PAYLOAD_BUILDER_VERSION`**, uses **state slot** and **parent block root from state**, and records pending payments with **`get_beacon_proposer_index(state)`**.
> 
> **Builder registry** registration passes an explicit **`version`** and **`Eth1Address`** instead of deriving them from withdrawal credentials; fork onboarding and builder deposit requests follow the updated spec paths.
> 
> **Fork choice (Gloas)** adds reference coverage for **`payload_data_availability`** and **`payload_timeliness`**, fixes PTC vote aggregation to use **`==`**, and adjusts **`should_build_on_full`** / **`should_extend_payload`**. **Proposer slashing** only clears a builder pending payment when the slashed header’s proposer matches the payment’s **`proposer_index`**.
> 
> SSZ static tests for **`BuilderDepositRequest`** / **`BuilderExitRequest`** are wired up; large **specrefs** diffs track containers, constants, and fork-choice helper renames (e.g. **`is_epoch_boundary`** vs **`is_shuffling_stable`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309c1717a200088d04f64d11cffd962385b3d8f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->