### PR TITLE
Fixed dual stack port binding on same port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 
 ### Bug Fixes
  - Updated Libp2p to remove handshake info message.
+ - Dual-stack P2P nodes can now bind IPv4 and IPv6 listeners to the same port.

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryService;
 import tech.pegasys.teku.networking.p2p.libp2p.MultiaddrUtil;
+import tech.pegasys.teku.networking.p2p.network.config.DualStackPortBindings;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
@@ -106,6 +107,13 @@ public class DiscV5Service extends Service implements DiscoveryService {
       // IPv4 and IPv6 (dual-stack)
       final InetSocketAddress[] listenAddresses =
           networkInterfaces.stream()
+              .filter(
+                  networkInterface ->
+                      DualStackPortBindings.shouldListenOnAddress(
+                          networkInterfaces,
+                          networkInterface,
+                          discoConfig.getListenUdpPort(),
+                          discoConfig.getListenUpdPortIpv6()))
               .map(
                   networkInterface -> {
                     final int listenUdpPort =

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -52,6 +52,7 @@ import tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetworkBuilder
 import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerHandler;
+import tech.pegasys.teku.networking.p2p.network.config.DualStackPortBindings;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
@@ -176,7 +177,7 @@ public class LibP2PNetworkBuilder {
         .flatMap(
             networkInterface -> {
               final List<String> addresses = new ArrayList<>();
-              if (config.isTcpEnabled()) {
+              if (shouldListenOnTcp(config, networkInterface, singleStack)) {
                 addresses.add(
                     MultiaddrUtil.fromInetSocketAddress(
                             new InetSocketAddress(
@@ -184,7 +185,7 @@ public class LibP2PNetworkBuilder {
                                 listenTcpPort(config, networkInterface, singleStack)))
                         .toString());
               }
-              if (config.isQuicEnabled()) {
+              if (shouldListenOnQuic(config, networkInterface, singleStack)) {
                 addresses.add(
                     MultiaddrUtil.fromInetSocketAddressAsQuic(
                             new InetSocketAddress(
@@ -212,10 +213,10 @@ public class LibP2PNetworkBuilder {
         .flatMap(
             networkInterface -> {
               final List<Integer> ports = new ArrayList<>();
-              if (config.isTcpEnabled()) {
+              if (shouldListenOnTcp(config, networkInterface, singleStack)) {
                 ports.add(listenTcpPort(config, networkInterface, singleStack));
               }
-              if (config.isQuicEnabled()) {
+              if (shouldListenOnQuic(config, networkInterface, singleStack)) {
                 ports.add(listenQuicPort(config, networkInterface, singleStack));
               }
               return ports.stream();
@@ -265,6 +266,39 @@ public class LibP2PNetworkBuilder {
       case IP_V4 -> config.getListenQuicPort();
       case IP_V6 -> config.getListenQuicPortIpv6();
     };
+  }
+
+  private static boolean shouldListenOnTcp(
+      final NetworkConfig config, final String networkInterface, final boolean singleStack) {
+    return config.isTcpEnabled()
+        && shouldListenOnAddress(
+            config,
+            networkInterface,
+            singleStack,
+            config.getListenPort(),
+            config.getListenPortIpv6());
+  }
+
+  private static boolean shouldListenOnQuic(
+      final NetworkConfig config, final String networkInterface, final boolean singleStack) {
+    return config.isQuicEnabled()
+        && shouldListenOnAddress(
+            config,
+            networkInterface,
+            singleStack,
+            config.getListenQuicPort(),
+            config.getListenQuicPortIpv6());
+  }
+
+  private static boolean shouldListenOnAddress(
+      final NetworkConfig config,
+      final String networkInterface,
+      final boolean singleStack,
+      final int listenPort,
+      final int listenPortIpv6) {
+    return singleStack
+        || DualStackPortBindings.shouldListenOnAddress(
+            config.getNetworkInterfaces(), networkInterface, listenPort, listenPortIpv6);
   }
 
   protected List<? extends RpcHandler<?, ?, ?>> createRpcHandlers() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -177,7 +177,7 @@ public class LibP2PNetworkBuilder {
         .flatMap(
             networkInterface -> {
               final List<String> addresses = new ArrayList<>();
-              if (shouldListenOnTcp(config, networkInterface, singleStack)) {
+              if (shouldListenOnTcp(config, networkInterface)) {
                 addresses.add(
                     MultiaddrUtil.fromInetSocketAddress(
                             new InetSocketAddress(
@@ -185,7 +185,7 @@ public class LibP2PNetworkBuilder {
                                 listenTcpPort(config, networkInterface, singleStack)))
                         .toString());
               }
-              if (shouldListenOnQuic(config, networkInterface, singleStack)) {
+              if (shouldListenOnQuic(config, networkInterface)) {
                 addresses.add(
                     MultiaddrUtil.fromInetSocketAddressAsQuic(
                             new InetSocketAddress(
@@ -213,10 +213,10 @@ public class LibP2PNetworkBuilder {
         .flatMap(
             networkInterface -> {
               final List<Integer> ports = new ArrayList<>();
-              if (shouldListenOnTcp(config, networkInterface, singleStack)) {
+              if (shouldListenOnTcp(config, networkInterface)) {
                 ports.add(listenTcpPort(config, networkInterface, singleStack));
               }
-              if (shouldListenOnQuic(config, networkInterface, singleStack)) {
+              if (shouldListenOnQuic(config, networkInterface)) {
                 ports.add(listenQuicPort(config, networkInterface, singleStack));
               }
               return ports.stream();
@@ -269,36 +269,23 @@ public class LibP2PNetworkBuilder {
   }
 
   private static boolean shouldListenOnTcp(
-      final NetworkConfig config, final String networkInterface, final boolean singleStack) {
+      final NetworkConfig config, final String networkInterface) {
     return config.isTcpEnabled()
-        && shouldListenOnAddress(
-            config,
+        && DualStackPortBindings.shouldListenOnAddress(
+            config.getNetworkInterfaces(),
             networkInterface,
-            singleStack,
             config.getListenPort(),
             config.getListenPortIpv6());
   }
 
   private static boolean shouldListenOnQuic(
-      final NetworkConfig config, final String networkInterface, final boolean singleStack) {
+      final NetworkConfig config, final String networkInterface) {
     return config.isQuicEnabled()
-        && shouldListenOnAddress(
-            config,
+        && DualStackPortBindings.shouldListenOnAddress(
+            config.getNetworkInterfaces(),
             networkInterface,
-            singleStack,
             config.getListenQuicPort(),
             config.getListenQuicPortIpv6());
-  }
-
-  private static boolean shouldListenOnAddress(
-      final NetworkConfig config,
-      final String networkInterface,
-      final boolean singleStack,
-      final int listenPort,
-      final int listenPortIpv6) {
-    return singleStack
-        || DualStackPortBindings.shouldListenOnAddress(
-            config.getNetworkInterfaces(), networkInterface, listenPort, listenPortIpv6);
   }
 
   protected List<? extends RpcHandler<?, ?, ?>> createRpcHandlers() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/DualStackPortBindings.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/DualStackPortBindings.java
@@ -29,10 +29,12 @@ public final class DualStackPortBindings {
       final String networkInterface,
       final int listenPort,
       final int listenPortIpv6) {
+    // A wildcard IPv6 socket is used as the single dual-stack listener for the same port. This
+    // may broaden a specific IPv4 bind to all IPv4 interfaces, but avoids a double-bind failure
+    // when the IPv6 wildcard socket already owns the IPv4 port.
     return networkInterfaces.size() == 1
         || IPVersionResolver.resolve(networkInterface) == IPVersion.IP_V6
-        || !hasIpv6AnyLocalAddressOnSamePort(networkInterfaces, listenPort, listenPortIpv6)
-        || !isAnyLocalAddress(networkInterface);
+        || !hasIpv6AnyLocalAddressOnSamePort(networkInterfaces, listenPort, listenPortIpv6);
   }
 
   private static boolean hasIpv6AnyLocalAddressOnSamePort(

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/DualStackPortBindings.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/DualStackPortBindings.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.network.config;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.io.IPVersionResolver;
+import tech.pegasys.teku.infrastructure.io.IPVersionResolver.IPVersion;
+
+public final class DualStackPortBindings {
+
+  private DualStackPortBindings() {}
+
+  public static boolean shouldListenOnAddress(
+      final List<String> networkInterfaces,
+      final String networkInterface,
+      final int listenPort,
+      final int listenPortIpv6) {
+    return networkInterfaces.size() == 1
+        || IPVersionResolver.resolve(networkInterface) == IPVersion.IP_V6
+        || !hasIpv6AnyLocalAddressOnSamePort(networkInterfaces, listenPort, listenPortIpv6)
+        || !isAnyLocalAddress(networkInterface);
+  }
+
+  private static boolean hasIpv6AnyLocalAddressOnSamePort(
+      final List<String> networkInterfaces, final int listenPort, final int listenPortIpv6) {
+    return listenPort == listenPortIpv6
+        && networkInterfaces.stream()
+            .anyMatch(
+                networkInterface ->
+                    IPVersionResolver.resolve(networkInterface) == IPVersion.IP_V6
+                        && isAnyLocalAddress(networkInterface));
+  }
+
+  private static boolean isAnyLocalAddress(final String address) {
+    try {
+      return InetAddress.getByName(address).isAnyLocalAddress();
+    } catch (final UnknownHostException ex) {
+      throw new InvalidConfigurationException("Invalid network interface: " + address, ex);
+    }
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5ServiceTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5ServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.discovery.discv5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.libp2p.core.crypto.KeyKt;
+import io.libp2p.core.crypto.KeyType;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.DiscoverySystemBuilder;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
+import tech.pegasys.teku.infrastructure.io.IPVersionResolver;
+import tech.pegasys.teku.infrastructure.io.IPVersionResolver.IPVersion;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
+import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.storage.store.MemKeyValueStore;
+
+class DiscV5ServiceTest {
+
+  @Test
+  void dualStackSameUdpPortUsesSingleIpv6WildcardListenAddress() {
+    final CapturingDiscoverySystemBuilder discoverySystemBuilder =
+        new CapturingDiscoverySystemBuilder();
+    final DiscoveryConfig discoveryConfig =
+        DiscoveryConfig.builder().listenUdpPort(9000).listenUdpPortIpv6(9000).build();
+    final NetworkConfig networkConfig =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("0.0.0.0", "::"))
+            .advertisedIps(Optional.of(List.of("127.0.0.1", "::1")))
+            .build();
+
+    createService(discoveryConfig, networkConfig, discoverySystemBuilder);
+
+    assertThat(discoverySystemBuilder.listenAddresses).hasSize(1);
+    assertThat(discoverySystemBuilder.listenAddresses[0].getPort()).isEqualTo(9000);
+    assertThat(discoverySystemBuilder.listenAddresses[0].getAddress().isAnyLocalAddress()).isTrue();
+    assertThat(IPVersionResolver.resolve(discoverySystemBuilder.listenAddresses[0]))
+        .isEqualTo(IPVersion.IP_V6);
+  }
+
+  private static void createService(
+      final DiscoveryConfig discoveryConfig,
+      final NetworkConfig networkConfig,
+      final DiscoverySystemBuilder discoverySystemBuilder) {
+    final Bytes privateKey =
+        Bytes.wrap(KeyKt.generateKeyPair(KeyType.SECP256K1).component1().raw());
+    final Spec spec = TestSpecFactory.createMinimalPhase0();
+
+    new DiscV5Service(
+        new NoOpMetricsSystem(),
+        DelayedExecutorAsyncRunner.create(),
+        discoveryConfig,
+        networkConfig,
+        new MemKeyValueStore<>(),
+        privateKey,
+        spec::getGenesisSchemaDefinitions,
+        Optional.empty(),
+        discoverySystemBuilder,
+        DiscV5Service.DEFAULT_NODE_RECORD_CONVERTER);
+  }
+
+  private static class CapturingDiscoverySystemBuilder extends DiscoverySystemBuilder {
+    private InetSocketAddress[] listenAddresses = new InetSocketAddress[0];
+
+    @Override
+    public DiscoverySystemBuilder listen(final InetSocketAddress... listenAddresses) {
+      this.listenAddresses = listenAddresses;
+      return super.listen(listenAddresses);
+    }
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5ServiceTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5ServiceTest.java
@@ -56,6 +56,27 @@ class DiscV5ServiceTest {
         .isEqualTo(IPVersion.IP_V6);
   }
 
+  @Test
+  void dualStackSpecificIpv4SameUdpPortUsesSingleIpv6WildcardListenAddress() {
+    final CapturingDiscoverySystemBuilder discoverySystemBuilder =
+        new CapturingDiscoverySystemBuilder();
+    final DiscoveryConfig discoveryConfig =
+        DiscoveryConfig.builder().listenUdpPort(9000).listenUdpPortIpv6(9000).build();
+    final NetworkConfig networkConfig =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("127.0.0.1", "::"))
+            .advertisedIps(Optional.of(List.of("127.0.0.1", "::1")))
+            .build();
+
+    createService(discoveryConfig, networkConfig, discoverySystemBuilder);
+
+    assertThat(discoverySystemBuilder.listenAddresses).hasSize(1);
+    assertThat(discoverySystemBuilder.listenAddresses[0].getPort()).isEqualTo(9000);
+    assertThat(discoverySystemBuilder.listenAddresses[0].getAddress().isAnyLocalAddress()).isTrue();
+    assertThat(IPVersionResolver.resolve(discoverySystemBuilder.listenAddresses[0]))
+        .isEqualTo(IPVersion.IP_V6);
+  }
+
   private static void createService(
       final DiscoveryConfig discoveryConfig,
       final NetworkConfig networkConfig,

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
@@ -177,12 +177,47 @@ class LibP2PNetworkBuilderTest {
   }
 
   @Test
+  void buildListenAddresses_dualStackSpecificIpv4SameTcpPortUsesIpv6WildcardTcpSocket() {
+    final NetworkConfig config =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("127.0.0.1", "::"))
+            .listenPort(9000)
+            .listenPortIpv6(9000)
+            .quicEnabled(false)
+            .build();
+
+    assertThat(List.of(LibP2PNetworkBuilder.buildListenAddresses(config)))
+        .containsExactly("/ip6/::/tcp/9000");
+  }
+
+  @Test
   void start_dualStackSameTcpPortDoesNotBindTcpPortTwice() throws Exception {
     Assumptions.assumeTrue(canBindIpv6Wildcard());
     final int listenPort = findAvailablePort();
     final NetworkConfig config =
         NetworkConfig.builder()
             .networkInterfaces(List.of("0.0.0.0", "::"))
+            .advertisedIps(Optional.of(List.of("127.0.0.1", "::1")))
+            .listenPort(listenPort)
+            .listenPortIpv6(listenPort)
+            .quicEnabled(false)
+            .build();
+    final P2PNetwork<Peer> network = createNetwork(config);
+
+    try {
+      assertThatCode(() -> Waiter.waitFor(network.start())).doesNotThrowAnyException();
+    } finally {
+      Waiter.waitFor(network.stop());
+    }
+  }
+
+  @Test
+  void start_dualStackSpecificIpv4SameTcpPortDoesNotBindTcpPortTwice() throws Exception {
+    Assumptions.assumeTrue(canBindIpv6Wildcard());
+    final int listenPort = findAvailablePort();
+    final NetworkConfig config =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("127.0.0.1", "::"))
             .advertisedIps(Optional.of(List.of("127.0.0.1", "::1")))
             .listenPort(listenPort)
             .listenPortIpv6(listenPort)

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilderTest.java
@@ -14,14 +14,32 @@
 package tech.pegasys.teku.networking.p2p.libp2p;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.libp2p.core.PeerId;
+import io.libp2p.core.crypto.KeyKt;
+import io.libp2p.core.crypto.KeyType;
 import io.libp2p.core.multiformats.Multiaddr;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.Optional;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
+import tech.pegasys.teku.infrastructure.async.Waiter;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.networking.p2p.connection.PeerPools;
+import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
+import tech.pegasys.teku.networking.p2p.reputation.DefaultReputationManager;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.Constants;
 
 class LibP2PNetworkBuilderTest {
 
@@ -66,6 +84,19 @@ class LibP2PNetworkBuilderTest {
   void buildListenPorts_dualStackTcpOnly() {
     final NetworkConfig config = dualStackConfig().quicEnabled(false).build();
     assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000, 9090);
+  }
+
+  @Test
+  void buildListenPorts_dualStackSameTcpPortUsesSingleDualStackTcpSocket() {
+    final NetworkConfig config =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("0.0.0.0", "::"))
+            .listenPort(9000)
+            .listenPortIpv6(9000)
+            .quicEnabled(false)
+            .build();
+
+    assertThat(LibP2PNetworkBuilder.buildListenPorts(config)).containsExactly(9000);
   }
 
   @Test
@@ -131,7 +162,81 @@ class LibP2PNetworkBuilderTest {
     assertThat(addresses).anyMatch(addr -> addr.contains("/udp/9001/quic-v1"));
   }
 
+  @Test
+  void buildListenAddresses_dualStackSameTcpPortUsesIpv6WildcardTcpSocket() {
+    final NetworkConfig config =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("0.0.0.0", "::"))
+            .listenPort(9000)
+            .listenPortIpv6(9000)
+            .quicEnabled(false)
+            .build();
+
+    assertThat(List.of(LibP2PNetworkBuilder.buildListenAddresses(config)))
+        .containsExactly("/ip6/::/tcp/9000");
+  }
+
+  @Test
+  void start_dualStackSameTcpPortDoesNotBindTcpPortTwice() throws Exception {
+    Assumptions.assumeTrue(canBindIpv6Wildcard());
+    final int listenPort = findAvailablePort();
+    final NetworkConfig config =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("0.0.0.0", "::"))
+            .advertisedIps(Optional.of(List.of("127.0.0.1", "::1")))
+            .listenPort(listenPort)
+            .listenPortIpv6(listenPort)
+            .quicEnabled(false)
+            .build();
+    final P2PNetwork<Peer> network = createNetwork(config);
+
+    try {
+      assertThatCode(() -> Waiter.waitFor(network.start())).doesNotThrowAnyException();
+    } finally {
+      Waiter.waitFor(network.stop());
+    }
+  }
+
   private static List<String> asStrings(final List<Multiaddr> addresses) {
     return addresses.stream().map(Multiaddr::toString).toList();
+  }
+
+  private static P2PNetwork<Peer> createNetwork(final NetworkConfig config) {
+    final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+    final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
+    final PeerPools peerPools = new PeerPools();
+    return LibP2PNetworkBuilder.create()
+        .asyncRunner(DelayedExecutorAsyncRunner.create())
+        .config(config)
+        .networkingSpecConfig(TestSpecFactory.createMinimalPhase0().getNetworkingConfig())
+        .privateKeyProvider(() -> KeyKt.generateKeyPair(KeyType.SECP256K1).component1())
+        .reputationManager(
+            new DefaultReputationManager(
+                metricsSystem, timeProvider, Constants.REPUTATION_MANAGER_CAPACITY, peerPools))
+        .metricsSystem(metricsSystem)
+        .rpcMethods(List.of())
+        .peerHandlers(List.of())
+        .preparedGossipMessageFactory(
+            (topic, payload, networkingSpecConfig, arrivalTimestamp) -> {
+              throw new UnsupportedOperationException();
+            })
+        .gossipTopicFilter(topic -> true)
+        .timeProvider(timeProvider)
+        .build();
+  }
+
+  private static int findAvailablePort() throws IOException {
+    try (final ServerSocket serverSocket = new ServerSocket(0)) {
+      return serverSocket.getLocalPort();
+    }
+  }
+
+  private static boolean canBindIpv6Wildcard() {
+    try (final ServerSocket serverSocket = new ServerSocket()) {
+      serverSocket.bind(new InetSocketAddress(InetAddress.getByName("::"), 0));
+      return true;
+    } catch (final IOException ex) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
- Add shared dual-stack binding logic to avoid duplicate IPv4 wildcard binds when an IPv6 wildcard listener is configured on the same port.
- Apply the same-port dual-stack handling to libp2p TCP/QUIC listeners and discv5 UDP discovery listeners.
- Add regression coverage for listener generation, libp2p startup, and discovery UDP listen address construction.

Fixes #8659.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how P2P and discovery sockets are bound in dual-stack same-port configs; a documented tradeoff is that skipping the IPv4 bind may widen a specific IPv4 address to all interfaces when `::` is used.
> 
> **Overview**
> Fixes dual-stack setups where IPv4 and IPv6 were configured to use the **same** listen port, which could fail when both stacks tried to bind separately.
> 
> Introduces **`DualStackPortBindings.shouldListenOnAddress`**: when v4/v6 ports match and an IPv6 wildcard (`::`) is in the interface list, listeners are built for the IPv6 wildcard only so one dual-stack socket owns the port instead of a second IPv4 bind. That logic is wired into **libp2p** TCP/QUIC listen address/port generation and **discv5** UDP discovery listen addresses.
> 
> Regression tests cover generated multiaddrs/ports, discovery listen construction, and libp2p startup without double TCP bind. Changelog notes dual-stack nodes can bind IPv4 and IPv6 on the same port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba4f9c500abc6f06c78047c37e82133236299a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->