### PR TITLE
Added optional fields to peers endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Additions and Improvements
 
+- Added some extra fields to the peers output for beacon-apis #606. Consumers of the peers endpoint should be aware of this new optional data.
+
 ### Bug Fixes
 
 - Prevent RPC rate-limited peers from immediately reconnecting inbound.

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Peer.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Peer.json
@@ -25,6 +25,16 @@
     "direction" : {
       "type" : "string",
       "enum" : [ "inbound", "outbound" ]
+    },
+    "agent_version" : {
+      "type" : "string",
+      "description" : "The peer's libp2p agent version string.",
+      "example" : "Lighthouse/v8.1.3-66919c2/aarch64-linux"
+    },
+    "score" : {
+      "type" : "number",
+      "format" : "double",
+      "description" : "Client-native peer score."
     }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_NODE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_DOUBLE_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_INTEGER_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.string;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
@@ -23,6 +24,7 @@ import static tech.pegasys.teku.infrastructure.restapi.endpoints.CacheLength.NO_
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
@@ -80,6 +82,16 @@ public class GetPeers extends RestApiEndpoint {
                   eth2Peer.peer().connectionInitiatedLocally()
                       ? Direction.outbound
                       : Direction.inbound)
+          .withOptionalField(
+              "agent_version",
+              string(
+                  "The peer's libp2p agent version string.",
+                  "Lighthouse/v8.1.3-66919c2/aarch64-linux"),
+              eth2Peer -> eth2Peer.peer().getAgentVersion())
+          .withOptionalField(
+              "score",
+              RAW_DOUBLE_TYPE.withDescription("Client-native peer score."),
+              eth2Peer -> Optional.ofNullable(eth2Peer.peer().getGossipScore()))
           .build();
 
   private static final SerializableTypeDefinition<Integer> PEERS_META_TYPE =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
@@ -55,6 +55,8 @@ public class GetPeerByIdTest extends AbstractMigratedBeaconHandlerTest {
     when(peer.getAddress()).thenReturn(new PeerAddress(peerId));
     when(peer.isConnected()).thenReturn(true);
     when(peer.connectionInitiatedLocally()).thenReturn(false);
+    when(peer.getAgentVersion()).thenReturn(Optional.empty());
+    when(peer.getGossipScore()).thenReturn(2.0);
   }
 
   @Test
@@ -101,6 +103,7 @@ public class GetPeerByIdTest extends AbstractMigratedBeaconHandlerTest {
         .isEqualTo(
             "{\"data\":{\"peer_id\":\"1111111111111111111111111111177em\","
                 + "\"enr\":\"enr:test\","
-                + "\"last_seen_p2p_address\":\"1111111111111111111111111111177em\",\"state\":\"connected\",\"direction\":\"inbound\"}}");
+                + "\"last_seen_p2p_address\":\"1111111111111111111111111111177em\","
+                + "\"state\":\"connected\",\"direction\":\"inbound\",\"score\":2.0}}");
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
@@ -57,11 +57,15 @@ public class GetPeersTest extends AbstractMigratedBeaconHandlerTest {
     when(peer1.getAddress()).thenReturn(new PeerAddress(peerId1));
     when(peer1.isConnected()).thenReturn(true);
     when(peer1.connectionInitiatedLocally()).thenReturn(false);
+    when(peer1.getAgentVersion()).thenReturn(Optional.of("Lighthouse/v8.1.3"));
+    when(peer1.getGossipScore()).thenReturn(-17.4828);
 
     when(peer2.getId()).thenReturn(peerId2);
     when(peer2.getAddress()).thenReturn(new PeerAddress(peerId2));
     when(peer2.isConnected()).thenReturn(true);
     when(peer2.connectionInitiatedLocally()).thenReturn(true);
+    when(peer2.getAgentVersion()).thenReturn(Optional.empty());
+    when(peer2.getGossipScore()).thenReturn(3.5);
   }
 
   @Test
@@ -92,9 +96,11 @@ public class GetPeersTest extends AbstractMigratedBeaconHandlerTest {
         .isEqualTo(
             "{\"data\":[{\"peer_id\":\"1111111111111111111111111111177em\","
                 + "\"last_seen_p2p_address\":\"1111111111111111111111111111177em\","
-                + "\"state\":\"connected\",\"direction\":\"inbound\"},"
+                + "\"state\":\"connected\",\"direction\":\"inbound\","
+                + "\"agent_version\":\"Lighthouse/v8.1.3\",\"score\":-17.4828},"
                 + "{\"peer_id\":\"11111111111111111111111111111hVqL\","
                 + "\"last_seen_p2p_address\":\"11111111111111111111111111111hVqL\","
-                + "\"state\":\"connected\",\"direction\":\"outbound\"}],\"meta\":{\"count\":2}}");
+                + "\"state\":\"connected\",\"direction\":\"outbound\","
+                + "\"score\":3.5}],\"meta\":{\"count\":2}}");
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -167,6 +167,11 @@ public class LibP2PPeer implements Peer {
   }
 
   @Override
+  public Optional<String> getAgentVersion() {
+    return maybeAgentString;
+  }
+
+  @Override
   public boolean isConnected() {
     return connected.get();
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/DelegatingPeer.java
@@ -48,6 +48,11 @@ public class DelegatingPeer implements Peer {
   }
 
   @Override
+  public Optional<String> getAgentVersion() {
+    return peer.getAgentVersion();
+  }
+
+  @Override
   public boolean isConnected() {
     return peer.isConnected();
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
@@ -37,6 +37,10 @@ public interface Peer {
 
   Double getGossipScore();
 
+  default Optional<String> getAgentVersion() {
+    return Optional.empty();
+  }
+
   boolean isConnected();
 
   default PeerClientType getPeerClientType() {

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
@@ -22,15 +22,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment.LARGE_PENALTY;
 
+import identify.pb.IdentifyOuterClass;
 import io.libp2p.core.Connection;
 import io.libp2p.core.PeerId;
+import io.libp2p.core.StreamPromise;
 import io.libp2p.core.crypto.PubKey;
 import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multistream.ProtocolBinding;
 import io.libp2p.core.security.SecureChannel.Session;
 import io.libp2p.crypto.keys.EcdsaKt;
 import io.libp2p.crypto.keys.Secp256k1Kt;
+import io.libp2p.protocol.IdentifyController;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -99,6 +104,27 @@ public class LibP2PPeerTest {
         new LibP2PPeer(connection, List.of(rpcHandler), ReputationManager.NOOP, p -> 0.0);
 
     assertThat(peer.getPubKey().raw()).isEqualTo(identityKey.raw());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void checkPeerIdentity_shouldExposeAgentVersion() {
+    final io.libp2p.core.mux.StreamMuxer.Session muxerSession =
+        mock(io.libp2p.core.mux.StreamMuxer.Session.class);
+    final IdentifyController identifyController = mock(IdentifyController.class);
+    final StreamPromise<IdentifyController> streamPromise =
+        new StreamPromise<>(new CompletableFuture<>(), new CompletableFuture<>());
+    final IdentifyOuterClass.Identify identify =
+        IdentifyOuterClass.Identify.newBuilder().setAgentVersion("Lighthouse/v8.1.3").build();
+    when(connection.muxerSession()).thenReturn(muxerSession);
+    when(muxerSession.createStream((ProtocolBinding<IdentifyController>) any()))
+        .thenReturn(streamPromise);
+    when(identifyController.id()).thenReturn(CompletableFuture.completedFuture(identify));
+
+    libP2PPeer.checkPeerIdentity();
+    streamPromise.getController().complete(identifyController);
+
+    assertThat(libP2PPeer.getAgentVersion()).contains("Lighthouse/v8.1.3");
   }
 
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored", "rawtypes"})


### PR DESCRIPTION
partially addresses https://github.com/ethereum/beacon-APIs/pull/606

is an alternative / partial implementation to #10715 

We'd need libp2p changes to build out some of the rest of the features, but this is readily accessible data.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional REST and Peer API fields with no change to connection or scoring behavior; low risk for strict API clients that reject unknown JSON keys.
> 
> **Overview**
> Extends the beacon REST **peers** responses (list and by-id, via shared `PEER_DATA_TYPE`) with optional **`agent_version`** and **`score`**, aligned with beacon-APIs #606. **`score`** maps to existing gossip scoring (`getGossipScore`); **`agent_version`** is exposed from libp2p identify data already collected in `LibP2PPeer`.
> 
> The P2P **`Peer`** interface gains **`getAgentVersion()`** (default empty), implemented on **`LibP2PPeer`** and **`DelegatingPeer`**. OpenAPI/schema and handler tests are updated; changelog notes consumers should treat the new fields as optional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef9dfa440e179abaac07269fc97a3f4139505cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->