### PR TITLE
Fix quic tests

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BootnodeModeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BootnodeModeAcceptanceTest.java
@@ -40,8 +40,7 @@ public class BootnodeModeAcceptanceTest extends AcceptanceTestBase {
 
     // The secp256k1 public key portion of the ENR is deterministic for a fixed private key,
     // while the rest (IP, signature) can vary with the container's network environment.
-    final String expectedPubKeyEncoding =
-        "c2VjcDI1NmsxoQLAvwqYDpQL10o51b3KEd9fKM5DOOkZ8O8mpPugtCmKWI";
+    final String expectedPubKeyEncoding = "AsC_CpgOlAvXSjnVvcoR318ozkM46Rnw7yak-6C0KYpY";
 
     bootnode.start();
     bootnode.waitForDiscoveryStarted();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -344,6 +344,7 @@ public class TekuNodeConfigBuilder {
     configMap.put("p2p-enabled", true);
     configMap.put("p2p-discovery-enabled", true);
     configMap.put("p2p-port", P2P_PORT);
+    configMap.put("Xp2p-quic-port", P2P_PORT + 1);
     configMap.put("p2p-advertised-port", P2P_PORT);
     configMap.put("p2p-interface", "0.0.0.0");
     configMap.put("p2p-private-key-file", PRIVATE_KEY_FILE_PATH);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -647,12 +647,8 @@ public class Eth2P2PNetworkFactory {
           peers.stream().flatMap(peer -> peer.getNodeAddresses().stream()).collect(toList());
 
       final Random random = new Random();
-      final int tcpPort = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
-      int candidateQuicPort;
-      do {
-        candidateQuicPort = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
-      } while (candidateQuicPort == tcpPort);
-      final int quicPort = candidateQuicPort;
+      final int tcpPort = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT - 1);
+      final int quicPort = tcpPort + 1;
 
       return P2PConfig.builder()
           .specProvider(spec)

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -647,14 +647,20 @@ public class Eth2P2PNetworkFactory {
           peers.stream().flatMap(peer -> peer.getNodeAddresses().stream()).collect(toList());
 
       final Random random = new Random();
-      final int port = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
+      final int tcpPort = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
+      int candidateQuicPort;
+      do {
+        candidateQuicPort = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
+      } while (candidateQuicPort == tcpPort);
+      final int quicPort = candidateQuicPort;
 
       return P2PConfig.builder()
           .specProvider(spec)
           .targetSubnetSubscriberCount(2)
           .network(
               b ->
-                  b.listenPort(port)
+                  b.listenPort(tcpPort)
+                      .listenQuicPort(quicPort)
                       .networkInterface("127.0.0.1")
                       .wireLogs(w -> w.logWireMuxFrames(true)))
           .discovery(

--- a/networking/p2p/build.gradle
+++ b/networking/p2p/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	testFixturesImplementation testFixtures(project(':infrastructure:async'))
 	testFixturesImplementation testFixtures(project(':infrastructure:crypto'))
 	testFixturesImplementation testFixtures(project(':infrastructure:time'))
+	testFixturesImplementation project(':infrastructure:exceptions')
 	testFixturesImplementation project(':infrastructure:subscribers')
 
 	testFixturesImplementation 'org.hyperledger.besu:besu-plugin-api'

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/DiscoveryNetworkFactory.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.network.p2p.jvmlibp2p.PrivateKeyGenerator;
@@ -94,7 +95,8 @@ public class DiscoveryNetworkFactory {
       int attempt = 1;
       while (true) {
         final Random random = new Random();
-        final int port = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT);
+        final int port = MIN_PORT + random.nextInt(MAX_PORT - MIN_PORT - 1);
+        final int quicPort = port + 1;
         final DiscoveryConfig discoveryConfig =
             DiscoveryConfig.builder()
                 .listenUdpPort(port)
@@ -104,6 +106,7 @@ public class DiscoveryNetworkFactory {
         final NetworkConfig config =
             NetworkConfig.builder()
                 .listenPort(port)
+                .listenQuicPort(quicPort)
                 .advertisedIp(Optional.of("127.0.0.1"))
                 .networkInterface("127.0.0.1")
                 .build();
@@ -149,7 +152,7 @@ public class DiscoveryNetworkFactory {
           networks.add(network);
           return network;
         } catch (final ExecutionException e) {
-          if (e.getCause() instanceof BindException) {
+          if (ExceptionUtil.hasCause(e, BindException.class)) {
             if (attempt > 10) {
               throw new RuntimeException("Failed to find a free port after multiple attempts", e);
             }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Some integration tests are not working with quic default on, fixing them

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures and acceptance tests; no production networking or runtime behavior is modified.
> 
> **Overview**
> Updates **test and acceptance harnesses** so they bind and configure **QUIC alongside TCP** now that QUIC is on by default, instead of assuming a single P2P listen port.
> 
> Bootnode DSL config sets **`Xp2p-quic-port`** to `P2P_PORT + 1`, and the bootnode ENR assertion uses a new **expected secp256k1 pubkey encoding** (`AsC_CpgOlAvXSjnVvcoR318ozkM46Rnw7yak-6C0KYpY`) matching the updated ENR representation.
> 
> **`Eth2P2PNetworkFactory`** and **`DiscoveryNetworkFactory`** pick a random TCP port, set **`listenQuicPort`** to `tcpPort + 1`, and narrow the random port range so both ports stay in range. Port-conflict retries in discovery tests use **`ExceptionUtil.hasCause(..., BindException.class)`** so failures from either transport still trigger a retry. **`networking/p2p`** test fixtures add a dependency on **`infrastructure:exceptions`** for that helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2190421f73971aba599c44c0908e2dc0700dff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->