### PR TITLE
Preserve Gloas state transition caches

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloasImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateGloasImpl.java
@@ -35,6 +35,13 @@ public class BeaconStateGloasImpl extends AbstractBeaconState<MutableBeaconState
   }
 
   BeaconStateGloasImpl(
+      final BeaconStateSchema<BeaconStateGloas, MutableBeaconStateGloas> schema,
+      final TransitionCaches transitionCaches,
+      final SlotCaches slotCaches) {
+    super(schema, schema.getDefaultTree(), null, transitionCaches, slotCaches);
+  }
+
+  BeaconStateGloasImpl(
       final SszCompositeSchema<?> type,
       final TreeNode backingNode,
       final IntCache<SszData> cache,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateSchemaGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/BeaconStateSchemaGloas.java
@@ -38,9 +38,12 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.SlotCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateSchemaFulu;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
 import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingDeposit;
@@ -220,6 +223,13 @@ public class BeaconStateSchemaGloas
   @Override
   public BeaconStateGloas createEmpty() {
     return createEmptyBeaconStateImpl();
+  }
+
+  public BeaconStateGloas createEmptyWithTransitionCachesFrom(final BeaconState sourceState) {
+    return new BeaconStateGloasImpl(
+        this,
+        BeaconStateCache.getTransitionCaches(sourceState).copy(),
+        SlotCaches.createNewEmpty());
   }
 
   private BeaconStateGloasImpl createEmptyBeaconStateImpl() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
@@ -83,7 +83,11 @@ public class GloasStateUpgrade implements StateUpgrade<BeaconStateFulu> {
     final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(preState);
     final BeaconStateFulu preStateFulu = BeaconStateFulu.required(preState);
 
-    return BeaconStateGloas.required(schemaDefinitions.getBeaconStateSchema().createEmpty())
+    final BeaconStateSchemaGloas targetStateSchema =
+        BeaconStateSchemaGloas.required(schemaDefinitions.getBeaconStateSchema());
+
+    return targetStateSchema
+        .createEmptyWithTransitionCachesFrom(preState)
         .updatedGloas(
             state -> {
               BeaconStateFields.copyCommonFieldsFromSource(state, preState);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgradeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgradeTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.gloas.forktransition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.ValidatorIndexCache;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateFulu;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateMutatorsGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.MiscHelpersGloas;
+import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class GloasStateUpgradeTest {
+
+  private static final UInt64 GLOAS_EPOCH = UInt64.valueOf(2);
+
+  private final Spec spec = TestSpecFactory.createMinimalWithGloasForkEpoch(GLOAS_EPOCH);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @Test
+  void shouldCarryValidatorIndexCacheAcrossUpgrade() {
+    final BeaconStateFulu preState =
+        BeaconStateFulu.required(
+            dataStructureUtil
+                .stateBuilder(SpecMilestone.FULU, 64, 0)
+                .setSlotToStartOfEpoch(GLOAS_EPOCH)
+                .build()
+                .updated(this::activateAllValidators));
+    final ValidatorIndexCache preStateValidatorIndexCache =
+        BeaconStateCache.getTransitionCaches(preState).getValidatorIndexCache();
+    preStateValidatorIndexCache.getValidatorIndex(
+        preState, preState.getValidators().get(0).getPublicKey());
+
+    final GloasStateUpgrade stateUpgrade = createStateUpgrade();
+    final BeaconStateGloas postState = BeaconStateGloas.required(stateUpgrade.upgrade(preState));
+
+    assertThat(BeaconStateCache.getTransitionCaches(postState).getValidatorIndexCache())
+        .isSameAs(preStateValidatorIndexCache);
+  }
+
+  private GloasStateUpgrade createStateUpgrade() {
+    final SpecVersion gloasSpecVersion = spec.atEpoch(GLOAS_EPOCH);
+    return new GloasStateUpgrade(
+        SpecConfigGloas.required(gloasSpecVersion.getConfig()),
+        SchemaDefinitionsGloas.required(gloasSpecVersion.getSchemaDefinitions()),
+        BeaconStateAccessorsGloas.required(gloasSpecVersion.beaconStateAccessors()),
+        PredicatesGloas.required(gloasSpecVersion.predicates()),
+        BeaconStateMutatorsGloas.required(gloasSpecVersion.beaconStateMutators()),
+        MiscHelpersGloas.required(gloasSpecVersion.miscHelpers()),
+        gloasSpecVersion.getValidatorsUtil());
+  }
+
+  private void activateAllValidators(final MutableBeaconState state) {
+    final SszMutableList<Validator> validators = state.getValidators();
+    for (int i = 0; i < validators.size(); i++) {
+      validators.update(
+          i,
+          validator ->
+              validator
+                  .withActivationEligibilityEpoch(UInt64.ZERO)
+                  .withActivationEpoch(UInt64.ZERO)
+                  .withExitEpoch(FAR_FUTURE_EPOCH)
+                  .withWithdrawableEpoch(FAR_FUTURE_EPOCH));
+    }
+  }
+}


### PR DESCRIPTION
Speeds up `onboardBuildersFromPendingDeposits` especially

### Cache migration soundness

The Gloas state upgrade runs after the normal epoch transition at the fork boundary:

1. process final Fulu slot
2. run Fulu epoch transition
3. set state slot to the Gloas fork slot
4. detect milestone change
5. run `GloasStateUpgrade`

So the upgrade receives the normal post-epoch Fulu state; it is not replacing epoch processing.

This cache migration mirrors regular state mutation behavior: `BeaconState.updated(...)` creates a mutable copy using `TransitionCaches.copy()`. That copy already preserves the `ValidatorIndexCache` by reference, while copying most other cache maps.

This is sound for Fulu -> Gloas because the upgrade does not reorder validators, remove validators, or change validator public keys. Cached validator indices therefore remain valid, and `ValidatorIndexCache` already guards against stale indices beyond the current validator list size.

The intended benefit is that `onboardBuildersFromPendingDeposits` can reuse a warmed validator-index cache when checking pending-deposit pubkeys, instead of rebuilding it on the freshly-created Gloas state.

Caveat: this is intentionally Gloas-specific. Carrying all transition caches should not be generalized blindly to future forks where cache semantics or fork-specific derivation logic may change.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9801ccb632f5a6b01c52374d3eb77db13ce89804. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->