### PR TITLE
Enabling new experimental features by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Additions and Improvements
 
 - Added some extra fields to the peers output for beacon-apis #606. Consumers of the peers endpoint should be aware of this new optional data.
+- QUIC enabled by default (uses UDP port 9001 by default)
+- New Engine API client with better performance enabled by default
 
 ### Bug Fixes
 

--- a/docker/jdk25/Dockerfile
+++ b/docker/jdk25/Dockerfile
@@ -50,8 +50,8 @@ ENV PATH="/opt/teku/bin:${PATH}"
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000"
 
 # List Exposed Ports
-# Metrics, Rest API, LibP2P, Discv5
-EXPOSE 8008 5051 9000 9000/udp
+# Metrics, Rest API, LibP2P (TCP and QUIC), Discv5
+EXPOSE 8008 5051 9000 9001/udp 9000/udp
 
 # specify default command
 ENTRYPOINT ["/opt/teku/bin/teku"]

--- a/docker/jdk26/Dockerfile
+++ b/docker/jdk26/Dockerfile
@@ -49,8 +49,8 @@ ENV PATH="/opt/teku/bin:${PATH}"
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000"
 
 # List Exposed Ports
-# Metrics, Rest API, LibP2P, Discv5
-EXPOSE 8008 5051 9000 9000/udp
+# Metrics, Rest API, LibP2P (TCP and QUIC), Discv5
+EXPOSE 8008 5051 9000 9001/udp 9000/udp
 
 # specify default command
 ENTRYPOINT ["/opt/teku/bin/teku"]

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -40,7 +40,7 @@ dependencyManagement {
 			entry 'javalin-rendering-thymeleaf'
 		}
 
-		dependency 'io.libp2p:jvm-libp2p:1.3.2-RELEASE'
+		dependency 'io.libp2p:jvm-libp2p:1.3.3-RELEASE'
 		dependency 'tech.pegasys:jblst:0.3.15'
 		dependency 'io.consensys.protocols:jc-kzg-4844:2.1.6'
 		dependency 'io.github.crate-crypto:java-eth-kzg:0.10.0'

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -52,7 +52,7 @@ public class NetworkConfig {
   public static final int DEFAULT_P2P_QUIC_PORT_IPV6 = 9091;
   public static final boolean DEFAULT_YAMUX_ENABLED = false;
   public static final boolean DEFAULT_STRICT_CONFIG_LOADING_ENABLED = false;
-  public static final boolean DEFAULT_QUIC_ENABLED = false;
+  public static final boolean DEFAULT_QUIC_ENABLED = true;
   public static final boolean DEFAULT_TCP_ENABLED = true;
 
   private final GossipConfig gossipConfig;

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
@@ -45,13 +45,13 @@ class LibP2PNetworkBuilderTest {
 
   @Test
   void buildListenPorts_singleStackTcpOnly() {
-    final NetworkConfig config = singleStackConfig().build();
+    final NetworkConfig config = singleStackConfig().quicEnabled(false).build();
     assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000);
   }
 
   @Test
   void buildListenPorts_singleStackTcpAndQuic() {
-    final NetworkConfig config = singleStackConfig().quicEnabled(true).build();
+    final NetworkConfig config = singleStackConfig().build();
     assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000, 9001);
   }
 
@@ -64,14 +64,14 @@ class LibP2PNetworkBuilderTest {
 
   @Test
   void buildListenPorts_dualStackTcpOnly() {
-    final NetworkConfig config = dualStackConfig().build();
+    final NetworkConfig config = dualStackConfig().quicEnabled(false).build();
     assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000, 9090);
   }
 
   @Test
   void buildListenPorts_dualStackTcpAndQuic() {
     // Regression: dual-stack QUIC must report all four ports, not just two.
-    final NetworkConfig config = dualStackConfig().quicEnabled(true).build();
+    final NetworkConfig config = dualStackConfig().build();
     assertThat(LibP2PNetworkBuilder.buildListenPorts(config))
         .containsExactly(9000, 9001, 9090, 9091);
   }

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -39,6 +39,7 @@ public class ExecutionLayerConfiguration {
   public static final boolean DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG = true;
   public static final boolean DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED = true;
   public static final String BUILDER_ALWAYS_KEYWORD = "BUILDER_ALWAYS";
+  public static final boolean DEFAULT_USE_NEW_ENGINE_API = true;
 
   private final Spec spec;
   private final Optional<String> engineEndpoint;
@@ -170,7 +171,7 @@ public class ExecutionLayerConfiguration {
     private boolean useShouldOverrideBuilderFlag = DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
     private boolean exchangeCapabilitiesMonitoringEnabled =
         DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
-    private boolean useNewEngineApiClient = false;
+    private boolean useNewEngineApiClient = DEFAULT_USE_NEW_ENGINE_API;
 
     private Builder() {}
 

--- a/services/executionlayer/src/test/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfigurationTest.java
+++ b/services/executionlayer/src/test/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfigurationTest.java
@@ -91,6 +91,19 @@ public class ExecutionLayerConfigurationTest {
   }
 
   @Test
+  public void shouldUseNewEngineApiClientByDefault() {
+    final ExecutionLayerConfiguration config = configBuilder.specProvider(bellatrixSpec).build();
+    assertThat(config.isUseNewEngineApiClient()).isTrue();
+  }
+
+  @Test
+  public void shouldAllowDisablingNewEngineApiClient() {
+    final ExecutionLayerConfiguration config =
+        configBuilder.specProvider(bellatrixSpec).useNewEngineApiClient(false).build();
+    assertThat(config.isUseNewEngineApiClient()).isFalse();
+  }
+
+  @Test
   public void noExceptionThrownIfEeEndpointSpecified() {
     final ExecutionLayerConfiguration config =
         configBuilder.specProvider(bellatrixSpec).engineEndpoint("someEndpoint").build();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfigurat
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
+import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_USE_NEW_ENGINE_API;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
 
 import picocli.CommandLine.Help.Visibility;
@@ -154,7 +155,7 @@ public class ExecutionLayerOptions {
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true",
       hidden = true)
-  private boolean useNewEngineApiClient = false;
+  private boolean useNewEngineApiClient = DEFAULT_USE_NEW_ENGINE_API;
 
   public void configure(final Builder builder) {
     builder.executionLayer(

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -304,6 +304,19 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void quic_shouldBeEnabledByDefault() {
+    final NetworkConfig config = getTekuConfigurationFromArguments().network();
+    assertThat(config.isQuicEnabled()).isTrue();
+  }
+
+  @Test
+  public void quic_shouldAcceptValue() {
+    final NetworkConfig config =
+        getTekuConfigurationFromArguments("--Xp2p-quic-enabled", "false").network();
+    assertThat(config.isQuicEnabled()).isFalse();
+  }
+
+  @Test
   public void advertisedIps_shouldDefaultToEmpty() {
     final NetworkConfig config = getTekuConfigurationFromArguments().network();
     assertThat(config.hasUserExplicitlySetAdvertisedIps()).isFalse();


### PR DESCRIPTION
- **Updated docker files to expose port 9001 UDP for QUIC**
- **QUIC now enabled by default (--Xp2p-quic-enabled=true)**
- **New Engine API now enabled by default (--Xnew-engine-api-client-enabled=true)**
- **Updated jvm-libp2p to 1.3.3**
- **Updated changelog**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on QUIC adds firewall/Docker port requirements and changes libp2p transport behavior; default-on Engine API client alters all EL JSON-RPC traffic paths without an explicit operator opt-in.
> 
> **Overview**
> Turns on two previously opt-in experimental paths for all default installs: **libp2p QUIC** and the **new Engine API client**.
> 
> **P2P / QUIC:** `DEFAULT_QUIC_ENABLED` is now `true`, so nodes listen and advertise QUIC on UDP **9001** (9091 on dual-stack IPv6) alongside TCP unless `--Xp2p-quic-enabled=false`. Official **jdk25/jdk26** Docker images now **EXPOSE `9001/udp`** so QUIC matches the new default. **`jvm-libp2p`** is bumped to **1.3.3-RELEASE**.
> 
> **Execution layer:** `DEFAULT_USE_NEW_ENGINE_API` is **true** for config, CLI (`--Xnew-engine-api-client-enabled`), and the builder default; operators can still disable via the hidden flag.
> 
> Tests and **CHANGELOG** are updated to document the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a47ad4eb7a1a29d0e807f80c8385b914b7c09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->