### PR TITLE
add new reject rule to Execution payload bid gossip validator (#10886)

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -219,6 +219,22 @@ public class ExecutionPayloadBidGossipValidator {
               final BeaconState state = maybeState.get();
 
               /*
+               * [REJECT] bid.prev_randao is the correct RANDAO mix -- i.e. validate that
+               * bid.prev_randao == get_randao_mix(parent_state, get_current_epoch(parent_state)).
+               */
+              final Bytes32 expectedRandaoMix =
+                  gossipValidationHelper.getRandaoMixForCurrentEpoch(state, bid.getSlot());
+              if (!bid.getPrevRandao().equals(expectedRandaoMix)) {
+                LOG.trace(
+                    "Bid prev_randao {} does not match expected RANDAO mix {}",
+                    bid.getPrevRandao(),
+                    expectedRandaoMix);
+                return reject(
+                    "Bid prev_randao %s does not match expected RANDAO mix %s",
+                    bid.getPrevRandao(), expectedRandaoMix);
+              }
+
+              /*
                * [REJECT] bid.builder_index is a valid/active builder index -- i.e. is_active_builder(state, bid.builder_index) returns True
                */
               if (!gossipValidationHelper.isActiveBuilder(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
@@ -246,6 +247,15 @@ public class GossipValidationHelper {
       final UInt64 builderIndex, final BeaconState state, final UInt64 slot) {
     return PredicatesGloas.required(spec.atSlot(slot).predicates())
         .isActiveBuilder(state, builderIndex);
+  }
+
+  /**
+   * Returns the RANDAO mix of the given state at the state's current epoch -- i.e.
+   * get_randao_mix(state, get_current_epoch(state)).
+   */
+  public Bytes32 getRandaoMixForCurrentEpoch(final BeaconState state, final UInt64 slot) {
+    final BeaconStateAccessors beaconStateAccessors = spec.atSlot(slot).beaconStateAccessors();
+    return beaconStateAccessors.getRandaoMix(state, beaconStateAccessors.getCurrentEpoch(state));
   }
 
   public boolean isSlotCurrentOrNext(final UInt64 slot) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
@@ -114,6 +114,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.getParentStateInBlockEpoch(slot.decrement(), parentBlockRoot, slot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(postState)));
     when(gossipValidationHelper.isActiveBuilder(builderIndex, postState, slot)).thenReturn(true);
+    when(gossipValidationHelper.getRandaoMixForCurrentEpoch(postState, slot))
+        .thenReturn(bid.getPrevRandao());
     when(gossipValidationHelper.builderHasEnoughBalanceForBid(
             bid.getValue(), builderIndex, postState, slot))
         .thenReturn(true);
@@ -307,6 +309,18 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.getParentStateInBlockEpoch(slot.decrement(), parentBlockRoot, slot))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(SAVE_FOR_FUTURE);
+  }
+
+  @TestTemplate
+  void shouldReject_whenPrevRandaoIsIncorrect() {
+    final Bytes32 incorrectRandaoMix = dataStructureUtil.randomBytes32();
+    when(gossipValidationHelper.getRandaoMixForCurrentEpoch(postState, slot))
+        .thenReturn(incorrectRandaoMix);
+    assertThatSafeFuture(bidValidator.validate(signedBid))
+        .isCompletedWithValue(
+            reject(
+                "Bid prev_randao %s does not match expected RANDAO mix %s",
+                bid.getPrevRandao(), incorrectRandaoMix));
   }
 
   @TestTemplate
@@ -564,6 +578,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
             slot.decrement(), message.getParentBlockRoot(), slot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(postState)));
     when(gossipValidationHelper.isActiveBuilder(builderIndex, postState, slot)).thenReturn(true);
+    when(gossipValidationHelper.getRandaoMixForCurrentEpoch(postState, slot))
+        .thenReturn(message.getPrevRandao());
     when(gossipValidationHelper.builderHasEnoughBalanceForBid(
             bidValue, builderIndex, postState, slot))
         .thenReturn(true);


### PR DESCRIPTION
(cherry picked from commit 5abb32d2d6a13d38c22b1a04a4a6a39fa6a4fd13)

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive gossip validation with unit tests; no auth, persistence, or consensus-critical path changes beyond stricter bid filtering.
> 
> **Overview**
> Adds a **REJECT** rule to execution payload bid gossip validation so `bid.prev_randao` must equal the parent beacon state's RANDAO mix for its current epoch (`get_randao_mix(state, get_current_epoch(state))`), matching the EPBS spec.
> 
> `GossipValidationHelper` gains `getRandaoMixForCurrentEpoch` (slot-aware `BeaconStateAccessors`). Tests stub the helper on happy paths and add `shouldReject_whenPrevRandaoIsIncorrect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600c3701ceebf68babd47775f5cc267f36965b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->