### PR TITLE
ExecutionRequestsDataCodec in SpecLogic + `DataStructureUtil` clean-up

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockGLOAS.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockGLOAS.json
@@ -1,13 +1,13 @@
 {
   "version": "gloas",
   "execution_payload_blinded": false,
-  "execution_payload_value": "35496387346092661263590124027748611045873920617010484475327370353770209161699",
-  "consensus_block_value": "9539761352249328967673942558291261761143915489986282246629250626813713189699",
+  "execution_payload_value": "85832942286078503862735908113948385571524527877668557374728713559918851204738",
+  "consensus_block_value": "94485150941741403171631500262704852817440366868100051543101979518330153131276",
   "data": {
     "slot": "1",
-    "proposer_index": "5073184892119317590",
-    "parent_root": "0xdbb36146f6c78513d4557fbee82d6490e87dcda8dcad4e354acf52f22ce2e4a2",
-    "state_root": "0x3b5944461642e26b9ea483970adaca91078dc8826c991ad82f55a4db6fc67958",
+    "proposer_index": "5101277123982816951",
+    "parent_root": "0x4afddc46d793346db6d7062f8cf4b4bd653ee2aee736f6ef8936c98442f0d941",
+    "state_root": "0x5d1ed74677df13b2ab1a6e5a607dc98a6b41e1409eff1eaab7b70c4d1c5191cc",
     "body": {
       "randao_reveal": "0x896972a61590fa3df074e8b86d9229c800e16b2c69c92b424c42947efb2c5c9badf3dea0289f088c86cf45ef8add162d1764bfe82b05fa69da6969f8a5ef4a5d70422b2d6568164b0f34de00e4592a05ab90c757c76b2edfc512fef7937c5a5a",
       "eth1_data": {
@@ -357,37 +357,27 @@
       },
       "payload_attestations": [
         {
-          "aggregation_bits": "0xaeb0",
+          "aggregation_bits": "0x8c8a",
           "data": {
-            "beacon_block_root": "0xdbabc5418e28d8265fe892d2129c8395d0dd064a0845545f3a3c532fa2eddf8c",
-            "slot": "16699259415",
+            "beacon_block_root": "0xb469d1414e91199d7562c47b6a8a5afbc3d708269bb302ebdf39cc9eed2b7177",
+            "slot": "17768459895",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0x98ffde69b4d92a4510b5d42ae9bcc05315ed0a20fab2ff6fc8e416678f150d7bfb961da6774e86213ee711a2b065c3d300a13fcf630d7f303c59d848ec47905d2b439e7bb4f3348b6ddc448aa00f7c6eb6f64513182a3d335e2753f66cbec83e"
+          "signature": "0xa29e82672b9b023ec4496bc5ba26cd0e12ae4e168591a2412dc2c62cfbf0466710810999921e34e7249e3a4700c837ec115bb6bee111a50c55a1af9d2f996bb6600a4767e23781cf4eb177845372b39df6156906f9e24c5b908920161a44d8fa"
         },
         {
-          "aggregation_bits": "0xba32",
+          "aggregation_bits": "0xb69a",
           "data": {
-            "beacon_block_root": "0x9ecb7542cf4bad14a20f79bc45931b8d1483242ea9bf8c8edd186ab70a94624b",
-            "slot": "11686939575",
+            "beacon_block_root": "0xea4f5e424f7a2a28771b166a93b66dc12d8f207683e22f77941d78d874174076",
+            "slot": "3106087671",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xb9014738ce2ebfe44a8255a53e34b604f223702435a966b81276bd7967cc1e172a4dbace09be70a1f73b300d83a7a8ec161cdc911b167a8a6489def11edca95a3587eab704e98325ce29eb4f86a477755421b480ca39020c82f07e4977d9e859"
+          "signature": "0xb875609f4aa01bb03c08b4f13459fa7696b969fc5e8440c89f690478820b8b5b4ad75e7fbf03c4b0e919cdc80b07857604bd81f75128f2bbc61861d0b5a7744e21eb4ad008f05b46be2c2780900a7913abc2cd3591390f29e05e2d5b2dba570b"
         },
         {
-          "aggregation_bits": "0x4c37",
-          "data": {
-            "beacon_block_root": "0x5d163b420f4066c536ad816e89ebe88f53a11ae2c99624d4a7240d8a925c8cb6",
-            "slot": "23308551639",
-            "payload_present": false,
-            "blob_data_available": false
-          },
-          "signature": "0x954da68af7adf486693e9213a63a082fcf1b1ed99c320314b73e64c322470329df27c891348c17b92dc7972dbc7d9b4215c7746c756c1aa2194c7217ab902459290981a0905683fa8563a2a7241f2bc3a3d6e4fca48d9fce1c6c322c4835dc1b"
-        },
-        {
-          "aggregation_bits": "0x18d1",
+          "aggregation_bits": "0xea64",
           "data": {
             "beacon_block_root": "0x83582f424fd7244f213350c530fd112a5fa71806352876480227941a471efbcb",
             "slot": "17944383863",
@@ -395,57 +385,67 @@
             "blob_data_available": false
           },
           "signature": "0xb710f44c80db8d91f996614df20b5e9293a578f28f55e4cd65f017063fa9e36eead8417ff871fda70f6f8238fa906376066788d928178215cf5b285a0630956453a2b53fd2ecdd614e247a7c89502de682385310134924ee896501d9a1a5265a"
+        },
+        {
+          "aggregation_bits": "0xfe04",
+          "data": {
+            "beacon_block_root": "0x7f8344414da8081272a9728d415e47355920f1d5b384d55e295620656640a278",
+            "slot": "4725799414",
+            "payload_present": false,
+            "blob_data_available": false
+          },
+          "signature": "0x893702a25c8f5517f07ae9287a034dc80db9ba5fbe230b86cfee1dee11daf16c3fb20fda7be4c5c74cae4d7db9a8fbb40c2a4aa47bbc7deac6fdb446328bc340840cc2cc3b4db057be94e494efc95ac1d30b31978a6fad2f54a03a9a79ecc03f"
         }
       ],
       "parent_execution_requests": {
         "deposits": [
           {
-            "pubkey": "0xaacb0e7f3717c59e23c32cb07ce03be33c2bb8366da2d27a9954b77f2c9198a1b5f3aea585faffcdfa4800b592c4d5d8",
-            "withdrawal_credentials": "0x0100000000000000000000007f8344414da8081272a9728d415e47355920f1d5",
-            "amount": "4701376009451598829",
-            "signature": "0xa9bf2689fe47ca9ac1fb90da3b08259115adab480b4f387669f209ee7747f7451af8f61e4a9c057bc33ffc18f0b08c3407be0a59b8c61c741572f5d28e2a1f6af0fc17db7c3f48901c9267606c3d7831a3d3647b885946fc95fb5689d24f7b8d",
-            "index": "4691461101561559469"
+            "pubkey": "0xb7fbe0486f002e790bb3d674b4259c18c6bf66510576e381e128aee6c2de771d3d5c9dda65b4078b058b2667f30e1637",
+            "withdrawal_credentials": "0x010000000000000000000000188c15414d0503391cc1ace8dfa4eb9d8b38e965",
+            "amount": "4688156139423158509",
+            "signature": "0xa01b45fff3e1e813ee035becd43cfde49bd8e12be359d4225ef26086b3467e633f66b93c5ea84934053fc9d54f29855d164e0c2ccc5ed1ebef93c6c0527b9948170a9a0f2e35c95e2c0d3606b5aa849f3177c0ecafbbbcdd73a2d674674d3033",
+            "index": "4731120720236815022"
           },
           {
-            "pubkey": "0xb8fa03e47468016f15b89212a91f203194684e0cbbac07b6cd428fc7e10cb7d8a363985b46972eedd7bc434fc701c4b3",
-            "withdrawal_credentials": "0x0100000000000000000000003ece09418d9cc1c206477b3f86b61438983ee789",
-            "amount": "4684851168694822957",
-            "signature": "0xa529495633ab9ab138c0756646074fc7753fafbb44389490ddd46048f29267f6b85e46abbc1fe71c42fc98513ed0f6f800ebc9eaa04b484e29af7d7bb0c38b5e088435aee8583a812545b3057c184a4634957604ec0647d1fa81da2d15a5f198",
-            "index": "4688156139423158509"
+            "pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
+            "withdrawal_credentials": "0x01000000000000000000000073b496418e85d24d0900cd2dafe227fe02f6fed9",
+            "amount": "4724510778780143918",
+            "signature": "0xb60a1e11b6a297fb8aa2b59483fba95f892c157444892bbc5f7c2cd0e0ac87e4fb732333cb46538b0169da9ea199f4eb127641ef2a11ad2ddde793cec87a2310473bdb4086726490ae3a73f58cd339ec5323ec1458b01f41fb226df46a20bf6a",
+            "index": "4727815749508479470"
           }
         ],
         "withdrawals": [
           {
-            "source_address": "0x01eeb941cebf96b04a6e6129b9adac2fdce3046e",
-            "validator_pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
-            "amount": "4726163266291795342"
+            "source_address": "0x9af68a41ce1c91d7f3859b8456f450980efcfcfd",
+            "validator_pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
+            "amount": "4712943396263355021"
           }
         ],
         "consolidations": [
           {
-            "source_address": "0x60939c41ee39f30814bd6502db591331fcf2ff47",
-            "source_pubkey": "0xa4a90125ab79fbbe706de307f1de84a6b0dc21adef413c6a5e91ab58e575164bd13c0517a318394a56adab9326607e82",
-            "target_pubkey": "0x83feea64397a7a9d3fbac0b9a16ccbfd63c4d4fa5d0fd8bbfa13739148e752ce1e9b1e01654b56cb56a196fd8d64db3f"
+            "source_address": "0xf99b6d41ed96ed2fbed49f5d78a0b7992e0bf8d7",
+            "source_pubkey": "0x80e72169819ea12b0aca8160fad8f1192e227806df31b13256cabf9c2dc9c598a3600a7f5f61a91c603e17d16381fb96",
+            "target_pubkey": "0x99b20a6a3e75af8e62e7f3f5143a149ab8e4ff041b0bf44e70174c19184e0ad2d612a3cd648ac30b428469bde0d1cea2"
           }
         ],
         "builder_deposits": [
           {
-            "pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
-            "withdrawal_credentials": "0x0cbd67418de2cc74b31707894c29cc66340ef7696dd0e001164f8bb348fb5538",
-            "amount": "4711290908751703597",
-            "signature": "0xa3943f03f5aff0a7df04a6b61b4415ee89f4a9fedb785b5c837cc9d26e180666c639fa40e278230ca8dd9cbaf6188370100f2812051f83d804c6dc7f8473620962a30344b3d53cbdb83bd6e85cc521f8b420596529a3f9451c6e8e3c2020c6fe"
+            "pubkey": "0xacd1d20f8f61838e5c6e66553615105252510977d06a323d98f6e6c160d253671cfdaed6749bf15db1b838d4c99d3e25",
+            "withdrawal_credentials": "0x02f65546365f449dbedb4d15903f8d2af483cbcc493fa0a9a6d1d982e0a353b8",
+            "amount": "5073184892119317590",
+            "signature": "0x86f4272ff604389cd7bb8e63b4379e6b57dc09d7d209dc3033c802eb2b143281ae6b8e8c0036ab78325df8c0af74df3d0537de897bfc4a127fea05f63ac012b19ba58ded843c8d3c8d30767e5f0e70a7cbc6da73c38cc758b2acb5d7da1bf1b7"
           },
           {
-            "pubkey": "0x85808a97e324987cd03bfc33e49aaa6cbc8a5cb66fb44111b0d8bc8c6b7c810638e6a6ac88d640b3492a684c19053f61",
-            "withdrawal_credentials": "0xa250734616e5e744f48c493c6d932629d574d0f2b953d406c14b88999cbfbe02",
-            "amount": "5074837375336001718",
-            "signature": "0x80f502e5703e37ce36fa24f0dd4f467d42aac01400d2d3cc9f11bc630ca5a2587e479de9c1e499ed489aadfba7362bee10127449182f438b820ee3018596ee2fca2e416a99567b961a1fdb3a9ef53a7f44897212ac566c039d215aac1bb8bebc"
+            "pubkey": "0xaa7d67cf12895fe67b0023fb9c2fb0b7a60bd3b9c90c01dd758002a19265cc9c2fa5338b6a59a5a0b648140752ddf8a0",
+            "withdrawal_credentials": "0x15175046d6aa23e2b31eb54063c8a1f7fa86ca5eff07c963d4521d4bbb040b43",
+            "amount": "5064922476035896950",
+            "signature": "0x908c76204e93cde92176902d2699c34b8374b54c6d1649a9fe75c592c128c4d0087a574342b6150aef7c414edfd39f9514973edf90c36395275e1914849ab9b12433b3a7d78050f57103d5d272f0adb2b3f633f369db96b299430a2d8c44b003"
           }
         ],
         "builder_exits": [
           {
-            "source_address": "0xefd45b4696136558c998e6e9bcb6785dee80cc3a",
-            "pubkey": "0x8b585aa726039b4472f9552d0c79479cb6adc817b80667143271f83ddea3228455397c6ac7e29e6fa703eb31e8674828"
+            "source_address": "0x74bc3246f624803a7d6db919857408f91a96c538",
+            "pubkey": "0xa3d1a6f01e1a2573d23e686a0d97f4b10c154729e8434317845668453903c604c9f3be8998291809cf344f0dd489f3b2"
           }
         ]
       }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockHEZE.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/v3/newBlockHEZE.json
@@ -1,13 +1,13 @@
 {
   "version": "heze",
   "execution_payload_blinded": false,
-  "execution_payload_value": "35496387346092661263590124027748611045873920617010484475327370353770209161699",
-  "consensus_block_value": "9539761352249328967673942558291261761143915489986282246629250626813713189699",
+  "execution_payload_value": "85832942286078503862735908113948385571524527877668557374728713559918851204738",
+  "consensus_block_value": "94485150941741403171631500262704852817440366868100051543101979518330153131276",
   "data": {
     "slot": "1",
-    "proposer_index": "5073184892119317590",
-    "parent_root": "0xdbb36146f6c78513d4557fbee82d6490e87dcda8dcad4e354acf52f22ce2e4a2",
-    "state_root": "0x3b5944461642e26b9ea483970adaca91078dc8826c991ad82f55a4db6fc67958",
+    "proposer_index": "5101277123982816951",
+    "parent_root": "0x4afddc46d793346db6d7062f8cf4b4bd653ee2aee736f6ef8936c98442f0d941",
+    "state_root": "0x5d1ed74677df13b2ab1a6e5a607dc98a6b41e1409eff1eaab7b70c4d1c5191cc",
     "body": {
       "randao_reveal": "0x896972a61590fa3df074e8b86d9229c800e16b2c69c92b424c42947efb2c5c9badf3dea0289f088c86cf45ef8add162d1764bfe82b05fa69da6969f8a5ef4a5d70422b2d6568164b0f34de00e4592a05ab90c757c76b2edfc512fef7937c5a5a",
       "eth1_data": {
@@ -357,37 +357,27 @@
       },
       "payload_attestations": [
         {
-          "aggregation_bits": "0xaeb0",
+          "aggregation_bits": "0x8c8a",
           "data": {
-            "beacon_block_root": "0xdbabc5418e28d8265fe892d2129c8395d0dd064a0845545f3a3c532fa2eddf8c",
-            "slot": "16699259415",
+            "beacon_block_root": "0xb469d1414e91199d7562c47b6a8a5afbc3d708269bb302ebdf39cc9eed2b7177",
+            "slot": "17768459895",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0x98ffde69b4d92a4510b5d42ae9bcc05315ed0a20fab2ff6fc8e416678f150d7bfb961da6774e86213ee711a2b065c3d300a13fcf630d7f303c59d848ec47905d2b439e7bb4f3348b6ddc448aa00f7c6eb6f64513182a3d335e2753f66cbec83e"
+          "signature": "0xa29e82672b9b023ec4496bc5ba26cd0e12ae4e168591a2412dc2c62cfbf0466710810999921e34e7249e3a4700c837ec115bb6bee111a50c55a1af9d2f996bb6600a4767e23781cf4eb177845372b39df6156906f9e24c5b908920161a44d8fa"
         },
         {
-          "aggregation_bits": "0xba32",
+          "aggregation_bits": "0xb69a",
           "data": {
-            "beacon_block_root": "0x9ecb7542cf4bad14a20f79bc45931b8d1483242ea9bf8c8edd186ab70a94624b",
-            "slot": "11686939575",
+            "beacon_block_root": "0xea4f5e424f7a2a28771b166a93b66dc12d8f207683e22f77941d78d874174076",
+            "slot": "3106087671",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xb9014738ce2ebfe44a8255a53e34b604f223702435a966b81276bd7967cc1e172a4dbace09be70a1f73b300d83a7a8ec161cdc911b167a8a6489def11edca95a3587eab704e98325ce29eb4f86a477755421b480ca39020c82f07e4977d9e859"
+          "signature": "0xb875609f4aa01bb03c08b4f13459fa7696b969fc5e8440c89f690478820b8b5b4ad75e7fbf03c4b0e919cdc80b07857604bd81f75128f2bbc61861d0b5a7744e21eb4ad008f05b46be2c2780900a7913abc2cd3591390f29e05e2d5b2dba570b"
         },
         {
-          "aggregation_bits": "0x4c37",
-          "data": {
-            "beacon_block_root": "0x5d163b420f4066c536ad816e89ebe88f53a11ae2c99624d4a7240d8a925c8cb6",
-            "slot": "23308551639",
-            "payload_present": false,
-            "blob_data_available": false
-          },
-          "signature": "0x954da68af7adf486693e9213a63a082fcf1b1ed99c320314b73e64c322470329df27c891348c17b92dc7972dbc7d9b4215c7746c756c1aa2194c7217ab902459290981a0905683fa8563a2a7241f2bc3a3d6e4fca48d9fce1c6c322c4835dc1b"
-        },
-        {
-          "aggregation_bits": "0x18d1",
+          "aggregation_bits": "0xea64",
           "data": {
             "beacon_block_root": "0x83582f424fd7244f213350c530fd112a5fa71806352876480227941a471efbcb",
             "slot": "17944383863",
@@ -395,57 +385,67 @@
             "blob_data_available": false
           },
           "signature": "0xb710f44c80db8d91f996614df20b5e9293a578f28f55e4cd65f017063fa9e36eead8417ff871fda70f6f8238fa906376066788d928178215cf5b285a0630956453a2b53fd2ecdd614e247a7c89502de682385310134924ee896501d9a1a5265a"
+        },
+        {
+          "aggregation_bits": "0xfe04",
+          "data": {
+            "beacon_block_root": "0x7f8344414da8081272a9728d415e47355920f1d5b384d55e295620656640a278",
+            "slot": "4725799414",
+            "payload_present": false,
+            "blob_data_available": false
+          },
+          "signature": "0x893702a25c8f5517f07ae9287a034dc80db9ba5fbe230b86cfee1dee11daf16c3fb20fda7be4c5c74cae4d7db9a8fbb40c2a4aa47bbc7deac6fdb446328bc340840cc2cc3b4db057be94e494efc95ac1d30b31978a6fad2f54a03a9a79ecc03f"
         }
       ],
       "parent_execution_requests": {
         "deposits": [
           {
-            "pubkey": "0xaacb0e7f3717c59e23c32cb07ce03be33c2bb8366da2d27a9954b77f2c9198a1b5f3aea585faffcdfa4800b592c4d5d8",
-            "withdrawal_credentials": "0x0100000000000000000000007f8344414da8081272a9728d415e47355920f1d5",
-            "amount": "4701376009451598829",
-            "signature": "0xa9bf2689fe47ca9ac1fb90da3b08259115adab480b4f387669f209ee7747f7451af8f61e4a9c057bc33ffc18f0b08c3407be0a59b8c61c741572f5d28e2a1f6af0fc17db7c3f48901c9267606c3d7831a3d3647b885946fc95fb5689d24f7b8d",
-            "index": "4691461101561559469"
+            "pubkey": "0xb7fbe0486f002e790bb3d674b4259c18c6bf66510576e381e128aee6c2de771d3d5c9dda65b4078b058b2667f30e1637",
+            "withdrawal_credentials": "0x010000000000000000000000188c15414d0503391cc1ace8dfa4eb9d8b38e965",
+            "amount": "4688156139423158509",
+            "signature": "0xa01b45fff3e1e813ee035becd43cfde49bd8e12be359d4225ef26086b3467e633f66b93c5ea84934053fc9d54f29855d164e0c2ccc5ed1ebef93c6c0527b9948170a9a0f2e35c95e2c0d3606b5aa849f3177c0ecafbbbcdd73a2d674674d3033",
+            "index": "4731120720236815022"
           },
           {
-            "pubkey": "0xb8fa03e47468016f15b89212a91f203194684e0cbbac07b6cd428fc7e10cb7d8a363985b46972eedd7bc434fc701c4b3",
-            "withdrawal_credentials": "0x0100000000000000000000003ece09418d9cc1c206477b3f86b61438983ee789",
-            "amount": "4684851168694822957",
-            "signature": "0xa529495633ab9ab138c0756646074fc7753fafbb44389490ddd46048f29267f6b85e46abbc1fe71c42fc98513ed0f6f800ebc9eaa04b484e29af7d7bb0c38b5e088435aee8583a812545b3057c184a4634957604ec0647d1fa81da2d15a5f198",
-            "index": "4688156139423158509"
+            "pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
+            "withdrawal_credentials": "0x01000000000000000000000073b496418e85d24d0900cd2dafe227fe02f6fed9",
+            "amount": "4724510778780143918",
+            "signature": "0xb60a1e11b6a297fb8aa2b59483fba95f892c157444892bbc5f7c2cd0e0ac87e4fb732333cb46538b0169da9ea199f4eb127641ef2a11ad2ddde793cec87a2310473bdb4086726490ae3a73f58cd339ec5323ec1458b01f41fb226df46a20bf6a",
+            "index": "4727815749508479470"
           }
         ],
         "withdrawals": [
           {
-            "source_address": "0x01eeb941cebf96b04a6e6129b9adac2fdce3046e",
-            "validator_pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
-            "amount": "4726163266291795342"
+            "source_address": "0x9af68a41ce1c91d7f3859b8456f450980efcfcfd",
+            "validator_pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
+            "amount": "4712943396263355021"
           }
         ],
         "consolidations": [
           {
-            "source_address": "0x60939c41ee39f30814bd6502db591331fcf2ff47",
-            "source_pubkey": "0xa4a90125ab79fbbe706de307f1de84a6b0dc21adef413c6a5e91ab58e575164bd13c0517a318394a56adab9326607e82",
-            "target_pubkey": "0x83feea64397a7a9d3fbac0b9a16ccbfd63c4d4fa5d0fd8bbfa13739148e752ce1e9b1e01654b56cb56a196fd8d64db3f"
+            "source_address": "0xf99b6d41ed96ed2fbed49f5d78a0b7992e0bf8d7",
+            "source_pubkey": "0x80e72169819ea12b0aca8160fad8f1192e227806df31b13256cabf9c2dc9c598a3600a7f5f61a91c603e17d16381fb96",
+            "target_pubkey": "0x99b20a6a3e75af8e62e7f3f5143a149ab8e4ff041b0bf44e70174c19184e0ad2d612a3cd648ac30b428469bde0d1cea2"
           }
         ],
         "builder_deposits": [
           {
-            "pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
-            "withdrawal_credentials": "0x0cbd67418de2cc74b31707894c29cc66340ef7696dd0e001164f8bb348fb5538",
-            "amount": "4711290908751703597",
-            "signature": "0xa3943f03f5aff0a7df04a6b61b4415ee89f4a9fedb785b5c837cc9d26e180666c639fa40e278230ca8dd9cbaf6188370100f2812051f83d804c6dc7f8473620962a30344b3d53cbdb83bd6e85cc521f8b420596529a3f9451c6e8e3c2020c6fe"
+            "pubkey": "0xacd1d20f8f61838e5c6e66553615105252510977d06a323d98f6e6c160d253671cfdaed6749bf15db1b838d4c99d3e25",
+            "withdrawal_credentials": "0x02f65546365f449dbedb4d15903f8d2af483cbcc493fa0a9a6d1d982e0a353b8",
+            "amount": "5073184892119317590",
+            "signature": "0x86f4272ff604389cd7bb8e63b4379e6b57dc09d7d209dc3033c802eb2b143281ae6b8e8c0036ab78325df8c0af74df3d0537de897bfc4a127fea05f63ac012b19ba58ded843c8d3c8d30767e5f0e70a7cbc6da73c38cc758b2acb5d7da1bf1b7"
           },
           {
-            "pubkey": "0x85808a97e324987cd03bfc33e49aaa6cbc8a5cb66fb44111b0d8bc8c6b7c810638e6a6ac88d640b3492a684c19053f61",
-            "withdrawal_credentials": "0xa250734616e5e744f48c493c6d932629d574d0f2b953d406c14b88999cbfbe02",
-            "amount": "5074837375336001718",
-            "signature": "0x80f502e5703e37ce36fa24f0dd4f467d42aac01400d2d3cc9f11bc630ca5a2587e479de9c1e499ed489aadfba7362bee10127449182f438b820ee3018596ee2fca2e416a99567b961a1fdb3a9ef53a7f44897212ac566c039d215aac1bb8bebc"
+            "pubkey": "0xaa7d67cf12895fe67b0023fb9c2fb0b7a60bd3b9c90c01dd758002a19265cc9c2fa5338b6a59a5a0b648140752ddf8a0",
+            "withdrawal_credentials": "0x15175046d6aa23e2b31eb54063c8a1f7fa86ca5eff07c963d4521d4bbb040b43",
+            "amount": "5064922476035896950",
+            "signature": "0x908c76204e93cde92176902d2699c34b8374b54c6d1649a9fe75c592c128c4d0087a574342b6150aef7c414edfd39f9514973edf90c36395275e1914849ab9b12433b3a7d78050f57103d5d272f0adb2b3f633f369db96b299430a2d8c44b003"
           }
         ],
         "builder_exits": [
           {
-            "source_address": "0xefd45b4696136558c998e6e9bcb6785dee80cc3a",
-            "pubkey": "0x8b585aa726039b4472f9552d0c79479cb6adc817b80667143271f83ddea3228455397c6ac7e29e6fa703eb31e8674828"
+            "source_address": "0x74bc3246f624803a7d6db919857408f91a96c538",
+            "pubkey": "0xa3d1a6f01e1a2573d23e686a0d97f4b10c154729e8434317845668453903c604c9f3be8998291809cf344f0dd489f3b2"
           }
         ]
       }

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/getExecutionPayload.json
@@ -73,23 +73,23 @@
         ],
         "builder_deposits": [
           {
-            "pubkey": "0xb94235fc2765496162b52009ab14fa6d0d0ed1debc25fbbd1fa6da8c64b58e5edaf39419489b556cb563cdd1d08c2eb0",
-            "withdrawal_credentials": "0x8afa683fea95afdc0ad91e4937a9c6185315a1076506bd45a4357cc27fe5a75c",
-            "amount": "4560914871608938506",
-            "signature": "0x81f173b724a40d8b729570158524a2726ac3bfe244452b6d22f3ad25183de08172ebd10cbaee58393db7d74d95b1a1ec02fe9de1487a744ba3d5d9ba01359c4050fc5d6eec7672662b703d6035100800a3952f4e4b2d9e4143ab0d9f044e5aed"
+            "pubkey": "0xb272b83b21044842822fa9d80b3aed0865c98691bf1c053f6011ec845fad96c422e2667b04ee5ce854f61b8aa8f2dd56",
+            "withdrawal_credentials": "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12",
+            "amount": "4559262388392254378",
+            "signature": "0x8166b2ed13e982e6b9f05d30f42681b826099135a533d2614ef5f4f59811714245db0e1821a644859559f97ec1e614bf08b2edb294fa2edc1527f46596399534af23c98613e1b74c01871bf1dd2af9618bc0ba23ddfce8026b897cdbba8c1bce"
           }
         ],
         "builder_exits": [
           {
-            "source_address": "0xd67e513f6ac42cf0dfe4bbf686cc184d6c219d4f",
-            "pubkey": "0x83b9036200e9e907c86ede7f98b23297389e8af19d403466e00f1946867db735d8620019e28aa42739f49c65b78a2806"
+            "source_address": "0x49452e3f298a688d9e7627fb7c01941b923397bb",
+            "pubkey": "0x83919971606b0afef79e35e8a49c53b213230dcdb6d04f4fd65a951060a052bd2bafa867b1f9b0258a30cda8db072831"
           }
         ]
       },
-      "builder_index": "1998500",
-      "beacon_block_root": "0x10e23f3f49a7cabebfadf178016756b47f2a9a056183da5ce5bd543c778bab27",
-      "parent_beacon_block_root": "0x23033a3fe9f2a903b4f058a4d4ef6a81852d9997184c0317133f980452ec62b2"
+      "builder_index": "2383249",
+      "beacon_block_root": "0xe5ca603e08e1eff7259e45ea6bb662256d9d74b1724ee8feb0ea59f6e2ebe3be",
+      "parent_beacon_block_root": "0xf8eb5a3ea82ccf3c1be1ac153e3f77f273a07343291711b9de6b9dbebc4c9b49"
     },
-    "signature": "0xaacffaf60c8253477ecad70de8589f2ef7670d0b0dc446d4baac3b465a901d3e64bb6d2c3d8bdb58aed45ac30466261416d152d5ae242204201bf6decfddde697ae0c5d44cf31ca3d43aa18f2799461fc1ee14dbf905b1e31f242fd31c083c5a"
+    "signature": "0xa774e8ae3c67080cc333af2d9cedac9848978d30cea81cd86bd757448d8af577d85402cb167f8c2da650ab150772ef5805fb0897209b1acd7b068eba2dadabb0b5a2c06e97033f51a7c081da085a03b2da1e09e0962c04f0bafc181a2e60cf17"
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4.java
@@ -21,35 +21,26 @@ import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV4Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
 public class EngineGetPayloadV4 extends AbstractEngineJsonRpcMethod<GetPayloadResponse> {
 
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
-  private final ExecutionRequestsDataCodec executionRequestsDataDecoder;
 
   public EngineGetPayloadV4(final ExecutionEngineClient executionEngineClient, final Spec spec) {
     super(executionEngineClient);
     this.spec = spec;
-    this.executionRequestsDataDecoder =
-        new ExecutionRequestsDataCodec(
-            SchemaDefinitionsElectra.required(
-                    spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
-                .getExecutionRequestsSchema());
   }
 
   @Override
@@ -87,7 +78,7 @@ public class EngineGetPayloadV4 extends AbstractEngineJsonRpcMethod<GetPayloadRe
                   response.executionPayload.asInternalExecutionPayload(payloadSchema);
               final BlobsBundle blobsBundle = getBlobsBundle(response, schemaDefinitions);
               final ExecutionRequests executionRequests =
-                  executionRequestsDataDecoder.decode(response.executionRequests);
+                  spec.getExecutionRequestsDataCodec(slot).decode(response.executionRequests);
               return new GetPayloadResponse(
                   executionPayload,
                   response.blockValue,

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV5.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV5.java
@@ -21,35 +21,26 @@ import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV5Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
 public class EngineGetPayloadV5 extends AbstractEngineJsonRpcMethod<GetPayloadResponse> {
 
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
-  private final ExecutionRequestsDataCodec executionRequestsDataDecoder;
 
   public EngineGetPayloadV5(final ExecutionEngineClient executionEngineClient, final Spec spec) {
     super(executionEngineClient);
     this.spec = spec;
-    this.executionRequestsDataDecoder =
-        new ExecutionRequestsDataCodec(
-            SchemaDefinitionsElectra.required(
-                    spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
-                .getExecutionRequestsSchema());
   }
 
   @Override
@@ -87,7 +78,7 @@ public class EngineGetPayloadV5 extends AbstractEngineJsonRpcMethod<GetPayloadRe
                   response.executionPayload.asInternalExecutionPayload(payloadSchema);
               final BlobsBundle blobsBundle = getBlobsBundle(response, schemaDefinitions);
               final ExecutionRequests executionRequests =
-                  executionRequestsDataDecoder.decode(response.executionRequests);
+                  spec.getExecutionRequestsDataCodec(slot).decode(response.executionRequests);
               return new GetPayloadResponse(
                   executionPayload,
                   response.blockValue,

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
@@ -65,8 +64,6 @@ public class EngineGetPayloadV6 extends AbstractEngineJsonRpcMethod<GetPayloadRe
 
     final SchemaDefinitionsElectra schemaDefinitions =
         SchemaDefinitionsElectra.required(spec.atSlot(slot).getSchemaDefinitions());
-    final ExecutionRequestsDataCodec executionRequestsDataDecoder =
-        new ExecutionRequestsDataCodec(schemaDefinitions.getExecutionRequestsSchema());
 
     return executionEngineClient
         .getPayloadV6(executionPayloadContext.getPayloadId())
@@ -78,7 +75,7 @@ public class EngineGetPayloadV6 extends AbstractEngineJsonRpcMethod<GetPayloadRe
                       schemaDefinitions.getExecutionPayloadSchema());
               final BlobsBundle blobsBundle = getBlobsBundle(response, schemaDefinitions);
               final ExecutionRequests executionRequests =
-                  executionRequestsDataDecoder.decode(response.executionRequests);
+                  spec.getExecutionRequestsDataCodec(slot).decode(response.executionRequests);
               return new GetPayloadResponse(
                   executionPayload,
                   response.blockValue,

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
@@ -28,7 +28,6 @@ import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSeri
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 
 public class GetPayloadV4Response {
@@ -66,12 +65,12 @@ public class GetPayloadV4Response {
   public GetPayloadResponse asInternalGetPayloadResponse(
       final ExecutionPayloadSchema<?> executionPayloadSchema,
       final BlobSchema blobSchema,
-      final ExecutionRequestsSchema<?> executionRequestsSchema) {
+      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
     return new GetPayloadResponse(
         executionPayload.asInternalExecutionPayload(executionPayloadSchema),
         blockValue,
         blobsBundle.asInternalBlobsBundle(blobSchema),
         shouldOverrideBuilder,
-        new ExecutionRequestsDataCodec(executionRequestsSchema).decode(executionRequests));
+        executionRequestsDataCodec.decode(executionRequests));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV5Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV5Response.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSeri
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 
 public class GetPayloadV5Response {
@@ -68,12 +67,12 @@ public class GetPayloadV5Response {
   public GetPayloadResponse asInternalGetPayloadResponse(
       final ExecutionPayloadSchema<?> executionPayloadSchema,
       final BlobSchema blobSchema,
-      final ExecutionRequestsSchema<?> executionRequestsSchema) {
+      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
     return new GetPayloadResponse(
         executionPayload.asInternalExecutionPayload(executionPayloadSchema),
         blockValue,
         blobsBundle.asInternalBlobsBundle(blobSchema),
         shouldOverrideBuilder,
-        new ExecutionRequestsDataCodec(executionRequestsSchema).decode(executionRequests));
+        executionRequestsDataCodec.decode(executionRequests));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV6Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV6Response.java
@@ -28,7 +28,6 @@ import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSeri
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 
 public class GetPayloadV6Response {
@@ -66,12 +65,12 @@ public class GetPayloadV6Response {
   public GetPayloadResponse asInternalGetPayloadResponse(
       final ExecutionPayloadSchema<?> executionPayloadSchema,
       final BlobSchema blobSchema,
-      final ExecutionRequestsSchema<?> executionRequestsSchema) {
+      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
     return new GetPayloadResponse(
         executionPayload.asInternalExecutionPayload(executionPayloadSchema),
         blockValue,
         blobsBundle.asInternalBlobsBundle(blobSchema),
         shouldOverrideBuilder,
-        new ExecutionRequestsDataCodec(executionRequestsSchema).decode(executionRequests));
+        executionRequestsDataCodec.decode(executionRequests));
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV4Test.java
@@ -39,16 +39,13 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class EngineGetPayloadV4Test {
@@ -56,11 +53,6 @@ class EngineGetPayloadV4Test {
   private final Spec spec = TestSpecFactory.createMinimalElectra();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
-  private final ExecutionRequestsDataCodec executionRequestsDataCodec =
-      new ExecutionRequestsDataCodec(
-          SchemaDefinitionsElectra.required(
-                  spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
-              .getExecutionRequestsSchema());
   private EngineGetPayloadV4 jsonRpcMethod;
 
   @BeforeEach
@@ -130,7 +122,7 @@ class EngineGetPayloadV4Test {
     final ExecutionPayload executionPayloadElectra = dataStructureUtil.randomExecutionPayload();
     final ExecutionRequests executionRequests = dataStructureUtil.randomExecutionRequests();
     final List<Bytes> encodedExecutionRequests =
-        executionRequestsDataCodec.encode(executionRequests);
+        spec.getExecutionRequestsDataCodec(UInt64.ZERO).encode(executionRequests);
     assertThat(executionPayloadElectra).isInstanceOf(ExecutionPayloadDeneb.class);
 
     when(executionEngineClient.getPayloadV4(eq(executionPayloadContext.getPayloadId())))

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV5Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV5Test.java
@@ -39,16 +39,13 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class EngineGetPayloadV5Test {
@@ -56,11 +53,6 @@ class EngineGetPayloadV5Test {
   private final Spec spec = TestSpecFactory.createMinimalFulu();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
-  private final ExecutionRequestsDataCodec executionRequestsDataCodec =
-      new ExecutionRequestsDataCodec(
-          SchemaDefinitionsFulu.required(
-                  spec.forMilestone(SpecMilestone.FULU).getSchemaDefinitions())
-              .getExecutionRequestsSchema());
   private EngineGetPayloadV5 jsonRpcMethod;
 
   @BeforeEach
@@ -130,7 +122,7 @@ class EngineGetPayloadV5Test {
     final ExecutionPayload executionPayloadFulu = dataStructureUtil.randomExecutionPayload();
     final ExecutionRequests executionRequests = dataStructureUtil.randomExecutionRequests();
     final List<Bytes> encodedExecutionRequests =
-        executionRequestsDataCodec.encode(executionRequests);
+        spec.getExecutionRequestsDataCodec(UInt64.ZERO).encode(executionRequests);
     assertThat(executionPayloadFulu).isInstanceOf(ExecutionPayloadDeneb.class);
 
     when(executionEngineClient.getPayloadV5(eq(executionPayloadContext.getPayloadId())))

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV6Test.java
@@ -39,16 +39,13 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsFulu;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class EngineGetPayloadV6Test {
@@ -56,11 +53,6 @@ class EngineGetPayloadV6Test {
   private final Spec spec = TestSpecFactory.createMinimalGloas();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
-  private final ExecutionRequestsDataCodec executionRequestsDataCodec =
-      new ExecutionRequestsDataCodec(
-          SchemaDefinitionsFulu.required(
-                  spec.forMilestone(SpecMilestone.GLOAS).getSchemaDefinitions())
-              .getExecutionRequestsSchema());
   private EngineGetPayloadV6 jsonRpcMethod;
 
   @BeforeEach
@@ -131,7 +123,7 @@ class EngineGetPayloadV6Test {
     final ExecutionPayload executionPayloadFulu = dataStructureUtil.randomExecutionPayload(slot);
     final ExecutionRequests executionRequests = dataStructureUtil.randomExecutionRequests(slot);
     final List<Bytes> encodedExecutionRequests =
-        executionRequestsDataCodec.encode(executionRequests);
+        spec.getExecutionRequestsDataCodec(slot).encode(executionRequests);
     assertThat(executionPayloadFulu).isInstanceOf(ExecutionPayloadDeneb.class);
 
     when(executionEngineClient.getPayloadV6(eq(executionPayloadContext.getPayloadId())))

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ElectraExecutionClientHandlerTest.java
@@ -89,9 +89,7 @@ public class ElectraExecutionClientHandlerTest extends ExecutionHandlerClientTes
     final BlobSchema blobSchema = schemaDefinitionElectra.getBlobSchema();
     final GetPayloadResponse expectedGetPayloadResponse =
         responseData.asInternalGetPayloadResponse(
-            executionPayloadSchema,
-            blobSchema,
-            schemaDefinitionElectra.getExecutionRequestsSchema());
+            executionPayloadSchema, blobSchema, spec.getExecutionRequestsDataCodec(slot));
     assertThat(future).isCompletedWithValue(expectedGetPayloadResponse);
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/FuluExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/FuluExecutionClientHandlerTest.java
@@ -92,7 +92,7 @@ public class FuluExecutionClientHandlerTest extends ExecutionHandlerClientTest {
     final BlobSchema blobSchema = schemaDefinitionFulu.getBlobSchema();
     final GetPayloadResponse expectedGetPayloadResponse =
         responseData.asInternalGetPayloadResponse(
-            executionPayloadSchema, blobSchema, schemaDefinitionFulu.getExecutionRequestsSchema());
+            executionPayloadSchema, blobSchema, spec.getExecutionRequestsDataCodec(slot));
     assertThat(future).isCompletedWithValue(expectedGetPayloadResponse);
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/GloasExecutionClientHandlerTest.java
@@ -93,7 +93,7 @@ public class GloasExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final BlobSchema blobSchema = schemaDefinitionGloas.getBlobSchema();
     final GetPayloadResponse expectedGetPayloadResponse =
         responseData.asInternalGetPayloadResponse(
-            executionPayloadSchema, blobSchema, schemaDefinitionGloas.getExecutionRequestsSchema());
+            executionPayloadSchema, blobSchema, spec.getExecutionRequestsDataCodec(slot));
     assertThat(future).isCompletedWithValue(expectedGetPayloadResponse);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -83,6 +83,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloa
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
@@ -1201,6 +1202,15 @@ public class Spec {
             () ->
                 new IllegalStateException(
                     "Attempting to use execution requests processor when spec does not have execution requests processor"));
+  }
+
+  public ExecutionRequestsDataCodec getExecutionRequestsDataCodec(final UInt64 slot) {
+    return atSlot(slot)
+        .getExecutionRequestsDataCodec()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Attempting to use execution requests data codec when spec does not have execution requests data codec"));
   }
 
   // Data Column Sidecar Util

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic;
 
 import java.util.Optional;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerifier;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
@@ -126,6 +127,11 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return specLogic.getExecutionRequestsProcessor();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
+    return specLogic.getExecutionRequestsDataCodec();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic;
 
 import java.util.Optional;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerifier;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
@@ -85,6 +86,8 @@ public interface SpecLogic {
   Optional<WithdrawalsHelpers> getWithdrawalsHelpers();
 
   Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor();
+
+  Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec();
 
   Optional<ExecutionPayloadVerifier> getExecutionPayloadVerifier();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.altair;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerifier;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
@@ -226,6 +227,11 @@ public class SpecLogicAltair extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.bellatrix;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerifier;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
@@ -237,6 +238,11 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.capella;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerifier;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
@@ -246,6 +247,11 @@ public class SpecLogicCapella extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.deneb;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerifier;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
@@ -242,6 +243,11 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -62,6 +62,7 @@ public class SpecLogicElectra extends AbstractSpecLogic {
   private final Optional<LightClientUtil> lightClientUtil;
   private final Optional<WithdrawalsHelpers> withdrawalsHelpers;
   private final Optional<ExecutionRequestsProcessor> executionRequestsProcessor;
+  private final Optional<ExecutionRequestsDataCodec> executionRequestsDataCodec;
 
   private SpecLogicElectra(
       final Predicates predicates,
@@ -78,6 +79,7 @@ public class SpecLogicElectra extends AbstractSpecLogic {
       final EpochProcessorElectra epochProcessor,
       final WithdrawalsHelpersElectra withdrawalsHelpers,
       final ExecutionRequestsProcessorElectra executionRequestsProcessor,
+      final ExecutionRequestsDataCodec executionRequestsDataCodec,
       final BlockProcessorElectra blockProcessor,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil,
@@ -107,6 +109,7 @@ public class SpecLogicElectra extends AbstractSpecLogic {
     this.lightClientUtil = Optional.of(lightClientUtil);
     this.withdrawalsHelpers = Optional.of(withdrawalsHelpers);
     this.executionRequestsProcessor = Optional.of(executionRequestsProcessor);
+    this.executionRequestsDataCodec = Optional.of(executionRequestsDataCodec);
   }
 
   public static SpecLogicElectra create(
@@ -233,6 +236,7 @@ public class SpecLogicElectra extends AbstractSpecLogic {
         epochProcessor,
         withdrawalsHelpers,
         executionRequestsProcessor,
+        executionRequestsDataCodec,
         blockProcessor,
         forkChoiceUtil,
         blockProposalUtil,
@@ -265,6 +269,11 @@ public class SpecLogicElectra extends AbstractSpecLogic {
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return executionRequestsProcessor;
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
+    return executionRequestsDataCodec;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/SpecLogicFulu.java
@@ -68,6 +68,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
   private final Optional<LightClientUtil> lightClientUtil;
   private final Optional<WithdrawalsHelpers> withdrawalsHelpers;
   private final Optional<ExecutionRequestsProcessor> executionRequestsProcessor;
+  private final Optional<ExecutionRequestsDataCodec> executionRequestsDataCodec;
   private final Optional<DataColumnSidecarUtil> dataColumnSidecarUtil;
 
   private SpecLogicFulu(
@@ -85,6 +86,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
       final EpochProcessorElectra epochProcessor,
       final WithdrawalsHelpersElectra withdrawalsHelpers,
       final ExecutionRequestsProcessorElectra executionRequestsProcessor,
+      final ExecutionRequestsDataCodec executionRequestsDataCodec,
       final BlockProcessorFulu blockProcessor,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil,
@@ -115,6 +117,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
     this.lightClientUtil = Optional.of(lightClientUtil);
     this.withdrawalsHelpers = Optional.of(withdrawalsHelpers);
     this.executionRequestsProcessor = Optional.of(executionRequestsProcessor);
+    this.executionRequestsDataCodec = Optional.of(executionRequestsDataCodec);
     this.dataColumnSidecarUtil = Optional.of(dataColumnSidecarUtil);
   }
 
@@ -243,6 +246,7 @@ public class SpecLogicFulu extends AbstractSpecLogic {
         epochProcessor,
         withdrawalsHelpers,
         executionRequestsProcessor,
+        executionRequestsDataCodec,
         blockProcessor,
         forkChoiceUtil,
         blockProposalUtil,
@@ -276,6 +280,11 @@ public class SpecLogicFulu extends AbstractSpecLogic {
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return executionRequestsProcessor;
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
+    return executionRequestsDataCodec;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -65,6 +65,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
   private final Optional<LightClientUtil> lightClientUtil;
   private final Optional<WithdrawalsHelpers> withdrawalsHelpers;
   private final Optional<ExecutionRequestsProcessor> executionRequestsProcessor;
+  private final Optional<ExecutionRequestsDataCodec> executionRequestsDataCodec;
   private final Optional<ExecutionPayloadVerifier> executionPayloadVerifier;
   private final Optional<ExecutionPayloadProposalUtil> executionPayloadProposalUtil;
   private final Optional<DataColumnSidecarUtil> dataColumnSidecarUtil;
@@ -85,6 +86,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
       final EpochProcessorGloas epochProcessor,
       final WithdrawalsHelpersGloas withdrawalsHelpers,
       final ExecutionRequestsProcessorElectra executionRequestsProcessor,
+      final ExecutionRequestsDataCodec executionRequestsDataCodec,
       final BlockProcessorGloas blockProcessor,
       final ExecutionPayloadVerifierGloas executionPayloadVerifier,
       final ForkChoiceUtil forkChoiceUtil,
@@ -117,6 +119,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
     this.syncCommitteeUtil = Optional.of(syncCommitteeUtil);
     this.lightClientUtil = Optional.of(lightClientUtil);
     this.executionRequestsProcessor = Optional.of(executionRequestsProcessor);
+    this.executionRequestsDataCodec = Optional.of(executionRequestsDataCodec);
     this.withdrawalsHelpers = Optional.of(withdrawalsHelpers);
     this.executionPayloadVerifier = Optional.of(executionPayloadVerifier);
     this.executionPayloadProposalUtil = Optional.of(executionPayloadProposalUtil);
@@ -273,6 +276,7 @@ public class SpecLogicGloas extends AbstractSpecLogic {
         epochProcessor,
         withdrawalsHelpers,
         executionRequestsProcessor,
+        executionRequestsDataCodec,
         blockProcessor,
         executionPayloadVerifier,
         forkChoiceUtil,
@@ -309,6 +313,11 @@ public class SpecLogicGloas extends AbstractSpecLogic {
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return executionRequestsProcessor;
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
+    return executionRequestsDataCodec;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
@@ -63,6 +63,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
   private final Optional<LightClientUtil> lightClientUtil;
   private final Optional<WithdrawalsHelpers> withdrawalsHelpers;
   private final Optional<ExecutionRequestsProcessor> executionRequestsProcessor;
+  private final Optional<ExecutionRequestsDataCodec> executionRequestsDataCodec;
   private final Optional<ExecutionPayloadVerifier> executionPayloadVerifier;
   private final Optional<ExecutionPayloadProposalUtil> executionPayloadProposalUtil;
   private final Optional<DataColumnSidecarUtil> dataColumnSidecarUtil;
@@ -83,6 +84,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
       final EpochProcessorGloas epochProcessor,
       final WithdrawalsHelpersGloas withdrawalsHelpers,
       final ExecutionRequestsProcessorGloas executionRequestsProcessor,
+      final ExecutionRequestsDataCodec executionRequestsDataCodec,
       final BlockProcessorGloas blockProcessor,
       final ExecutionPayloadVerifierGloas executionPayloadVerifier,
       final ForkChoiceUtil forkChoiceUtil,
@@ -115,6 +117,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
     this.syncCommitteeUtil = Optional.of(syncCommitteeUtil);
     this.lightClientUtil = Optional.of(lightClientUtil);
     this.executionRequestsProcessor = Optional.of(executionRequestsProcessor);
+    this.executionRequestsDataCodec = Optional.of(executionRequestsDataCodec);
     this.withdrawalsHelpers = Optional.of(withdrawalsHelpers);
     this.executionPayloadVerifier = Optional.of(executionPayloadVerifier);
     this.executionPayloadProposalUtil = Optional.of(executionPayloadProposalUtil);
@@ -264,6 +267,7 @@ public class SpecLogicHeze extends AbstractSpecLogic {
         epochProcessor,
         withdrawalsHelpers,
         executionRequestsProcessor,
+        executionRequestsDataCodec,
         blockProcessor,
         executionPayloadVerifier,
         forkChoiceUtil,
@@ -300,6 +304,11 @@ public class SpecLogicHeze extends AbstractSpecLogic {
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
     return executionRequestsProcessor;
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
+    return executionRequestsDataCodec;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.phase0;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionPayloadVerifier;
 import tech.pegasys.teku.spec.logic.common.execution.ExecutionRequestsProcessor;
@@ -197,6 +198,11 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
 
   @Override
   public Optional<ExecutionRequestsProcessor> getExecutionRequestsProcessor() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionRequestsDataCodec> getExecutionRequestsDataCodec() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
@@ -24,13 +24,11 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodyElectra;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -43,7 +41,6 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProce
 import tech.pegasys.teku.spec.logic.versions.deneb.block.BlockProcessorDenebTest;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
 class BlockProcessorElectraTest extends BlockProcessorDenebTest {
 
@@ -162,7 +159,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
             .map(miscHelpers::kzgCommitmentToVersionedHash)
             .collect(Collectors.toList());
     final List<Bytes> expectedExecutionRequests =
-        getExecutionRequestsDataCodec().encode(blockBody.getExecutionRequests());
+        spec.getExecutionRequestsDataCodec(UInt64.ONE).encode(blockBody.getExecutionRequests());
 
     final NewPayloadRequest newPayloadRequest =
         spec.getBlockProcessor(UInt64.ONE).computeNewPayloadRequest(preState, blockBody);
@@ -185,12 +182,5 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
 
   private BlockProcessorElectra getBlockProcessor(final BeaconState state) {
     return (BlockProcessorElectra) spec.getBlockProcessor(state.getSlot());
-  }
-
-  private ExecutionRequestsDataCodec getExecutionRequestsDataCodec() {
-    return new ExecutionRequestsDataCodec(
-        SchemaDefinitionsElectra.required(
-                spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions())
-            .getExecutionRequestsSchema());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -246,7 +246,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "h2xVmQnJaUE3WPR4MDsWGY9Oig4Ne5/Glree2WT4+sEdcsAGlPMPGGeg4ZK6fsghGD1z1klGw3N9BwnodE9xQK/0nZfyIR4LJOf6VrilkXRfn0/+I3zAsdH9H7YcLmPJ"));
+                "jzKiAGsIdRaQBZu3BuDrZ0KODt5hZXgqLCT+7Ti8EzjCaO4GIezBOHvI5TD4+PY7FDHmq+Sc1AJqmHZ8D587uSiUMQsV5m6z9OFdYn+jhUfshGVhCNZIztsBEhXA0LM0"));
 
     final SafeFuture<BLSSignature> result = signer.signExecutionPayloadEnvelope(envelope, fork);
     asyncRunner.executeQueuedActions();
@@ -266,7 +266,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "tvf+z4784dw1b8XIDKuCBIAeGGQimNn0a6rH5s0NK3H8jKMgIKKadvR5Ui02bBtCGJwR7iLDGMF3KdzkMspzyVb1D+hdL600LttoSBp+HM+NJ0xsT5ajwNk1yO0RzajH"));
+                "qF7VPrbIcUkkpqELL9mhI2qOG85VXWPuf5SvCwIts/G5VIzaKr/i6pWlwKie9ijiEfHvudvljVvYpiT3NH41fb+k28mMPT3EUDGVqnfhk5vZyzDPbsN61xnjYOX797DD"));
 
     final SafeFuture<BLSSignature> result =
         signer.signPayloadAttestationData(payloadAttestationData, fork);
@@ -287,7 +287,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "hrCK+Ffg5SJNoCwgTAE52Sy+fYdr23zR0zb+hfl5i3KidjieMtDWLqTvZvM+Wnu0FMb92M1zry5uVEspby2UaAqI9ygITXFJPyjXjMehPBTRUEXzJts+S5T2bdGRBibT"));
+                "r663P2XmrOu3LmXCAJfeG46UmQMcmjLOhiL+A6SQ51xEtaHTuaZKtMNHvgFks/QgCQYsWxW1/imKbEjKNc/Ld0ivWCrtBuWzQSORDsulFDRT3RdOYp0hTce7XOwt1d8K"));
 
     final SafeFuture<BLSSignature> result =
         signer.signProposerPreferences(proposerPreferences, fork);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -167,7 +167,6 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionProof;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionProofSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsBuilder;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.TransactionSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
@@ -2726,8 +2725,7 @@ public final class DataStructureUtil {
   public SignedBlockContainer randomSignedBlockContents(final BlobsBundle blobsBundle) {
     final UInt64 slot = randomUInt64();
     final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema =
-        SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions())
-            .getBlobKzgCommitmentsSchema();
+        getDenebSchemaDefinitions(slot).getBlobKzgCommitmentsSchema();
     final SignedBeaconBlock signedBeaconBlock =
         randomSignedBeaconBlockWithCommitments(
             blobKzgCommitmentsSchema.createFromBlobsBundle(blobsBundle));
@@ -2897,8 +2895,7 @@ public final class DataStructureUtil {
                   signedBeaconBlockHeader
                       .map(blockHeader -> blockHeader.getMessage().getSlot())
                       .orElseGet(DataStructureUtil.this::randomSlot));
-      final SchemaDefinitionsFulu schemaDefinitions =
-          SchemaDefinitionsFulu.required(spec.atSlot(sidecarSlot).getSchemaDefinitions());
+      final SchemaDefinitionsFulu schemaDefinitions = getFuluSchemaDefinitions(sidecarSlot);
       final SignedBeaconBlockHeader signedBlockHeader =
           signedBeaconBlockHeader.orElseGet(
               () -> DataStructureUtil.this.randomSignedBeaconBlockHeader(sidecarSlot));
@@ -3103,7 +3100,7 @@ public final class DataStructureUtil {
   }
 
   public ExecutionRequestsBuilder randomExecutionRequestsBuilder(final UInt64 slot) {
-    return SchemaDefinitionsElectra.required(spec.atSlot(slot).getSchemaDefinitions())
+    return getElectraSchemaDefinitions(slot)
         .getExecutionRequestsSchema()
         .createBuilder()
         .deposits(randomDepositRequests())
@@ -3118,27 +3115,23 @@ public final class DataStructureUtil {
   }
 
   public BuilderDepositRequest randomBuilderDepositRequest() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getBuilderDepositRequestSchema()
         .create(randomPublicKey(), randomBytes32(), randomUInt64(), randomSignature());
   }
 
   public BuilderExitRequest randomBuilderExitRequest() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getBuilderExitRequestSchema()
         .create(randomEth1Address(), randomPublicKey());
   }
 
   public ExecutionRequests emptyExecutionRequests(final UInt64 slot) {
-    return SchemaDefinitionsElectra.required(spec.atSlot(slot).getSchemaDefinitions())
-        .getExecutionRequestsSchema()
-        .getDefault();
+    return getElectraSchemaDefinitions(slot).getExecutionRequestsSchema().getDefault();
   }
 
   public List<Bytes> randomEncodedExecutionRequests() {
-    return new ExecutionRequestsDataCodec(
-            getElectraSchemaDefinitions(randomSlot()).getExecutionRequestsSchema())
-        .encode(randomExecutionRequests());
+    return spec.getExecutionRequestsDataCodec(randomSlot()).encode(randomExecutionRequests());
   }
 
   public WithdrawalRequest randomWithdrawalRequest() {
@@ -3240,19 +3233,19 @@ public final class DataStructureUtil {
   }
 
   public PayloadAttestationData randomPayloadAttestationData() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getPayloadAttestationDataSchema()
         .create(randomBytes32(), randomSlot(), randomBoolean(), randomBoolean());
   }
 
   public PayloadAttestationData randomPayloadAttestationData(final UInt64 slot) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(slot)
         .getPayloadAttestationDataSchema()
         .create(randomBytes32(), slot, true, true);
   }
 
   public PayloadAttestation randomPayloadAttestation() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getPayloadAttestationSchema()
         .create(
             randomSszBitvector(getPtcSize()), randomPayloadAttestationData(), randomSignature());
@@ -3260,39 +3253,39 @@ public final class DataStructureUtil {
 
   public SszList<PayloadAttestation> emptyPayloadAttestations() {
     return BeaconBlockBodySchemaGloas.required(
-            getGloasSchemaDefinitions().getBeaconBlockBodySchema())
+            getGloasSchemaDefinitions(randomSlot()).getBeaconBlockBodySchema())
         .getPayloadAttestationsSchema()
         .createFromElements(List.of());
   }
 
   public BuilderPendingWithdrawal randomBuilderPendingWithdrawal() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getBuilderPendingWithdrawalSchema()
         .create(randomEth1Address(), randomUInt64(), randomUInt64());
   }
 
   public BuilderPendingPayment randomBuilderPendingPayment() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getBuilderPendingPaymentSchema()
         .create(randomUInt64(), randomBuilderPendingWithdrawal(), randomValidatorIndex());
   }
 
   public PayloadAttestationMessage randomPayloadAttestationMessage() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getPayloadAttestationMessageSchema()
         .create(randomValidatorIndex(), randomPayloadAttestationData(), randomSignature());
   }
 
   public PayloadAttestationMessage randomPayloadAttestationMessage(
       final PayloadAttestationData data) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(data.getSlot())
         .getPayloadAttestationMessageSchema()
         .create(randomValidatorIndex(), data, randomSignature());
   }
 
   public IndexedPayloadAttestation randomIndexedPayloadAttestation() {
     final IndexedPayloadAttestationSchema indexedPayloadAttestationSchema =
-        getGloasSchemaDefinitions().getIndexedPayloadAttestationSchema();
+        getGloasSchemaDefinitions(randomSlot()).getIndexedPayloadAttestationSchema();
     return indexedPayloadAttestationSchema.create(
         randomSszUInt64List(indexedPayloadAttestationSchema.getAttestingIndicesSchema()),
         randomPayloadAttestationData(),
@@ -3313,7 +3306,7 @@ public final class DataStructureUtil {
       final UInt64 builderIndex,
       final Bytes32 blockHash,
       final Bytes32 executionRequestsRoot) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(slot)
         .getExecutionPayloadBidSchema()
         .create(
             randomBytes32(),
@@ -3342,7 +3335,7 @@ public final class DataStructureUtil {
       final UInt64 builderIndex,
       final UInt64 value,
       final UInt64 executionPayment) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(slot)
         .getExecutionPayloadBidSchema()
         .create(
             parentBlockHash,
@@ -3364,21 +3357,22 @@ public final class DataStructureUtil {
   }
 
   public SignedExecutionPayloadBid randomSignedExecutionPayloadBid(final UInt64 executionPayment) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getSignedExecutionPayloadBidSchema()
         .create(randomExecutionPayloadBid(executionPayment), randomSignature());
   }
 
   public SignedExecutionPayloadBid randomSignedExecutionPayloadBid(
       final ExecutionPayloadBid executionPayloadBid) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(executionPayloadBid.getSlot())
         .getSignedExecutionPayloadBidSchema()
         .create(executionPayloadBid, randomSignature());
   }
 
   public SignedExecutionPayloadBid randomSignedExecutionPayloadBidWithCommitments(
       final SszList<SszKZGCommitment> blobKzgCommitments) {
-    final SchemaDefinitionsGloas schemaDefinitions = getGloasSchemaDefinitions();
+    final UInt64 slot = randomSlot();
+    final SchemaDefinitionsGloas schemaDefinitions = getGloasSchemaDefinitions(slot);
     return schemaDefinitions
         .getSignedExecutionPayloadBidSchema()
         .create(
@@ -3392,7 +3386,7 @@ public final class DataStructureUtil {
                     randomEth1Address(),
                     randomUInt64(),
                     randomBuilderIndex(),
-                    randomSlot(),
+                    slot,
                     randomUInt64(),
                     randomUInt64(),
                     blobKzgCommitments,
@@ -3401,13 +3395,14 @@ public final class DataStructureUtil {
   }
 
   public ProposerPreferences randomProposerPreferences() {
-    return getGloasSchemaDefinitions()
+    final UInt64 slot = randomSlot();
+    return getGloasSchemaDefinitions(slot)
         .getProposerPreferencesSchema()
-        .create(randomBytes32(), randomSlot(), randomUInt64(), randomEth1Address(), randomUInt64());
+        .create(randomBytes32(), slot, randomUInt64(), randomEth1Address(), randomUInt64());
   }
 
   public SignedProposerPreferences randomSignedProposerPreferences() {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(randomSlot())
         .getSignedProposerPreferencesSchema()
         .create(randomProposerPreferences(), randomSignature());
   }
@@ -3418,7 +3413,7 @@ public final class DataStructureUtil {
 
   public ExecutionPayloadEnvelope randomExecutionPayloadEnvelopeForBlock(
       final SignedBeaconBlock block) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(block.getSlot())
         .getExecutionPayloadEnvelopeSchema()
         .create(
             randomExecutionPayload(block.getSlot()),
@@ -3432,7 +3427,7 @@ public final class DataStructureUtil {
   }
 
   public ExecutionPayloadEnvelope randomExecutionPayloadEnvelope(final UInt64 slot) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(slot)
         .getExecutionPayloadEnvelopeSchema()
         .create(
             randomExecutionPayload(slot),
@@ -3443,13 +3438,13 @@ public final class DataStructureUtil {
   }
 
   public SignedExecutionPayloadEnvelope randomSignedExecutionPayloadEnvelope(final long slot) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(UInt64.valueOf(slot))
         .getSignedExecutionPayloadEnvelopeSchema()
         .create(randomExecutionPayloadEnvelope(UInt64.valueOf(slot)), randomSignature());
   }
 
   public BlindedExecutionPayloadEnvelope randomBlindedExecutionPayloadEnvelope() {
-    return randomExecutionPayloadEnvelope().blind(getGloasSchemaDefinitions());
+    return randomExecutionPayloadEnvelope().blind(getGloasSchemaDefinitions(randomSlot()));
   }
 
   public SignedBlindedExecutionPayloadEnvelope randomSignedBlindedExecutionPayloadEnvelope() {
@@ -3458,20 +3453,20 @@ public final class DataStructureUtil {
 
   public SignedBlindedExecutionPayloadEnvelope randomSignedBlindedExecutionPayloadEnvelope(
       final long slot) {
-    return randomSignedExecutionPayloadEnvelope(slot).blind(getGloasSchemaDefinitions());
+    return randomSignedExecutionPayloadEnvelope(slot)
+        .blind(getGloasSchemaDefinitions(UInt64.valueOf(slot)));
   }
 
   public SignedExecutionPayloadEnvelope randomSignedExecutionPayloadEnvelopeForBlock(
       final SignedBeaconBlock block) {
-    return getGloasSchemaDefinitions()
+    return getGloasSchemaDefinitions(block.getSlot())
         .getSignedExecutionPayloadEnvelopeSchema()
         .create(randomExecutionPayloadEnvelopeForBlock(block), randomSignature());
   }
 
   public ExecutionProof randomExecutionProof() {
     final SchemaDefinitionsElectra schemaDefinitionsElectra =
-        SchemaDefinitionsElectra.required(
-            spec.forMilestone(SpecMilestone.ELECTRA).getSchemaDefinitions());
+        getElectraSchemaDefinitions(randomSlot());
     final ExecutionProofSchema executionProofSchema =
         schemaDefinitionsElectra.getExecutionProofSchema();
     return executionProofSchema.create(
@@ -3483,16 +3478,12 @@ public final class DataStructureUtil {
   }
 
   public InclusionList randomInclusionList() {
-    final SchemaDefinitionsHeze schemaDefinitionsHeze =
-        SchemaDefinitionsHeze.required(
-            spec.forMilestone(SpecMilestone.HEZE).getSchemaDefinitions());
+    final UInt64 slot = randomSlot();
+    final SchemaDefinitionsHeze schemaDefinitionsHeze = getHezeSchemaDefinitions(slot);
     return schemaDefinitionsHeze
         .getInclusionListSchema()
         .create(
-            randomSlot(),
-            randomValidatorIndex(),
-            randomBytes32(),
-            randomExecutionPayloadTransactions());
+            slot, randomValidatorIndex(), randomBytes32(), randomExecutionPayloadTransactions());
   }
 
   private int randomInt(final int origin, final int bound) {
@@ -3527,9 +3518,12 @@ public final class DataStructureUtil {
     return SchemaDefinitionsFulu.required(spec.atSlot(slot).getSchemaDefinitions());
   }
 
-  private SchemaDefinitionsGloas getGloasSchemaDefinitions() {
-    return SchemaDefinitionsGloas.required(
-        spec.forMilestone(SpecMilestone.GLOAS).getSchemaDefinitions());
+  private SchemaDefinitionsGloas getGloasSchemaDefinitions(final UInt64 slot) {
+    return SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+  }
+
+  private SchemaDefinitionsHeze getHezeSchemaDefinitions(final UInt64 slot) {
+    return SchemaDefinitionsHeze.required(spec.atSlot(slot).getSchemaDefinitions());
   }
 
   int getEpochsPerEth1VotingPeriod() {

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.api.exceptions.RemoteServiceNotAvailableException;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
@@ -83,6 +84,11 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     final ProduceBlockRequest.ProduceBlockResponse blockResponse =
         new ProduceBlockRequest.ProduceBlockResponse(beaconBlock);
+
+    LOG.debug(
+        "Expected block in JSON: {}",
+        JsonUtil.serialize(
+            beaconBlock, schemaDefinitions.getBeaconBlockSchema().getJsonTypeDefinition()));
 
     final String mockResponse = readExpectedJsonResource(specMilestone, false, false);
 

--- a/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockGLOAS.json
+++ b/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockGLOAS.json
@@ -5,9 +5,9 @@
   "consensus_block_value": "123000000000",
   "data": {
     "slot": "1",
-    "proposer_index": "5073184892119317590",
-    "parent_root": "0xdbb36146f6c78513d4557fbee82d6490e87dcda8dcad4e354acf52f22ce2e4a2",
-    "state_root": "0x3b5944461642e26b9ea483970adaca91078dc8826c991ad82f55a4db6fc67958",
+    "proposer_index": "5101277123982816951",
+    "parent_root": "0x4afddc46d793346db6d7062f8cf4b4bd653ee2aee736f6ef8936c98442f0d941",
+    "state_root": "0x5d1ed74677df13b2ab1a6e5a607dc98a6b41e1409eff1eaab7b70c4d1c5191cc",
     "body": {
       "randao_reveal": "0x896972a61590fa3df074e8b86d9229c800e16b2c69c92b424c42947efb2c5c9badf3dea0289f088c86cf45ef8add162d1764bfe82b05fa69da6969f8a5ef4a5d70422b2d6568164b0f34de00e4592a05ab90c757c76b2edfc512fef7937c5a5a",
       "eth1_data": {
@@ -357,37 +357,27 @@
       },
       "payload_attestations": [
         {
-          "aggregation_bits": "0xaeb0",
+          "aggregation_bits": "0x8c8a",
           "data": {
-            "beacon_block_root": "0xdbabc5418e28d8265fe892d2129c8395d0dd064a0845545f3a3c532fa2eddf8c",
-            "slot": "16699259415",
+            "beacon_block_root": "0xb469d1414e91199d7562c47b6a8a5afbc3d708269bb302ebdf39cc9eed2b7177",
+            "slot": "17768459895",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0x98ffde69b4d92a4510b5d42ae9bcc05315ed0a20fab2ff6fc8e416678f150d7bfb961da6774e86213ee711a2b065c3d300a13fcf630d7f303c59d848ec47905d2b439e7bb4f3348b6ddc448aa00f7c6eb6f64513182a3d335e2753f66cbec83e"
+          "signature": "0xa29e82672b9b023ec4496bc5ba26cd0e12ae4e168591a2412dc2c62cfbf0466710810999921e34e7249e3a4700c837ec115bb6bee111a50c55a1af9d2f996bb6600a4767e23781cf4eb177845372b39df6156906f9e24c5b908920161a44d8fa"
         },
         {
-          "aggregation_bits": "0xba32",
+          "aggregation_bits": "0xb69a",
           "data": {
-            "beacon_block_root": "0x9ecb7542cf4bad14a20f79bc45931b8d1483242ea9bf8c8edd186ab70a94624b",
-            "slot": "11686939575",
+            "beacon_block_root": "0xea4f5e424f7a2a28771b166a93b66dc12d8f207683e22f77941d78d874174076",
+            "slot": "3106087671",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xb9014738ce2ebfe44a8255a53e34b604f223702435a966b81276bd7967cc1e172a4dbace09be70a1f73b300d83a7a8ec161cdc911b167a8a6489def11edca95a3587eab704e98325ce29eb4f86a477755421b480ca39020c82f07e4977d9e859"
+          "signature": "0xb875609f4aa01bb03c08b4f13459fa7696b969fc5e8440c89f690478820b8b5b4ad75e7fbf03c4b0e919cdc80b07857604bd81f75128f2bbc61861d0b5a7744e21eb4ad008f05b46be2c2780900a7913abc2cd3591390f29e05e2d5b2dba570b"
         },
         {
-          "aggregation_bits": "0x4c37",
-          "data": {
-            "beacon_block_root": "0x5d163b420f4066c536ad816e89ebe88f53a11ae2c99624d4a7240d8a925c8cb6",
-            "slot": "23308551639",
-            "payload_present": false,
-            "blob_data_available": false
-          },
-          "signature": "0x954da68af7adf486693e9213a63a082fcf1b1ed99c320314b73e64c322470329df27c891348c17b92dc7972dbc7d9b4215c7746c756c1aa2194c7217ab902459290981a0905683fa8563a2a7241f2bc3a3d6e4fca48d9fce1c6c322c4835dc1b"
-        },
-        {
-          "aggregation_bits": "0x18d1",
+          "aggregation_bits": "0xea64",
           "data": {
             "beacon_block_root": "0x83582f424fd7244f213350c530fd112a5fa71806352876480227941a471efbcb",
             "slot": "17944383863",
@@ -395,57 +385,67 @@
             "blob_data_available": false
           },
           "signature": "0xb710f44c80db8d91f996614df20b5e9293a578f28f55e4cd65f017063fa9e36eead8417ff871fda70f6f8238fa906376066788d928178215cf5b285a0630956453a2b53fd2ecdd614e247a7c89502de682385310134924ee896501d9a1a5265a"
+        },
+        {
+          "aggregation_bits": "0xfe04",
+          "data": {
+            "beacon_block_root": "0x7f8344414da8081272a9728d415e47355920f1d5b384d55e295620656640a278",
+            "slot": "4725799414",
+            "payload_present": false,
+            "blob_data_available": false
+          },
+          "signature": "0x893702a25c8f5517f07ae9287a034dc80db9ba5fbe230b86cfee1dee11daf16c3fb20fda7be4c5c74cae4d7db9a8fbb40c2a4aa47bbc7deac6fdb446328bc340840cc2cc3b4db057be94e494efc95ac1d30b31978a6fad2f54a03a9a79ecc03f"
         }
       ],
       "parent_execution_requests": {
         "deposits": [
           {
-            "pubkey": "0xaacb0e7f3717c59e23c32cb07ce03be33c2bb8366da2d27a9954b77f2c9198a1b5f3aea585faffcdfa4800b592c4d5d8",
-            "withdrawal_credentials": "0x0100000000000000000000007f8344414da8081272a9728d415e47355920f1d5",
-            "amount": "4701376009451598829",
-            "signature": "0xa9bf2689fe47ca9ac1fb90da3b08259115adab480b4f387669f209ee7747f7451af8f61e4a9c057bc33ffc18f0b08c3407be0a59b8c61c741572f5d28e2a1f6af0fc17db7c3f48901c9267606c3d7831a3d3647b885946fc95fb5689d24f7b8d",
-            "index": "4691461101561559469"
+            "pubkey": "0xb7fbe0486f002e790bb3d674b4259c18c6bf66510576e381e128aee6c2de771d3d5c9dda65b4078b058b2667f30e1637",
+            "withdrawal_credentials": "0x010000000000000000000000188c15414d0503391cc1ace8dfa4eb9d8b38e965",
+            "amount": "4688156139423158509",
+            "signature": "0xa01b45fff3e1e813ee035becd43cfde49bd8e12be359d4225ef26086b3467e633f66b93c5ea84934053fc9d54f29855d164e0c2ccc5ed1ebef93c6c0527b9948170a9a0f2e35c95e2c0d3606b5aa849f3177c0ecafbbbcdd73a2d674674d3033",
+            "index": "4731120720236815022"
           },
           {
-            "pubkey": "0xb8fa03e47468016f15b89212a91f203194684e0cbbac07b6cd428fc7e10cb7d8a363985b46972eedd7bc434fc701c4b3",
-            "withdrawal_credentials": "0x0100000000000000000000003ece09418d9cc1c206477b3f86b61438983ee789",
-            "amount": "4684851168694822957",
-            "signature": "0xa529495633ab9ab138c0756646074fc7753fafbb44389490ddd46048f29267f6b85e46abbc1fe71c42fc98513ed0f6f800ebc9eaa04b484e29af7d7bb0c38b5e088435aee8583a812545b3057c184a4634957604ec0647d1fa81da2d15a5f198",
-            "index": "4688156139423158509"
+            "pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
+            "withdrawal_credentials": "0x01000000000000000000000073b496418e85d24d0900cd2dafe227fe02f6fed9",
+            "amount": "4724510778780143918",
+            "signature": "0xb60a1e11b6a297fb8aa2b59483fba95f892c157444892bbc5f7c2cd0e0ac87e4fb732333cb46538b0169da9ea199f4eb127641ef2a11ad2ddde793cec87a2310473bdb4086726490ae3a73f58cd339ec5323ec1458b01f41fb226df46a20bf6a",
+            "index": "4727815749508479470"
           }
         ],
         "withdrawals": [
           {
-            "source_address": "0x01eeb941cebf96b04a6e6129b9adac2fdce3046e",
-            "validator_pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
-            "amount": "4726163266291795342"
+            "source_address": "0x9af68a41ce1c91d7f3859b8456f450980efcfcfd",
+            "validator_pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
+            "amount": "4712943396263355021"
           }
         ],
         "consolidations": [
           {
-            "source_address": "0x60939c41ee39f30814bd6502db591331fcf2ff47",
-            "source_pubkey": "0xa4a90125ab79fbbe706de307f1de84a6b0dc21adef413c6a5e91ab58e575164bd13c0517a318394a56adab9326607e82",
-            "target_pubkey": "0x83feea64397a7a9d3fbac0b9a16ccbfd63c4d4fa5d0fd8bbfa13739148e752ce1e9b1e01654b56cb56a196fd8d64db3f"
+            "source_address": "0xf99b6d41ed96ed2fbed49f5d78a0b7992e0bf8d7",
+            "source_pubkey": "0x80e72169819ea12b0aca8160fad8f1192e227806df31b13256cabf9c2dc9c598a3600a7f5f61a91c603e17d16381fb96",
+            "target_pubkey": "0x99b20a6a3e75af8e62e7f3f5143a149ab8e4ff041b0bf44e70174c19184e0ad2d612a3cd648ac30b428469bde0d1cea2"
           }
         ],
         "builder_deposits": [
           {
-            "pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
-            "withdrawal_credentials": "0x0cbd67418de2cc74b31707894c29cc66340ef7696dd0e001164f8bb348fb5538",
-            "amount": "4711290908751703597",
-            "signature": "0xa3943f03f5aff0a7df04a6b61b4415ee89f4a9fedb785b5c837cc9d26e180666c639fa40e278230ca8dd9cbaf6188370100f2812051f83d804c6dc7f8473620962a30344b3d53cbdb83bd6e85cc521f8b420596529a3f9451c6e8e3c2020c6fe"
+            "pubkey": "0xacd1d20f8f61838e5c6e66553615105252510977d06a323d98f6e6c160d253671cfdaed6749bf15db1b838d4c99d3e25",
+            "withdrawal_credentials": "0x02f65546365f449dbedb4d15903f8d2af483cbcc493fa0a9a6d1d982e0a353b8",
+            "amount": "5073184892119317590",
+            "signature": "0x86f4272ff604389cd7bb8e63b4379e6b57dc09d7d209dc3033c802eb2b143281ae6b8e8c0036ab78325df8c0af74df3d0537de897bfc4a127fea05f63ac012b19ba58ded843c8d3c8d30767e5f0e70a7cbc6da73c38cc758b2acb5d7da1bf1b7"
           },
           {
-            "pubkey": "0x85808a97e324987cd03bfc33e49aaa6cbc8a5cb66fb44111b0d8bc8c6b7c810638e6a6ac88d640b3492a684c19053f61",
-            "withdrawal_credentials": "0xa250734616e5e744f48c493c6d932629d574d0f2b953d406c14b88999cbfbe02",
-            "amount": "5074837375336001718",
-            "signature": "0x80f502e5703e37ce36fa24f0dd4f467d42aac01400d2d3cc9f11bc630ca5a2587e479de9c1e499ed489aadfba7362bee10127449182f438b820ee3018596ee2fca2e416a99567b961a1fdb3a9ef53a7f44897212ac566c039d215aac1bb8bebc"
+            "pubkey": "0xaa7d67cf12895fe67b0023fb9c2fb0b7a60bd3b9c90c01dd758002a19265cc9c2fa5338b6a59a5a0b648140752ddf8a0",
+            "withdrawal_credentials": "0x15175046d6aa23e2b31eb54063c8a1f7fa86ca5eff07c963d4521d4bbb040b43",
+            "amount": "5064922476035896950",
+            "signature": "0x908c76204e93cde92176902d2699c34b8374b54c6d1649a9fe75c592c128c4d0087a574342b6150aef7c414edfd39f9514973edf90c36395275e1914849ab9b12433b3a7d78050f57103d5d272f0adb2b3f633f369db96b299430a2d8c44b003"
           }
         ],
         "builder_exits": [
           {
-            "source_address": "0xefd45b4696136558c998e6e9bcb6785dee80cc3a",
-            "pubkey": "0x8b585aa726039b4472f9552d0c79479cb6adc817b80667143271f83ddea3228455397c6ac7e29e6fa703eb31e8674828"
+            "source_address": "0x74bc3246f624803a7d6db919857408f91a96c538",
+            "pubkey": "0xa3d1a6f01e1a2573d23e686a0d97f4b10c154729e8434317845668453903c604c9f3be8998291809cf344f0dd489f3b2"
           }
         ]
       }

--- a/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockHEZE.json
+++ b/validator/remote/src/integration-test/resources/responses/produce_block_responses/newBlockHEZE.json
@@ -5,9 +5,9 @@
   "consensus_block_value": "123000000000",
   "data": {
     "slot": "1",
-    "proposer_index": "5073184892119317590",
-    "parent_root": "0xdbb36146f6c78513d4557fbee82d6490e87dcda8dcad4e354acf52f22ce2e4a2",
-    "state_root": "0x3b5944461642e26b9ea483970adaca91078dc8826c991ad82f55a4db6fc67958",
+    "proposer_index": "5101277123982816951",
+    "parent_root": "0x4afddc46d793346db6d7062f8cf4b4bd653ee2aee736f6ef8936c98442f0d941",
+    "state_root": "0x5d1ed74677df13b2ab1a6e5a607dc98a6b41e1409eff1eaab7b70c4d1c5191cc",
     "body": {
       "randao_reveal": "0x896972a61590fa3df074e8b86d9229c800e16b2c69c92b424c42947efb2c5c9badf3dea0289f088c86cf45ef8add162d1764bfe82b05fa69da6969f8a5ef4a5d70422b2d6568164b0f34de00e4592a05ab90c757c76b2edfc512fef7937c5a5a",
       "eth1_data": {
@@ -357,37 +357,27 @@
       },
       "payload_attestations": [
         {
-          "aggregation_bits": "0xaeb0",
+          "aggregation_bits": "0x8c8a",
           "data": {
-            "beacon_block_root": "0xdbabc5418e28d8265fe892d2129c8395d0dd064a0845545f3a3c532fa2eddf8c",
-            "slot": "16699259415",
+            "beacon_block_root": "0xb469d1414e91199d7562c47b6a8a5afbc3d708269bb302ebdf39cc9eed2b7177",
+            "slot": "17768459895",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0x98ffde69b4d92a4510b5d42ae9bcc05315ed0a20fab2ff6fc8e416678f150d7bfb961da6774e86213ee711a2b065c3d300a13fcf630d7f303c59d848ec47905d2b439e7bb4f3348b6ddc448aa00f7c6eb6f64513182a3d335e2753f66cbec83e"
+          "signature": "0xa29e82672b9b023ec4496bc5ba26cd0e12ae4e168591a2412dc2c62cfbf0466710810999921e34e7249e3a4700c837ec115bb6bee111a50c55a1af9d2f996bb6600a4767e23781cf4eb177845372b39df6156906f9e24c5b908920161a44d8fa"
         },
         {
-          "aggregation_bits": "0xba32",
+          "aggregation_bits": "0xb69a",
           "data": {
-            "beacon_block_root": "0x9ecb7542cf4bad14a20f79bc45931b8d1483242ea9bf8c8edd186ab70a94624b",
-            "slot": "11686939575",
+            "beacon_block_root": "0xea4f5e424f7a2a28771b166a93b66dc12d8f207683e22f77941d78d874174076",
+            "slot": "3106087671",
             "payload_present": false,
             "blob_data_available": false
           },
-          "signature": "0xb9014738ce2ebfe44a8255a53e34b604f223702435a966b81276bd7967cc1e172a4dbace09be70a1f73b300d83a7a8ec161cdc911b167a8a6489def11edca95a3587eab704e98325ce29eb4f86a477755421b480ca39020c82f07e4977d9e859"
+          "signature": "0xb875609f4aa01bb03c08b4f13459fa7696b969fc5e8440c89f690478820b8b5b4ad75e7fbf03c4b0e919cdc80b07857604bd81f75128f2bbc61861d0b5a7744e21eb4ad008f05b46be2c2780900a7913abc2cd3591390f29e05e2d5b2dba570b"
         },
         {
-          "aggregation_bits": "0x4c37",
-          "data": {
-            "beacon_block_root": "0x5d163b420f4066c536ad816e89ebe88f53a11ae2c99624d4a7240d8a925c8cb6",
-            "slot": "23308551639",
-            "payload_present": false,
-            "blob_data_available": false
-          },
-          "signature": "0x954da68af7adf486693e9213a63a082fcf1b1ed99c320314b73e64c322470329df27c891348c17b92dc7972dbc7d9b4215c7746c756c1aa2194c7217ab902459290981a0905683fa8563a2a7241f2bc3a3d6e4fca48d9fce1c6c322c4835dc1b"
-        },
-        {
-          "aggregation_bits": "0x18d1",
+          "aggregation_bits": "0xea64",
           "data": {
             "beacon_block_root": "0x83582f424fd7244f213350c530fd112a5fa71806352876480227941a471efbcb",
             "slot": "17944383863",
@@ -395,57 +385,67 @@
             "blob_data_available": false
           },
           "signature": "0xb710f44c80db8d91f996614df20b5e9293a578f28f55e4cd65f017063fa9e36eead8417ff871fda70f6f8238fa906376066788d928178215cf5b285a0630956453a2b53fd2ecdd614e247a7c89502de682385310134924ee896501d9a1a5265a"
+        },
+        {
+          "aggregation_bits": "0xfe04",
+          "data": {
+            "beacon_block_root": "0x7f8344414da8081272a9728d415e47355920f1d5b384d55e295620656640a278",
+            "slot": "4725799414",
+            "payload_present": false,
+            "blob_data_available": false
+          },
+          "signature": "0x893702a25c8f5517f07ae9287a034dc80db9ba5fbe230b86cfee1dee11daf16c3fb20fda7be4c5c74cae4d7db9a8fbb40c2a4aa47bbc7deac6fdb446328bc340840cc2cc3b4db057be94e494efc95ac1d30b31978a6fad2f54a03a9a79ecc03f"
         }
       ],
       "parent_execution_requests": {
         "deposits": [
           {
-            "pubkey": "0xaacb0e7f3717c59e23c32cb07ce03be33c2bb8366da2d27a9954b77f2c9198a1b5f3aea585faffcdfa4800b592c4d5d8",
-            "withdrawal_credentials": "0x0100000000000000000000007f8344414da8081272a9728d415e47355920f1d5",
-            "amount": "4701376009451598829",
-            "signature": "0xa9bf2689fe47ca9ac1fb90da3b08259115adab480b4f387669f209ee7747f7451af8f61e4a9c057bc33ffc18f0b08c3407be0a59b8c61c741572f5d28e2a1f6af0fc17db7c3f48901c9267606c3d7831a3d3647b885946fc95fb5689d24f7b8d",
-            "index": "4691461101561559469"
+            "pubkey": "0xb7fbe0486f002e790bb3d674b4259c18c6bf66510576e381e128aee6c2de771d3d5c9dda65b4078b058b2667f30e1637",
+            "withdrawal_credentials": "0x010000000000000000000000188c15414d0503391cc1ace8dfa4eb9d8b38e965",
+            "amount": "4688156139423158509",
+            "signature": "0xa01b45fff3e1e813ee035becd43cfde49bd8e12be359d4225ef26086b3467e633f66b93c5ea84934053fc9d54f29855d164e0c2ccc5ed1ebef93c6c0527b9948170a9a0f2e35c95e2c0d3606b5aa849f3177c0ecafbbbcdd73a2d674674d3033",
+            "index": "4731120720236815022"
           },
           {
-            "pubkey": "0xb8fa03e47468016f15b89212a91f203194684e0cbbac07b6cd428fc7e10cb7d8a363985b46972eedd7bc434fc701c4b3",
-            "withdrawal_credentials": "0x0100000000000000000000003ece09418d9cc1c206477b3f86b61438983ee789",
-            "amount": "4684851168694822957",
-            "signature": "0xa529495633ab9ab138c0756646074fc7753fafbb44389490ddd46048f29267f6b85e46abbc1fe71c42fc98513ed0f6f800ebc9eaa04b484e29af7d7bb0c38b5e088435aee8583a812545b3057c184a4634957604ec0647d1fa81da2d15a5f198",
-            "index": "4688156139423158509"
+            "pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
+            "withdrawal_credentials": "0x01000000000000000000000073b496418e85d24d0900cd2dafe227fe02f6fed9",
+            "amount": "4724510778780143918",
+            "signature": "0xb60a1e11b6a297fb8aa2b59483fba95f892c157444892bbc5f7c2cd0e0ac87e4fb732333cb46538b0169da9ea199f4eb127641ef2a11ad2ddde793cec87a2310473bdb4086726490ae3a73f58cd339ec5323ec1458b01f41fb226df46a20bf6a",
+            "index": "4727815749508479470"
           }
         ],
         "withdrawals": [
           {
-            "source_address": "0x01eeb941cebf96b04a6e6129b9adac2fdce3046e",
-            "validator_pubkey": "0x97995c0a4cf28bb77bfea20753ecd1e3b3469492921c9542d99a1e81355f6d09ea4cbcb35e3b8f1240e8261d20da657b",
-            "amount": "4726163266291795342"
+            "source_address": "0x9af68a41ce1c91d7f3859b8456f450980efcfcfd",
+            "validator_pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
+            "amount": "4712943396263355021"
           }
         ],
         "consolidations": [
           {
-            "source_address": "0x60939c41ee39f30814bd6502db591331fcf2ff47",
-            "source_pubkey": "0xa4a90125ab79fbbe706de307f1de84a6b0dc21adef413c6a5e91ab58e575164bd13c0517a318394a56adab9326607e82",
-            "target_pubkey": "0x83feea64397a7a9d3fbac0b9a16ccbfd63c4d4fa5d0fd8bbfa13739148e752ce1e9b1e01654b56cb56a196fd8d64db3f"
+            "source_address": "0xf99b6d41ed96ed2fbed49f5d78a0b7992e0bf8d7",
+            "source_pubkey": "0x80e72169819ea12b0aca8160fad8f1192e227806df31b13256cabf9c2dc9c598a3600a7f5f61a91c603e17d16381fb96",
+            "target_pubkey": "0x99b20a6a3e75af8e62e7f3f5143a149ab8e4ff041b0bf44e70174c19184e0ad2d612a3cd648ac30b428469bde0d1cea2"
           }
         ],
         "builder_deposits": [
           {
-            "pubkey": "0xaafd198509805b36458bfa1c0202ea15976ab05f75100f8ed811fb700b4d657531e364c12a87d345f4799c43e2bb5ae6",
-            "withdrawal_credentials": "0x0cbd67418de2cc74b31707894c29cc66340ef7696dd0e001164f8bb348fb5538",
-            "amount": "4711290908751703597",
-            "signature": "0xa3943f03f5aff0a7df04a6b61b4415ee89f4a9fedb785b5c837cc9d26e180666c639fa40e278230ca8dd9cbaf6188370100f2812051f83d804c6dc7f8473620962a30344b3d53cbdb83bd6e85cc521f8b420596529a3f9451c6e8e3c2020c6fe"
+            "pubkey": "0xacd1d20f8f61838e5c6e66553615105252510977d06a323d98f6e6c160d253671cfdaed6749bf15db1b838d4c99d3e25",
+            "withdrawal_credentials": "0x02f65546365f449dbedb4d15903f8d2af483cbcc493fa0a9a6d1d982e0a353b8",
+            "amount": "5073184892119317590",
+            "signature": "0x86f4272ff604389cd7bb8e63b4379e6b57dc09d7d209dc3033c802eb2b143281ae6b8e8c0036ab78325df8c0af74df3d0537de897bfc4a127fea05f63ac012b19ba58ded843c8d3c8d30767e5f0e70a7cbc6da73c38cc758b2acb5d7da1bf1b7"
           },
           {
-            "pubkey": "0x85808a97e324987cd03bfc33e49aaa6cbc8a5cb66fb44111b0d8bc8c6b7c810638e6a6ac88d640b3492a684c19053f61",
-            "withdrawal_credentials": "0xa250734616e5e744f48c493c6d932629d574d0f2b953d406c14b88999cbfbe02",
-            "amount": "5074837375336001718",
-            "signature": "0x80f502e5703e37ce36fa24f0dd4f467d42aac01400d2d3cc9f11bc630ca5a2587e479de9c1e499ed489aadfba7362bee10127449182f438b820ee3018596ee2fca2e416a99567b961a1fdb3a9ef53a7f44897212ac566c039d215aac1bb8bebc"
+            "pubkey": "0xaa7d67cf12895fe67b0023fb9c2fb0b7a60bd3b9c90c01dd758002a19265cc9c2fa5338b6a59a5a0b648140752ddf8a0",
+            "withdrawal_credentials": "0x15175046d6aa23e2b31eb54063c8a1f7fa86ca5eff07c963d4521d4bbb040b43",
+            "amount": "5064922476035896950",
+            "signature": "0x908c76204e93cde92176902d2699c34b8374b54c6d1649a9fe75c592c128c4d0087a574342b6150aef7c414edfd39f9514973edf90c36395275e1914849ab9b12433b3a7d78050f57103d5d272f0adb2b3f633f369db96b299430a2d8c44b003"
           }
         ],
         "builder_exits": [
           {
-            "source_address": "0xefd45b4696136558c998e6e9bcb6785dee80cc3a",
-            "pubkey": "0x8b585aa726039b4472f9552d0c79479cb6adc817b80667143271f83ddea3228455397c6ac7e29e6fa703eb31e8674828"
+            "source_address": "0x74bc3246f624803a7d6db919857408f91a96c538",
+            "pubkey": "0xa3d1a6f01e1a2573d23e686a0d97f4b10c154729e8434317845668453903c604c9f3be8998291809cf344f0dd489f3b2"
           }
         ]
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
I think it's better to have the `ExecutionRequestsDataCodec` in SpecLogic rather than creating a new instance every time.

Also cleanup `DataStructureUtil` to have `getGloasSchemaDefinitions` pass the slot following the similar pattern we had before. This ensures any new extended containers in future forks won't be bound to Gloas schemas.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution-layer payload decoding for execution requests across engine API versions; wrong slot/schema pairing could mis-decode EL data, though behavior is largely a refactor to existing slot resolution.
> 
> **Overview**
> **Execution requests encoding/decoding** is centralized on slot-aware spec logic: `Spec.getExecutionRequestsDataCodec(slot)` and `SpecLogic.getExecutionRequestsDataCodec()` (Electra through Heze), with pre-Electra milestones returning empty. **Engine API** `engine_getPayload` handlers V4–V6 and related response helpers now decode execution requests through that codec instead of constructing `ExecutionRequestsDataCodec` from a fixed Electra milestone schema.
> 
> **`DataStructureUtil`** is aligned with slot-based schemas—`getGloasSchemaDefinitions` / Heze helpers take a slot and use `spec.atSlot(slot)` rather than pinning to the Gloas milestone—so random test data and codecs follow the fork active at the slot.
> 
> Tests and golden JSON fixtures were refreshed where deterministic generators and signing expectations shifted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9a6597d072079df86a3d88e57a7c3755b24543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->