### PR TITLE
Update Discord links to new server invite

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -14,6 +14,6 @@ Individual Contributor License Agreement.
 
 If you have any questions, you can reach us on [Discord].
 
-[Discord]: https://discord.gg/7hPv2T6
+[Discord]: https://discord.gg/teku
 [GitHub]: https://github.com/
 [the current version of the CLA]: https://gist.github.com/rojotek/978b48a5e8b68836856a8961d6887992

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Start by looking through the 'good first issue' and 'help wanted' issues:
 
 Please reach out in discord if you're looking to help out, and we can assist you in finding a good candidate ticket to work on, or discuss the idea you have. 
 
-We have a [Teku](https://discord.com/channels/697535391594446898/697539289042649190) channel, and also a [Teku Contributors](https://discord.com/channels/697535391594446898/1050616638497640548) channel.
+We have a [Teku](https://discord.gg/teku) channel, and also a [Teku Contributors](https://discord.gg/teku) channel.
 
 Due to the prevalence of 'airdrop farming' type practices, this unfortunately puts heightened scrutiny on first time contributors, but if you're genuinely looking to help out, we'd really love to assist you in any way we can.
 This does mean however that we will generally reject 'random' fixes such as 'TODO' fixes, typos, and generally things that add no value that we haven't identified as something we need. These are likely to be rejected with 'due to contribution guidelines' type responses.
@@ -141,5 +141,5 @@ We have a set of [coding conventions](https://wiki.hyperledger.org/display/BESU/
 * Reference issues and pull requests liberally
 
 [private-quorum@consensys.net]: mailto:private-quorum@consensys.net
-[Discord]: https://discord.gg/7hPv2T6
+[Discord]: https://discord.gg/teku
 [CLA.md]: CLA.md

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  [![GitHub License](https://img.shields.io/github/license/Consensys/teku.svg?logo=apache)](https://github.com/Consensys/teku/blob/master/LICENSE)
  [![Documentation](https://img.shields.io/badge/docs-readme-blue?logo=readme&logoColor=white)](https://docs.teku.consensys.io/)
  [![consensus-specs](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FConsensys%2Fteku%2Frefs%2Fheads%2Fmaster%2Fbuild.gradle&search=refTestVersion.*%22(v%5B%5E%22%5D%2B)%22&replace=%241&label=consensus-specs)](https://github.com/ethereum/consensus-specs/releases)
- [![Discord](https://img.shields.io/badge/Chat-on%20Discord-%235865F2?logo=discord&logoColor=white)](https://discord.gg/7hPv2T6)
+ [![Discord](https://img.shields.io/badge/Chat-on%20Discord-%235865F2?logo=discord&logoColor=white)](https://discord.gg/teku)
  [![Twitter Follow](https://img.shields.io/twitter/follow/Teku_Consensys)](https://twitter.com/Teku_Consensys)
  [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/ConsenSys/teku/badge)](https://www.gitpoap.io/gh/ConsenSys/teku)
 
@@ -26,7 +26,7 @@ See the [Changelog](https://github.com/Consensys/teku/releases) for details of t
 See our [user documentation](https://docs.teku.consensys.io/).
 
 Raise a [documentation issue](https://github.com/Consensys/doc.teku/issues) or get in touch in
-the #teku channel on [Discord](https://discord.gg/7hPv2T6) if you've got questions or feedback.
+the #teku channel on [Discord](https://discord.gg/teku) if you've got questions or feedback.
 
 ## Teku developers
 
@@ -47,7 +47,7 @@ the latest changes on testnets.
 Release notifications are available via:
 * Sign up to our [release announcements](https://pages.consensys.net/teku-sign-up) email list (release and important announcements only, no marketing)
 * Follow us on [Twitter](https://twitter.com/Teku_Consensys)
-* `teku` in [Consensys Discord](https://discord.gg/7hPv2T6),
+* `teku` in [Consensys Discord](https://discord.gg/teku),
 * Subscribe to release notifications on github for [teku](https://github.com/Consensys/teku)
 
 ## Build Instructions

--- a/community-membership.md
+++ b/community-membership.md
@@ -128,4 +128,4 @@ This document is adapted from the following sources:
 [contributor guide]: CONTRIBUTING.md
 [New contributors]: CONTRIBUTING.md
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
-[Teku Discord]: https://discord.gg/7hPv2T6
+[Teku Discord]: https://discord.gg/teku


### PR DESCRIPTION
Replace old Discord invite (`discord.gg/7hPv2T6`) and stale server channel deep-links with the new invite `https://discord.gg/teku`.

Files updated:
- `CLA.md`
- `CONTRIBUTING.md`
- `README.md`
- `community-membership.md`

Note: `CONTRIBUTING.md` previously had two old server channel deep-links ("Teku" and "Teku Contributors") that are dead with the new server — both now point to the new invite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL updates with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates community documentation so every Discord entry point uses the new invite **`https://discord.gg/teku`** instead of the retired **`discord.gg/7hPv2T6`** invite.
> 
> In **`CONTRIBUTING.md`**, the separate Teku and Teku Contributors **server channel deep-links** are both replaced with the new invite, since those old channel URLs no longer work on the new server. The same invite URL is applied in **`CLA.md`**, **`README.md`** (badge, user support text, and release notifications), and **`community-membership.md`** (member requirement link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8234f37201c2eb0dc00c7d2fd5cd1a2bd348a78c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->