### PR TITLE
Enabled blobdb on new db only

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -424,35 +424,44 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   }
 
   /**
-   * Determines whether the RocksDB BlobDB feature should be used for static-data columns.
+   * Determines whether the RocksDB BlobDB feature should be used for static-data columns and
+   * persists that decision so it remains fixed for the lifetime of the database.
    *
-   * <p>BlobDB is an opt-in, sticky choice. By default static-data columns are persisted as SST. The
-   * first time a user enables {@code --Xdata-storage-rocksdb-blob-db-enabled}, the decision is
-   * recorded in {@code blob-db-mode.txt} and BlobDB is used from then on for the lifetime of the
-   * database, regardless of whether the flag is supplied on subsequent restarts.
+   * <p>BlobDB may only be enabled when creating a fresh database. An already populated database
+   * must keep persisting those columns as SST so the on-disk format never changes underneath it.
+   * Whether a real database already exists is determined by the presence of RocksDB's {@code
+   * CURRENT} file in the database directory rather than by side files such as {@code db.version},
+   * so that wiping the database directory (while leaving metadata behind) is correctly treated as a
+   * fresh start.
    *
    * <ul>
-   *   <li>A recorded mode is present: it is authoritative and the configured flag is ignored, so a
-   *       database never switches its on-disk format underneath the user.
-   *   <li>No recorded mode and the flag is enabled: the user is switching to BlobDB, so the
-   *       decision is recorded and BlobDB is used from now on.
-   *   <li>No recorded mode and the flag is disabled: static-data columns stay as SST and nothing is
-   *       recorded.
+   *   <li>Existing database with a recorded mode: the recorded value is authoritative (the mode was
+   *       fixed when the database was created) and the configured flag is ignored.
+   *   <li>Existing database without a recorded mode: it predates this tracking, so BlobDB stays
+   *       disabled (SST).
+   *   <li>Fresh database: the configured flag is honoured, replacing any stale recorded mode left
+   *       behind by a previous database in the same directory.
    * </ul>
    *
    * @return the effective BlobDB mode to apply
    */
   private boolean resolveAndPersistBlobDbMode() {
-    final Optional<Boolean> persistedMode = readBlobDbMode();
-    if (persistedMode.isPresent()) {
-      return persistedMode.get();
-    }
-    if (rocksdbBlobDbEnabled) {
-      saveBlobDbMode(true);
-      LOG.info("RocksDB BlobDB for static data columns has been enabled for this database");
-      return true;
-    }
-    return false;
+    final boolean databaseExists = rocksDbDataExists();
+    final boolean blobDbEnabled =
+        databaseExists ? readBlobDbMode().orElse(false) : rocksdbBlobDbEnabled;
+    saveBlobDbMode(blobDbEnabled);
+    LOG.info(
+        "RocksDB BlobDB for static data columns is {} for this database",
+        blobDbEnabled ? "enabled" : "disabled");
+    return blobDbEnabled;
+  }
+
+  /**
+   * @return whether the RocksDB database directory already contains a database, detected via the
+   *     presence of RocksDB's {@code CURRENT} pointer file
+   */
+  private boolean rocksDbDataExists() {
+    return dbDirectory.toPath().resolve("CURRENT").toFile().exists();
   }
 
   private Optional<Boolean> readBlobDbMode() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -457,11 +457,18 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   }
 
   /**
-   * @return whether the RocksDB database directory already contains a database, detected via the
-   *     presence of RocksDB's {@code CURRENT} pointer file
+   * @return whether a RocksDB database already exists, detected via the presence of RocksDB's
+   *     {@code CURRENT} pointer file. The archive directory is also checked so that V4/V5 databases
+   *     (which use a separate hot and archive RocksDB) are still treated as existing if only the
+   *     hot directory was wiped. For V6 the archive directory is never created, so that check is a
+   *     no-op.
    */
   private boolean rocksDbDataExists() {
-    return dbDirectory.toPath().resolve("CURRENT").toFile().exists();
+    return rocksDbDataExists(dbDirectory) || rocksDbDataExists(v5ArchiveDirectory);
+  }
+
+  private static boolean rocksDbDataExists(final File directory) {
+    return directory.toPath().resolve("CURRENT").toFile().exists();
   }
 
   private Optional<Boolean> readBlobDbMode() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -424,58 +424,62 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   }
 
   /**
-   * Determines whether the RocksDB BlobDB feature should be used for static-data columns and
-   * persists that decision so it remains fixed for the lifetime of the database.
+   * Determines whether the RocksDB BlobDB feature should be used for static-data columns.
    *
-   * <p>BlobDB may only be enabled when creating a fresh database. An already populated database
-   * must keep persisting those columns as SST so the on-disk format never changes underneath it.
-   * Whether a real database already exists is determined by the presence of RocksDB's {@code
-   * CURRENT} file in the database directory rather than by side files such as {@code db.version},
-   * so that wiping the database directory (while leaving metadata behind) is correctly treated as a
-   * fresh start.
+   * <p>BlobDB is an opt-in, sticky choice. By default static-data columns are persisted as SST. The
+   * first time a user enables {@code --Xdata-storage-rocksdb-blob-db-enabled}, the decision is
+   * recorded in {@code blob-db-mode.txt} and BlobDB is used from then on for the lifetime of the
+   * database, regardless of whether the flag is supplied on subsequent restarts.
    *
    * <ul>
-   *   <li>Existing database with a recorded mode: the recorded value is authoritative (the mode was
-   *       fixed when the database was created) and the configured flag is ignored.
-   *   <li>Existing database without a recorded mode: it predates this tracking, so BlobDB stays
-   *       disabled (SST).
-   *   <li>Fresh database: the configured flag is honoured, replacing any stale recorded mode left
-   *       behind by a previous database in the same directory.
+   *   <li>A recorded mode is present: it is authoritative and the configured flag is ignored, so a
+   *       database never switches its on-disk format underneath the user.
+   *   <li>No recorded mode and the flag is enabled: the user is switching to BlobDB, so the
+   *       decision is recorded and BlobDB is used from now on.
+   *   <li>No recorded mode and the flag is disabled: static-data columns stay as SST and nothing is
+   *       recorded.
    * </ul>
    *
    * @return the effective BlobDB mode to apply
    */
   private boolean resolveAndPersistBlobDbMode() {
-    final boolean databaseExists = rocksDbDataExists();
-    final boolean blobDbEnabled =
-        databaseExists ? readBlobDbMode().orElse(false) : rocksdbBlobDbEnabled;
-    saveBlobDbMode(blobDbEnabled);
-    LOG.info(
-        "RocksDB BlobDB for static data columns is {} for this database",
-        blobDbEnabled ? "enabled" : "disabled");
-    return blobDbEnabled;
-  }
-
-  /**
-   * @return whether the RocksDB database directory already contains a database, detected via the
-   *     presence of RocksDB's {@code CURRENT} pointer file
-   */
-  private boolean rocksDbDataExists() {
-    return dbDirectory.toPath().resolve("CURRENT").toFile().exists();
+    final Optional<Boolean> persistedMode = readBlobDbMode();
+    if (persistedMode.isPresent()) {
+      return persistedMode.get();
+    }
+    if (rocksdbBlobDbEnabled) {
+      saveBlobDbMode(true);
+      LOG.info("RocksDB BlobDB for static data columns has been enabled for this database");
+      return true;
+    }
+    return false;
   }
 
   private Optional<Boolean> readBlobDbMode() {
     try {
       return dbSettingFileSyncDataAccessor
           .read(dbBlobDbModeFile.toPath())
-          .map(
-              bytes ->
-                  Boolean.parseBoolean(
-                      new String(bytes.toArrayUnsafe(), StandardCharsets.UTF_8).trim()));
+          .map(bytes -> new String(bytes.toArrayUnsafe(), StandardCharsets.UTF_8).trim())
+          .map(this::parseBlobDbMode);
     } catch (final IOException e) {
       throw DatabaseStorageException.unrecoverable(
           "Failed to read blob db mode from file " + dbBlobDbModeFile.getAbsolutePath(), e);
     }
+  }
+
+  private boolean parseBlobDbMode(final String value) {
+    // This marker is authoritative for an existing database, so reject anything we didn't write
+    // rather than silently defaulting (which could flip an existing BlobDB database to SST).
+    if ("true".equals(value)) {
+      return true;
+    }
+    if ("false".equals(value)) {
+      return false;
+    }
+    throw DatabaseStorageException.unrecoverable(
+        String.format(
+            "Unrecognized blob db mode '%s' in file %s",
+            value, dbBlobDbModeFile.getAbsolutePath()));
   }
 
   private void saveBlobDbMode(final boolean blobDbEnabled) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -50,6 +50,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   public static final String DB_VERSION_FILENAME = "db.version";
 
   public static final String STORAGE_MODE_FILENAME = "data-storage-mode.txt";
+  public static final String BLOB_DB_MODE_FILENAME = "blob-db-mode.txt";
   public static final String METADATA_FILENAME = "metadata.yml";
   public static final String NETWORK_FILENAME = "network.yml";
 
@@ -61,6 +62,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   private final File v5ArchiveDirectory;
   private final File dbVersionFile;
   private final File dbStorageModeFile;
+  private final File dbBlobDbModeFile;
   private final StateStorageMode stateStorageMode;
   private final DatabaseVersion createDatabaseVersion;
   private final long stateStorageFrequency;
@@ -93,6 +95,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
     this.v5ArchiveDirectory = this.dataDirectory.toPath().resolve(ARCHIVE_PATH).toFile();
     this.dbVersionFile = this.dataDirectory.toPath().resolve(DB_VERSION_FILENAME).toFile();
     this.dbStorageModeFile = this.dataDirectory.toPath().resolve(STORAGE_MODE_FILENAME).toFile();
+    this.dbBlobDbModeFile = this.dataDirectory.toPath().resolve(BLOB_DB_MODE_FILENAME).toFile();
 
     dbSettingFileSyncDataAccessor = SyncDataAccessor.create(dataDirectory.toPath());
     this.stateStorageMode = config.getDataStorageMode();
@@ -188,6 +191,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   private Database createV4Database() {
     try {
+      final boolean blobDbEnabled = resolveAndPersistBlobDbMode();
       DatabaseNetwork.init(
           getNetworkFile(),
           spec.getGenesisSpecConfig().getGenesisForkVersion(),
@@ -196,10 +200,9 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           maybeNetwork);
       return RocksDbDatabaseFactory.createV4(
           metricsSystem,
-          KvStoreConfiguration.v4Settings(dbDirectory.toPath())
-              .withBlobDbEnabled(rocksdbBlobDbEnabled),
+          KvStoreConfiguration.v4Settings(dbDirectory.toPath()).withBlobDbEnabled(blobDbEnabled),
           KvStoreConfiguration.v4Settings(v5ArchiveDirectory.toPath())
-              .withBlobDbEnabled(rocksdbBlobDbEnabled),
+              .withBlobDbEnabled(blobDbEnabled),
           stateStorageMode,
           stateStorageFrequency,
           storeNonCanonicalBlocks,
@@ -216,6 +219,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
    */
   private Database createV5Database() {
     try {
+      final boolean blobDbEnabled = resolveAndPersistBlobDbMode();
       final V5DatabaseMetadata metaData =
           V5DatabaseMetadata.init(getMetadataFile(), V5DatabaseMetadata.v5Defaults());
       DatabaseNetwork.init(
@@ -229,11 +233,11 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           metaData
               .getHotDbConfiguration()
               .withDatabaseDir(dbDirectory.toPath())
-              .withBlobDbEnabled(rocksdbBlobDbEnabled),
+              .withBlobDbEnabled(blobDbEnabled),
           metaData
               .getArchiveDbConfiguration()
               .withDatabaseDir(v5ArchiveDirectory.toPath())
-              .withBlobDbEnabled(rocksdbBlobDbEnabled),
+              .withBlobDbEnabled(blobDbEnabled),
           stateStorageMode,
           stateStorageFrequency,
           storeNonCanonicalBlocks,
@@ -245,13 +249,13 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
 
   private Database createV6Database() {
     try {
-
+      final boolean blobDbEnabled = resolveAndPersistBlobDbMode();
       final KvStoreConfiguration dbConfiguration = initV6Configuration();
 
       final V6SchemaCombinedSnapshot schema = V6SchemaCombinedSnapshot.createV6(spec);
       return RocksDbDatabaseFactory.createV6(
           metricsSystem,
-          dbConfiguration.withDatabaseDir(dbDirectory.toPath()),
+          dbConfiguration.withDatabaseDir(dbDirectory.toPath()).withBlobDbEnabled(blobDbEnabled),
           schema,
           stateStorageMode,
           stateStorageFrequency,
@@ -333,10 +337,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
         spec.getGenesisSpecConfig().getDepositChainId(),
         maybeNetwork);
 
-    return metaData
-        .getSingleDbConfiguration()
-        .getConfiguration()
-        .withBlobDbEnabled(rocksdbBlobDbEnabled);
+    return metaData.getSingleDbConfiguration().getConfiguration();
   }
 
   private File getMetadataFile() {
@@ -419,6 +420,72 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       throw DatabaseStorageException.unrecoverable(
           "Failed to write database storage mode to file " + dbStorageModeFile.getAbsolutePath(),
           e);
+    }
+  }
+
+  /**
+   * Determines whether the RocksDB BlobDB feature should be used for static-data columns and
+   * persists that decision so it remains fixed for the lifetime of the database.
+   *
+   * <p>BlobDB may only be enabled when creating a fresh database. An already populated database
+   * must keep persisting those columns as SST so the on-disk format never changes underneath it.
+   * Whether a real database already exists is determined by the presence of RocksDB's {@code
+   * CURRENT} file in the database directory rather than by side files such as {@code db.version},
+   * so that wiping the database directory (while leaving metadata behind) is correctly treated as a
+   * fresh start.
+   *
+   * <ul>
+   *   <li>Existing database with a recorded mode: the recorded value is authoritative (the mode was
+   *       fixed when the database was created) and the configured flag is ignored.
+   *   <li>Existing database without a recorded mode: it predates this tracking, so BlobDB stays
+   *       disabled (SST).
+   *   <li>Fresh database: the configured flag is honoured, replacing any stale recorded mode left
+   *       behind by a previous database in the same directory.
+   * </ul>
+   *
+   * @return the effective BlobDB mode to apply
+   */
+  private boolean resolveAndPersistBlobDbMode() {
+    final boolean databaseExists = rocksDbDataExists();
+    final boolean blobDbEnabled =
+        databaseExists ? readBlobDbMode().orElse(false) : rocksdbBlobDbEnabled;
+    saveBlobDbMode(blobDbEnabled);
+    LOG.info(
+        "RocksDB BlobDB for static data columns is {} for this database",
+        blobDbEnabled ? "enabled" : "disabled");
+    return blobDbEnabled;
+  }
+
+  /**
+   * @return whether the RocksDB database directory already contains a database, detected via the
+   *     presence of RocksDB's {@code CURRENT} pointer file
+   */
+  private boolean rocksDbDataExists() {
+    return dbDirectory.toPath().resolve("CURRENT").toFile().exists();
+  }
+
+  private Optional<Boolean> readBlobDbMode() {
+    try {
+      return dbSettingFileSyncDataAccessor
+          .read(dbBlobDbModeFile.toPath())
+          .map(
+              bytes ->
+                  Boolean.parseBoolean(
+                      new String(bytes.toArrayUnsafe(), StandardCharsets.UTF_8).trim()));
+    } catch (final IOException e) {
+      throw DatabaseStorageException.unrecoverable(
+          "Failed to read blob db mode from file " + dbBlobDbModeFile.getAbsolutePath(), e);
+    }
+  }
+
+  private void saveBlobDbMode(final boolean blobDbEnabled) {
+    try {
+      dbSettingFileSyncDataAccessor.syncedWrite(
+          dbBlobDbModeFile.toPath(),
+          Bytes.of(Boolean.toString(blobDbEnabled).getBytes(StandardCharsets.UTF_8)));
+    } catch (final IOException e) {
+      throw DatabaseStorageException.unrecoverable(
+          "Failed to write blob db mode to file " + dbBlobDbModeFile.getAbsolutePath(), e);
     }
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -19,13 +19,10 @@ import static tech.pegasys.teku.storage.server.StateStorageMode.PRUNE;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Comparator;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -149,61 +146,47 @@ public class VersionedDatabaseFactoryTest {
   }
 
   @Test
-  public void createDatabase_freshDbWithBlobDbEnabled_persistsEnabledMode() throws Exception {
+  public void createDatabase_flagEnabled_enablesBlobDbAndRecordsIt() throws Exception {
     createAndCloseDatabase(blobDbFactory(true));
     assertBlobDbModeSaved(dataDir, true);
   }
 
   @Test
-  public void createDatabase_freshDbWithBlobDbDisabled_persistsDisabledMode() throws Exception {
+  public void createDatabase_flagDisabled_usesSstAndRecordsNothing() throws Exception {
     createAndCloseDatabase(blobDbFactory(false));
-    assertBlobDbModeSaved(dataDir, false);
+    assertBlobDbModeNotSaved(dataDir);
   }
 
   @Test
-  public void createDatabase_existingBlobDbDatabase_staysEnabledWhenFlagDisabled()
-      throws Exception {
+  public void createDatabase_blobDbMode_isStickyOnceEnabled() throws Exception {
     createAndCloseDatabase(blobDbFactory(true));
     assertBlobDbModeSaved(dataDir, true);
 
-    // Re-opening an existing BlobDB database must keep using BlobDB regardless of the flag.
+    // Once enabled, BlobDB stays enabled even when the flag is no longer supplied.
     createAndCloseDatabase(blobDbFactory(false));
     assertBlobDbModeSaved(dataDir, true);
   }
 
   @Test
-  public void createDatabase_existingSstDatabase_staysDisabledWhenFlagEnabled() throws Exception {
+  public void createDatabase_enablingFlag_switchesExistingSstDatabaseToBlobDb() throws Exception {
+    // A database that has only ever used SST records nothing.
     createAndCloseDatabase(blobDbFactory(false));
-    assertBlobDbModeSaved(dataDir, false);
+    assertBlobDbModeNotSaved(dataDir);
 
-    // Re-opening an existing SST database must keep using SST regardless of the flag.
-    createAndCloseDatabase(blobDbFactory(true));
-    assertBlobDbModeSaved(dataDir, false);
-  }
-
-  @Test
-  public void createDatabase_existingDatabaseWithoutModeFile_keepsSst() throws Exception {
-    // Simulate a database created before blob-db mode tracking existed: real data on disk but no
-    // recorded mode.
-    createAndCloseDatabase(blobDbFactory(true));
-    Files.delete(dataDir.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME));
-
-    createAndCloseDatabase(blobDbFactory(true));
-    assertBlobDbModeSaved(dataDir, false);
-  }
-
-  @Test
-  public void createDatabase_wipedDbDirectory_isTreatedAsFresh() throws Exception {
-    // A populated SST database, recorded as such.
-    createAndCloseDatabase(blobDbFactory(false));
-    assertBlobDbModeSaved(dataDir, false);
-
-    // The user wipes the db directory but leaves the side files (db.version, blob-db-mode.txt)
-    // behind. The recorded mode is now stale and must not govern the fresh database.
-    deleteRecursively(dataDir.resolve(VersionedDatabaseFactory.DB_PATH));
-
+    // The user opts into BlobDB: the decision is recorded and used from now on.
     createAndCloseDatabase(blobDbFactory(true));
     assertBlobDbModeSaved(dataDir, true);
+  }
+
+  @Test
+  public void createDatabase_corruptedModeFile_failsFast() throws Exception {
+    createAndCloseDatabase(blobDbFactory(true));
+    Files.writeString(
+        dataDir.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME), "not-a-boolean");
+
+    assertThatThrownBy(() -> createAndCloseDatabase(blobDbFactory(true)))
+        .isInstanceOf(DatabaseStorageException.class)
+        .hasMessageContaining("Unrecognized blob db mode");
   }
 
   private VersionedDatabaseFactory blobDbFactory(final boolean blobDbEnabled) {
@@ -221,23 +204,6 @@ public class VersionedDatabaseFactoryTest {
   private void createAndCloseDatabase(final DatabaseFactory dbFactory) throws Exception {
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
-    }
-  }
-
-  private static void deleteRecursively(final Path path) throws IOException {
-    if (!Files.exists(path)) {
-      return;
-    }
-    try (final Stream<Path> walk = Files.walk(path)) {
-      walk.sorted(Comparator.reverseOrder())
-          .forEach(
-              p -> {
-                try {
-                  Files.delete(p);
-                } catch (final IOException e) {
-                  throw new UncheckedIOException(e);
-                }
-              });
     }
   }
 
@@ -278,5 +244,10 @@ public class VersionedDatabaseFactoryTest {
     final String blobDbModeValue =
         Files.readString(dataDirectory.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME));
     assertThat(Boolean.parseBoolean(blobDbModeValue.trim())).isEqualTo(expectedBlobDbEnabled);
+  }
+
+  private void assertBlobDbModeNotSaved(final Path dataDirectory) {
+    assertThat(dataDirectory.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME))
+        .doesNotExist();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -217,13 +217,33 @@ public class VersionedDatabaseFactoryTest {
     assertBlobDbModeSaved(dataDir, true);
   }
 
+  @Test
+  public void createDatabase_v5WithOnlyHotDirectoryWiped_isTreatedAsExisting() throws Exception {
+    // V4/V5 use a separate hot and archive RocksDB. A populated SST database, recorded as such.
+    createAndCloseDatabase(blobDbFactory(false, DatabaseVersion.V5));
+    assertBlobDbModeSaved(dataDir, false);
+
+    // Only the hot db directory is wiped; the archive RocksDB still exists, so this is not a fresh
+    // database and BlobDB must not be enabled on the surviving SST archive.
+    deleteRecursively(dataDir.resolve(VersionedDatabaseFactory.DB_PATH));
+
+    createAndCloseDatabase(blobDbFactory(true, DatabaseVersion.V5));
+    assertBlobDbModeSaved(dataDir, false);
+  }
+
   private VersionedDatabaseFactory blobDbFactory(final boolean blobDbEnabled) {
+    return blobDbFactory(blobDbEnabled, DatabaseVersion.DEFAULT_VERSION);
+  }
+
+  private VersionedDatabaseFactory blobDbFactory(
+      final boolean blobDbEnabled, final DatabaseVersion createDbVersion) {
     return new VersionedDatabaseFactory(
         new StubMetricsSystem(),
         dataDir,
         StorageConfiguration.builder()
             .specProvider(spec)
             .eth1DepositContract(eth1Address)
+            .dataStorageCreateDbVersion(createDbVersion)
             .rocksdbBlobDbEnabled(blobDbEnabled)
             .build(),
         Optional.empty());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -19,10 +19,13 @@ import static tech.pegasys.teku.storage.server.StateStorageMode.PRUNE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -146,36 +149,47 @@ public class VersionedDatabaseFactoryTest {
   }
 
   @Test
-  public void createDatabase_flagEnabled_enablesBlobDbAndRecordsIt() throws Exception {
+  public void createDatabase_freshDbWithBlobDbEnabled_persistsEnabledMode() throws Exception {
     createAndCloseDatabase(blobDbFactory(true));
     assertBlobDbModeSaved(dataDir, true);
   }
 
   @Test
-  public void createDatabase_flagDisabled_usesSstAndRecordsNothing() throws Exception {
+  public void createDatabase_freshDbWithBlobDbDisabled_persistsDisabledMode() throws Exception {
     createAndCloseDatabase(blobDbFactory(false));
-    assertBlobDbModeNotSaved(dataDir);
+    assertBlobDbModeSaved(dataDir, false);
   }
 
   @Test
-  public void createDatabase_blobDbMode_isStickyOnceEnabled() throws Exception {
+  public void createDatabase_existingBlobDbDatabase_staysEnabledWhenFlagDisabled()
+      throws Exception {
     createAndCloseDatabase(blobDbFactory(true));
     assertBlobDbModeSaved(dataDir, true);
 
-    // Once enabled, BlobDB stays enabled even when the flag is no longer supplied.
+    // Re-opening an existing BlobDB database must keep using BlobDB regardless of the flag.
     createAndCloseDatabase(blobDbFactory(false));
     assertBlobDbModeSaved(dataDir, true);
   }
 
   @Test
-  public void createDatabase_enablingFlag_switchesExistingSstDatabaseToBlobDb() throws Exception {
-    // A database that has only ever used SST records nothing.
+  public void createDatabase_existingSstDatabase_staysDisabledWhenFlagEnabled() throws Exception {
     createAndCloseDatabase(blobDbFactory(false));
-    assertBlobDbModeNotSaved(dataDir);
+    assertBlobDbModeSaved(dataDir, false);
 
-    // The user opts into BlobDB: the decision is recorded and used from now on.
+    // Re-opening an existing SST database must keep using SST regardless of the flag.
     createAndCloseDatabase(blobDbFactory(true));
-    assertBlobDbModeSaved(dataDir, true);
+    assertBlobDbModeSaved(dataDir, false);
+  }
+
+  @Test
+  public void createDatabase_existingDatabaseWithoutModeFile_keepsSst() throws Exception {
+    // Simulate a database created before blob-db mode tracking existed: real data on disk but no
+    // recorded mode.
+    createAndCloseDatabase(blobDbFactory(true));
+    Files.delete(dataDir.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME));
+
+    createAndCloseDatabase(blobDbFactory(true));
+    assertBlobDbModeSaved(dataDir, false);
   }
 
   @Test
@@ -187,6 +201,20 @@ public class VersionedDatabaseFactoryTest {
     assertThatThrownBy(() -> createAndCloseDatabase(blobDbFactory(true)))
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("Unrecognized blob db mode");
+  }
+
+  @Test
+  public void createDatabase_wipedDbDirectory_isTreatedAsFresh() throws Exception {
+    // A populated SST database, recorded as such.
+    createAndCloseDatabase(blobDbFactory(false));
+    assertBlobDbModeSaved(dataDir, false);
+
+    // The user wipes the db directory but leaves the side files (db.version, blob-db-mode.txt)
+    // behind. The recorded mode is now stale and must not govern the fresh database.
+    deleteRecursively(dataDir.resolve(VersionedDatabaseFactory.DB_PATH));
+
+    createAndCloseDatabase(blobDbFactory(true));
+    assertBlobDbModeSaved(dataDir, true);
   }
 
   private VersionedDatabaseFactory blobDbFactory(final boolean blobDbEnabled) {
@@ -204,6 +232,23 @@ public class VersionedDatabaseFactoryTest {
   private void createAndCloseDatabase(final DatabaseFactory dbFactory) throws Exception {
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
+    }
+  }
+
+  private static void deleteRecursively(final Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (final Stream<Path> walk = Files.walk(path)) {
+      walk.sorted(Comparator.reverseOrder())
+          .forEach(
+              p -> {
+                try {
+                  Files.delete(p);
+                } catch (final IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              });
     }
   }
 
@@ -244,10 +289,5 @@ public class VersionedDatabaseFactoryTest {
     final String blobDbModeValue =
         Files.readString(dataDirectory.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME));
     assertThat(Boolean.parseBoolean(blobDbModeValue.trim())).isEqualTo(expectedBlobDbEnabled);
-  }
-
-  private void assertBlobDbModeNotSaved(final Path dataDirectory) {
-    assertThat(dataDirectory.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME))
-        .doesNotExist();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -19,10 +19,13 @@ import static tech.pegasys.teku.storage.server.StateStorageMode.PRUNE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -145,6 +148,99 @@ public class VersionedDatabaseFactoryTest {
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(version);
   }
 
+  @Test
+  public void createDatabase_freshDbWithBlobDbEnabled_persistsEnabledMode() throws Exception {
+    createAndCloseDatabase(blobDbFactory(true));
+    assertBlobDbModeSaved(dataDir, true);
+  }
+
+  @Test
+  public void createDatabase_freshDbWithBlobDbDisabled_persistsDisabledMode() throws Exception {
+    createAndCloseDatabase(blobDbFactory(false));
+    assertBlobDbModeSaved(dataDir, false);
+  }
+
+  @Test
+  public void createDatabase_existingBlobDbDatabase_staysEnabledWhenFlagDisabled()
+      throws Exception {
+    createAndCloseDatabase(blobDbFactory(true));
+    assertBlobDbModeSaved(dataDir, true);
+
+    // Re-opening an existing BlobDB database must keep using BlobDB regardless of the flag.
+    createAndCloseDatabase(blobDbFactory(false));
+    assertBlobDbModeSaved(dataDir, true);
+  }
+
+  @Test
+  public void createDatabase_existingSstDatabase_staysDisabledWhenFlagEnabled() throws Exception {
+    createAndCloseDatabase(blobDbFactory(false));
+    assertBlobDbModeSaved(dataDir, false);
+
+    // Re-opening an existing SST database must keep using SST regardless of the flag.
+    createAndCloseDatabase(blobDbFactory(true));
+    assertBlobDbModeSaved(dataDir, false);
+  }
+
+  @Test
+  public void createDatabase_existingDatabaseWithoutModeFile_keepsSst() throws Exception {
+    // Simulate a database created before blob-db mode tracking existed: real data on disk but no
+    // recorded mode.
+    createAndCloseDatabase(blobDbFactory(true));
+    Files.delete(dataDir.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME));
+
+    createAndCloseDatabase(blobDbFactory(true));
+    assertBlobDbModeSaved(dataDir, false);
+  }
+
+  @Test
+  public void createDatabase_wipedDbDirectory_isTreatedAsFresh() throws Exception {
+    // A populated SST database, recorded as such.
+    createAndCloseDatabase(blobDbFactory(false));
+    assertBlobDbModeSaved(dataDir, false);
+
+    // The user wipes the db directory but leaves the side files (db.version, blob-db-mode.txt)
+    // behind. The recorded mode is now stale and must not govern the fresh database.
+    deleteRecursively(dataDir.resolve(VersionedDatabaseFactory.DB_PATH));
+
+    createAndCloseDatabase(blobDbFactory(true));
+    assertBlobDbModeSaved(dataDir, true);
+  }
+
+  private VersionedDatabaseFactory blobDbFactory(final boolean blobDbEnabled) {
+    return new VersionedDatabaseFactory(
+        new StubMetricsSystem(),
+        dataDir,
+        StorageConfiguration.builder()
+            .specProvider(spec)
+            .eth1DepositContract(eth1Address)
+            .rocksdbBlobDbEnabled(blobDbEnabled)
+            .build(),
+        Optional.empty());
+  }
+
+  private void createAndCloseDatabase(final DatabaseFactory dbFactory) throws Exception {
+    try (final Database db = dbFactory.createDatabase()) {
+      assertThat(db).isNotNull();
+    }
+  }
+
+  private static void deleteRecursively(final Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (final Stream<Path> walk = Files.walk(path)) {
+      walk.sorted(Comparator.reverseOrder())
+          .forEach(
+              p -> {
+                try {
+                  Files.delete(p);
+                } catch (final IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              });
+    }
+  }
+
   private void createDbDirectory(final Path dataPath) {
     final File dbDirectory =
         Paths.get(dataPath.toAbsolutePath().toString(), VersionedDatabaseFactory.DB_PATH).toFile();
@@ -175,5 +271,12 @@ public class VersionedDatabaseFactoryTest {
     final String storageModeValue =
         Files.readString(dataDirectory.resolve(VersionedDatabaseFactory.STORAGE_MODE_FILENAME));
     assertThat(storageModeValue).isEqualTo(expectedStorageMode.toString());
+  }
+
+  private void assertBlobDbModeSaved(final Path dataDirectory, final boolean expectedBlobDbEnabled)
+      throws IOException {
+    final String blobDbModeValue =
+        Files.readString(dataDirectory.resolve(VersionedDatabaseFactory.BLOB_DB_MODE_FILENAME));
+    assertThat(Boolean.parseBoolean(blobDbModeValue.trim())).isEqualTo(expectedBlobDbEnabled);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR changes the behaviour of how we read the blobsdb-enabled flag, it adds a file in the database directory to identify when a database has started from sctrach using blobsdb, after analysis we found that blobdb can save ~5% of disk usage in a full custody node. 
If a database is using SST we will simply ignore the flag and keep using SST files only and no blobdb will be enabled as we found this could cause a bit of backlog to accrue due to SSTs taking a long time to get cleanup and compacted (in some extreme cases it looks like we don't even get to reclaim the disk back).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk storage layout policy for beacon chain data; mistakes could flip formats or mis-detect fresh vs existing DBs, though detection uses RocksDB CURRENT and tests cover edge cases.
> 
> **Overview**
> **RocksDB BlobDB** for static data columns is no longer driven by the runtime config flag on every open. The factory now resolves an effective mode via `resolveAndPersistBlobDbMode()`, writes it to **`blob-db-mode.txt`**, and applies that value when creating V4/V5/V6 databases.
> 
> **Fresh** databases (no RocksDB `CURRENT` in hot or archive dirs) honor `rocksdbBlobDbEnabled`, including when stale side files remain after wiping `db/`. **Existing** databases keep the recorded mode (or SST if the file is missing for legacy DBs); the CLI flag is ignored so SST stores are not switched to BlobDB mid-life. Invalid mode file contents fail fast instead of defaulting.
> 
> V6 metadata init no longer applies the blob flag there; blob mode is set only at database creation time. Unit tests cover persistence, re-open behavior, legacy DBs, corruption, wiped hot dir, and V5 archive-only survival.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a57c6c0af9bf919379df2bab0cbdced5de01c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->