### PR TITLE
updated libp2p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 ### Additions and Improvements
 
 ### Bug Fixes
+ - Updated Libp2p to remove handshake info message.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -40,7 +40,7 @@ dependencyManagement {
 			entry 'javalin-rendering-thymeleaf'
 		}
 
-		dependency 'io.libp2p:jvm-libp2p:1.3.4-RELEASE'
+		dependency 'io.libp2p:jvm-libp2p:1.3.5-RELEASE'
 		dependency 'tech.pegasys:jblst:0.3.15'
 		dependency 'io.consensys.protocols:jc-kzg-4844:2.1.6'
 		dependency 'io.github.crate-crypto:java-eth-kzg:0.10.0'


### PR DESCRIPTION
fixes #10919 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Libp2p drives beacon-node P2P; a library upgrade can affect handshakes and peer compatibility even though Teku code is unchanged.
> 
> **Overview**
> Bumps the managed **`io.libp2p:jvm-libp2p`** dependency from **1.3.4-RELEASE** to **1.3.5-RELEASE** in `gradle/versions.gradle`, pulling in upstream behavior that **drops the handshake info message** (changelog; addresses #10919).
> 
> There are **no Teku source changes** in this PR—only the version pin and an unreleased **Bug Fixes** changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c14409a3286781e0fa683760c6bccf3ae4b61f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->