### PR TITLE
Add JSON log format option

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -81,6 +81,7 @@ dependencyManagement {
 		dependencySet(group: 'org.apache.logging.log4j', version: '2.26.0') {
 			entry 'log4j-api'
 			entry 'log4j-core'
+			entry 'log4j-layout-template-json'
 			entry 'log4j-slf4j-impl'
 			entry 'log4j-slf4j2-impl'
 		}

--- a/infrastructure/logging/build.gradle
+++ b/infrastructure/logging/build.gradle
@@ -4,8 +4,10 @@ dependencies {
 
 	implementation 'org.web3j:utils'
 	implementation 'org.apache.logging.log4j:log4j-core'
+	implementation 'org.apache.logging.log4j:log4j-layout-template-json'
 	compileOnly 'com.github.oshi:oshi-core'
 
 	testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
+	testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 	testImplementation 'com.github.oshi:oshi-core'
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
@@ -32,6 +32,7 @@ public class LoggingConfig {
   private final boolean includeValidatorDutiesEnabled;
   private final boolean includeP2pWarningsEnabled;
   private final LoggingDestination destination;
+  private final LoggingFormat format;
   private final String logFile;
   private final String logFileNamePattern;
   private final int dbOpAlertThresholdMillis;
@@ -43,6 +44,7 @@ public class LoggingConfig {
       final boolean includeValidatorDutiesEnabled,
       final boolean includeP2pWarningsEnabled,
       final LoggingDestination destination,
+      final LoggingFormat format,
       final String logFile,
       final String logFileNamePattern,
       final int dbOpAlertThresholdMillis) {
@@ -52,6 +54,7 @@ public class LoggingConfig {
     this.includeValidatorDutiesEnabled = includeValidatorDutiesEnabled;
     this.includeP2pWarningsEnabled = includeP2pWarningsEnabled;
     this.destination = destination;
+    this.format = format;
     this.logFile = logFile;
     this.logFileNamePattern = logFileNamePattern;
     this.dbOpAlertThresholdMillis = dbOpAlertThresholdMillis;
@@ -85,6 +88,10 @@ public class LoggingConfig {
     return destination;
   }
 
+  public LoggingFormat getFormat() {
+    return format;
+  }
+
   public String getLogFile() {
     return logFile;
   }
@@ -113,6 +120,7 @@ public class LoggingConfig {
         && dbOpAlertThresholdMillis == that.dbOpAlertThresholdMillis
         && Objects.equals(logLevel, that.logLevel)
         && destination == that.destination
+        && format == that.format
         && Objects.equals(logFile, that.logFile)
         && Objects.equals(logFileNamePattern, that.logFileNamePattern);
   }
@@ -126,6 +134,7 @@ public class LoggingConfig {
         includeValidatorDutiesEnabled,
         includeP2pWarningsEnabled,
         destination,
+        format,
         logFile,
         logFileNamePattern,
         dbOpAlertThresholdMillis);
@@ -140,6 +149,7 @@ public class LoggingConfig {
     private boolean includeValidatorDutiesEnabled = true;
     private boolean includeP2pWarningsEnabled = false;
     private LoggingDestination destination = LoggingDestination.DEFAULT_BOTH;
+    private LoggingFormat format = LoggingFormat.PLAIN;
 
     private String logFileNamePrefix = DEFAULT_LOG_FILE_NAME_PREFIX;
     private String logFileName;
@@ -218,6 +228,11 @@ public class LoggingConfig {
       return this;
     }
 
+    public LoggingConfigBuilder format(final LoggingFormat format) {
+      this.format = format;
+      return this;
+    }
+
     public LoggingConfigBuilder dataDirectory(final String dataDirectory) {
       this.dataDirectory = dataDirectory;
       return this;
@@ -268,6 +283,7 @@ public class LoggingConfig {
           includeValidatorDutiesEnabled,
           includeP2pWarningsEnabled,
           destination,
+          format,
           logPath,
           logPathPattern,
           dbOpAlertThresholdMillis);

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.pattern.RegexReplacement;
+import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
 import org.apache.logging.log4j.status.StatusLogger;
 
 public class LoggingConfigurator {
@@ -50,11 +51,22 @@ public class LoggingConfigurator {
   private static final String FILE_APPENDER_NAME = "teku-log-appender";
   private static final String FILE_MESSAGE_FORMAT =
       "%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n";
+  private static final String JSON_LOG_EVENT_TEMPLATE =
+      "{\"timestamp\":{\"$resolver\":\"timestamp\"},"
+          + "\"level\":{\"$resolver\":\"level\",\"field\":\"name\"},"
+          + "\"loggerName\":{\"$resolver\":\"logger\",\"field\":\"name\"},"
+          + "\"threadName\":{\"$resolver\":\"thread\",\"field\":\"name\"},"
+          + "\"message\":{\"$resolver\":\"message\",\"stringified\":true},"
+          + "\"exception\":{\"$resolver\":\"exception\",\"field\":\"stackTrace\","
+          + "\"stackTrace\":{\"stringified\":true}}}";
   private static final AtomicBoolean COLOR = new AtomicBoolean();
   private static final StatusLogger STATUS_LOG = StatusLogger.getLogger();
 
   @SuppressWarnings("NonFinalStaticField")
   private static LoggingDestination destination;
+
+  @SuppressWarnings("NonFinalStaticField")
+  private static LoggingFormat format;
 
   @SuppressWarnings("NonFinalStaticField")
   private static boolean includeEvents;
@@ -121,6 +133,7 @@ public class LoggingConfigurator {
     configuration.getLogLevel().ifPresent(LoggingConfigurator::setAllLevels);
     COLOR.set(configuration.isColorEnabled());
     destination = configuration.getDestination();
+    format = configuration.getFormat();
     includeEvents = configuration.isIncludeEventsEnabled();
     includeValidatorDuties = configuration.isIncludeValidatorDutiesEnabled();
     includeP2pWarnings = configuration.isIncludeP2pWarningsEnabled();
@@ -228,6 +241,7 @@ public class LoggingConfigurator {
     STATUS_LOG.info("Logging includes events: {}", includeEvents);
     STATUS_LOG.info("Logging includes validator duties: {}", includeValidatorDuties);
     STATUS_LOG.info("Logging includes color: {}", COLOR);
+    STATUS_LOG.info("Logging format: {}", format);
   }
 
   private static void displayCustomLog4jConfigUsed() {
@@ -255,6 +269,14 @@ public class LoggingConfigurator {
   static LoggingDestination setDestination(final LoggingDestination destination) {
     final LoggingDestination original = LoggingConfigurator.destination;
     LoggingConfigurator.destination = destination;
+    return original;
+  }
+
+  @VisibleForTesting
+  // returns the original format
+  static LoggingFormat setFormat(final LoggingFormat format) {
+    final LoggingFormat original = LoggingConfigurator.format;
+    LoggingConfigurator.format = format;
     return original;
   }
 
@@ -315,8 +337,12 @@ public class LoggingConfigurator {
   }
 
   @VisibleForTesting
-  static PatternLayout consoleAppenderLayout(
+  static Layout<?> consoleAppenderLayout(
       final AbstractConfiguration configuration, final boolean omitStackTraces) {
+    if (format == LoggingFormat.JSON) {
+      return jsonLayout(configuration);
+    }
+
     final Pattern logReplacement =
         Pattern.compile(isColorEnabled() ? COLOR_LOG_REGEX : NO_COLOR_LOG_REGEX);
     return PatternLayout.newBuilder()
@@ -344,13 +370,25 @@ public class LoggingConfigurator {
   }
 
   @VisibleForTesting
-  static PatternLayout fileAppenderLayout(final AbstractConfiguration configuration) {
+  static Layout<?> fileAppenderLayout(final AbstractConfiguration configuration) {
+    if (format == LoggingFormat.JSON) {
+      return jsonLayout(configuration);
+    }
+
     final Pattern logReplacement =
         Pattern.compile(isColorEnabled() ? COLOR_LOG_REGEX : NO_COLOR_LOG_REGEX);
     return PatternLayout.newBuilder()
         .withRegexReplacement(RegexReplacement.createRegexReplacement(logReplacement, ""))
         .withPattern(FILE_MESSAGE_FORMAT)
         .withConfiguration(configuration)
+        .build();
+  }
+
+  private static JsonTemplateLayout jsonLayout(final AbstractConfiguration configuration) {
+    return JsonTemplateLayout.newBuilder()
+        .setConfiguration(configuration)
+        .setEventTemplate(JSON_LOG_EVENT_TEMPLATE)
+        .setEventDelimiter(System.lineSeparator())
         .build();
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingFormat.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingFormat.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.logging;
+
+public enum LoggingFormat {
+  PLAIN,
+  JSON
+}

--- a/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
+++ b/infrastructure/logging/src/test/java/tech/pegasys/teku/infrastructure/logging/LoggingConfiguratorTest.java
@@ -15,11 +15,15 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.CharArrayWriter;
+import java.io.IOException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.WriterAppender;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +35,7 @@ public class LoggingConfiguratorTest {
   public static final String STRIPPED_COLOR_STRING = "a[30mb[31mc[37md" + ENDL;
   private WriterAppender appender;
   private final CharArrayWriter outContent = new CharArrayWriter();
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
   void toFile_shouldPrintColorIfEnabled() {
@@ -143,6 +148,32 @@ public class LoggingConfiguratorTest {
     }
   }
 
+  @Test
+  void toFile_shouldPrintJsonIfEnabled() throws IOException {
+    final LoggingFormat initialFormat = LoggingConfigurator.setFormat(LoggingFormat.JSON);
+    try {
+      fileAppenderLog("ab");
+      final JsonNode jsonLog = objectMapper.readTree(outContent.toString());
+      assertThat(jsonLog.get("message").asText()).isEqualTo("ab");
+      assertThat(jsonLog.get("loggerName").asText()).isEqualTo("TestLogger");
+    } finally {
+      LoggingConfigurator.setFormat(initialFormat);
+    }
+  }
+
+  @Test
+  void toConsole_shouldPrintJsonIfEnabled() throws IOException {
+    final LoggingFormat initialFormat = LoggingConfigurator.setFormat(LoggingFormat.JSON);
+    try {
+      consoleAppenderLog("ab");
+      final JsonNode jsonLog = objectMapper.readTree(outContent.toString());
+      assertThat(jsonLog.get("message").asText()).isEqualTo("ab");
+      assertThat(jsonLog.get("loggerName").asText()).isEqualTo("TestLogger");
+    } finally {
+      LoggingConfigurator.setFormat(initialFormat);
+    }
+  }
+
   private void fileAppenderLog(final String message) {
     log(message, LoggingConfigurator.fileAppenderLayout(null));
   }
@@ -151,7 +182,7 @@ public class LoggingConfiguratorTest {
     log(message, LoggingConfigurator.consoleAppenderLayout(null, true));
   }
 
-  private void log(final String message, final PatternLayout layout) {
+  private void log(final String message, final Layout<?> layout) {
     try {
       appender =
           WriterAppender.newBuilder()
@@ -164,6 +195,7 @@ public class LoggingConfiguratorTest {
           Log4jLogEvent.newBuilder()
               .setLoggerName("TestLogger")
               .setLoggerFqcn(LoggingConfiguratorTest.class.getName())
+              .setLevel(Level.INFO)
               .setMessage(new SimpleMessage(message))
               .build();
       appender.append(event);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.cli.converter.LogTypeConverter;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
+import tech.pegasys.teku.infrastructure.logging.LoggingFormat;
 
 public class LoggingOptions {
   private static final String LINUX_SEP = "/";
@@ -79,6 +80,13 @@ public class LoggingOptions {
           "Whether a logger is added for the console, the log file, or both (Valid values: ${COMPLETION-CANDIDATES})",
       arity = "1")
   private LoggingDestination logDestination = DEFAULT_BOTH;
+
+  @Option(
+      names = {"--log-format"},
+      paramLabel = "<LOG_FORMAT>",
+      description = "Format for log output (Valid values: ${COMPLETION-CANDIDATES})",
+      arity = "1")
+  private LoggingFormat logFormat = LoggingFormat.PLAIN;
 
   @Option(
       names = {"--log-file"},
@@ -187,6 +195,7 @@ public class LoggingOptions {
         .includeEventsEnabled(logIncludeEventsEnabled)
         .includeValidatorDutiesEnabled(logIncludeValidatorDutiesEnabled)
         .includeP2pWarningsEnabled(logIncludeP2pWarningsEnabled)
+        .format(logFormat)
         .destination(logDestination);
     return loggingBuilder.build();
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.cli.OSUtils;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
+import tech.pegasys.teku.infrastructure.logging.LoggingFormat;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.networking.p2p.network.config.WireLogsConfig;
 
@@ -42,6 +43,7 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
     final LoggingConfig loggingConfig = getLoggingConfigFromFile("loggingOptions_config.yaml");
 
     assertThat(loggingConfig.getDestination()).isEqualTo(LoggingDestination.FILE);
+    assertThat(loggingConfig.getFormat()).isEqualTo(LoggingFormat.JSON);
     assertThat(loggingConfig.isColorEnabled()).isFalse();
     assertThat(loggingConfig.isIncludeEventsEnabled()).isFalse();
     assertThat(loggingConfig.getLogFile())
@@ -96,6 +98,20 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
   public void logDestination_shouldAcceptBothAsDestination() {
     final LoggingConfig config = getLoggingConfigurationFromArguments("--log-destination", "both");
     assertThat(config.getDestination()).isEqualTo(LoggingDestination.BOTH);
+  }
+
+  @Test
+  public void logFormat_shouldHaveSensibleDefaultValue() {
+    beaconNodeCommand.parse(new String[0]);
+
+    final LoggingConfig config = getResultingLoggingConfiguration();
+    assertThat(config.getFormat()).isEqualTo(LoggingFormat.PLAIN);
+  }
+
+  @Test
+  public void logFormat_shouldAcceptJsonFormat() {
+    final LoggingConfig config = getLoggingConfigurationFromArguments("--log-format", "json");
+    assertThat(config.getFormat()).isEqualTo(LoggingFormat.JSON);
   }
 
   @Test

--- a/teku/src/test/resources/loggingOptions_config.yaml
+++ b/teku/src/test/resources/loggingOptions_config.yaml
@@ -2,5 +2,6 @@
 log-color-enabled: False
 log-include-events-enabled: False
 log-destination: "FILE"
+log-format: "JSON"
 log-file: "a.log"
 log-file-name-pattern: "a%d.log"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Adds a `--log-format` CLI option for selecting Teku log output format.

The option supports:
- `plain`, which is the default and preserves the existing log output.
- `json`, which configures console and file appenders with Log4j's `JsonTemplateLayout` for structured JSON logs.

The JSON layout includes timestamp, level, logger name, thread name, message, and exception stack trace fields. This makes Teku logs easier to ingest in log analysis and monitoring systems without requiring users to provide a custom Log4j configuration.


fixes #10247

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with plain as default; JSON path is additive and covered by unit tests.
> 
> **Overview**
> Adds a **`--log-format`** CLI / config option (`plain` default, `json`) so Teku can emit **structured JSON logs** on console and file appenders without a custom Log4j config.
> 
> When `json` is selected, **`LoggingConfigurator`** uses Log4j **`JsonTemplateLayout`** (new **`log4j-layout-template-json`** dependency) instead of pattern layouts. Each line includes timestamp, level, logger name, thread, message, and exception stack trace. **`LoggingConfig`** and a new **`LoggingFormat`** enum thread the setting through startup; existing plain behavior is unchanged unless the option is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7761c0013efc1ebea87ba80aebddbecd33f5bfeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->