### PR TITLE
Break down peers_direction_current metric by transport (tcp/quic)

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeer.java
@@ -22,6 +22,7 @@ import io.libp2p.core.crypto.KeyKt;
 import io.libp2p.core.crypto.PubKey;
 import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.core.multiformats.Multihash;
+import io.libp2p.core.multiformats.Protocol;
 import io.libp2p.protocol.Identify;
 import io.libp2p.protocol.IdentifyController;
 import io.netty.buffer.ByteBufUtil;
@@ -44,6 +45,7 @@ import tech.pegasys.teku.networking.p2p.peer.DisconnectRequestHandler;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedSubscriber;
+import tech.pegasys.teku.networking.p2p.peer.Transport;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
@@ -63,6 +65,7 @@ public class LibP2PPeer implements Peer {
   private final Connection connection;
   private final AtomicBoolean connected = new AtomicBoolean(true);
   private final MultiaddrPeerAddress peerAddress;
+  private final Transport transport;
   private final PeerId peerId;
   private final PubKey pubKey;
   private volatile PeerClientType peerClientType = PeerClientType.UNKNOWN;
@@ -100,6 +103,7 @@ public class LibP2PPeer implements Peer {
     final NodeId nodeId = new LibP2PNodeId(peerId);
     final Multiaddr remoteAddress = connection.remoteAddress();
     peerAddress = new MultiaddrPeerAddress(nodeId, remoteAddress);
+    this.transport = transportFromMultiaddr(remoteAddress);
     if (remoteAddress != null) {
       LOG.debug("Connected to peer {} via {}", nodeId, remoteAddress);
     }
@@ -156,6 +160,19 @@ public class LibP2PPeer implements Peer {
     }
   }
 
+  private static Transport transportFromMultiaddr(final Multiaddr multiaddr) {
+    if (multiaddr == null) {
+      return Transport.UNKNOWN;
+    }
+    if (multiaddr.hasAny(Protocol.QUICV1, Protocol.QUIC)) {
+      return Transport.QUIC;
+    }
+    if (multiaddr.has(Protocol.TCP)) {
+      return Transport.TCP;
+    }
+    return Transport.UNKNOWN;
+  }
+
   @Override
   public PeerAddress getAddress() {
     return peerAddress;
@@ -179,6 +196,11 @@ public class LibP2PPeer implements Peer {
   @Override
   public PeerClientType getPeerClientType() {
     return peerClientType;
+  }
+
+  @Override
+  public Transport getTransport() {
+    return transport;
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManager.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,6 +40,7 @@ import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
+import tech.pegasys.teku.networking.p2p.peer.Transport;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 
 public class PeerManager implements ConnectionHandler {
@@ -85,14 +87,29 @@ public class PeerManager implements ConnectionHandler {
         metricsSystem.createLabelledSuppliedGauge(
             TekuMetricCategory.LIBP2P,
             "peers_direction_current",
-            "The number of peers by direction including inbound and outbound",
-            "direction");
-    peerDirectionLabelledGauge.labels(
-        () -> connectedPeerMap.values().stream().filter(Peer::connectionInitiatedRemotely).count(),
-        "inbound");
-    peerDirectionLabelledGauge.labels(
-        () -> connectedPeerMap.values().stream().filter(Peer::connectionInitiatedLocally).count(),
-        "outbound");
+            "The number of peers by direction and transport",
+            "direction",
+            "transport");
+    registerPeersByDirectionAndTransport(
+        peerDirectionLabelledGauge, "inbound", Peer::connectionInitiatedRemotely);
+    registerPeersByDirectionAndTransport(
+        peerDirectionLabelledGauge, "outbound", Peer::connectionInitiatedLocally);
+  }
+
+  private void registerPeersByDirectionAndTransport(
+      final LabelledSuppliedMetric gauge,
+      final String direction,
+      final Predicate<Peer> directionPredicate) {
+    for (final Transport transport : List.of(Transport.TCP, Transport.QUIC)) {
+      gauge.labels(
+          () ->
+              connectedPeerMap.values().stream()
+                  .filter(directionPredicate)
+                  .filter(peer -> peer.getTransport() == transport)
+                  .count(),
+          direction,
+          transport.getLabel());
+    }
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Peer.java
@@ -47,6 +47,10 @@ public interface Peer {
     return PeerClientType.UNKNOWN;
   }
 
+  default Transport getTransport() {
+    return Transport.UNKNOWN;
+  }
+
   default void checkPeerIdentity() {}
 
   void disconnectImmediately(Optional<DisconnectReason> reason, boolean locallyInitiated);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Transport.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/peer/Transport.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.peer;
+
+public enum Transport {
+  TCP("tcp"),
+  QUIC("quic"),
+  UNKNOWN("unknown");
+
+  private final String label;
+
+  Transport(final String label) {
+    this.label = label;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PPeerTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.networking.p2p.peer.Transport;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
@@ -208,5 +209,27 @@ public class LibP2PPeerTest {
     peer.adjustReputation(LARGE_PENALTY);
 
     assertThat(disconnectReason).hasValue(DisconnectReason.BAD_SCORE);
+  }
+
+  @Test
+  public void getTransport_returnsTcpForTcpMultiaddr() {
+    assertThat(libP2PPeer.getTransport()).isEqualTo(Transport.TCP);
+  }
+
+  @Test
+  public void getTransport_returnsQuicForQuicMultiaddr() {
+    when(connection.remoteAddress())
+        .thenReturn(Multiaddr.fromString("/ip4/127.0.0.1/udp/9000/quic-v1/"));
+    final LibP2PPeer peer =
+        new LibP2PPeer(connection, List.of(rpcHandler), ReputationManager.NOOP, p -> 0.0);
+    assertThat(peer.getTransport()).isEqualTo(Transport.QUIC);
+  }
+
+  @Test
+  public void getTransport_returnsUnknownForNonTcpQuicMultiaddr() {
+    when(connection.remoteAddress()).thenReturn(Multiaddr.fromString("/ip4/127.0.0.1/udp/9000/"));
+    final LibP2PPeer peer =
+        new LibP2PPeer(connection, List.of(rpcHandler), ReputationManager.NOOP, p -> 0.0);
+    assertThat(peer.getTransport()).isEqualTo(Transport.UNKNOWN);
   }
 }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/PeerManagerTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 import tech.pegasys.teku.networking.p2p.network.PeerHandler;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.networking.p2p.peer.Transport;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 
 public class PeerManagerTest {
@@ -93,7 +94,11 @@ public class PeerManagerTest {
             eq(TekuMetricCategory.LIBP2P), eq("connected_peers_current"), any(), eq("client")))
         .thenReturn(peerClientLabelledGauge);
     when(metricsSystem.createLabelledSuppliedGauge(
-            eq(TekuMetricCategory.LIBP2P), eq("peers_direction_current"), any(), eq("direction")))
+            eq(TekuMetricCategory.LIBP2P),
+            eq("peers_direction_current"),
+            any(),
+            eq("direction"),
+            eq("transport")))
         .thenReturn(peerDirectionLabelledGauge);
     new PeerManager(
         metricsSystem,
@@ -105,8 +110,10 @@ public class PeerManagerTest {
     for (PeerClientType type : PeerClientType.values()) {
       verify(peerClientLabelledGauge).labels(any(), eq(type.getDisplayName()));
     }
-    verify(peerDirectionLabelledGauge).labels(any(), eq("inbound"));
-    verify(peerDirectionLabelledGauge).labels(any(), eq("outbound"));
+    verify(peerDirectionLabelledGauge).labels(any(), eq("inbound"), eq("tcp"));
+    verify(peerDirectionLabelledGauge).labels(any(), eq("inbound"), eq("quic"));
+    verify(peerDirectionLabelledGauge).labels(any(), eq("outbound"), eq("tcp"));
+    verify(peerDirectionLabelledGauge).labels(any(), eq("outbound"), eq("quic"));
   }
 
   @Test
@@ -230,42 +237,57 @@ public class PeerManagerTest {
   }
 
   @Test
-  public void testPeerDirectionMetric() {
-    // Sanity check
-    validatePeerMetrics(0, 0);
+  public void testPeerDirectionAndTransportMetric() {
+    // Sanity check — all four series start at zero
+    validatePeerMetric("outbound", "tcp", 0);
+    validatePeerMetric("outbound", "quic", 0);
+    validatePeerMetric("inbound", "tcp", 0);
+    validatePeerMetric("inbound", "quic", 0);
 
-    // Add a peer
-    final Peer outboundPeer1 = createPeerWithDirection(1, true);
-    peerManager.onConnectedPeer(outboundPeer1);
-    validatePeerMetrics(1, 0);
+    final Peer outboundTcp = createPeer(1, true, Transport.TCP);
+    peerManager.onConnectedPeer(outboundTcp);
+    validatePeerMetric("outbound", "tcp", 1);
 
-    // Add another peer
-    final Peer inboundPeer1 = createPeerWithDirection(2, false);
-    peerManager.onConnectedPeer(inboundPeer1);
-    validatePeerMetrics(1, 1);
+    final Peer inboundQuic = createPeer(2, false, Transport.QUIC);
+    peerManager.onConnectedPeer(inboundQuic);
+    validatePeerMetric("inbound", "quic", 1);
 
-    // Disconnect a peer
-    peerManager.onDisconnectedPeer(outboundPeer1, Optional.empty(), true);
-    validatePeerMetrics(0, 1);
+    final Peer outboundQuic = createPeer(3, true, Transport.QUIC);
+    peerManager.onConnectedPeer(outboundQuic);
+    validatePeerMetric("outbound", "quic", 1);
 
-    // Add another peer
-    final Peer inboundPeer2 = createPeerWithDirection(3, false);
-    peerManager.onConnectedPeer(inboundPeer2);
-    validatePeerMetrics(0, 2);
+    final Peer inboundTcp = createPeer(4, false, Transport.TCP);
+    peerManager.onConnectedPeer(inboundTcp);
+    validatePeerMetric("inbound", "tcp", 1);
+
+    // Final state of every series
+    validatePeerMetric("outbound", "tcp", 1);
+    validatePeerMetric("outbound", "quic", 1);
+    validatePeerMetric("inbound", "tcp", 1);
+    validatePeerMetric("inbound", "quic", 1);
+
+    // Disconnect the outbound TCP peer
+    peerManager.onDisconnectedPeer(outboundTcp, Optional.empty(), true);
+    validatePeerMetric("outbound", "tcp", 0);
+
+    // Disconnect the inbound TCP peer
+    peerManager.onDisconnectedPeer(inboundTcp, Optional.empty(), true);
+    validatePeerMetric("inbound", "tcp", 0);
   }
 
-  private void validatePeerMetrics(final double expectedOutbound, final double expectedInbound) {
+  private void validatePeerMetric(
+      final String direction, final String transport, final double expected) {
     final StubLabelledGauge labelledGauge =
         metricsSystem.getLabelledGauge(TekuMetricCategory.LIBP2P, "peers_direction_current");
-    assertThat(labelledGauge.getValue("inbound")).hasValue(expectedInbound);
-    assertThat(labelledGauge.getValue("outbound")).hasValue(expectedOutbound);
+    assertThat(labelledGauge.getValue(direction, transport)).hasValue(expected);
   }
 
-  private Peer createPeerWithDirection(final int id, final boolean outbound) {
+  private Peer createPeer(final int id, final boolean outbound, final Transport transport) {
     final Peer peer = mock(Peer.class);
     when(peer.getId()).thenReturn(new MockNodeId(id));
     when(peer.connectionInitiatedLocally()).thenReturn(outbound);
     when(peer.connectionInitiatedRemotely()).thenReturn(!outbound);
+    when(peer.getTransport()).thenReturn(transport);
     return peer;
   }
 }


### PR DESCRIPTION
## Summary

Adds a `transport` label (`tcp`/`quic`) to the existing `peers_direction_current` libp2p gauge, so connected peers can be broken down by both connection direction and transport.

## Metrics change
**Before**
```
peers_direction_current{direction="inbound"}
peers_direction_current{direction="outbound"}
```

**After**
```
peers_direction_current{direction="inbound",  transport="tcp"}
peers_direction_current{direction="inbound",  transport="quic"}
peers_direction_current{direction="outbound", transport="tcp"}
peers_direction_current{direction="outbound", transport="quic"}
```

This metric is not used in our dashboard, so it should not cause any issues with our panels.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with no connection or gossip logic changes; external monitors must adopt the new `transport` label on `peers_direction_current`.
> 
> **Overview**
> Adds peer **transport** classification (`tcp`, `quic`, `unknown`) and uses it to split the libp2p `peers_direction_current` gauge by both **direction** and **transport** instead of direction alone.
> 
> `LibP2PPeer` sets transport once from the connection’s remote multiaddr (QUIC/`quic-v1`, TCP, or unknown). The `Peer` API exposes `getTransport()` with a default of `UNKNOWN` for non-libp2p peers.
> 
> `PeerManager` now registers four time series per direction (`inbound`/`outbound` × `tcp`/`quic`). Peers classified as `unknown` are not counted in those series. Existing queries that only used the `direction` label need to include `transport` (or aggregate over it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff5d7787f8ae1a2f222f9f028023718a3343378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->