### PR TITLE
Produce block scripts

### DIFF
--- a/scripts/produce-block-v3.sh
+++ b/scripts/produce-block-v3.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Produce a block via the Beacon API produceBlockV3 endpoint (pre-Gloas forks).
+#   GET /eth/v3/validator/blocks/{slot}?randao_reveal=...
+#
+# Subscribes to the beacon node's SSE 'head' event stream, waits for the first
+# head event, then requests a block for the next slot using a random
+# randao_reveal and exits. skip_randao_verification is set so the node does not
+# reject the random signature.
+#
+# Usage:
+#   ./produce-block-v3.sh [BEACON_URL]
+#
+# Env:
+#   BEACON_URL   Beacon node REST endpoint (default: http://localhost:5051)
+
+set -euo pipefail
+
+BEACON_URL="${1:-${BEACON_URL:-http://localhost:5051}}"
+
+for cmd in curl jq; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: '$cmd' is required" >&2; exit 1; }
+done
+
+# 1. Subscribe to the head SSE event stream and read the first head event's slot.
+echo "waiting for head event from ${BEACON_URL}..." >&2
+head_slot=""
+while IFS= read -r line; do
+  # SSE data lines look like: data: {"slot":"123","block":"0x..",...}
+  if [[ "$line" == data:* ]]; then
+    head_slot="$(printf '%s' "${line#data:}" | jq -r '.slot // empty' 2>/dev/null || true)"
+    if [[ -n "$head_slot" && "$head_slot" != "null" ]]; then
+      break
+    fi
+  fi
+done < <(curl -sfN -H 'Accept: text/event-stream' \
+  "${BEACON_URL}/eth/v1/events?topics=head")
+
+if [[ -z "$head_slot" || "$head_slot" == "null" ]]; then
+  echo "error: could not read head slot from ${BEACON_URL} event stream" >&2
+  exit 1
+fi
+
+# 2. Target the next slot.
+next_slot=$((head_slot + 1))
+
+# 3. Random randao_reveal: a 96-byte BLS signature (0x + 192 hex chars).
+randao_reveal="0x$(head -c 96 /dev/urandom | xxd -p -c 256)"
+
+echo "head slot:      ${head_slot}" >&2
+echo "producing slot: ${next_slot}" >&2
+echo "randao_reveal:  ${randao_reveal}" >&2
+echo >&2
+
+# 4. Call produceBlockV3 and pretty-print the response.
+#    The fork (version) is returned in the Eth-Consensus-Version response header
+#    and in the JSON body's "version" field. On a non-2xx status the response
+#    body (which carries the error message) is printed so the failure is visible.
+response="$(curl -sS -G "${BEACON_URL}/eth/v3/validator/blocks/${next_slot}" \
+  --data-urlencode "randao_reveal=${randao_reveal}" \
+  --data-urlencode "skip_randao_verification=" \
+  -w $'\n%{http_code}')"
+
+http_code="${response##*$'\n'}"
+body="${response%$'\n'*}"
+
+if [[ "$http_code" != 2* ]]; then
+  echo "error: produceBlockV3 returned HTTP ${http_code}" >&2
+  printf '%s\n' "$body" | jq . 2>/dev/null || printf '%s\n' "$body" >&2
+  exit 1
+fi
+
+printf '%s\n' "$body" | jq .

--- a/scripts/produce-block-v3.sh
+++ b/scripts/produce-block-v3.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 BEACON_URL="${1:-${BEACON_URL:-http://localhost:5051}}"
 
-for cmd in curl jq; do
+for cmd in curl jq xxd; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "error: '$cmd' is required" >&2; exit 1; }
 done
 

--- a/scripts/produce-block-v3.sh
+++ b/scripts/produce-block-v3.sh
@@ -13,6 +13,9 @@
 #
 # Env:
 #   BEACON_URL   Beacon node REST endpoint (default: http://localhost:5051)
+#   GRAFFITI     If set, passed as the graffiti query param. May be a plain
+#                UTF-8 string or a 0x-prefixed hex value; at most 32 bytes
+#                (bytes32).
 
 set -euo pipefail
 
@@ -21,6 +24,41 @@ BEACON_URL="${1:-${BEACON_URL:-http://localhost:5051}}"
 for cmd in curl jq; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "error: '$cmd' is required" >&2; exit 1; }
 done
+
+# 0. Validate/normalize optional GRAFFITI up front so bad input fails fast
+#    (before we block waiting for a head event).
+#    The API expects a bytes32 hex value. A 0x-prefixed value is used as-is;
+#    a plain string is UTF-8 encoded to hex. Either way it is zero-padded on the
+#    right to exactly 32 bytes.
+extra_args=()
+if [[ -n "${GRAFFITI:-}" ]]; then
+  if [[ "$GRAFFITI" == 0x* || "$GRAFFITI" == 0X* ]]; then
+    graffiti_hex="${GRAFFITI:2}"
+    if [[ ! "$graffiti_hex" =~ ^[0-9a-fA-F]*$ ]]; then
+      echo "error: GRAFFITI is 0x-prefixed but contains non-hex characters" >&2
+      exit 1
+    fi
+    if (( ${#graffiti_hex} % 2 != 0 )); then
+      echo "error: GRAFFITI hex value must have an even number of digits" >&2
+      exit 1
+    fi
+  else
+    graffiti_hex="$(printf '%s' "$GRAFFITI" | xxd -p -c 256 | tr -d '\n')"
+  fi
+  if (( ${#graffiti_hex} > 64 )); then
+    echo "error: GRAFFITI is $(( ${#graffiti_hex} / 2 )) bytes; maximum is 32 (bytes32)" >&2
+    exit 1
+  fi
+  # Right-pad with zeros to 32 bytes (64 hex chars).
+  pad=$(( 64 - ${#graffiti_hex} ))
+  if (( pad > 0 )); then
+    printf -v zeros '%*s' "$pad" ''
+    graffiti_hex="${graffiti_hex}${zeros// /0}"
+  fi
+  graffiti_value="0x${graffiti_hex}"
+  extra_args+=(--data-urlencode "graffiti=${graffiti_value}")
+  echo "graffiti:       ${GRAFFITI} -> ${graffiti_value}" >&2
+fi
 
 # 1. Subscribe to the head SSE event stream and read the first head event's slot.
 echo "waiting for head event from ${BEACON_URL}..." >&2
@@ -59,6 +97,7 @@ echo >&2
 response="$(curl -sS -G "${BEACON_URL}/eth/v3/validator/blocks/${next_slot}" \
   --data-urlencode "randao_reveal=${randao_reveal}" \
   --data-urlencode "skip_randao_verification=" \
+  "${extra_args[@]}" \
   -w $'\n%{http_code}')"
 
 http_code="${response##*$'\n'}"

--- a/scripts/produce-block-v4.sh
+++ b/scripts/produce-block-v4.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Produce a block via the Beacon API produceBlockV4 endpoint.
+#   GET /eth/v4/validator/blocks/{slot}?randao_reveal=...
+#
+# Subscribes to the beacon node's SSE 'head' event stream, waits for the first
+# head event, then requests a block for the next slot using a random
+# randao_reveal and exits. skip_randao_verification is set so the node does not
+# reject the random signature.
+#
+# Usage:
+#   ./produce-block-v4.sh [BEACON_URL]
+#
+# Env:
+#   BEACON_URL   Beacon node REST endpoint (default: http://localhost:5051)
+
+set -euo pipefail
+
+BEACON_URL="${1:-${BEACON_URL:-http://localhost:5051}}"
+
+for cmd in curl jq; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: '$cmd' is required" >&2; exit 1; }
+done
+
+# 1. Subscribe to the head SSE event stream and read the first head event's slot.
+echo "waiting for head event from ${BEACON_URL}..." >&2
+head_slot=""
+while IFS= read -r line; do
+  # SSE data lines look like: data: {"slot":"123","block":"0x..",...}
+  if [[ "$line" == data:* ]]; then
+    head_slot="$(printf '%s' "${line#data:}" | jq -r '.slot // empty' 2>/dev/null || true)"
+    if [[ -n "$head_slot" && "$head_slot" != "null" ]]; then
+      break
+    fi
+  fi
+done < <(curl -sfN -H 'Accept: text/event-stream' \
+  "${BEACON_URL}/eth/v1/events?topics=head")
+
+if [[ -z "$head_slot" || "$head_slot" == "null" ]]; then
+  echo "error: could not read head slot from ${BEACON_URL} event stream" >&2
+  exit 1
+fi
+
+# 2. Target the next slot.
+next_slot=$((head_slot + 1))
+
+# 3. Random randao_reveal: a 96-byte BLS signature (0x + 192 hex chars).
+randao_reveal="0x$(head -c 96 /dev/urandom | xxd -p -c 256)"
+
+echo "head slot:      ${head_slot}" >&2
+echo "producing slot: ${next_slot}" >&2
+echo "randao_reveal:  ${randao_reveal}" >&2
+echo >&2
+
+# 4. Call produceBlockV4 and pretty-print the response. On a non-2xx status the
+#    response body (which carries the error message) is printed so the failure
+#    is visible.
+response="$(curl -sS -G "${BEACON_URL}/eth/v4/validator/blocks/${next_slot}" \
+  --data-urlencode "randao_reveal=${randao_reveal}" \
+  --data-urlencode "skip_randao_verification=" \
+  -w $'\n%{http_code}')"
+
+http_code="${response##*$'\n'}"
+body="${response%$'\n'*}"
+
+if [[ "$http_code" != 2* ]]; then
+  echo "error: produceBlockV4 returned HTTP ${http_code}" >&2
+  printf '%s\n' "$body" | jq . 2>/dev/null || printf '%s\n' "$body" >&2
+  exit 1
+fi
+
+printf '%s\n' "$body" | jq .

--- a/scripts/produce-block-v4.sh
+++ b/scripts/produce-block-v4.sh
@@ -12,7 +12,9 @@
 #   ./produce-block-v4.sh [BEACON_URL]
 #
 # Env:
-#   BEACON_URL   Beacon node REST endpoint (default: http://localhost:5051)
+#   BEACON_URL        Beacon node REST endpoint (default: http://localhost:5051)
+#   INCLUDE_PAYLOAD   If set (expects 'true' or 'false'), passed as the
+#                     include_payload query param on the produceBlockV4 request.
 
 set -euo pipefail
 
@@ -55,9 +57,16 @@ echo >&2
 # 4. Call produceBlockV4 and pretty-print the response. On a non-2xx status the
 #    response body (which carries the error message) is printed so the failure
 #    is visible.
+include_payload_args=()
+if [[ -n "${INCLUDE_PAYLOAD:-}" ]]; then
+  include_payload_args+=(--data-urlencode "include_payload=${INCLUDE_PAYLOAD}")
+  echo "include_payload: ${INCLUDE_PAYLOAD}" >&2
+fi
+
 response="$(curl -sS -G "${BEACON_URL}/eth/v4/validator/blocks/${next_slot}" \
   --data-urlencode "randao_reveal=${randao_reveal}" \
   --data-urlencode "skip_randao_verification=" \
+  "${include_payload_args[@]}" \
   -w $'\n%{http_code}')"
 
 http_code="${response##*$'\n'}"

--- a/scripts/produce-block-v4.sh
+++ b/scripts/produce-block-v4.sh
@@ -23,43 +23,12 @@ set -euo pipefail
 
 BEACON_URL="${1:-${BEACON_URL:-http://localhost:5051}}"
 
-for cmd in curl jq; do
+for cmd in curl jq xxd; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "error: '$cmd' is required" >&2; exit 1; }
 done
 
-# 1. Subscribe to the head SSE event stream and read the first head event's slot.
-echo "waiting for head event from ${BEACON_URL}..." >&2
-head_slot=""
-while IFS= read -r line; do
-  # SSE data lines look like: data: {"slot":"123","block":"0x..",...}
-  if [[ "$line" == data:* ]]; then
-    head_slot="$(printf '%s' "${line#data:}" | jq -r '.slot // empty' 2>/dev/null || true)"
-    if [[ -n "$head_slot" && "$head_slot" != "null" ]]; then
-      break
-    fi
-  fi
-done < <(curl -sfN -H 'Accept: text/event-stream' \
-  "${BEACON_URL}/eth/v1/events?topics=head")
-
-if [[ -z "$head_slot" || "$head_slot" == "null" ]]; then
-  echo "error: could not read head slot from ${BEACON_URL} event stream" >&2
-  exit 1
-fi
-
-# 2. Target the next slot.
-next_slot=$((head_slot + 1))
-
-# 3. Random randao_reveal: a 96-byte BLS signature (0x + 192 hex chars).
-randao_reveal="0x$(head -c 96 /dev/urandom | xxd -p -c 256)"
-
-echo "head slot:      ${head_slot}" >&2
-echo "producing slot: ${next_slot}" >&2
-echo "randao_reveal:  ${randao_reveal}" >&2
-echo >&2
-
-# 4. Call produceBlockV4 and pretty-print the response. On a non-2xx status the
-#    response body (which carries the error message) is printed so the failure
-#    is visible.
+# 0. Build/validate optional query params up front so bad input fails fast
+#    (before we block waiting for a head event).
 extra_args=()
 if [[ -n "${INCLUDE_PAYLOAD:-}" ]]; then
   extra_args+=(--data-urlencode "include_payload=${INCLUDE_PAYLOAD}")
@@ -98,6 +67,39 @@ if [[ -n "${GRAFFITI:-}" ]]; then
   echo "graffiti:       ${GRAFFITI} -> ${graffiti_value}" >&2
 fi
 
+# 1. Subscribe to the head SSE event stream and read the first head event's slot.
+echo "waiting for head event from ${BEACON_URL}..." >&2
+head_slot=""
+while IFS= read -r line; do
+  # SSE data lines look like: data: {"slot":"123","block":"0x..",...}
+  if [[ "$line" == data:* ]]; then
+    head_slot="$(printf '%s' "${line#data:}" | jq -r '.slot // empty' 2>/dev/null || true)"
+    if [[ -n "$head_slot" && "$head_slot" != "null" ]]; then
+      break
+    fi
+  fi
+done < <(curl -sfN -H 'Accept: text/event-stream' \
+  "${BEACON_URL}/eth/v1/events?topics=head")
+
+if [[ -z "$head_slot" || "$head_slot" == "null" ]]; then
+  echo "error: could not read head slot from ${BEACON_URL} event stream" >&2
+  exit 1
+fi
+
+# 2. Target the next slot.
+next_slot=$((head_slot + 1))
+
+# 3. Random randao_reveal: a 96-byte BLS signature (0x + 192 hex chars).
+randao_reveal="0x$(head -c 96 /dev/urandom | xxd -p -c 256)"
+
+echo "head slot:      ${head_slot}" >&2
+echo "producing slot: ${next_slot}" >&2
+echo "randao_reveal:  ${randao_reveal}" >&2
+echo >&2
+
+# 4. Call produceBlockV4 and pretty-print the response. On a non-2xx status the
+#    response body (which carries the error message) is printed so the failure
+#    is visible.
 response="$(curl -sS -G "${BEACON_URL}/eth/v4/validator/blocks/${next_slot}" \
   --data-urlencode "randao_reveal=${randao_reveal}" \
   --data-urlencode "skip_randao_verification=" \

--- a/scripts/produce-block-v4.sh
+++ b/scripts/produce-block-v4.sh
@@ -15,6 +15,9 @@
 #   BEACON_URL        Beacon node REST endpoint (default: http://localhost:5051)
 #   INCLUDE_PAYLOAD   If set (expects 'true' or 'false'), passed as the
 #                     include_payload query param on the produceBlockV4 request.
+#   GRAFFITI          If set, passed as the graffiti query param. May be a plain
+#                     UTF-8 string or a 0x-prefixed hex value; at most 32 bytes
+#                     (bytes32).
 
 set -euo pipefail
 
@@ -57,16 +60,48 @@ echo >&2
 # 4. Call produceBlockV4 and pretty-print the response. On a non-2xx status the
 #    response body (which carries the error message) is printed so the failure
 #    is visible.
-include_payload_args=()
+extra_args=()
 if [[ -n "${INCLUDE_PAYLOAD:-}" ]]; then
-  include_payload_args+=(--data-urlencode "include_payload=${INCLUDE_PAYLOAD}")
+  extra_args+=(--data-urlencode "include_payload=${INCLUDE_PAYLOAD}")
   echo "include_payload: ${INCLUDE_PAYLOAD}" >&2
+fi
+
+if [[ -n "${GRAFFITI:-}" ]]; then
+  # The API expects a bytes32 hex value. A 0x-prefixed value is used as-is;
+  # a plain string is UTF-8 encoded to hex. Either way it is zero-padded on the
+  # right to exactly 32 bytes.
+  if [[ "$GRAFFITI" == 0x* || "$GRAFFITI" == 0X* ]]; then
+    graffiti_hex="${GRAFFITI:2}"
+    if [[ ! "$graffiti_hex" =~ ^[0-9a-fA-F]*$ ]]; then
+      echo "error: GRAFFITI is 0x-prefixed but contains non-hex characters" >&2
+      exit 1
+    fi
+    if (( ${#graffiti_hex} % 2 != 0 )); then
+      echo "error: GRAFFITI hex value must have an even number of digits" >&2
+      exit 1
+    fi
+  else
+    graffiti_hex="$(printf '%s' "$GRAFFITI" | xxd -p -c 256 | tr -d '\n')"
+  fi
+  if (( ${#graffiti_hex} > 64 )); then
+    echo "error: GRAFFITI is $(( ${#graffiti_hex} / 2 )) bytes; maximum is 32 (bytes32)" >&2
+    exit 1
+  fi
+  # Right-pad with zeros to 32 bytes (64 hex chars).
+  pad=$(( 64 - ${#graffiti_hex} ))
+  if (( pad > 0 )); then
+    printf -v zeros '%*s' "$pad" ''
+    graffiti_hex="${graffiti_hex}${zeros// /0}"
+  fi
+  graffiti_value="0x${graffiti_hex}"
+  extra_args+=(--data-urlencode "graffiti=${graffiti_value}")
+  echo "graffiti:       ${GRAFFITI} -> ${graffiti_value}" >&2
 fi
 
 response="$(curl -sS -G "${BEACON_URL}/eth/v4/validator/blocks/${next_slot}" \
   --data-urlencode "randao_reveal=${randao_reveal}" \
   --data-urlencode "skip_randao_verification=" \
-  "${include_payload_args[@]}" \
+  "${extra_args[@]}" \
   -w $'\n%{http_code}')"
 
 http_code="${response##*$'\n'}"

--- a/scripts/test/test-produce-block-v3.sh
+++ b/scripts/test/test-produce-block-v3.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Basic test coverage for produce-block-v3.sh.
+#
+# Input-validation tests run unconditionally (they fail fast without a node).
+# Block-production tests only run when a beacon node is reachable; node
+# availability is probed via GET /eth/v1/node/identity.
+#
+# Usage:
+#   ./test-produce-block-v3.sh [BEACON_URL]
+#
+# Env:
+#   BEACON_URL   Beacon node REST endpoint (default: http://localhost:5051)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRODUCE="${SCRIPT_DIR}/../produce-block-v3.sh"
+BEACON_URL="${1:-${BEACON_URL:-http://localhost:5051}}"
+
+pass=0
+fail=0
+
+ok()   { echo "  PASS: $1"; pass=$((pass + 1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail + 1)); }
+
+# expect_reject <desc> <needle> <cmd...>
+# Assert <cmd...> exits non-zero and prints an error containing <needle>.
+expect_reject() {
+  local desc="$1" needle="$2"; shift 2
+  local out rc
+  out="$("$@" "$PRODUCE" "$BEACON_URL" 2>&1)"
+  rc=$?
+  if (( rc == 0 )); then
+    bad "${desc} (expected non-zero exit, got 0)"
+  elif [[ "$out" != *"$needle"* ]]; then
+    bad "${desc} (missing '${needle}' in output: ${out})"
+  else
+    ok "$desc"
+  fi
+}
+
+# expect_graffiti_prefix <desc> <expected-hex-prefix> <cmd...>
+# Run <cmd...>, extract the block graffiti, assert it starts with the prefix.
+expect_graffiti_prefix() {
+  local desc="$1" prefix="$2"; shift 2
+  local graffiti
+  graffiti="$("$@" "$PRODUCE" "$BEACON_URL" 2>/dev/null | jq -r '.data.body.graffiti')"
+  if [[ "$graffiti" == "${prefix}"* ]]; then
+    ok "${desc} -> ${graffiti}"
+  else
+    bad "${desc} (expected prefix ${prefix}, got ${graffiti})"
+  fi
+}
+
+echo "== input validation (no node required) =="
+# Oversized string (33 bytes > 32).
+expect_reject "rejects >32-byte string" "maximum is 32" \
+  env GRAFFITI="this is exactly thirty-three byte"
+# Oversized hex (33 bytes).
+expect_reject "rejects >32-byte hex" "maximum is 32" \
+  env GRAFFITI="0x$(printf '%066x' 0)"
+# Odd number of hex digits.
+expect_reject "rejects odd-length hex" "even number of digits" \
+  env GRAFFITI="0xabc"
+# Non-hex characters after 0x.
+expect_reject "rejects non-hex 0x value" "non-hex characters" \
+  env GRAFFITI="0xzz"
+
+echo
+echo "== node probe (${BEACON_URL}/eth/v1/node/identity) =="
+if ! curl -sf "${BEACON_URL}/eth/v1/node/identity" >/dev/null 2>&1; then
+  echo "  SKIP: node not reachable; skipping block-production tests"
+  echo
+  echo "== summary: ${pass} passed, ${fail} failed (production tests skipped) =="
+  (( fail == 0 )) || exit 1
+  exit 0
+fi
+echo "  node is up"
+
+echo
+echo "== block production (node required) =="
+# Use full 32-byte inputs so the returned graffiti is verbatim: with fewer than
+# 32 bytes the node may append its client-version watermark into the free space.
+#
+# Full 32-byte hex is returned exactly.
+full_hex="0x1111111111111111111111111111111111111111111111111111111111111111"
+expect_graffiti_prefix "full 32-byte hex passes through" "$full_hex" \
+  env GRAFFITI="$full_hex"
+# Full 32-char string is UTF-8 encoded to exactly 32 bytes and returned exactly.
+str32="abcdefghabcdefghabcdefghabcdefgh"
+str32_hex="0x$(printf '%s' "$str32" | xxd -p -c 256 | tr -d '\n')"
+expect_graffiti_prefix "full 32-char string encodes to hex" "$str32_hex" \
+  env GRAFFITI="$str32"
+# No graffiti set: the script must still produce a valid block.
+if env -u GRAFFITI "$PRODUCE" "$BEACON_URL" 2>/dev/null | jq -e '.data.body.graffiti' >/dev/null; then
+  ok "no GRAFFITI still produces a block"
+else
+  bad "no GRAFFITI still produces a block"
+fi
+
+echo
+echo "== summary: ${pass} passed, ${fail} failed =="
+(( fail == 0 ))


### PR DESCRIPTION
Some utility scripts to call our rest api to create an unsigned block when testing. 

not suitable for production use.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds standalone dev/test shell scripts only; no changes to node runtime, consensus, or production paths.
> 
> **Overview**
> Adds **bash utilities for local/testing use** that request an unsigned beacon block from a running node via the Validator REST API.
> 
> **`produce-block-v3.sh`** and **`produce-block-v4.sh`** wait on the SSE `head` topic, target **head slot + 1**, call `GET /eth/v3|v4/validator/blocks/{slot}` with a random `randao_reveal` and `skip_randao_verification`, then pretty-print JSON (or surface API errors on non-2xx). Optional **`GRAFFITI`** is validated and normalized to bytes32 hex; v4 also supports **`INCLUDE_PAYLOAD`**.
> 
> **`scripts/test/test-produce-block-v3.sh`** covers graffiti validation without a node and, when `/eth/v1/node/identity` succeeds, checks block production and graffiti handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d75017ac8c080eaabc47699c752a75ecb0e1af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->