### PR TITLE
updated changelog 26.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,6 @@
 
 ### Breaking Changes
 
- * Dropped Windows support. Teku is no longer built, tested, or distributed for Windows. The `gradlew.bat` wrapper, Windows CI job, and Windows-specific native dependencies (LevelDB JNI) have been removed.
-
 ### Additions and Improvements
 
-- Added some extra fields to the peers output for beacon-apis #606. Consumers of the peers endpoint should be aware of this new optional data.
-- QUIC enabled by default (uses UDP port 9001 by default)
-- New Engine API client with better performance enabled by default
-- QUIC port command arguments `p2p-quic-port` (default 9001) and `p2p-quic-port-ipv6` (default 9091) were unhidden. Users will need to update firewall rules to allow incoming connections for QUIC (UDP).
-- QUIC advertised-port command arguments `p2p-advertised-quic-port` and `p2p-advertised-quic-port-ipv6` have been unhidden.
-
 ### Bug Fixes
-
-- Prevent RPC rate-limited peers from immediately reconnecting inbound.
-- Fixed missing `process_cpu_seconds_total` metric in the Docker images by adding the `jdk.management` module to the custom Java runtime.


### PR DESCRIPTION
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or API behavior changes.
> 
> **Overview**
> Clears the **Unreleased Changes** section in `CHANGELOG.md` ahead of the **26.7.0** release by removing all pending bullets.
> 
> Removed entries covered dropping Windows support, QUIC/Engine API default changes and related CLI flags, peers API output fields, and bug fixes (RPC rate-limit reconnects, Docker `process_cpu_seconds_total` metric). The section headers remain with no content underneath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124e482fdf7a1b468e13c81ad7478c90062063aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->