### PR TITLE
Updated port flags to be not hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added some extra fields to the peers output for beacon-apis #606. Consumers of the peers endpoint should be aware of this new optional data.
 - QUIC enabled by default (uses UDP port 9001 by default)
 - New Engine API client with better performance enabled by default
+- Quic port command arguments `p2p-quic-port` (default 9001) and `p2p-quic-port-ipv6` (default 9091) were unhidden. Users will need to update firewall rules to allow incoming connections for QUIC (UDP).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - QUIC enabled by default (uses UDP port 9001 by default)
 - New Engine API client with better performance enabled by default
 - Quic port command arguments `p2p-quic-port` (default 9001) and `p2p-quic-port-ipv6` (default 9091) were unhidden. Users will need to update firewall rules to allow incoming connections for QUIC (UDP).
-- Quick advertised-port command arguments `p2p-advertised-quic-port` and `p2p-advertised-quic-port-ipv6` have been unhidden.
+- Quic advertised-port command arguments `p2p-advertised-quic-port` and `p2p-advertised-quic-port-ipv6` have been unhidden.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - QUIC enabled by default (uses UDP port 9001 by default)
 - New Engine API client with better performance enabled by default
 - Quic port command arguments `p2p-quic-port` (default 9001) and `p2p-quic-port-ipv6` (default 9091) were unhidden. Users will need to update firewall rules to allow incoming connections for QUIC (UDP).
+- Quick advertised-port command arguments `p2p-advertised-quic-port` and `p2p-advertised-quic-port-ipv6` have been unhidden.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 - Added some extra fields to the peers output for beacon-apis #606. Consumers of the peers endpoint should be aware of this new optional data.
 - QUIC enabled by default (uses UDP port 9001 by default)
 - New Engine API client with better performance enabled by default
-- Quic port command arguments `p2p-quic-port` (default 9001) and `p2p-quic-port-ipv6` (default 9091) were unhidden. Users will need to update firewall rules to allow incoming connections for QUIC (UDP).
-- Quic advertised-port command arguments `p2p-advertised-quic-port` and `p2p-advertised-quic-port-ipv6` have been unhidden.
+- QUIC port command arguments `p2p-quic-port` (default 9001) and `p2p-quic-port-ipv6` (default 9091) were unhidden. Users will need to update firewall rules to allow incoming connections for QUIC (UDP).
+- QUIC advertised-port command arguments `p2p-advertised-quic-port` and `p2p-advertised-quic-port-ipv6` have been unhidden.
 
 ### Bug Fixes
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -344,7 +344,7 @@ public class TekuNodeConfigBuilder {
     configMap.put("p2p-enabled", true);
     configMap.put("p2p-discovery-enabled", true);
     configMap.put("p2p-port", P2P_PORT);
-    configMap.put("Xp2p-quic-port", P2P_PORT + 1);
+    configMap.put("p2p-quic-port", P2P_PORT + 1);
     configMap.put("p2p-advertised-port", P2P_PORT);
     configMap.put("p2p-interface", "0.0.0.0");
     configMap.put("p2p-private-key-file", PRIVATE_KEY_FILE_PATH);

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -403,13 +403,13 @@ public class NetworkConfig {
     }
 
     public Builder listenQuicPort(final int listenQuicPort) {
-      validatePort(listenQuicPort, "--Xp2p-quic-port");
+      validatePort(listenQuicPort, "--p2p-quic-port");
       this.listenQuicPort = listenQuicPort;
       return this;
     }
 
     public Builder listenQuicPortIpv6(final int listenQuicPortIpv6) {
-      validatePort(listenQuicPortIpv6, "--Xp2p-quic-port-ipv6");
+      validatePort(listenQuicPortIpv6, "--p2p-quic-port-ipv6");
       this.listenQuicPortIpv6 = listenQuicPortIpv6;
       return this;
     }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -430,7 +430,7 @@ public class NetworkConfig {
 
     public Builder advertisedQuicPort(final OptionalInt advertisedQuicPort) {
       checkNotNull(advertisedQuicPort);
-      advertisedQuicPort.ifPresent(port -> validatePort(port, "--Xp2p-advertised-quic-port"));
+      advertisedQuicPort.ifPresent(port -> validatePort(port, "--p2p-advertised-quic-port"));
       this.advertisedQuicPort = advertisedQuicPort;
       return this;
     }
@@ -438,7 +438,7 @@ public class NetworkConfig {
     public Builder advertisedQuicPortIpv6(final OptionalInt advertisedQuicPortIpv6) {
       checkNotNull(advertisedQuicPortIpv6);
       advertisedQuicPortIpv6.ifPresent(
-          port -> validatePort(port, "--Xp2p-advertised-quic-port-ipv6"));
+          port -> validatePort(port, "--p2p-advertised-quic-port-ipv6"));
       this.advertisedQuicPortIpv6 = advertisedQuicPortIpv6;
       return this;
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -182,6 +182,7 @@ public class P2POptions {
       arity = "1")
   private Integer p2pAdvertisedPortIpv6;
 
+
   @Option(
       names = {"--p2p-advertised-udp-port"},
       paramLabel = "<INTEGER>",
@@ -201,22 +202,20 @@ public class P2POptions {
   private Integer p2pAdvertisedUdpPortIpv6;
 
   @Option(
-      names = {"--Xp2p-advertised-quic-port"},
+      names = {"--p2p-advertised-quic-port"},
       paramLabel = "<INTEGER>",
       description =
           "P2P advertised QUIC port. The default is the port specified in --p2p-quic-port",
-      hidden = true,
       arity = "1")
   private Integer p2pAdvertisedQuicPort;
 
   @Option(
-      names = {"--Xp2p-advertised-quic-port-ipv6"},
+      names = {"--p2p-advertised-quic-port-ipv6"},
       paramLabel = "<INTEGER>",
       description =
           """
                       P2P advertised IPv6 QUIC port. This port is only used when advertising both IPv4 and IPv6 addresses.
                       The default is the port specified in --p2p-quic-port-ipv6.""",
-      hidden = true,
       arity = "1")
   private Integer p2pAdvertisedQuicPortIpv6;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -116,19 +116,17 @@ public class P2POptions {
   private boolean p2pTcpEnabled = NetworkConfig.DEFAULT_TCP_ENABLED;
 
   @Option(
-      names = {"--Xp2p-quic-port"},
+      names = {"--p2p-quic-port"},
       paramLabel = "<INTEGER>",
       description = "P2P QUIC port",
-      hidden = true,
       arity = "1")
   private Integer p2pQuicPort = NetworkConfig.DEFAULT_P2P_QUIC_PORT;
 
   @Option(
-      names = {"--Xp2p-quic-port-ipv6"},
+      names = {"--p2p-quic-port-ipv6"},
       paramLabel = "<INTEGER>",
       description =
           "P2P IPv6 QUIC port. This port is only used when listening over both IPv4 and IPv6.",
-      hidden = true,
       arity = "1")
   private int p2pQuicPortIpv6 = NetworkConfig.DEFAULT_P2P_QUIC_PORT_IPV6;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -182,7 +182,6 @@ public class P2POptions {
       arity = "1")
   private Integer p2pAdvertisedPortIpv6;
 
-
   @Option(
       names = {"--p2p-advertised-udp-port"},
       paramLabel = "<INTEGER>",


### PR DESCRIPTION
 - p2p-quic-port
 - p2p-quic-port-ipv6

 Added a brief changelog notice about firewall rules needing to be added, so that hopefully we remember during the release process.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI naming and visibility only; defaults and wiring are unchanged aside from fixing the acceptance test config key.
> 
> **Overview**
> **Promotes QUIC listen and advertised port options** from hidden experimental flags (`--Xp2p-quic-port*`) to supported CLI options (`--p2p-quic-port`, `--p2p-quic-port-ipv6`, `--p2p-advertised-quic-port`, `--p2p-advertised-quic-port-ipv6`). Help text and `NetworkConfig` port validation now reference the public flag names.
> 
> The acceptance bootnode fixture is updated to use the correct `p2p-quic-port` config key (fixing a typo). **CHANGELOG** notes that operators should open **UDP** firewall rules for QUIC now that these ports are documented defaults (9001 / 9091 IPv6).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba6a61953b6591f67380fe2d9e60d6e21cf6e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->