### PR TITLE
validate exeution payload block hash

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -54,8 +54,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBlockHashCalculator;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -85,6 +87,8 @@ public class HistoricalBatchFetcher {
   private final SafeFuture<SignedBeaconBlock> future = new SafeFuture<>();
   private final Deque<SignedBeaconBlock> blocksToImport = new ConcurrentLinkedDeque<>();
   private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlotToImport =
+      new ConcurrentHashMap<>();
+  private final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloadsByBlockRootToImport =
       new ConcurrentHashMap<>();
   private final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope>
       blindedExecutionPayloadsByBlockRootToImport = new ConcurrentHashMap<>();
@@ -298,13 +302,27 @@ public class HistoricalBatchFetcher {
   @VisibleForTesting
   void processExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayloadEnvelope) {
-    final SchemaDefinitionsGloas schemaDefinitions =
-        SchemaDefinitionsGloas.required(
-            spec.atSlot(signedExecutionPayloadEnvelope.getMessage().getSlot())
-                .getSchemaDefinitions());
-    blindedExecutionPayloadsByBlockRootToImport.put(
-        signedExecutionPayloadEnvelope.getBeaconBlockRoot(),
-        signedExecutionPayloadEnvelope.blind(schemaDefinitions));
+    validateExecutionPayloadBlockHash(signedExecutionPayloadEnvelope);
+    executionPayloadsByBlockRootToImport.put(
+        signedExecutionPayloadEnvelope.getBeaconBlockRoot(), signedExecutionPayloadEnvelope);
+  }
+
+  private void validateExecutionPayloadBlockHash(
+      final SignedExecutionPayloadEnvelope signedExecutionPayloadEnvelope) {
+    final ExecutionPayloadEnvelope envelope = signedExecutionPayloadEnvelope.getMessage();
+    final Bytes32 computedBlockHash =
+        ExecutionPayloadBlockHashCalculator.computeGloasBlockHash(
+            envelope, spec.getExecutionRequestsDataCodec(envelope.getSlot()));
+    final Bytes32 payloadBlockHash = envelope.getPayload().getBlockHash();
+    if (!computedBlockHash.equals(payloadBlockHash)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Execution payload block hash mismatch for block root %s at slot %s: expected %s but computed %s",
+              signedExecutionPayloadEnvelope.getBeaconBlockRoot(),
+              envelope.getSlot(),
+              payloadBlockHash,
+              computedBlockHash));
+    }
   }
 
   private boolean shouldRetryByRangeRequest() {
@@ -404,6 +422,7 @@ public class HistoricalBatchFetcher {
               validateExecutionPayloadEnvelopes(blocksToImport);
 
               final SignedBeaconBlock newEarliestBlock = blocksToImport.getFirst();
+              blindExecutionPayloadsForImport();
               return storageUpdateChannel
                   .onFinalizedBlocks(
                       blocksToImport,
@@ -420,6 +439,7 @@ public class HistoricalBatchFetcher {
         .alwaysRun(
             () -> {
               blobSidecarsBySlotToImport.clear();
+              executionPayloadsByBlockRootToImport.clear();
               blindedExecutionPayloadsByBlockRootToImport.clear();
               maybeEarliestBlobSidecarSlot = Optional.empty();
             });
@@ -468,24 +488,24 @@ public class HistoricalBatchFetcher {
   }
 
   private void pruneExecutionPayloadsNotInBatch() {
-    if (blindedExecutionPayloadsByBlockRootToImport.isEmpty()) {
+    if (executionPayloadsByBlockRootToImport.isEmpty()) {
       return;
     }
     final Set<Bytes32> blockRoots =
         blocksToImport.stream().map(SignedBeaconBlock::getRoot).collect(Collectors.toSet());
-    blindedExecutionPayloadsByBlockRootToImport.keySet().retainAll(blockRoots);
+    executionPayloadsByBlockRootToImport.keySet().retainAll(blockRoots);
   }
 
   private void validateExecutionPayloadEnvelopes(final Collection<SignedBeaconBlock> blocks) {
-    if (!blindedExecutionPayloadsByBlockRootToImport.isEmpty()) {
+    if (!executionPayloadsByBlockRootToImport.isEmpty()) {
       LOG.trace("Validating execution payload envelopes for a batch");
       final Map<Bytes32, SignedBeaconBlock> blocksByRoot =
           blocks.stream()
               .collect(Collectors.toMap(SignedBeaconBlock::getRoot, Function.identity()));
-      blindedExecutionPayloadsByBlockRootToImport.forEach(
+      executionPayloadsByBlockRootToImport.forEach(
           (blockRoot, signedEnvelope) ->
               validateExecutionPayloadEnvelope(
-                  signedEnvelope,
+                  blindExecutionPayloadEnvelope(signedEnvelope),
                   Optional.ofNullable(blocksByRoot.get(blockRoot))
                       .orElseThrow(
                           () ->
@@ -496,6 +516,23 @@ public class HistoricalBatchFetcher {
     }
 
     validateExecutionPayloadEnvelopesPresence(blocks);
+  }
+
+  private void blindExecutionPayloadsForImport() {
+    blindedExecutionPayloadsByBlockRootToImport.clear();
+    executionPayloadsByBlockRootToImport.forEach(
+        (blockRoot, signedEnvelope) ->
+            blindedExecutionPayloadsByBlockRootToImport.put(
+                blockRoot, blindExecutionPayloadEnvelope(signedEnvelope)));
+  }
+
+  private SignedBlindedExecutionPayloadEnvelope blindExecutionPayloadEnvelope(
+      final SignedExecutionPayloadEnvelope signedExecutionPayloadEnvelope) {
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(
+            spec.atSlot(signedExecutionPayloadEnvelope.getMessage().getSlot())
+                .getSchemaDefinitions());
+    return signedExecutionPayloadEnvelope.blind(schemaDefinitions);
   }
 
   @VisibleForTesting
@@ -554,7 +591,7 @@ public class HistoricalBatchFetcher {
       // Execution chain did not advance, so previous block's payload was not delivered
       return;
     }
-    if (blindedExecutionPayloadsByBlockRootToImport.containsKey(previousBlock.getRoot())) {
+    if (executionPayloadsByBlockRootToImport.containsKey(previousBlock.getRoot())) {
       return;
     }
     throw new IllegalArgumentException(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -88,8 +88,6 @@ public class HistoricalBatchFetcher {
   private final Deque<SignedBeaconBlock> blocksToImport = new ConcurrentLinkedDeque<>();
   private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlotToImport =
       new ConcurrentHashMap<>();
-  private final Map<Bytes32, SignedExecutionPayloadEnvelope> executionPayloadsByBlockRootToImport =
-      new ConcurrentHashMap<>();
   private final Map<Bytes32, SignedBlindedExecutionPayloadEnvelope>
       blindedExecutionPayloadsByBlockRootToImport = new ConcurrentHashMap<>();
   private Optional<UInt64> maybeEarliestBlobSidecarSlot = Optional.empty();
@@ -303,8 +301,9 @@ public class HistoricalBatchFetcher {
   void processExecutionPayload(
       final SignedExecutionPayloadEnvelope signedExecutionPayloadEnvelope) {
     validateExecutionPayloadBlockHash(signedExecutionPayloadEnvelope);
-    executionPayloadsByBlockRootToImport.put(
-        signedExecutionPayloadEnvelope.getBeaconBlockRoot(), signedExecutionPayloadEnvelope);
+    blindedExecutionPayloadsByBlockRootToImport.put(
+        signedExecutionPayloadEnvelope.getBeaconBlockRoot(),
+        blindExecutionPayloadEnvelope(signedExecutionPayloadEnvelope));
   }
 
   private void validateExecutionPayloadBlockHash(
@@ -422,7 +421,6 @@ public class HistoricalBatchFetcher {
               validateExecutionPayloadEnvelopes(blocksToImport);
 
               final SignedBeaconBlock newEarliestBlock = blocksToImport.getFirst();
-              blindExecutionPayloadsForImport();
               return storageUpdateChannel
                   .onFinalizedBlocks(
                       blocksToImport,
@@ -439,7 +437,6 @@ public class HistoricalBatchFetcher {
         .alwaysRun(
             () -> {
               blobSidecarsBySlotToImport.clear();
-              executionPayloadsByBlockRootToImport.clear();
               blindedExecutionPayloadsByBlockRootToImport.clear();
               maybeEarliestBlobSidecarSlot = Optional.empty();
             });
@@ -488,24 +485,24 @@ public class HistoricalBatchFetcher {
   }
 
   private void pruneExecutionPayloadsNotInBatch() {
-    if (executionPayloadsByBlockRootToImport.isEmpty()) {
+    if (blindedExecutionPayloadsByBlockRootToImport.isEmpty()) {
       return;
     }
     final Set<Bytes32> blockRoots =
         blocksToImport.stream().map(SignedBeaconBlock::getRoot).collect(Collectors.toSet());
-    executionPayloadsByBlockRootToImport.keySet().retainAll(blockRoots);
+    blindedExecutionPayloadsByBlockRootToImport.keySet().retainAll(blockRoots);
   }
 
   private void validateExecutionPayloadEnvelopes(final Collection<SignedBeaconBlock> blocks) {
-    if (!executionPayloadsByBlockRootToImport.isEmpty()) {
+    if (!blindedExecutionPayloadsByBlockRootToImport.isEmpty()) {
       LOG.trace("Validating execution payload envelopes for a batch");
       final Map<Bytes32, SignedBeaconBlock> blocksByRoot =
           blocks.stream()
               .collect(Collectors.toMap(SignedBeaconBlock::getRoot, Function.identity()));
-      executionPayloadsByBlockRootToImport.forEach(
+      blindedExecutionPayloadsByBlockRootToImport.forEach(
           (blockRoot, signedEnvelope) ->
               validateExecutionPayloadEnvelope(
-                  blindExecutionPayloadEnvelope(signedEnvelope),
+                  signedEnvelope,
                   Optional.ofNullable(blocksByRoot.get(blockRoot))
                       .orElseThrow(
                           () ->
@@ -516,14 +513,6 @@ public class HistoricalBatchFetcher {
     }
 
     validateExecutionPayloadEnvelopesPresence(blocks);
-  }
-
-  private void blindExecutionPayloadsForImport() {
-    blindedExecutionPayloadsByBlockRootToImport.clear();
-    executionPayloadsByBlockRootToImport.forEach(
-        (blockRoot, signedEnvelope) ->
-            blindedExecutionPayloadsByBlockRootToImport.put(
-                blockRoot, blindExecutionPayloadEnvelope(signedEnvelope)));
   }
 
   private SignedBlindedExecutionPayloadEnvelope blindExecutionPayloadEnvelope(
@@ -591,7 +580,7 @@ public class HistoricalBatchFetcher {
       // Execution chain did not advance, so previous block's payload was not delivered
       return;
     }
-    if (executionPayloadsByBlockRootToImport.containsKey(previousBlock.getRoot())) {
+    if (blindedExecutionPayloadsByBlockRootToImport.containsKey(previousBlock.getRoot())) {
       return;
     }
     throw new IllegalArgumentException(

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherGloasTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherGloasTest.java
@@ -44,9 +44,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.BlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedBlindedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.Transaction;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadGloas;
 import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadHeaderGloas;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -160,6 +164,37 @@ public class HistoricalBatchFetcherGloasTest {
     // Envelope signatures are intentionally not verified (builder indices are reusable in Gloas),
     // so the signature verifier is called only once (for block signatures)
     verify(signatureVerifier, times(1)).verify(any(), any(), anyList());
+  }
+
+  @TestTemplate
+  public void processExecutionPayload_throwsWhenPayloadBlockHashDoesNotMatchComputedHash() {
+    final SignedExecutionPayloadEnvelope original =
+        chainBuilder.getExecutionPayloadAtSlot(UInt64.valueOf(15)).orElseThrow();
+    final ExecutionPayloadEnvelope originalEnvelope = original.getMessage();
+    final ExecutionPayload tamperedPayload =
+        copyPayloadWithStateRoot(
+            originalEnvelope.getPayload(), originalEnvelope.getPayload().getStateRoot().not());
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(
+            spec.atSlot(originalEnvelope.getSlot()).getSchemaDefinitions());
+    final ExecutionPayloadEnvelope tamperedEnvelope =
+        schemaDefinitions
+            .getExecutionPayloadEnvelopeSchema()
+            .create(
+                tamperedPayload,
+                originalEnvelope.getExecutionRequests(),
+                originalEnvelope.getBuilderIndex(),
+                originalEnvelope.getBeaconBlockRoot(),
+                originalEnvelope.getParentBeaconBlockRoot());
+    final SignedExecutionPayloadEnvelope signedTamperedEnvelope =
+        schemaDefinitions
+            .getSignedExecutionPayloadEnvelopeSchema()
+            .create(tamperedEnvelope, original.getSignature());
+
+    assertThatThrownBy(() -> fetcher.processExecutionPayload(signedTamperedEnvelope))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Execution payload block hash mismatch")
+        .hasMessageContaining(originalEnvelope.getBeaconBlockRoot().toHexString());
   }
 
   @TestTemplate
@@ -285,6 +320,36 @@ public class HistoricalBatchFetcherGloasTest {
         .orElseThrow()
         .getSignedExecutionPayloadBid()
         .getMessage();
+  }
+
+  private ExecutionPayload copyPayloadWithStateRoot(
+      final ExecutionPayload payload, final Bytes32 stateRoot) {
+    final ExecutionPayloadGloas gloasPayload = ExecutionPayloadGloas.required(payload);
+    return gloasPayload
+        .getSchema()
+        .createExecutionPayload(
+            builder ->
+                builder
+                    .parentHash(gloasPayload.getParentHash())
+                    .feeRecipient(gloasPayload.getFeeRecipient())
+                    .stateRoot(stateRoot)
+                    .receiptsRoot(gloasPayload.getReceiptsRoot())
+                    .logsBloom(gloasPayload.getLogsBloom())
+                    .prevRandao(gloasPayload.getPrevRandao())
+                    .blockNumber(gloasPayload.getBlockNumber())
+                    .gasLimit(gloasPayload.getGasLimit())
+                    .gasUsed(gloasPayload.getGasUsed())
+                    .timestamp(gloasPayload.getTimestamp())
+                    .extraData(gloasPayload.getExtraData())
+                    .baseFeePerGas(gloasPayload.getBaseFeePerGas())
+                    .blockHash(gloasPayload.getBlockHash())
+                    .transactions(
+                        gloasPayload.getTransactions().stream().map(Transaction::getBytes).toList())
+                    .withdrawals(gloasPayload.getWithdrawals()::asList)
+                    .blobGasUsed(gloasPayload::getBlobGasUsed)
+                    .excessBlobGas(gloasPayload::getExcessBlobGas)
+                    .blockAccessList(() -> gloasPayload.getBlockAccessList().getBytes())
+                    .slotNumber(gloasPayload::getSlotNumber));
   }
 
   private ExecutionPayloadHeader copyPayloadHeaderWithSlot(

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -13,6 +13,10 @@ dependencies {
 	implementation 'io.consensys.tuweni:tuweni-bytes'
 	implementation 'io.consensys.tuweni:tuweni-ssz'
 	implementation 'io.consensys.tuweni:tuweni-units'
+	implementation 'org.hyperledger.besu.internal:besu-ethereum-core'
+	implementation 'org.hyperledger.besu.internal:besu-ethereum-rlp'
+	implementation 'org.hyperledger.besu:besu-datatypes'
+	implementation 'org.hyperledger.besu:besu-plugin-api'
 	implementation project(':ethereum:performance-trackers')
 	implementation project(':ethereum:execution-types')
 	implementation project(':ethereum:pow:api')
@@ -40,6 +44,7 @@ dependencies {
 	testFixturesImplementation 'io.consensys.tuweni:tuweni-units'
 	testFixturesImplementation 'io.consensys.tuweni:tuweni-ssz'
 	testFixturesImplementation 'org.hyperledger.besu.internal:besu-ethereum-core'
+	testFixturesImplementation 'org.hyperledger.besu.internal:besu-ethereum-rlp'
 	testFixturesImplementation 'org.hyperledger.besu.internal:besu-config'
 	testFixturesImplementation 'org.hyperledger.besu:besu-datatypes'
 	testFixturesImplementation 'org.hyperledger.besu:besu-evm'

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBlockHashCalculator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBlockHashCalculator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import static tech.pegasys.teku.infrastructure.crypto.Hash.keccak256;
+import static tech.pegasys.teku.infrastructure.crypto.Hash.sha256;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.BlobGas;
+import org.hyperledger.besu.datatypes.GWei;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.LogsBloomFilter;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.Util;
+import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
+import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadGloas;
+
+public class ExecutionPayloadBlockHashCalculator {
+
+  public static Bytes32 computeGloasBlockHash(
+      final ExecutionPayloadEnvelope executionPayloadEnvelope,
+      final ExecutionRequestsDataCodec executionRequestsDataCodec) {
+    final ExecutionPayloadGloas payload =
+        ExecutionPayloadGloas.required(executionPayloadEnvelope.getPayload());
+    final BlockHeader blockHeader =
+        BlockHeaderBuilder.create()
+            .parentHash(Hash.wrap(payload.getParentHash()))
+            .ommersHash(Hash.EMPTY_LIST_HASH)
+            .coinbase(Address.wrap(payload.getFeeRecipient().getWrappedBytes()))
+            .stateRoot(Hash.wrap(payload.getStateRoot()))
+            .transactionsRoot(computeTransactionsRoot(payload))
+            .receiptsRoot(Hash.wrap(payload.getReceiptsRoot()))
+            .logsBloom(new LogsBloomFilter(payload.getLogsBloom()))
+            .difficulty(Difficulty.ZERO)
+            .number(toLong(payload.getBlockNumber()))
+            .gasLimit(toLong(payload.getGasLimit()))
+            .gasUsed(toLong(payload.getGasUsed()))
+            .timestamp(toLong(payload.getTimestamp()))
+            .extraData(payload.getExtraData())
+            .baseFee(Wei.of(payload.getBaseFeePerGas().toBigInteger()))
+            .prevRandao(payload.getPrevRandao())
+            .nonce(0L)
+            .withdrawalsRoot(computeWithdrawalsRoot(payload))
+            .blobGasUsed(toLong(payload.getBlobGasUsed()))
+            .excessBlobGas(BlobGas.of(payload.getExcessBlobGas().bigIntegerValue()))
+            .parentBeaconBlockRoot(executionPayloadEnvelope.getParentBeaconBlockRoot())
+            .requestsHash(
+                computeRequestsHash(
+                    executionRequestsDataCodec.encode(
+                        executionPayloadEnvelope.getExecutionRequests())))
+            .balHash(BodyValidation.balHash(payload.getBlockAccessList().getBytes()))
+            .slotNumber(toLong(payload.getSlotNumber()))
+            .blockHeaderFunctions(new MainnetBlockHeaderFunctions())
+            .buildBlockHeader();
+
+    final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
+    blockHeader.writeTo(rlpOutput);
+    return keccak256(rlpOutput.encoded());
+  }
+
+  private static Hash computeTransactionsRoot(final ExecutionPayloadGloas executionPayloadGloas) {
+    return Util.getRootFromListOfBytes(
+        executionPayloadGloas.getTransactions().stream().map(Transaction::getBytes).toList());
+  }
+
+  private static Hash computeWithdrawalsRoot(final ExecutionPayloadGloas executionPayloadGloas) {
+    return BodyValidation.withdrawalsRoot(
+        executionPayloadGloas.getWithdrawals().stream()
+            .map(ExecutionPayloadBlockHashCalculator::toBesuWithdrawal)
+            .toList());
+  }
+
+  private static org.hyperledger.besu.ethereum.core.Withdrawal toBesuWithdrawal(
+      final Withdrawal withdrawal) {
+    return new org.hyperledger.besu.ethereum.core.Withdrawal(
+        org.apache.tuweni.units.bigints.UInt64.valueOf(withdrawal.getIndex().bigIntegerValue()),
+        org.apache.tuweni.units.bigints.UInt64.valueOf(
+            withdrawal.getValidatorIndex().bigIntegerValue()),
+        Address.wrap(withdrawal.getAddress().getWrappedBytes()),
+        GWei.of(withdrawal.getAmount().bigIntegerValue()));
+  }
+
+  private static Hash computeRequestsHash(final List<Bytes> executionRequestsData) {
+    final List<Bytes> requestHashes =
+        executionRequestsData.stream().map(bytes -> (Bytes) sha256(bytes)).toList();
+    return Hash.wrap(sha256(Bytes.wrap(requestHashes)));
+  }
+
+  private static long toLong(final UInt64 value) {
+    return value.longValue();
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBlockHashCalculatorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadBlockHashCalculatorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
+
+@TestSpecContext(milestone = {GLOAS})
+class ExecutionPayloadBlockHashCalculatorTest {
+
+  private static final UInt64 SLOT = UInt64.valueOf(12);
+  private static final UInt64 GAS_LIMIT = UInt64.valueOf(30_000_000);
+  private static final UInt64 TIMESTAMP = UInt64.valueOf(1_234_567);
+  private static final Bytes EMPTY_BLOCK_ACCESS_LIST = createEmptyBlockAccessList();
+
+  private Spec spec;
+  private SchemaDefinitionsGloas schemaDefinitions;
+
+  @BeforeEach
+  void setUp(final SpecContext specContext) {
+    spec = specContext.getSpec();
+    schemaDefinitions = SchemaDefinitionsGloas.required(spec.atSlot(SLOT).getSchemaDefinitions());
+  }
+
+  @TestTemplate
+  void computeGloasBlockHashChangesWhenPayloadBodyChanges() {
+    final ExecutionRequests executionRequests =
+        schemaDefinitions.getExecutionRequestsSchema().createBuilder().build();
+    final ExecutionPayload payload = createExecutionPayload(Bytes32.ZERO, Bytes32.ZERO);
+    final ExecutionPayloadEnvelope envelope = createEnvelope(payload, executionRequests);
+
+    final Bytes32 originalBlockHash =
+        ExecutionPayloadBlockHashCalculator.computeGloasBlockHash(
+            envelope, spec.getExecutionRequestsDataCodec(SLOT));
+
+    final ExecutionPayload tamperedPayload =
+        createExecutionPayload(Bytes32.ZERO.not(), Bytes32.ZERO);
+    final ExecutionPayloadEnvelope tamperedEnvelope =
+        createEnvelope(tamperedPayload, executionRequests);
+
+    assertThat(
+            ExecutionPayloadBlockHashCalculator.computeGloasBlockHash(
+                tamperedEnvelope, spec.getExecutionRequestsDataCodec(SLOT)))
+        .isNotEqualTo(originalBlockHash);
+  }
+
+  private ExecutionPayloadEnvelope createEnvelope(
+      final ExecutionPayload payload, final ExecutionRequests executionRequests) {
+    return schemaDefinitions
+        .getExecutionPayloadEnvelopeSchema()
+        .create(payload, executionRequests, UInt64.ZERO, Bytes32.ZERO, Bytes32.ZERO);
+  }
+
+  private ExecutionPayload createExecutionPayload(
+      final Bytes32 stateRoot, final Bytes32 blockHash) {
+    return schemaDefinitions
+        .getExecutionPayloadSchema()
+        .createExecutionPayload(
+            builder ->
+                builder
+                    .parentHash(Bytes32.ZERO)
+                    .feeRecipient(Bytes20.ZERO)
+                    .stateRoot(stateRoot)
+                    .receiptsRoot(Bytes32.ZERO)
+                    .logsBloom(Bytes.wrap(new byte[256]))
+                    .prevRandao(Bytes32.ZERO)
+                    .blockNumber(SLOT)
+                    .gasLimit(GAS_LIMIT)
+                    .gasUsed(UInt64.ZERO)
+                    .timestamp(TIMESTAMP)
+                    .extraData(Bytes.EMPTY)
+                    .baseFeePerGas(UInt256.ONE)
+                    .blockHash(blockHash)
+                    .transactions(List.of())
+                    .withdrawals(List::of)
+                    .blobGasUsed(() -> UInt64.ZERO)
+                    .excessBlobGas(() -> UInt64.ZERO)
+                    .blockAccessList(() -> EMPTY_BLOCK_ACCESS_LIST)
+                    .slotNumber(() -> SLOT));
+  }
+
+  private static Bytes createEmptyBlockAccessList() {
+    final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
+    rlpOutput.startList();
+    rlpOutput.endList();
+    return rlpOutput.encoded();
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.ssz.SSZ;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -44,12 +45,16 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBlockHashCalculator;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.Transaction;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionPayloadGloas;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -75,6 +80,7 @@ public class BlockProposalTestUtil {
 
   private final Spec spec;
   private final DataStructureUtil dataStructureUtil;
+  private final Bytes emptyBlockAccessList;
 
   // used for ePBS to cache the data required for proposing the execution payload by the builder
   private final Map<UInt64, ExecutionPayloadProposalData> executionPayloadProposalDataCache =
@@ -83,6 +89,7 @@ public class BlockProposalTestUtil {
   public BlockProposalTestUtil(final Spec spec) {
     this.spec = spec;
     this.dataStructureUtil = new DataStructureUtil(spec);
+    this.emptyBlockAccessList = createEmptyBlockAccessList();
   }
 
   public SafeFuture<SignedBlockAndState> createBlock(
@@ -314,13 +321,21 @@ public class BlockProposalTestUtil {
                 builder.executionRequests(dataStructureUtil.randomExecutionRequests(newSlot));
               }
               if (builder.supportsSignedExecutionPayloadBid()) {
+                final ExecutionRequests executionRequests = createExecutionRequests(newSlot);
+                final ExecutionPayload payload =
+                    executionPayload.orElseGet(
+                        () ->
+                            createExecutionPayload(
+                                newSlot,
+                                blockSlotState,
+                                transactions,
+                                terminalBlock,
+                                Optional.of(executionRequests),
+                                parentBlockSigningRoot));
                 final ExecutionPayloadProposalData executionPayloadProposalData =
                     new ExecutionPayloadProposalData(
-                        executionPayload.orElseGet(
-                            () ->
-                                createExecutionPayload(
-                                    newSlot, blockSlotState, transactions, terminalBlock)),
-                        createExecutionRequests(newSlot),
+                        payload,
+                        executionRequests,
                         kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments));
                 executionPayloadProposalDataCache.put(newSlot, executionPayloadProposalData);
                 builder.signedExecutionPayloadBid(
@@ -417,13 +432,21 @@ public class BlockProposalTestUtil {
                 builder.executionRequests(dataStructureUtil.randomExecutionRequests(newSlot));
               }
               if (builder.supportsSignedExecutionPayloadBid()) {
+                final ExecutionRequests executionRequests = createExecutionRequests(newSlot);
+                final ExecutionPayload payload =
+                    executionPayload.orElseGet(
+                        () ->
+                            createExecutionPayload(
+                                newSlot,
+                                blockSlotState,
+                                transactions,
+                                terminalBlock,
+                                Optional.of(executionRequests),
+                                parentBlockSigningRoot));
                 final ExecutionPayloadProposalData executionPayloadProposalData =
                     new ExecutionPayloadProposalData(
-                        executionPayload.orElseGet(
-                            () ->
-                                createExecutionPayload(
-                                    newSlot, blockSlotState, transactions, terminalBlock)),
-                        createExecutionRequests(newSlot),
+                        payload,
+                        executionRequests,
                         kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments));
                 executionPayloadProposalDataCache.put(newSlot, executionPayloadProposalData);
                 builder.signedExecutionPayloadBid(
@@ -471,6 +494,24 @@ public class BlockProposalTestUtil {
       final BeaconState state,
       final Optional<List<Bytes>> transactions,
       final Optional<Bytes32> terminalBlock) {
+    return createExecutionPayload(
+        newSlot,
+        state,
+        transactions,
+        terminalBlock,
+        spec.isExecutionPayloadEnvelopeAvailableAtSlot(newSlot)
+            ? Optional.of(createExecutionRequests(newSlot))
+            : Optional.empty(),
+        Bytes32.ZERO);
+  }
+
+  private ExecutionPayload createExecutionPayload(
+      final UInt64 newSlot,
+      final BeaconState state,
+      final Optional<List<Bytes>> transactions,
+      final Optional<Bytes32> terminalBlock,
+      final Optional<ExecutionRequests> maybeExecutionRequests,
+      final Bytes32 parentBeaconBlockRoot) {
     final SpecVersion specVersion = spec.atSlot(newSlot);
     final ExecutionPayloadSchema<?> schema =
         SchemaDefinitionsBellatrix.required(specVersion.getSchemaDefinitions())
@@ -493,29 +534,95 @@ public class BlockProposalTestUtil {
     final Bytes32 parentHash = terminalBlock.orElse(currentExecutionPayloadBlockHash);
     final UInt64 currentEpoch = specVersion.beaconStateAccessors().getCurrentEpoch(state);
 
-    return schema.createExecutionPayload(
-        builder ->
-            builder
-                .parentHash(parentHash)
-                .feeRecipient(Bytes20.ZERO)
-                .stateRoot(dataStructureUtil.randomBytes32())
-                .receiptsRoot(dataStructureUtil.randomBytes32())
-                .logsBloom(dataStructureUtil.randomBytes256())
-                .prevRandao(specVersion.beaconStateAccessors().getRandaoMix(state, currentEpoch))
-                .blockNumber(newSlot)
-                .gasLimit(UInt64.valueOf(30_000_000L))
-                .gasUsed(UInt64.valueOf(30_000_000L))
-                .timestamp(
-                    specVersion.miscHelpers().computeTimeAtSlot(state.getGenesisTime(), newSlot))
-                .extraData(dataStructureUtil.randomBytes32())
-                .baseFeePerGas(UInt256.ONE)
-                .blockHash(dataStructureUtil.randomBytes32())
-                .transactions(transactions.orElse(Collections.emptyList()))
-                .withdrawals(List::of)
-                .blobGasUsed(() -> UInt64.ZERO)
-                .excessBlobGas(() -> UInt64.ZERO)
-                .blockAccessList(() -> Bytes32.ZERO)
-                .slotNumber(() -> newSlot));
+    final ExecutionPayload payload =
+        schema.createExecutionPayload(
+            builder ->
+                builder
+                    .parentHash(parentHash)
+                    .feeRecipient(Bytes20.ZERO)
+                    .stateRoot(dataStructureUtil.randomBytes32())
+                    .receiptsRoot(dataStructureUtil.randomBytes32())
+                    .logsBloom(dataStructureUtil.randomBytes256())
+                    .prevRandao(
+                        specVersion.beaconStateAccessors().getRandaoMix(state, currentEpoch))
+                    .blockNumber(newSlot)
+                    .gasLimit(UInt64.valueOf(30_000_000L))
+                    .gasUsed(UInt64.valueOf(30_000_000L))
+                    .timestamp(
+                        specVersion
+                            .miscHelpers()
+                            .computeTimeAtSlot(state.getGenesisTime(), newSlot))
+                    .extraData(dataStructureUtil.randomBytes32())
+                    .baseFeePerGas(UInt256.ONE)
+                    .blockHash(dataStructureUtil.randomBytes32())
+                    .transactions(transactions.orElse(Collections.emptyList()))
+                    .withdrawals(List::of)
+                    .blobGasUsed(() -> UInt64.ZERO)
+                    .excessBlobGas(() -> UInt64.ZERO)
+                    .blockAccessList(() -> emptyBlockAccessList)
+                    .slotNumber(() -> newSlot));
+    if (!spec.isExecutionPayloadEnvelopeAvailableAtSlot(newSlot)) {
+      return payload;
+    }
+    return withComputedBlockHash(
+        newSlot,
+        payload,
+        maybeExecutionRequests.orElseGet(() -> createExecutionRequests(newSlot)),
+        parentBeaconBlockRoot);
+  }
+
+  private ExecutionPayload withComputedBlockHash(
+      final UInt64 slot,
+      final ExecutionPayload payload,
+      final ExecutionRequests executionRequests,
+      final Bytes32 parentBeaconBlockRoot) {
+    final SchemaDefinitionsGloas schemaDefinitions =
+        SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions());
+    final ExecutionPayloadEnvelope envelope =
+        schemaDefinitions
+            .getExecutionPayloadEnvelopeSchema()
+            .create(
+                payload,
+                executionRequests,
+                BUILDER_INDEX_SELF_BUILD,
+                Bytes32.ZERO,
+                parentBeaconBlockRoot);
+    final Bytes32 blockHash =
+        ExecutionPayloadBlockHashCalculator.computeGloasBlockHash(
+            envelope, spec.getExecutionRequestsDataCodec(slot));
+    final ExecutionPayloadGloas payloadGloas = ExecutionPayloadGloas.required(payload);
+    return schemaDefinitions
+        .getExecutionPayloadSchema()
+        .createExecutionPayload(
+            builder ->
+                builder
+                    .parentHash(payloadGloas.getParentHash())
+                    .feeRecipient(payloadGloas.getFeeRecipient())
+                    .stateRoot(payloadGloas.getStateRoot())
+                    .receiptsRoot(payloadGloas.getReceiptsRoot())
+                    .logsBloom(payloadGloas.getLogsBloom())
+                    .prevRandao(payloadGloas.getPrevRandao())
+                    .blockNumber(payloadGloas.getBlockNumber())
+                    .gasLimit(payloadGloas.getGasLimit())
+                    .gasUsed(payloadGloas.getGasUsed())
+                    .timestamp(payloadGloas.getTimestamp())
+                    .extraData(payloadGloas.getExtraData())
+                    .baseFeePerGas(payloadGloas.getBaseFeePerGas())
+                    .blockHash(blockHash)
+                    .transactions(
+                        payloadGloas.getTransactions().stream().map(Transaction::getBytes).toList())
+                    .withdrawals(payloadGloas.getWithdrawals()::asList)
+                    .blobGasUsed(payloadGloas::getBlobGasUsed)
+                    .excessBlobGas(payloadGloas::getExcessBlobGas)
+                    .blockAccessList(() -> payloadGloas.getBlockAccessList().getBytes())
+                    .slotNumber(payloadGloas::getSlotNumber));
+  }
+
+  private Bytes createEmptyBlockAccessList() {
+    final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
+    rlpOutput.startList();
+    rlpOutput.endList();
+    return rlpOutput.encoded();
   }
 
   private ExecutionRequests createExecutionRequests(final UInt64 newSlot) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add Gloas execution payload block hash validation using Besu RLP/header utilities and Teku hashing. Historical sync now verifies downloaded execution payload envelopes by recomputing the payload block hash before blinding and storing them

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #10884 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes historical sync acceptance of Gloas execution payloads and ties hash correctness to Besu header encoding; wrong logic would reject valid peers or accept bad data, but scope is Gloas envelope import only.
> 
> **Overview**
> Adds **Gloas execution payload block hash validation** so historical sync rejects tampered or inconsistent envelopes before they are blinded and stored.
> 
> A new `ExecutionPayloadBlockHashCalculator` recomputes the execution block hash from the envelope (payload fields, execution requests, parent beacon root, BAL, slot number, etc.) using Besu header/RLP helpers and keccak256. `HistoricalBatchFetcher.processExecutionPayload` now calls this check and throws `IllegalArgumentException` on mismatch.
> 
> The `ethereum/spec` module gains Besu dependencies for that computation. Test fixtures in `BlockProposalTestUtil` set **computed** `blockHash` on Gloas payloads so chain builders and sync tests stay consistent with the validator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8563d278278c9f048b7c6f3e74efe74f36501107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->