### PR TITLE
Handle worker failure in AggregatingSignatureVerificationService

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationService.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationService.java
@@ -163,7 +163,34 @@ public class AggregatingSignatureVerificationService extends SignatureVerificati
     while (isRunning()) {
       final List<SignatureTask> tasks = waitForBatch();
       if (!tasks.isEmpty()) {
-        batchVerifySignatures(tasks);
+        try {
+          batchVerifySignatures(tasks);
+        } catch (final RuntimeException ex) {
+          // Batch verification can throw on malformed input (for example a BLS aggregate public
+          // key at infinity). Keep the worker alive by falling back to verifying the tasks
+          // individually rather than letting the exception unwind the loop and drop the thread.
+          LOG.error("Unexpected error during batch signature verification", ex);
+          verifyTasksIndividually(tasks);
+        }
+      }
+    }
+  }
+
+  @VisibleForTesting
+  void verifyTasksIndividually(final List<SignatureTask> tasks) {
+    for (final SignatureTask task : tasks) {
+      if (task.result.isDone()) {
+        // Already verified before the failure; skip it so we don't repeat the expensive
+        // verification or overwrite its result.
+        continue;
+      }
+      try {
+        final boolean taskIsValid =
+            BLSSignatureVerifier.SIMPLE.verify(task.publicKeys, task.messages, task.signatures);
+        task.completeAsync(taskIsValid);
+      } catch (final RuntimeException ex) {
+        // Isolate the failure to this task so the rest of the batch still completes.
+        task.completeExceptionallyAsync(ex);
       }
     }
   }
@@ -209,7 +236,7 @@ public class AggregatingSignatureVerificationService extends SignatureVerificati
       }
     } else if (tasks.size() == 1) {
       // We only had 1 signature, so it must be invalid
-      tasks.get(0).completeAsync(false);
+      tasks.getFirst().completeAsync(false);
     } else if (tasks.size() >= minBatchSizeToSplit) {
       // Split up tasks and try to verify in smaller batches
       final List<List<SignatureTask>> splitTasks = splitTasks(tasks);
@@ -257,6 +284,12 @@ public class AggregatingSignatureVerificationService extends SignatureVerificati
 
     public void completeAsync(final boolean isValid) {
       asyncRunner.runAsync(() -> result.complete(isValid)).finish(result::completeExceptionally);
+    }
+
+    public void completeExceptionallyAsync(final Throwable error) {
+      asyncRunner
+          .runAsync(() -> result.completeExceptionally(error))
+          .finish(result::completeExceptionally);
     }
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationServiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/signatures/AggregatingSignatureVerificationServiceTest.java
@@ -278,6 +278,66 @@ public class AggregatingSignatureVerificationServiceTest {
     }
   }
 
+  @Test
+  public void verifyTasksIndividually_completesPendingTasksAndSkipsCompletedOnes() {
+    startService();
+
+    final SafeFuture<Boolean> alreadyCompleted = executeValidVerify(0, 0);
+    final SafeFuture<Boolean> pendingValid = executeValidVerify(1, 1);
+    // Mismatched key / message / signature list sizes make verification throw for this task.
+    final SafeFuture<Boolean> pendingMalformed =
+        service.verify(
+            List.of(List.of(KEYS.get(2).getPublicKey())), List.of(Bytes.of(2)), List.of());
+    final List<SignatureTask> tasks = getPendingTasks();
+
+    // Complete the first task up front, as if it had already been verified earlier in the batch.
+    tasks.getFirst().completeAsync(true);
+    completionRunner.executeQueuedActions();
+    assertThat(alreadyCompleted).isCompletedWithValue(true);
+
+    service.verifyTasksIndividually(tasks);
+    completionRunner.executeQueuedActions();
+
+    // The already-completed task is left untouched, the pending valid one is verified, and the
+    // malformed one fails in isolation without affecting the others.
+    assertThat(alreadyCompleted).isCompletedWithValue(true);
+    assertThat(pendingValid).isCompletedWithValue(true);
+    assertThat(pendingMalformed).isCompletedExceptionally();
+  }
+
+  @Test
+  public void run_isolatesFailureAndKeepsWorkerAliveWhenBatchVerificationThrows() throws Exception {
+    final MetricsSystem metrics = new StubMetricsSystem();
+    final AsyncRunnerFactory realRunnerFactory =
+        AsyncRunnerFactory.createDefault(new MetricTrackingExecutorFactory(metrics));
+    service =
+        new AggregatingSignatureVerificationService(
+            metrics,
+            realRunnerFactory,
+            realRunnerFactory.create("completion", 1),
+            // Single worker thread: if a thrown batch permanently killed the worker, the following
+            // valid task would hang and the test would time out.
+            1,
+            queueCapacity,
+            batchSize,
+            minBatchSizeToSplit,
+            strictThreadLimitEnabled);
+    startService();
+
+    // Mismatched public key / message / signature list sizes make the underlying BLS batch
+    // verification throw. This used to kill the worker thread permanently.
+    final SafeFuture<Boolean> malformed =
+        service.verify(
+            List.of(List.of(KEYS.get(0).getPublicKey())), List.of(Bytes.of(1)), List.of());
+    Waiter.waitFor(malformed.exceptionally(err -> false), Duration.ofSeconds(5));
+    assertThat(malformed).isCompletedExceptionally();
+
+    // The worker survived the failure, so a subsequent valid signature is still verified.
+    final SafeFuture<Boolean> valid = executeValidVerify(0, 0);
+    Waiter.waitFor(valid, Duration.ofSeconds(5));
+    assertThat(valid).isCompletedWithValue(true);
+  }
+
   @SuppressWarnings("FutureReturnValueIgnored")
   @Test
   public void splitTasks_evenNumber() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

  A `RuntimeException` from batch BLS verification (e.g. an aggregate public key at infinity) escaped the worker loop and terminated the thread — before this fix a failed worker was never reused, so verification could stall until restart when all workers are damaged.
  The worker loop now catches such errors and falls back to verifying each task individually, keeping the thread alive and failing only the offending task in isolation.
  Already-completed tasks are skipped so the expensive verification isn't repeated; adds tests covering worker survival and the skip/isolation behaviour.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical async BLS verification; incorrect fallback could mis-handle futures, but behavior is narrowly defensive with new regression tests.
> 
> **Overview**
> **Batch BLS verification** in `AggregatingSignatureVerificationService` no longer lets a `RuntimeException` (e.g. malformed inputs or aggregate key at infinity) escape the worker loop and permanently kill the thread.
> 
> The worker **`run()`** loop now catches batch failures, logs them, and falls back to **`verifyTasksIndividually`**, which verifies pending tasks with simple per-task BLS checks, skips tasks whose futures are already done, and completes only the failing task exceptionally via new **`completeExceptionallyAsync`** on **`SignatureTask`**.
> 
> Tests cover worker survival after a throwing batch and the skip/isolate behavior for mixed valid, completed, and malformed tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89612c05a77522c3dd81b50b01c721018b44a502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->