### PR TITLE
Make reorderImports explicit to fix environmental issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -380,7 +380,7 @@ allprojects {
 			endWithNewline()
 			licenseHeaderFile "${rootDir}/gradle/spotless.java.license"
 			// See gradle.properties for exports/opens flags required by JDK 16 and Google Java Format plugin
-			googleJavaFormat('1.35.0')
+			googleJavaFormat('1.35.0').reorderImports(true)
 		}
 	}
 


### PR DESCRIPTION
**Summary**

Spotless `8.7.0` can produce different Java import-order results depending on the formatter/JDK environment. CI currently passes on Ubuntu with Temurin JDK 25, but local builds on Oracle JDK 25.0.3/macOS fail `spotlessJavaCheck` with import-order violations across existing files.

This PR makes the intended behavior explicit by enabling google-java-format import reordering:

```groovy
googleJavaFormat('1.35.0').reorderImports(true)
```

That is the minimal fix: it preserves the existing checked-in import style, avoids a large formatting-only rewrite, and keeps the Spotless `8.7.0` upgrade.

**Testing**

```bash
./gradlew :data:spotlessJavaCheck -q
./gradlew spotlessCheck -q
```

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tool formatting configuration only; no runtime or application logic changes.
> 
> **Overview**
> **Spotless Java** now calls `googleJavaFormat('1.35.0').reorderImports(true)` instead of `googleJavaFormat('1.35.0')` alone.
> 
> That makes import reordering explicit so `spotlessJavaCheck` behaves the same across JDK/vendor/OS after Spotless **8.7.0**, without rewriting existing files to a new import style. The existing `importOrder` rule for `tech.pegasys`, `net.consensys`, `java`, and static imports is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f43a8f509f28d29d54ac638e1f1a7b1faa58ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->