### PR TITLE
Fix BootnodeService package name

### DIFF
--- a/services/bootnode/src/main/java/tech/pegasys/teku/services/bootnode/BootnodeService.java
+++ b/services/bootnode/src/main/java/tech/pegasys/teku/services/bootnode/BootnodeService.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package teku.pegasys.teku.services.bootnode;
+package tech.pegasys.teku.services.bootnode;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/teku/src/main/java/tech/pegasys/teku/services/BootnodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BootnodeServiceController.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.services;
 
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
-import teku.pegasys.teku.services.bootnode.BootnodeService;
+import tech.pegasys.teku.services.bootnode.BootnodeService;
 
 public class BootnodeServiceController extends ServiceController {
 


### PR DESCRIPTION
Move `BootnodeService` from the incorrect `teku.pegasys.teku.services.bootnode` package to `tech.pegasys.teku.services.bootnode`, relocate the file to the matching source directory, and update its importer (`BootnodeServiceController`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Namespace/import-only fix with no behavioral changes to bootnode or discovery logic.
> 
> **Overview**
> Corrects a **package declaration mismatch** for `BootnodeService`: it was declared under `teku.pegasys.teku.services.bootnode` while living under the `tech.pegasys.teku` source tree.
> 
> The class is now in **`tech.pegasys.teku.services.bootnode`**, and **`BootnodeServiceController`** imports that package so bootnode wiring compiles and matches the rest of Teku’s module layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 512593196a078bb2aee72751acd931b9005aaf13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->