### PR TITLE
Tolerate individual malformed ENRs in discv5

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5Service.java
@@ -131,7 +131,7 @@ public class DiscV5Service extends Service implements DiscoveryService {
         kvStore.get(SEQ_NO_STORE_KEY).map(UInt64::fromBytes).orElse(UInt64.ZERO).add(1);
     final NewAddressHandler maybeUpdateNodeRecordHandler = maybeUpdateNodeRecord(p2pConfig);
     this.bootnodes =
-        discoConfig.getBootnodes().stream().map(NodeRecordFactory.DEFAULT::fromEnr).toList();
+        discoConfig.getBootnodes().stream().flatMap(enr -> parseBootnode(enr).stream()).toList();
     final NodeRecordBuilder nodeRecordBuilder =
         new NodeRecordBuilder().signer(localNodeSigner).seq(seqNo);
     final List<String> advertisedIps = p2pConfig.getAdvertisedIps();
@@ -284,6 +284,16 @@ public class DiscV5Service extends Service implements DiscoveryService {
     final SchemaDefinitions schemaDefinitions =
         currentSchemaDefinitionsSupplier.getSchemaDefinitions();
     return foundNodes.stream().flatMap(nodeRecordToDiscoveryPeer(schemaDefinitions)).toList();
+  }
+
+  private static Optional<NodeRecord> parseBootnode(final String enr) {
+    try {
+      return Optional.of(NodeRecordFactory.DEFAULT.fromEnr(enr));
+    } catch (final RuntimeException e) {
+      // One malformed bootnode must not prevent startup or discard the others.
+      LOG.warn("Ignoring malformed bootnode ENR: {}", enr, e);
+      return Optional.empty();
+    }
   }
 
   private Function<NodeRecord, Stream<DiscoveryPeer>> nodeRecordToDiscoveryPeer(

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java
@@ -59,13 +59,19 @@ public class NodeRecordConverter {
       final Optional<Integer> maxDasCustodyGroupCount) {
     final Optional<InetSocketAddress> tcpAddress;
     final Optional<InetSocketAddress> quicAddress;
-    if (supportsIpv6) {
-      // prefer IPv6 address
-      tcpAddress = nodeRecord.getTcp6Address().or(nodeRecord::getTcpAddress);
-      quicAddress = nodeRecord.getQuic6Address().or(nodeRecord::getQuicAddress);
-    } else {
-      tcpAddress = nodeRecord.getTcpAddress();
-      quicAddress = nodeRecord.getQuicAddress();
+    try {
+      if (supportsIpv6) {
+        // prefer IPv6 address
+        tcpAddress = nodeRecord.getTcp6Address().or(nodeRecord::getTcpAddress);
+        quicAddress = nodeRecord.getQuic6Address().or(nodeRecord::getQuicAddress);
+      } else {
+        tcpAddress = nodeRecord.getTcpAddress();
+        quicAddress = nodeRecord.getQuicAddress();
+      }
+    } catch (final RuntimeException e) {
+      // A single malformed record (e.g. an out-of-range port) must not drop the rest of the batch.
+      LOG.debug("Ignoring node record with unusable address: {}", nodeRecord, e);
+      return Optional.empty();
     }
     return tcpAddress.map(
         address ->

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5ServiceTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/DiscV5ServiceTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.p2p.discovery.discv5;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.libp2p.core.crypto.KeyKt;
 import io.libp2p.core.crypto.KeyType;
@@ -75,6 +76,27 @@ class DiscV5ServiceTest {
     assertThat(discoverySystemBuilder.listenAddresses[0].getAddress().isAnyLocalAddress()).isTrue();
     assertThat(IPVersionResolver.resolve(discoverySystemBuilder.listenAddresses[0]))
         .isEqualTo(IPVersion.IP_V6);
+  }
+
+  @Test
+  void shouldSkipMalformedBootnodeWithoutFailingStartup() {
+    final DiscoveryConfig discoveryConfig =
+        DiscoveryConfig.builder()
+            .listenUdpPort(9000)
+            .listenUdpPortIpv6(9000)
+            .bootnodes(List.of("enr:-not-valid-base64!!!"))
+            .build();
+    final NetworkConfig networkConfig =
+        NetworkConfig.builder()
+            .networkInterfaces(List.of("0.0.0.0", "::"))
+            .advertisedIps(Optional.of(List.of("127.0.0.1", "::1")))
+            .build();
+
+    assertThatCode(
+            () ->
+                createService(
+                    discoveryConfig, networkConfig, new CapturingDiscoverySystemBuilder()))
+        .doesNotThrowAnyException();
   }
 
   private static void createService(

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
@@ -116,6 +116,16 @@ class NodeRecordConverterTest {
   }
 
   @Test
+  public void shouldNotConvertRecordWithOutOfRangeTcpPort() {
+    assertThat(
+            convertNodeRecordWithFields(
+                false,
+                new EnrField(EnrField.IP_V4, Bytes.wrap(new byte[] {127, 0, 0, 1})),
+                new EnrField(EnrField.TCP, 70000)))
+        .isEmpty();
+  }
+
+  @Test
   public void shouldUseV4PortIfV6PortSpecifiedWithNoV6Ip() {
     assertThat(
             convertNodeRecordWithFields(


### PR DESCRIPTION
## Changes

Two related robustness fixes so that a single malformed ENR cannot disrupt discv5 beyond that one record:

- `NodeRecordConverter.convertToDiscoveryPeer`: address resolution (`getTcpAddress` / `getQuicAddress`) can throw on a record with an out-of-range port. Because the conversion is consumed via `flatMap` (`streamKnownPeers` / `convertToDiscoveryPeers`), one throwing record aborted the entire peer-conversion batch. It now catches the failure per record and skips only that record.
- `DiscV5Service` constructor: bootnodes were decoded with `.map(NodeRecordFactory.DEFAULT::fromEnr)`, so one un-decodable `--p2p-discovery-bootnodes` entry threw and prevented node startup. Bootnodes are now parsed individually, skipping a bad entry.

Found during a cross-client discv5 audit.

## Testing

Unit tests added to `NodeRecordConverterTest` (out-of-range port → skipped) and `DiscV5ServiceTest` (malformed bootnode → startup does not fail); both fail before the change and pass after. `spotlessApply` + `:networking:p2p:test` run clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive error handling in P2P discovery with unit test coverage; behavior change is to ignore bad ENRs rather than fail.
> 
> **Overview**
> Discv5 no longer lets **one bad ENR** take down startup or wipe an entire peer batch.
> 
> **Bootnodes:** `DiscV5Service` decodes each `--p2p-discovery-bootnodes` entry via `parseBootnode`, which catches decode failures, logs a warning, and drops only that ENR instead of failing constructor startup.
> 
> **Peer conversion:** `NodeRecordConverter.convertToDiscoveryPeer` wraps TCP/QUIC address resolution in try/catch so records with invalid ports (etc.) return empty and are skipped when `streamKnownPeers` / `convertToDiscoveryPeers` flatMap over node records.
> 
> Unit tests cover malformed bootnode startup and out-of-range TCP port conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd80b4f7f71396935b1e20ff6e57f4cc3eb8b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->