### PR TITLE
disable blocks circuit breaker post gloas

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImpl.java
@@ -16,14 +16,11 @@ package tech.pegasys.teku.ethereum.executionlayer;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.HashSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.util.BuilderCircuitBreakerUtil;
 
 public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
   private static final Logger LOG = LogManager.getLogger();
@@ -49,22 +46,23 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
   @Override
   public boolean isEngaged(final BeaconState state) {
 
-    final InspectionWindowCounters inspectionWindowCounters = getInspectionWindowCounters(state);
-    if (inspectionWindowCounters.uniqueBlockRootsCount < minimumUniqueBlockRootsInWindow) {
+    final BuilderCircuitBreakerUtil.InspectionWindowCounters inspectionWindowCounters =
+        getInspectionWindowCounters(state);
+    if (inspectionWindowCounters.uniqueBlockRootsCount() < minimumUniqueBlockRootsInWindow) {
       LOG.debug(
           "Builder circuit breaker engaged: slot: {}, uniqueBlockRootsCount: {}, window: {},  minimumUniqueBlockRootsInWindow: {}",
           state.getSlot(),
-          inspectionWindowCounters.uniqueBlockRootsCount,
+          inspectionWindowCounters.uniqueBlockRootsCount(),
           faultInspectionWindow,
           minimumUniqueBlockRootsInWindow);
       return true;
     }
 
-    if (inspectionWindowCounters.lastConsecutiveEmptySlots > consecutiveAllowedFaults) {
+    if (inspectionWindowCounters.lastConsecutiveEmptySlots() > consecutiveAllowedFaults) {
       LOG.debug(
           "Builder circuit breaker engaged: slot: {}, lastConsecutiveEmptySlots: {}, window: {},  consecutiveAllowedFaults: {}",
           state.getSlot(),
-          inspectionWindowCounters.lastConsecutiveEmptySlots,
+          inspectionWindowCounters.lastConsecutiveEmptySlots(),
           faultInspectionWindow,
           consecutiveAllowedFaults);
       return true;
@@ -76,60 +74,11 @@ public class BuilderCircuitBreakerImpl implements BuilderCircuitBreaker {
   }
 
   @VisibleForTesting
-  InspectionWindowCounters getInspectionWindowCounters(final BeaconState state)
-      throws IllegalArgumentException {
+  BuilderCircuitBreakerUtil.InspectionWindowCounters getInspectionWindowCounters(
+      final BeaconState state) throws IllegalArgumentException {
     final int slotsPerHistoricalRoot =
         spec.atSlot(state.getSlot()).getConfig().getSlotsPerHistoricalRoot();
-    checkArgument(
-        faultInspectionWindow <= slotsPerHistoricalRoot,
-        "faultInspectionWindow (%s) cannot exceed slotsPerHistoricalRoot config (%s)",
-        faultInspectionWindow,
-        slotsPerHistoricalRoot);
-
-    final HashSet<Bytes32> uniqueBlockRoots = new HashSet<>();
-    final SszBytes32Vector blockRoots = state.getBlockRoots();
-
-    // state slot is the slot we are building for
-    // thus our fault window will be (inclusive)
-    // FROM (state_slot-1)-(faultInspectionWindow-1) TO state_slot-1
-
-    // of which:
-    // state_slot-1 -> will be represented by getLatestBlockHeader
-    // FROM (state_slot-1)-(faultInspectionWindow-1) TO state_slot-2 -> to be found in blockRoots
-
-    // (state_slot-1)-(faultInspectionWindow-1) = state_slot-faultInspectionWindow
-    final UInt64 firstSlotOfInspectionWindow = state.getSlot().minusMinZero(faultInspectionWindow);
-    final UInt64 lastSlotOfInspectionWindow = state.getSlot().minusMinZero(1);
-
-    int lastConsecutiveEmptySlots =
-        lastSlotOfInspectionWindow.minus(state.getLatestBlockHeader().getSlot()).intValue();
-
-    if (lastConsecutiveEmptySlots >= faultInspectionWindow) {
-      return new InspectionWindowCounters(0, lastConsecutiveEmptySlots);
-    }
-
-    // we can consider getLatestBlockHeader root because at this stage has been already updated with
-    // state root
-    uniqueBlockRoots.add(state.getLatestBlockHeader().getRoot());
-
-    UInt64 currentSlot = firstSlotOfInspectionWindow;
-    while (currentSlot.isLessThan(lastSlotOfInspectionWindow)) {
-      final int currentBlockRootIndex = currentSlot.mod(slotsPerHistoricalRoot).intValue();
-      uniqueBlockRoots.add(blockRoots.getElement(currentBlockRootIndex));
-      currentSlot = currentSlot.increment();
-    }
-
-    return new InspectionWindowCounters(uniqueBlockRoots.size(), lastConsecutiveEmptySlots);
-  }
-
-  protected static class InspectionWindowCounters {
-    final int uniqueBlockRootsCount;
-    final int lastConsecutiveEmptySlots;
-
-    private InspectionWindowCounters(
-        final int uniqueBlockRootsCount, final int lastConsecutiveEmptySlots) {
-      this.uniqueBlockRootsCount = uniqueBlockRootsCount;
-      this.lastConsecutiveEmptySlots = lastConsecutiveEmptySlots;
-    }
+    return spec.getBuilderCircuitBreakerUtil(state.getSlot())
+        .getInspectionWindowCounters(state, faultInspectionWindow, slotsPerHistoricalRoot);
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderCircuitBreakerImplTest.java
@@ -14,13 +14,24 @@
 package tech.pegasys.teku.ethereum.executionlayer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.SpecMilestone.ALTAIR;
+import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
+import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
+import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
+import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.FULU;
+import static tech.pegasys.teku.spec.SpecMilestone.PHASE0;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
@@ -177,6 +188,36 @@ public class BuilderCircuitBreakerImplTest {
     assertCounters(state, 0, 10);
   }
 
+  @Nested
+  @TestSpecContext(
+      allMilestones = true,
+      ignoredMilestones = {PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA, FULU},
+      signatureVerifierNoop = true)
+  class PostGloasBuilderCircuitBreakerTest {
+    @TestTemplate
+    void shouldNotEngage(final SpecContext specContext)
+        throws SlotProcessingException, EpochProcessingException {
+      assertCircuitBreakerDoesNotEngage(specContext.getSpec());
+    }
+  }
+
+  private void assertCircuitBreakerDoesNotEngage(final Spec spec)
+      throws SlotProcessingException, EpochProcessingException {
+    final UInt64 blockBuildingSlot = UInt64.valueOf(69);
+    final ChainBuilder chainBuilder = ChainBuilder.create(spec);
+    final BuilderCircuitBreakerImpl builderCircuitBreaker =
+        new BuilderCircuitBreakerImpl(
+            spec, INSPECTION_WINDOW, ALLOWED_FAULTS, ALLOWED_CONSECUTIVE_FAULTS);
+
+    chainBuilder.generateGenesis();
+    chainBuilder.generateBlocksUpToSlot(58);
+
+    final BeaconState state =
+        spec.processSlots(chainBuilder.getLatestBlockAndState().getState(), blockBuildingSlot);
+
+    assertThat(builderCircuitBreaker.isEngaged(state)).isFalse();
+  }
+
   private BeaconState advance(final long toSlot, final boolean missing) {
     if (missing) {
       chainBuilder.generateBlockAtSlot(toSlot);
@@ -192,10 +233,10 @@ public class BuilderCircuitBreakerImplTest {
       final int lastConsecutiveIdenticalBlockRoots) {
     assertThat(builderCircuitBreaker.getInspectionWindowCounters(state))
         .matches(
-            counters -> counters.uniqueBlockRootsCount == uniqueBlockRootsCount,
+            counters -> counters.uniqueBlockRootsCount() == uniqueBlockRootsCount,
             "uniqueBlockRootsCount must match")
         .matches(
-            counters -> counters.lastConsecutiveEmptySlots == lastConsecutiveIdenticalBlockRoots,
+            counters -> counters.lastConsecutiveEmptySlots() == lastConsecutiveIdenticalBlockRoots,
             "lastConsecutiveIdenticalBlockRoots must match");
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -120,6 +120,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProces
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.BuilderCircuitBreakerUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil.ExecutionPayloadProposalData;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
@@ -1220,6 +1221,10 @@ public class Spec {
         .getDataColumnSidecarUtil()
         .orElseThrow(
             () -> new IllegalStateException("DataColumnSidecarUtil not available at slot " + slot));
+  }
+
+  public BuilderCircuitBreakerUtil getBuilderCircuitBreakerUtil(final UInt64 slot) {
+    return atSlot(slot).getBuilderCircuitBreakerUtil();
   }
 
   // Proposer Preferences Util

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.BuilderCircuitBreakerUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
@@ -92,6 +93,11 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public BlockProposalUtil getBlockProposalUtil() {
     return specLogic.getBlockProposalUtil();
+  }
+
+  @Override
+  public BuilderCircuitBreakerUtil getBuilderCircuitBreakerUtil() {
+    return specLogic.getBuilderCircuitBreakerUtil();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.BuilderCircuitBreakerUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
@@ -60,6 +61,8 @@ public interface SpecLogic {
   ForkChoiceUtil getForkChoiceUtil();
 
   BlockProposalUtil getBlockProposalUtil();
+
+  BuilderCircuitBreakerUtil getBuilderCircuitBreakerUtil();
 
   Optional<BlindBlockUtil> getBlindBlockUtil();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/AbstractSpecLogic.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.BuilderCircuitBreakerUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.ProposerPreferencesUtil;
@@ -55,6 +56,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   protected final BlockProcessor blockProcessor;
   protected final ForkChoiceUtil forkChoiceUtil;
   protected final BlockProposalUtil blockProposalUtil;
+  protected final BuilderCircuitBreakerUtil builderCircuitBreakerUtil;
   protected final Optional<BlindBlockUtil> blockConversionUtil;
 
   // State upgrade
@@ -92,6 +94,7 @@ public abstract class AbstractSpecLogic implements SpecLogic {
     this.blockProcessor = blockProcessor;
     this.forkChoiceUtil = forkChoiceUtil;
     this.blockProposalUtil = blockProposalUtil;
+    this.builderCircuitBreakerUtil = BuilderCircuitBreakerUtil.BLOCK_ROOT;
     this.blockConversionUtil = blockConversionUtil;
     this.operationValidator = operationValidator;
     this.stateUpgrade = stateUpgrade;
@@ -140,6 +143,11 @@ public abstract class AbstractSpecLogic implements SpecLogic {
   @Override
   public BlockProposalUtil getBlockProposalUtil() {
     return blockProposalUtil;
+  }
+
+  @Override
+  public BuilderCircuitBreakerUtil getBuilderCircuitBreakerUtil() {
+    return builderCircuitBreakerUtil;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BuilderCircuitBreakerUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BuilderCircuitBreakerUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.HashSet;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public abstract class BuilderCircuitBreakerUtil {
+  public static final BuilderCircuitBreakerUtil BLOCK_ROOT =
+      new BlockRootBuilderCircuitBreakerUtil();
+
+  public static final BuilderCircuitBreakerUtil NOOP =
+      new BuilderCircuitBreakerUtil() {
+        @Override
+        public InspectionWindowCounters getInspectionWindowCounters(
+            final BeaconState state,
+            final int faultInspectionWindow,
+            final int slotsPerHistoricalRoot) {
+          return new InspectionWindowCounters(Integer.MAX_VALUE, 0);
+        }
+      };
+
+  public abstract InspectionWindowCounters getInspectionWindowCounters(
+      BeaconState state, int faultInspectionWindow, int slotsPerHistoricalRoot);
+
+  public record InspectionWindowCounters(
+      int uniqueBlockRootsCount, int lastConsecutiveEmptySlots) {}
+
+  private static class BlockRootBuilderCircuitBreakerUtil extends BuilderCircuitBreakerUtil {
+    @Override
+    public InspectionWindowCounters getInspectionWindowCounters(
+        final BeaconState state,
+        final int faultInspectionWindow,
+        final int slotsPerHistoricalRoot) {
+      checkArgument(
+          faultInspectionWindow <= slotsPerHistoricalRoot,
+          "faultInspectionWindow (%s) cannot exceed slotsPerHistoricalRoot config (%s)",
+          faultInspectionWindow,
+          slotsPerHistoricalRoot);
+
+      final HashSet<Bytes32> uniqueBlockRoots = new HashSet<>();
+      final SszBytes32Vector blockRoots = state.getBlockRoots();
+      final UInt64 firstSlotOfInspectionWindow =
+          state.getSlot().minusMinZero(faultInspectionWindow);
+      final UInt64 lastSlotOfInspectionWindow = state.getSlot().minusMinZero(1);
+
+      final int lastConsecutiveEmptySlots =
+          lastSlotOfInspectionWindow.minus(state.getLatestBlockHeader().getSlot()).intValue();
+
+      if (lastConsecutiveEmptySlots >= faultInspectionWindow) {
+        return new InspectionWindowCounters(0, lastConsecutiveEmptySlots);
+      }
+
+      uniqueBlockRoots.add(state.getLatestBlockHeader().getRoot());
+
+      UInt64 currentSlot = firstSlotOfInspectionWindow;
+      while (currentSlot.isLessThan(lastSlotOfInspectionWindow)) {
+        final int currentBlockRootIndex = currentSlot.mod(slotsPerHistoricalRoot).intValue();
+        uniqueBlockRoots.add(blockRoots.getElement(currentBlockRootIndex));
+        currentSlot = currentSlot.increment();
+      }
+
+      return new InspectionWindowCounters(uniqueBlockRoots.size(), lastConsecutiveEmptySlots);
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/SpecLogicGloas.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.BuilderCircuitBreakerUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
@@ -333,6 +334,11 @@ public class SpecLogicGloas extends AbstractSpecLogic {
   @Override
   public Optional<DataColumnSidecarUtil> getDataColumnSidecarUtil() {
     return dataColumnSidecarUtil;
+  }
+
+  @Override
+  public BuilderCircuitBreakerUtil getBuilderCircuitBreakerUtil() {
+    return BuilderCircuitBreakerUtil.NOOP;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/heze/SpecLogicHeze.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
+import tech.pegasys.teku.spec.logic.common.util.BuilderCircuitBreakerUtil;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.common.util.ExecutionPayloadProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
@@ -324,6 +325,11 @@ public class SpecLogicHeze extends AbstractSpecLogic {
   @Override
   public Optional<DataColumnSidecarUtil> getDataColumnSidecarUtil() {
     return dataColumnSidecarUtil;
+  }
+
+  @Override
+  public BuilderCircuitBreakerUtil getBuilderCircuitBreakerUtil() {
+    return BuilderCircuitBreakerUtil.NOOP;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Post Gloas, use the NOOP builder circuit breaker.
This is a first step before enabling a new circuit breaker logic (based on the execution payloads) for the post Gloas forks.
It introduces a fork aware circuit breaker util.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
partially fixes #10702 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when validators fall back from external builders to local execution during weak chain conditions; post-Gloas disables that safeguard intentionally until new payload-based logic lands.
> 
> **Overview**
> Introduces a **fork-aware** `BuilderCircuitBreakerUtil` and moves block-root inspection window logic out of `BuilderCircuitBreakerImpl` into the spec layer (`BLOCK_ROOT` vs `NOOP`).
> 
> `BuilderCircuitBreakerImpl` now resolves counters via `Spec.getBuilderCircuitBreakerUtil(slot)`; engagement rules are unchanged for pre-Gloas forks. **Gloas and Heze** override the util to **`NOOP`**, so the builder circuit breaker **never engages** after Gloas (prep for future execution-payload-based logic). Tests cover post-Gloas milestones with `shouldNotEngage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf9316e4e33f4a16349aacda0d71bfcf38c8b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->