### PR TITLE
quiet the license check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -715,8 +715,19 @@ tasks.register('deploy') {}
 generateLicenseReport.enabled = false
 checkLicense.enabled = false
 tasks.register('licenseCheck', Exec) {
+	def output = new ByteArrayOutputStream()
 	workingDir rootDir
 	commandLine './gradlew', 'generateLicenseReport', 'checkLicense', '--no-parallel', '-PenableLicenseReport=true'
+	standardOutput = output
+	errorOutput = output
+	ignoreExitValue = true
+	doLast {
+		def result = executionResult.get()
+		if (result.exitValue != 0) {
+			logger.error(output.toString().trim())
+			throw new GradleException("License check failed")
+		}
+	}
 }
 if (project.hasProperty('enableLicenseReport')) {
 	generateLicenseReport.enabled = true


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Gradle task behavior; no runtime, security, or application logic changes.
> 
> **Overview**
> The **`licenseCheck`** Gradle `Exec` task now captures the nested `./gradlew generateLicenseReport checkLicense` output instead of printing it during a successful run, so default builds stay quieter.
> 
> On failure it still fails the build: **`ignoreExitValue`** defers handling to **`doLast`**, which logs the captured stdout/stderr once and throws **`GradleException("License check failed")`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd8208e5eb9c0329a6b9245d118ac00d4b33cdfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->