### PR TITLE
add new reject rule to Execution payload bid gossip validator

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -219,6 +219,22 @@ public class ExecutionPayloadBidGossipValidator {
               final BeaconState state = maybeState.get();
 
               /*
+               * [REJECT] bid.prev_randao is the correct RANDAO mix -- i.e. validate that
+               * bid.prev_randao == get_randao_mix(parent_state, get_current_epoch(parent_state)).
+               */
+              final Bytes32 expectedRandaoMix =
+                  gossipValidationHelper.getRandaoMixForCurrentEpoch(state, bid.getSlot());
+              if (!bid.getPrevRandao().equals(expectedRandaoMix)) {
+                LOG.trace(
+                    "Bid prev_randao {} does not match expected RANDAO mix {}",
+                    bid.getPrevRandao(),
+                    expectedRandaoMix);
+                return reject(
+                    "Bid prev_randao %s does not match expected RANDAO mix %s",
+                    bid.getPrevRandao(), expectedRandaoMix);
+              }
+
+              /*
                * [REJECT] bid.builder_index is a valid/active builder index -- i.e. is_active_builder(state, bid.builder_index) returns True
                */
               if (!gossipValidationHelper.isActiveBuilder(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
@@ -251,6 +252,15 @@ public class GossipValidationHelper {
       final UInt64 builderIndex, final BeaconState state, final UInt64 slot) {
     return MiscHelpersGloas.required(spec.atSlot(slot).miscHelpers())
         .isActiveBuilder(state, builderIndex);
+  }
+
+  /**
+   * Returns the RANDAO mix of the given state at the state's current epoch -- i.e.
+   * get_randao_mix(state, get_current_epoch(state)).
+   */
+  public Bytes32 getRandaoMixForCurrentEpoch(final BeaconState state, final UInt64 slot) {
+    final BeaconStateAccessors beaconStateAccessors = spec.atSlot(slot).beaconStateAccessors();
+    return beaconStateAccessors.getRandaoMix(state, beaconStateAccessors.getCurrentEpoch(state));
   }
 
   public boolean isSlotCurrentOrNext(final UInt64 slot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
@@ -114,6 +114,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.getParentStateInBlockEpoch(slot.decrement(), parentBlockRoot, slot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(postState)));
     when(gossipValidationHelper.isActiveBuilder(builderIndex, postState, slot)).thenReturn(true);
+    when(gossipValidationHelper.getRandaoMixForCurrentEpoch(postState, slot))
+        .thenReturn(bid.getPrevRandao());
     when(gossipValidationHelper.builderHasEnoughBalanceForBid(
             bid.getValue(), builderIndex, postState, slot))
         .thenReturn(true);
@@ -307,6 +309,18 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.getParentStateInBlockEpoch(slot.decrement(), parentBlockRoot, slot))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(SAVE_FOR_FUTURE);
+  }
+
+  @TestTemplate
+  void shouldReject_whenPrevRandaoIsIncorrect() {
+    final Bytes32 incorrectRandaoMix = dataStructureUtil.randomBytes32();
+    when(gossipValidationHelper.getRandaoMixForCurrentEpoch(postState, slot))
+        .thenReturn(incorrectRandaoMix);
+    assertThatSafeFuture(bidValidator.validate(signedBid))
+        .isCompletedWithValue(
+            reject(
+                "Bid prev_randao %s does not match expected RANDAO mix %s",
+                bid.getPrevRandao(), incorrectRandaoMix));
   }
 
   @TestTemplate
@@ -564,6 +578,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
             slot.decrement(), message.getParentBlockRoot(), slot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(postState)));
     when(gossipValidationHelper.isActiveBuilder(builderIndex, postState, slot)).thenReturn(true);
+    when(gossipValidationHelper.getRandaoMixForCurrentEpoch(postState, slot))
+        .thenReturn(message.getPrevRandao());
     when(gossipValidationHelper.builderHasEnoughBalanceForBid(
             bidValue, builderIndex, postState, slot))
         .thenReturn(true);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
add the missing rule to execution payload bid gossip that rejects it when prev_randao isn't the correct RANDAO mix

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes https://github.com/Consensys/teku/issues/10870

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-facing gossip validation for Gloas bids; incorrect implementation could reject valid bids or accept invalid ones, though the change is a narrow additive check aligned with the spec.
> 
> **Overview**
> Closes a gap in **execution payload bid** gossip validation by enforcing the spec rule that **`bid.prev_randao`** must equal the parent beacon state's RANDAO mix for its current epoch (`get_randao_mix(state, get_current_epoch(state))`). Mismatches are **rejected** once parent state is available (same async path as other state-dependent checks).
> 
> `GossipValidationHelper` gains **`getRandaoMixForCurrentEpoch`** to resolve that mix via slot-appropriate `BeaconStateAccessors`. Tests stub the helper on happy paths and add **`shouldReject_whenPrevRandaoIsIncorrect`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ea27eb2ace6d570865ae5b4381cf59d2d8fc2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->