### PR TITLE
Treat QUIC STOP_SENDING and stream closes as benign in RPC/gossip logging

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
@@ -85,7 +85,7 @@ public class GossipFailureLogger {
               "Failed to publish {}{} because no active outbound stream for the required gossip topic",
               messageType,
               slotLog);
-      // a closed/half-closed stream is benign peer churn (e.g. a disconnecting peer, or one that
+      // a closed/half-closed stream is expected peer churn (e.g. a disconnecting peer, or one that
       // sent STOP_SENDING); ChannelOutputShutdownException is not a ClosedChannelException so it
       // must be handled separately.
       case ClosedChannelException ignored ->

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLogger.java
@@ -17,6 +17,8 @@ import com.google.common.base.Throwables;
 import io.libp2p.core.SemiDuplexNoOutboundStreamException;
 import io.libp2p.pubsub.MessageAlreadySeenException;
 import io.libp2p.pubsub.NoPeersForOutboundMessageException;
+import io.netty.channel.socket.ChannelOutputShutdownException;
+import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -83,6 +85,13 @@ public class GossipFailureLogger {
               "Failed to publish {}{} because no active outbound stream for the required gossip topic",
               messageType,
               slotLog);
+      // a closed/half-closed stream is benign peer churn (e.g. a disconnecting peer, or one that
+      // sent STOP_SENDING); ChannelOutputShutdownException is not a ClosedChannelException so it
+      // must be handled separately.
+      case ClosedChannelException ignored ->
+          LOG.debug("Failed to publish {}{} because the stream was closed", messageType, slotLog);
+      case ChannelOutputShutdownException ignored ->
+          LOG.debug("Failed to publish {}{} because the stream was closed", messageType, slotLog);
       default ->
           LOG.log(
               suppress ? Level.DEBUG : Level.ERROR,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
 import com.google.common.base.Throwables;
+import io.netty.channel.socket.ChannelOutputShutdownException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +64,11 @@ public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMess
       return;
     }
 
-    if (rootCause instanceof StreamClosedException || rootCause instanceof ClosedChannelException) {
+    // a closed/half-closed stream is benign peer churn; ChannelOutputShutdownException (e.g. the
+    // peer sent STOP_SENDING) is not a ClosedChannelException so it must be matched separately.
+    if (rootCause instanceof StreamClosedException
+        || rootCause instanceof ClosedChannelException
+        || rootCause instanceof ChannelOutputShutdownException) {
       LOG.trace("Stream closed while sending requested {}", type, error);
       callback.completeWithUnexpectedError(error);
       return;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
@@ -64,7 +64,7 @@ public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMess
       return;
     }
 
-    // a closed/half-closed stream is benign peer churn; ChannelOutputShutdownException (e.g. the
+    // a closed/half-closed stream is expected peer churn; ChannelOutputShutdownException (e.g. the
     // peer sent STOP_SENDING) is not a ClosedChannelException so it must be matched separately.
     if (rootCause instanceof StreamClosedException
         || rootCause instanceof ClosedChannelException

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
@@ -69,7 +69,22 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
   public void completeWithErrorResponse(final RpcException error) {
     LOG.debug("Responding to RPC request with error: {}", error.getErrorMessageString());
     try {
-      rpcStream.writeBytes(responseEncoder.encodeErrorResponse(error)).finishStackTrace();
+      rpcStream
+          .writeBytes(responseEncoder.encodeErrorResponse(error))
+          .finish(
+              RootCauseExceptionHandler.builder()
+                  .addCatch(
+                      ClosedChannelException.class,
+                      err ->
+                          LOG.trace(
+                              "Failed to write error response because channel was closed", err))
+                  .addCatch(
+                      ChannelOutputShutdownException.class,
+                      err ->
+                          LOG.trace(
+                              "Failed to write error response because peer stopped reading the stream (STOP_SENDING)",
+                              err))
+                  .defaultCatch(err -> LOG.error("Failed to write req/resp error response", err)));
     } catch (StreamClosedException e) {
       LOG.debug(
           "Unable to send error message ({}) to peer, rpc stream already closed: {}",

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import io.netty.channel.socket.ChannelOutputShutdownException;
 import java.nio.channels.ClosedChannelException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -49,6 +50,12 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
                 .addCatch(
                     ClosedChannelException.class,
                     err -> LOG.trace("Failed to write because channel was closed", err))
+                .addCatch(
+                    ChannelOutputShutdownException.class,
+                    err ->
+                        LOG.trace(
+                            "Failed to write because peer stopped reading the stream (STOP_SENDING)",
+                            err))
                 .defaultCatch(err -> LOG.error("Failed to write req/resp response", err)));
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
@@ -87,7 +87,7 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
       rpcStream.closeAbruptly().finishTrace(LOG);
       return;
     }
-    // A closed/half-closed stream is benign peer churn. Writing a server error response to it is
+    // A closed/half-closed stream is expected peer churn. Writing a server error response to it is
     // pointless: the write would just fail again and resurface as a noisy uncaught exception (e.g.
     // the peer sent STOP_SENDING, which is a ChannelOutputShutdownException rather than a
     // ClosedChannelException, so each close type must be matched separately).

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import com.google.common.base.Throwables;
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import java.nio.channels.ClosedChannelException;
 import org.apache.logging.log4j.LogManager;
@@ -84,8 +85,20 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
       LOG.trace("Not sending RPC response as peer has already disconnected");
       // But close the stream just to be completely sure we don't leak any resources.
       rpcStream.closeAbruptly().finishTrace(LOG);
-    } else {
-      completeWithErrorResponse(new ServerErrorException());
+      return;
     }
+    // A closed/half-closed stream is benign peer churn. Writing a server error response to it is
+    // pointless: the write would just fail again and resurface as a noisy uncaught exception (e.g.
+    // the peer sent STOP_SENDING, which is a ChannelOutputShutdownException rather than a
+    // ClosedChannelException, so each close type must be matched separately).
+    final Throwable rootCause = Throwables.getRootCause(error);
+    if (rootCause instanceof StreamClosedException
+        || rootCause instanceof ClosedChannelException
+        || rootCause instanceof ChannelOutputShutdownException) {
+      LOG.trace("Not sending RPC response as the stream is already closed", error);
+      rpcStream.closeAbruptly().finishTrace(LOG);
+      return;
+    }
+    completeWithErrorResponse(new ServerErrorException());
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLoggerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/GossipFailureLoggerTest.java
@@ -13,12 +13,15 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.networking.eth2.gossip.GossipFailureLogger.createNonSuppressing;
 import static tech.pegasys.teku.networking.eth2.gossip.GossipFailureLogger.createSuppressing;
 
 import io.libp2p.core.SemiDuplexNoOutboundStreamException;
 import io.libp2p.pubsub.MessageAlreadySeenException;
 import io.libp2p.pubsub.NoPeersForOutboundMessageException;
+import io.netty.channel.socket.ChannelOutputShutdownException;
+import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.infrastructure.logging.LogCaptor;
@@ -120,6 +123,27 @@ class GossipFailureLoggerTest {
   }
 
   @Test
+  void shouldLogClosedChannelExceptionAtDebugLevel() {
+    try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
+      loggerSuppressing.log(new RuntimeException("Foo", new ClosedChannelException()), SLOT);
+      logCaptor.assertDebugLog(streamClosedMessage(SLOT, true));
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldLogChannelOutputShutdownExceptionAtDebugLevel() {
+    try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
+      loggerSuppressing.log(
+          new RuntimeException(
+              "Foo", new ChannelOutputShutdownException("STOP_SENDING frame received")),
+          SLOT);
+      logCaptor.assertDebugLog(streamClosedMessage(SLOT, true));
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
   void shouldLogFirstGenericErrorAtErrorLevel() {
     try (final LogCaptor logCaptor = LogCaptor.forClass(GossipFailureLogger.class)) {
       loggerSuppressing.log(new RuntimeException("Foo", new IllegalStateException("Boom")), SLOT);
@@ -214,5 +238,13 @@ class GossipFailureLoggerTest {
     return "Failed to publish thingy"
         + (shouldSuppress ? "(s)" : "")
         + slot.map(s -> " for slot " + s).orElse("");
+  }
+
+  private static String streamClosedMessage(
+      final Optional<UInt64> slot, final boolean shouldSuppress) {
+    return "Failed to publish thingy"
+        + (shouldSuppress ? "(s)" : "")
+        + slot.map(s -> " for slot " + s).orElse("")
+        + " because the stream was closed";
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandlerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.netty.channel.socket.ChannelOutputShutdownException;
+import java.nio.channels.ClosedChannelException;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.infrastructure.logging.LogCaptor;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+
+class PeerRequiredLocalMessageHandlerTest {
+
+  @SuppressWarnings("unchecked")
+  private final ResponseCallback<SszData> callback = mock(ResponseCallback.class);
+
+  private final PeerRequiredLocalMessageHandler<Object, SszData> handler =
+      new PeerRequiredLocalMessageHandler<>() {
+        @Override
+        protected void onIncomingMessage(
+            final String protocolId,
+            final Eth2Peer peer,
+            final Object message,
+            final ResponseCallback<SszData> callback) {}
+      };
+
+  @Test
+  void shouldHandleStopSendingAsBenignStreamClose() {
+    final Throwable error =
+        new RuntimeException(new ChannelOutputShutdownException("STOP_SENDING frame received"));
+
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(PeerRequiredLocalMessageHandler.class, Level.TRACE)) {
+      handler.handleError(error, callback, "thingy");
+
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+      assertThat(logCaptor.getTraceLogs())
+          .anySatisfy(log -> assertThat(log).contains("Stream closed while sending requested"));
+    }
+    verify(callback).completeWithUnexpectedError(error);
+  }
+
+  @Test
+  void shouldHandleClosedChannelAsBenignStreamClose() {
+    final Throwable error = new RuntimeException(new ClosedChannelException());
+
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(PeerRequiredLocalMessageHandler.class, Level.TRACE)) {
+      handler.handleError(error, callback, "thingy");
+
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+    verify(callback).completeWithUnexpectedError(error);
+  }
+
+  @Test
+  void shouldLogUnexpectedErrorAtErrorLevel() {
+    final Throwable error = new RuntimeException(new IllegalStateException("Boom"));
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(PeerRequiredLocalMessageHandler.class)) {
+      handler.handleError(error, callback, "thingy");
+
+      logCaptor.assertErrorLog("Failed to process thingy request");
+    }
+    verify(callback).completeWithUnexpectedError(error);
+  }
+}

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandlerTest.java
@@ -41,7 +41,7 @@ class PeerRequiredLocalMessageHandlerTest {
       };
 
   @Test
-  void shouldHandleStopSendingAsBenignStreamClose() {
+  void shouldHandleStopSendingAsExpectedStreamClose() {
     final Throwable error =
         new RuntimeException(new ChannelOutputShutdownException("STOP_SENDING frame received"));
 
@@ -57,7 +57,7 @@ class PeerRequiredLocalMessageHandlerTest {
   }
 
   @Test
-  void shouldHandleClosedChannelAsBenignStreamClose() {
+  void shouldHandleClosedChannelAsExpectedStreamClose() {
     final Throwable error = new RuntimeException(new ClosedChannelException());
 
     try (final LogCaptor logCaptor =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
@@ -118,6 +118,49 @@ class RpcResponseCallbackTest {
     verify(rpcStream).writeBytes(any());
   }
 
+  @Test
+  void completeWithErrorResponseShouldNotLogErrorWhenWriteFailsWithStopSending() {
+    failErrorResponseWriteWith(new ChannelOutputShutdownException("STOP_SENDING frame received"));
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.completeWithErrorResponse(new RpcException.ServerErrorException());
+
+      // The peer sent STOP_SENDING, so failing to write the error response is expected churn, not
+      // a noisy uncaught exception.
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+      assertThat(logCaptor.getTraceLogs())
+          .anySatisfy(log -> assertThat(log).contains("STOP_SENDING"));
+    }
+  }
+
+  @Test
+  void completeWithErrorResponseShouldNotLogErrorWhenWriteFailsWithClosedChannel() {
+    failErrorResponseWriteWith(new ClosedChannelException());
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.completeWithErrorResponse(new RpcException.ServerErrorException());
+
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void completeWithErrorResponseShouldLogErrorWhenWriteFailsWithUnexpectedError() {
+    failErrorResponseWriteWith(new IllegalStateException("Boom"));
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class)) {
+      callback.completeWithErrorResponse(new RpcException.ServerErrorException());
+
+      logCaptor.assertErrorLog("Failed to write req/resp error response");
+    }
+  }
+
+  private void failErrorResponseWriteWith(final Throwable error) {
+    when(responseEncoder.encodeErrorResponse(any())).thenReturn(Bytes.EMPTY);
+    when(rpcStream.writeBytes(any())).thenReturn(SafeFuture.failedFuture(error));
+    when(rpcStream.closeWriteStream()).thenReturn(SafeFuture.COMPLETE);
+  }
+
   private void failWriteWith(final Throwable error) {
     when(responseEncoder.encodeSuccessfulResponse(any())).thenReturn(Bytes.EMPTY);
     when(rpcStream.writeBytes(any())).thenReturn(SafeFuture.failedFuture(error));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.rpc.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.netty.channel.socket.ChannelOutputShutdownException;
+import java.nio.channels.ClosedChannelException;
+import org.apache.logging.log4j.Level;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.infrastructure.logging.LogCaptor;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
+
+class RpcResponseCallbackTest {
+
+  private final RpcStream rpcStream = mock(RpcStream.class);
+
+  @SuppressWarnings("unchecked")
+  private final RpcResponseEncoder<SszData, ?> responseEncoder = mock(RpcResponseEncoder.class);
+
+  private final SszData data = mock(SszData.class);
+
+  private final RpcResponseCallback<SszData> callback =
+      new RpcResponseCallback<>(rpcStream, responseEncoder);
+
+  @Test
+  void shouldNotLogErrorWhenWriteFailsWithStopSending() {
+    failWriteWith(new ChannelOutputShutdownException("STOP_SENDING frame received"));
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.respondAndCompleteSuccessfully(data);
+
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+      assertThat(logCaptor.getTraceLogs())
+          .anySatisfy(log -> assertThat(log).contains("STOP_SENDING"));
+    }
+  }
+
+  @Test
+  void shouldNotLogErrorWhenWriteFailsWithClosedChannel() {
+    failWriteWith(new ClosedChannelException());
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.respondAndCompleteSuccessfully(data);
+
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldLogErrorWhenWriteFailsWithUnexpectedError() {
+    failWriteWith(new IllegalStateException("Boom"));
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class)) {
+      callback.respondAndCompleteSuccessfully(data);
+
+      logCaptor.assertErrorLog("Failed to write req/resp response");
+    }
+  }
+
+  private void failWriteWith(final Throwable error) {
+    when(responseEncoder.encodeSuccessfulResponse(any())).thenReturn(Bytes.EMPTY);
+    when(rpcStream.writeBytes(any())).thenReturn(SafeFuture.failedFuture(error));
+  }
+}

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.networking.eth2.rpc.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.netty.channel.socket.ChannelOutputShutdownException;
@@ -27,6 +29,7 @@ import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
+import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 
 class RpcResponseCallbackTest {
 
@@ -73,6 +76,46 @@ class RpcResponseCallbackTest {
 
       logCaptor.assertErrorLog("Failed to write req/resp response");
     }
+  }
+
+  @Test
+  void completeWithUnexpectedErrorShouldNotWriteErrorResponseWhenStreamClosedByStopSending() {
+    when(rpcStream.closeAbruptly()).thenReturn(SafeFuture.COMPLETE);
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.completeWithUnexpectedError(
+          new RuntimeException(new ChannelOutputShutdownException("STOP_SENDING frame received")));
+
+      // The peer has stopped reading the stream, so writing a server error response is pointless
+      // and would just fail again and resurface as a noisy uncaught exception.
+      verify(rpcStream, never()).writeBytes(any());
+      verify(rpcStream).closeAbruptly();
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void completeWithUnexpectedErrorShouldNotWriteErrorResponseWhenStreamAlreadyClosed() {
+    when(rpcStream.closeAbruptly()).thenReturn(SafeFuture.COMPLETE);
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.completeWithUnexpectedError(new StreamClosedException());
+
+      verify(rpcStream, never()).writeBytes(any());
+      verify(rpcStream).closeAbruptly();
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void completeWithUnexpectedErrorShouldWriteErrorResponseForUnexpectedError() {
+    when(responseEncoder.encodeErrorResponse(any())).thenReturn(Bytes.EMPTY);
+    when(rpcStream.writeBytes(any())).thenReturn(SafeFuture.COMPLETE);
+    when(rpcStream.closeWriteStream()).thenReturn(SafeFuture.COMPLETE);
+
+    callback.completeWithUnexpectedError(new IllegalStateException("Boom"));
+
+    verify(rpcStream).writeBytes(any());
   }
 
   private void failWriteWith(final Throwable error) {


### PR DESCRIPTION
## PR Description

When a peer sends a QUIC STOP_SENDING frame, Netty fails our queued writes with ChannelOutputShutdownException.

ChannelOutputShutdownException can be treated as a acceptable half-close in:
- RpcResponseCallback (TRACE, alongside ClosedChannelException)
- PeerRequiredLocalMessageHandler#handleError (TRACE)
- GossipFailureLogger#log (DEBUG)

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and defensive error-path handling only; no changes to consensus, auth, or data persistence.
> 
> **Overview**
> When peers disconnect or send QUIC **STOP_SENDING**, Netty surfaces **`ChannelOutputShutdownException`** (distinct from **`ClosedChannelException`**). Those failures were previously logged as errors or triggered pointless follow-up RPC writes.
> 
> This PR classifies closed/half-closed streams as **expected churn** across gossip publish logging, inbound RPC error handling, and outbound req/resp completion: **DEBUG** for gossip publish failures, **TRACE** for RPC paths, and **no server error response** when the stream is already gone in `RpcResponseCallback#completeWithUnexpectedError`. Error-response writes now use the same **`RootCauseExceptionHandler`** pattern as successful responses.
> 
> Unit tests cover the new log levels and the “don’t write on dead stream” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ab021c5730fb98448bb1bbb7b1f4eb8084eee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->