### PR TITLE
Ssz additional optimizations

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/ProgressiveSszBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/ProgressiveSszBenchmark.java
@@ -1,0 +1,603 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.benchmarks.ssz;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableContainer;
+import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszMutablePrimitiveList;
+import tech.pegasys.teku.infrastructure.ssz.impl.SszContainerImpl;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.NamedSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {"-Xmx2g", "-Xms2g"})
+public class ProgressiveSszBenchmark {
+
+  private static final int RANDOM_ACCESS_COUNT = 1024;
+  private static final int DEFAULT_LIST_SIZE = 65_536;
+  private static final int DEFAULT_CONTAINER_FIELD_COUNT = 64;
+  private static final int ELEMENT_FIELD_COUNT = 4;
+
+  public enum Representation {
+    BOUNDED,
+    PROGRESSIVE
+  }
+
+  @State(Scope.Thread)
+  public static class ByteListState {
+
+    @Param({"BOUNDED", "PROGRESSIVE"})
+    public Representation representation;
+
+    @Param({"" + DEFAULT_LIST_SIZE})
+    public int size;
+
+    private SszByteListSchema<? extends SszByteList> schema;
+    private TreeNode backingNode;
+    private Bytes serialized;
+    private int[] randomIndexes;
+
+    @Setup
+    public void setup() {
+      schema =
+          representation == Representation.BOUNDED
+              ? SszByteListSchema.create(size + 1024L)
+              : new SszProgressiveByteListSchema<>();
+
+      final SszByteList list = schema.fromBytes(createBytes(size));
+      backingNode = list.getBackingNode();
+      serialized = list.sszSerialize();
+      randomIndexes = createRandomIndexes(size);
+    }
+
+    private SszByteList createView() {
+      return schema.createFromBackingNode(backingNode);
+    }
+  }
+
+  /**
+   * Tree nodes memoize their hashTreeRoot, so hashing benchmarks must rebuild an uncached tree
+   * before every invocation; otherwise they only measure a cached-field read after the first call.
+   */
+  @State(Scope.Thread)
+  public static class ByteListHashState {
+
+    private SszByteList freshList;
+
+    @Setup(Level.Invocation)
+    public void setupInvocation(final ByteListState listState) {
+      freshList = listState.schema.sszDeserialize(listState.serialized);
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class ProgressiveByteListMutationState {
+
+    @Param({"" + DEFAULT_LIST_SIZE})
+    public int size;
+
+    private SszByteList list;
+    private SszByte replacementValue;
+    private SszByte appendedValue;
+    private int mutationIndex;
+
+    @Setup
+    public void setup() {
+      final SszProgressiveByteListSchema<? extends SszByteList> schema =
+          new SszProgressiveByteListSchema<>();
+      list = schema.fromBytes(createBytes(size));
+      replacementValue = SszByte.of(0xAB);
+      appendedValue = SszByte.of(0xCD);
+      mutationIndex = size / 2;
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class BitlistState {
+
+    @Param({"BOUNDED", "PROGRESSIVE"})
+    public Representation representation;
+
+    @Param({"" + DEFAULT_LIST_SIZE})
+    public int size;
+
+    private SszBitlistSchema<? extends SszBitlist> schema;
+    private TreeNode backingNode;
+    private Bytes serialized;
+    private SszBitlist other;
+    private int[] randomIndexes;
+
+    @Setup
+    public void setup() {
+      schema =
+          representation == Representation.BOUNDED
+              ? SszBitlistSchema.create(size + 1024L)
+              : new SszProgressiveBitlistSchema();
+
+      final SszBitlist bitlist = schema.wrapBitSet(size, createBitSet(size, 17, 3));
+      backingNode = bitlist.getBackingNode();
+      serialized = bitlist.sszSerialize();
+      other = schema.wrapBitSet(size, createBitSet(size, 19, 5));
+      randomIndexes = createRandomIndexes(size);
+    }
+
+    private SszBitlist createView() {
+      return schema.createFromBackingNode(backingNode);
+    }
+  }
+
+  /** See {@link ByteListHashState} for why the tree is rebuilt per invocation. */
+  @State(Scope.Thread)
+  public static class BitlistHashState {
+
+    private SszBitlist freshList;
+
+    @Setup(Level.Invocation)
+    public void setupInvocation(final BitlistState bitlistState) {
+      freshList = bitlistState.schema.sszDeserialize(bitlistState.serialized);
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class ProgressiveBitlistMutationState {
+
+    @Param({"" + DEFAULT_LIST_SIZE})
+    public int size;
+
+    private SszBitlist list;
+    private int mutationIndex;
+
+    @Setup
+    public void setup() {
+      final SszProgressiveBitlistSchema schema = new SszProgressiveBitlistSchema();
+      list = schema.wrapBitSet(size, createBitSet(size, 17, 3));
+      mutationIndex = size / 2;
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class NonPrimitiveListState {
+
+    @Param({"BOUNDED", "PROGRESSIVE"})
+    public Representation representation;
+
+    @Param({"4096"})
+    public int size;
+
+    private SszListSchema<SszContainer, ? extends SszList<SszContainer>> schema;
+    private TreeNode backingNode;
+    private Bytes serialized;
+    private SszContainer replacementElement;
+    private SszContainer appendedElement;
+    private int mutationIndex;
+    private int[] randomIndexes;
+
+    @Setup
+    public void setup() {
+      final SszContainerSchema<SszContainer> elementSchema =
+          createRegularContainerSchema("BenchmarkElement", ELEMENT_FIELD_COUNT);
+      schema =
+          representation == Representation.BOUNDED
+              ? SszListSchema.create(elementSchema, size + 1024L)
+              : SszListSchema.createProgressive(elementSchema);
+
+      final List<SszContainer> elements =
+          IntStream.range(0, size)
+              .mapToObj(i -> createContainer(elementSchema, 10_000L + i * 100L))
+              .toList();
+      final SszList<SszContainer> list = schema.createFromElements(elements);
+
+      backingNode = list.getBackingNode();
+      serialized = list.sszSerialize();
+      replacementElement = createContainer(elementSchema, 700_000L);
+      appendedElement = createContainer(elementSchema, 800_000L);
+      mutationIndex = size / 2;
+      randomIndexes = createRandomIndexes(size);
+    }
+
+    private SszList<SszContainer> createView() {
+      return schema.createFromBackingNode(backingNode);
+    }
+  }
+
+  /** See {@link ByteListHashState} for why the tree is rebuilt per invocation. */
+  @State(Scope.Thread)
+  public static class NonPrimitiveListHashState {
+
+    private SszList<SszContainer> freshList;
+
+    @Setup(Level.Invocation)
+    public void setupInvocation(final NonPrimitiveListState listState) {
+      freshList = listState.schema.sszDeserialize(listState.serialized);
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class ContainerState {
+
+    @Param({"BOUNDED", "PROGRESSIVE"})
+    public Representation representation;
+
+    @Param({"" + DEFAULT_CONTAINER_FIELD_COUNT})
+    public int fieldCount;
+
+    private SszContainerSchema<SszContainer> schema;
+    private TreeNode backingNode;
+    private Bytes serialized;
+    private SszUInt64 replacementValue;
+    private int mutationIndex;
+    private int[] randomIndexes;
+
+    @Setup
+    public void setup() {
+      schema =
+          representation == Representation.BOUNDED
+              ? createRegularContainerSchema("BenchmarkContainer", fieldCount)
+              : createProgressiveContainerSchema("BenchmarkProgressiveContainer", fieldCount);
+
+      final SszContainer container = createContainer(schema, 900_000L);
+      backingNode = container.getBackingNode();
+      serialized = container.sszSerialize();
+      replacementValue = SszUInt64.of(UInt64.valueOf(1_234_567L));
+      mutationIndex = fieldCount / 2;
+      randomIndexes = createRandomIndexes(fieldCount);
+    }
+
+    private SszContainer createView() {
+      return schema.createFromBackingNode(backingNode);
+    }
+  }
+
+  /** See {@link ByteListHashState} for why the tree is rebuilt per invocation. */
+  @State(Scope.Thread)
+  public static class ContainerHashState {
+
+    private SszContainer freshContainer;
+
+    @Setup(Level.Invocation)
+    public void setupInvocation(final ContainerState containerState) {
+      freshContainer = containerState.schema.sszDeserialize(containerState.serialized);
+    }
+  }
+
+  @Benchmark
+  public void byteListCreateView(final ByteListState state, final Blackhole bh) {
+    bh.consume(state.createView());
+  }
+
+  @Benchmark
+  public void byteListSequentialAccess(final ByteListState state, final Blackhole bh) {
+    final SszByteList list = state.createView();
+    final int size = list.size();
+    for (int i = 0; i < size; i++) {
+      bh.consume(list.getElement(i));
+    }
+  }
+
+  @Benchmark
+  public void byteListRandomAccess(final ByteListState state, final Blackhole bh) {
+    final SszByteList list = state.createView();
+    for (int index : state.randomIndexes) {
+      bh.consume(list.getElement(index));
+    }
+  }
+
+  @Benchmark
+  public void byteListSerialize(final ByteListState state, final Blackhole bh) {
+    bh.consume(state.createView().sszSerialize());
+  }
+
+  @Benchmark
+  public void byteListDeserialize(final ByteListState state, final Blackhole bh) {
+    bh.consume(state.schema.sszDeserialize(state.serialized));
+  }
+
+  @Benchmark
+  public void byteListHashTreeRoot(final ByteListHashState state, final Blackhole bh) {
+    bh.consume(state.freshList.hashTreeRoot());
+  }
+
+  @Benchmark
+  public void progressiveByteListSetAndCommit(
+      final ProgressiveByteListMutationState state, final Blackhole bh) {
+    final SszMutablePrimitiveList<Byte, SszByte> writable = state.list.createWritableCopy();
+    writable.set(state.mutationIndex, state.replacementValue);
+    bh.consume(writable.commitChanges());
+  }
+
+  @Benchmark
+  public void progressiveByteListSetCommitAndHash(
+      final ProgressiveByteListMutationState state, final Blackhole bh) {
+    final SszMutablePrimitiveList<Byte, SszByte> writable = state.list.createWritableCopy();
+    writable.set(state.mutationIndex, state.replacementValue);
+    bh.consume(writable.commitChanges().hashTreeRoot());
+  }
+
+  @Benchmark
+  public void progressiveByteListAppendAndCommit(
+      final ProgressiveByteListMutationState state, final Blackhole bh) {
+    final SszMutablePrimitiveList<Byte, SszByte> writable = state.list.createWritableCopy();
+    writable.append(state.appendedValue);
+    bh.consume(writable.commitChanges());
+  }
+
+  @Benchmark
+  public void bitlistCreateView(final BitlistState state, final Blackhole bh) {
+    bh.consume(state.createView());
+  }
+
+  @Benchmark
+  public void bitlistSequentialAccess(final BitlistState state, final Blackhole bh) {
+    final SszBitlist bitlist = state.createView();
+    final int size = bitlist.size();
+    for (int i = 0; i < size; i++) {
+      bh.consume(bitlist.getBit(i));
+    }
+  }
+
+  @Benchmark
+  public void bitlistRandomAccess(final BitlistState state, final Blackhole bh) {
+    final SszBitlist bitlist = state.createView();
+    for (int index : state.randomIndexes) {
+      bh.consume(bitlist.getBit(index));
+    }
+  }
+
+  @Benchmark
+  public void bitlistOr(final BitlistState state, final Blackhole bh) {
+    bh.consume(state.createView().or(state.other));
+  }
+
+  @Benchmark
+  public void bitlistSerialize(final BitlistState state, final Blackhole bh) {
+    bh.consume(state.createView().sszSerialize());
+  }
+
+  @Benchmark
+  public void bitlistDeserialize(final BitlistState state, final Blackhole bh) {
+    bh.consume(state.schema.sszDeserialize(state.serialized));
+  }
+
+  @Benchmark
+  public void bitlistHashTreeRoot(final BitlistHashState state, final Blackhole bh) {
+    bh.consume(state.freshList.hashTreeRoot());
+  }
+
+  @Benchmark
+  public void progressiveBitlistSetAndCommit(
+      final ProgressiveBitlistMutationState state, final Blackhole bh) {
+    final SszMutablePrimitiveList<Boolean, SszBit> writable = state.list.createWritableCopy();
+    writable.set(state.mutationIndex, SszBit.of(true));
+    bh.consume(writable.commitChanges());
+  }
+
+  @Benchmark
+  public void progressiveBitlistAppendAndCommit(
+      final ProgressiveBitlistMutationState state, final Blackhole bh) {
+    final SszMutablePrimitiveList<Boolean, SszBit> writable = state.list.createWritableCopy();
+    writable.append(SszBit.of(true));
+    bh.consume(writable.commitChanges());
+  }
+
+  @Benchmark
+  public void nonPrimitiveListCreateView(final NonPrimitiveListState state, final Blackhole bh) {
+    bh.consume(state.createView());
+  }
+
+  @Benchmark
+  public void nonPrimitiveListSequentialAccess(
+      final NonPrimitiveListState state, final Blackhole bh) {
+    final SszList<SszContainer> list = state.createView();
+    final int size = list.size();
+    for (int i = 0; i < size; i++) {
+      bh.consume(list.get(i));
+    }
+  }
+
+  @Benchmark
+  public void nonPrimitiveListRandomAccess(final NonPrimitiveListState state, final Blackhole bh) {
+    final SszList<SszContainer> list = state.createView();
+    for (int index : state.randomIndexes) {
+      bh.consume(list.get(index));
+    }
+  }
+
+  @Benchmark
+  public void nonPrimitiveListSerialize(final NonPrimitiveListState state, final Blackhole bh) {
+    bh.consume(state.createView().sszSerialize());
+  }
+
+  @Benchmark
+  public void nonPrimitiveListDeserialize(final NonPrimitiveListState state, final Blackhole bh) {
+    bh.consume(state.schema.sszDeserialize(state.serialized));
+  }
+
+  @Benchmark
+  public void nonPrimitiveListHashTreeRoot(
+      final NonPrimitiveListHashState state, final Blackhole bh) {
+    bh.consume(state.freshList.hashTreeRoot());
+  }
+
+  @Benchmark
+  public void nonPrimitiveListSetAndCommit(final NonPrimitiveListState state, final Blackhole bh) {
+    final SszMutableList<SszContainer> writable = state.createView().createWritableCopy();
+    writable.set(state.mutationIndex, state.replacementElement);
+    bh.consume(writable.commitChanges());
+  }
+
+  @Benchmark
+  public void nonPrimitiveListSetCommitAndHash(
+      final NonPrimitiveListState state, final Blackhole bh) {
+    final SszMutableList<SszContainer> writable = state.createView().createWritableCopy();
+    writable.set(state.mutationIndex, state.replacementElement);
+    bh.consume(writable.commitChanges().hashTreeRoot());
+  }
+
+  @Benchmark
+  public void nonPrimitiveListAppendAndCommit(
+      final NonPrimitiveListState state, final Blackhole bh) {
+    final SszMutableList<SszContainer> writable = state.createView().createWritableCopy();
+    writable.append(state.appendedElement);
+    bh.consume(writable.commitChanges());
+  }
+
+  @Benchmark
+  public void containerCreateView(final ContainerState state, final Blackhole bh) {
+    bh.consume(state.createView());
+  }
+
+  @Benchmark
+  public void containerSequentialAccess(final ContainerState state, final Blackhole bh) {
+    final SszContainer container = state.createView();
+    final int size = container.size();
+    for (int i = 0; i < size; i++) {
+      bh.consume(container.get(i));
+    }
+  }
+
+  @Benchmark
+  public void containerRandomAccess(final ContainerState state, final Blackhole bh) {
+    final SszContainer container = state.createView();
+    for (int index : state.randomIndexes) {
+      bh.consume(container.get(index));
+    }
+  }
+
+  @Benchmark
+  public void containerSerialize(final ContainerState state, final Blackhole bh) {
+    bh.consume(state.createView().sszSerialize());
+  }
+
+  @Benchmark
+  public void containerDeserialize(final ContainerState state, final Blackhole bh) {
+    bh.consume(state.schema.sszDeserialize(state.serialized));
+  }
+
+  @Benchmark
+  public void containerHashTreeRoot(final ContainerHashState state, final Blackhole bh) {
+    bh.consume(state.freshContainer.hashTreeRoot());
+  }
+
+  @Benchmark
+  public void containerSetAndCommit(final ContainerState state, final Blackhole bh) {
+    final SszMutableContainer writable =
+        (SszMutableContainer) state.createView().createWritableCopy();
+    writable.set(state.mutationIndex, state.replacementValue);
+    bh.consume(writable.commitChanges());
+  }
+
+  @Benchmark
+  public void containerSetCommitAndHash(final ContainerState state, final Blackhole bh) {
+    final SszMutableContainer writable =
+        (SszMutableContainer) state.createView().createWritableCopy();
+    writable.set(state.mutationIndex, state.replacementValue);
+    bh.consume(writable.commitChanges().hashTreeRoot());
+  }
+
+  private static int[] createRandomIndexes(final int size) {
+    final int count = Math.min(size, RANDOM_ACCESS_COUNT);
+    final int[] indexes = new int[count];
+    for (int i = 0; i < count; i++) {
+      indexes[i] = Math.floorMod(i * 8191 + 17, size);
+    }
+    return indexes;
+  }
+
+  private static Bytes createBytes(final int size) {
+    final byte[] bytes = new byte[size];
+    for (int i = 0; i < size; i++) {
+      bytes[i] = (byte) (17 + i * 31);
+    }
+    return Bytes.wrap(bytes);
+  }
+
+  private static BitSet createBitSet(final int size, final int stride, final int offset) {
+    final BitSet bitSet = new BitSet(size);
+    for (int i = offset; i < size; i += stride) {
+      bitSet.set(i);
+    }
+    return bitSet;
+  }
+
+  private static SszContainerSchema<SszContainer> createRegularContainerSchema(
+      final String name, final int fieldCount) {
+    return SszContainerSchema.create(
+        name, createNamedUInt64Fields(fieldCount), SszContainerImpl::new);
+  }
+
+  private static SszContainerSchema<SszContainer> createProgressiveContainerSchema(
+      final String name, final int fieldCount) {
+    final boolean[] activeFields = new boolean[fieldCount];
+    Arrays.fill(activeFields, true);
+    return SszContainerSchema.createProgressive(
+        name, activeFields, createNamedUInt64Fields(fieldCount));
+  }
+
+  private static List<NamedSchema<?>> createNamedUInt64Fields(final int fieldCount) {
+    return IntStream.range(0, fieldCount)
+        .<NamedSchema<?>>mapToObj(
+            i -> NamedSchema.of("field" + i, SszPrimitiveSchemas.UINT64_SCHEMA))
+        .toList();
+  }
+
+  private static SszContainer createContainer(
+      final SszContainerSchema<SszContainer> schema, final long seed) {
+    final List<? extends SszData> fieldValues =
+        IntStream.range(0, schema.getFieldsCount())
+            .mapToObj(i -> SszUInt64.of(UInt64.valueOf(seed + i)))
+            .toList();
+    return schema.createFromFieldValues(fieldValues);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadSchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadSchemaBellatrix.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -92,7 +93,9 @@ public class ExecutionPayloadSchemaBellatrix
         namedSchema(
             TRANSACTIONS,
             SszListSchema.create(
-                new TransactionSchema(specConfig), specConfig.getMaxTransactionsPerPayload())));
+                new TransactionSchema(specConfig),
+                specConfig.getMaxTransactionsPerPayload(),
+                SszSchemaHints.sszPackedByteLists())));
 
     this.defaultExecutionPayload = createFromBackingNode(getDefaultTree());
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadSchemaCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadSchemaCapella.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -92,7 +93,9 @@ public class ExecutionPayloadSchemaCapella
         namedSchema(
             TRANSACTIONS,
             SszListSchema.create(
-                new TransactionSchema(specConfig), specConfig.getMaxTransactionsPerPayload())),
+                new TransactionSchema(specConfig),
+                specConfig.getMaxTransactionsPerPayload(),
+                SszSchemaHints.sszPackedByteLists())),
         namedSchema(
             WITHDRAWALS,
             SszListSchema.create(Withdrawal.SSZ_SCHEMA, specConfig.getMaxWithdrawalsPerPayload())));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadSchemaDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadSchemaDeneb.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -98,7 +99,9 @@ public class ExecutionPayloadSchemaDeneb
         namedSchema(
             TRANSACTIONS,
             SszListSchema.create(
-                new TransactionSchema(specConfig), specConfig.getMaxTransactionsPerPayload())),
+                new TransactionSchema(specConfig),
+                specConfig.getMaxTransactionsPerPayload(),
+                SszSchemaHints.sszPackedByteLists())),
         namedSchema(
             WITHDRAWALS,
             SszListSchema.create(Withdrawal.SSZ_SCHEMA, specConfig.getMaxWithdrawalsPerPayload())),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -102,7 +103,9 @@ public class ExecutionPayloadSchemaGloas
         namedSchema(
             TRANSACTIONS,
             SszListSchema.create(
-                new TransactionSchema(specConfig), specConfig.getMaxTransactionsPerPayload())),
+                new TransactionSchema(specConfig),
+                specConfig.getMaxTransactionsPerPayload(),
+                SszSchemaHints.sszPackedByteLists())),
         namedSchema(
             WITHDRAWALS,
             SszListSchema.create(Withdrawal.SSZ_SCHEMA, specConfig.getMaxWithdrawalsPerPayload())),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListSchema.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigHeze;
@@ -41,7 +42,9 @@ public class InclusionListSchema
         namedSchema(
             "transactions",
             SszListSchema.create(
-                new TransactionSchema(specConfig), specConfig.getMaxTransactionsPerPayload())));
+                new TransactionSchema(specConfig),
+                specConfig.getMaxTransactionsPerPayload(),
+                SszSchemaHints.sszPackedByteLists())));
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPackedTransactionsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPackedTransactionsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNode;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ExecutionPayloadPackedTransactionsTest {
+
+  @Test
+  public void executionPayloadTransactions_shouldRoundTripWithPackedBacking() {
+    final Spec spec = TestSpecFactory.createMinimalBellatrix();
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(1, spec);
+    final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
+    assertThat(payload.getTransactions()).isNotEmpty();
+
+    final Bytes serialized = payload.sszSerialize();
+    final ExecutionPayload deserialized = payload.getSchema().sszDeserialize(serialized);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(payload.hashTreeRoot());
+    assertThat(deserialized.sszSerialize()).isEqualTo(serialized);
+    assertThat(deserialized.getTransactions().getBackingNode().get(GIndexUtil.LEFT_CHILD_G_INDEX))
+        .isInstanceOf(SszPackedByteListsNode.class);
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPackedTransactionsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPackedTransactionsTest.java
@@ -14,21 +14,35 @@
 package tech.pegasys.teku.spec.datastructures.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.SpecMilestone.BELLATRIX;
+import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
+import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
+import static tech.pegasys.teku.spec.SpecMilestone.GLOAS;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
 import tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNode;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
+/// Covers the {@code ExecutionPayload.transactions} hinted packed-byte-lists backing across every
+/// fork that carries a transactions list. See {@code InclusionListPackedTransactionsTest} for the
+/// equivalent heze {@code InclusionList} coverage.
+@TestSpecContext(milestone = {BELLATRIX, CAPELLA, DENEB, GLOAS})
 public class ExecutionPayloadPackedTransactionsTest {
 
-  @Test
+  private DataStructureUtil dataStructureUtil;
+
+  @BeforeEach
+  void setUp(final SpecContext specContext) {
+    dataStructureUtil = specContext.getDataStructureUtil();
+  }
+
+  @TestTemplate
   public void executionPayloadTransactions_shouldRoundTripWithPackedBacking() {
-    final Spec spec = TestSpecFactory.createMinimalBellatrix();
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(1, spec);
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
     assertThat(payload.getTransactions()).isNotEmpty();
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListPackedTransactionsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/heze/InclusionListPackedTransactionsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution.versions.heze;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsHeze;
+
+/// Companion to {@code ExecutionPayloadPackedTransactionsTest}: the heze {@code InclusionList}
+/// transactions list is the identical {@code List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]}
+/// shape and also carries the {@code SszPackedByteListsHint}.
+public class InclusionListPackedTransactionsTest {
+
+  @Test
+  public void inclusionListTransactions_shouldRoundTripWithPackedBacking() {
+    final Spec hezeSpec = TestSpecFactory.createMinimalHeze();
+    final SchemaDefinitionsHeze schemaDefinitionsHeze =
+        SchemaDefinitionsHeze.required(hezeSpec.getGenesisSchemaDefinitions());
+    final InclusionListSchema inclusionListSchema = schemaDefinitionsHeze.getInclusionListSchema();
+
+    // deterministic, non-empty transaction set: three transactions of different sizes, including
+    // one zero-length one, so the packed offset table has more than a single entry
+    final List<Bytes> transactions = List.of(Bytes.of(1), Bytes.EMPTY, Bytes.wrap(new byte[33]));
+
+    final InclusionList inclusionList =
+        inclusionListSchema.create(
+            UInt64.valueOf(1), UInt64.valueOf(2), Bytes32.ZERO, transactions);
+    assertThat(inclusionList.getTransactions()).isNotEmpty();
+    assertThat(inclusionList.getTransactions().getBackingNode().get(GIndexUtil.LEFT_CHILD_G_INDEX))
+        .isInstanceOf(SszPackedByteListsNode.class);
+
+    final Bytes serialized = inclusionList.sszSerialize();
+    final InclusionList deserialized = inclusionListSchema.sszDeserialize(serialized);
+
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(inclusionList.hashTreeRoot());
+    assertThat(deserialized.sszSerialize()).isEqualTo(serialized);
+    assertThat(deserialized.getTransactions().getBackingNode().get(GIndexUtil.LEFT_CHILD_G_INDEX))
+        .isInstanceOf(SszPackedByteListsNode.class);
+    for (int i = 0; i < transactions.size(); i++) {
+      assertThat(deserialized.getTransactions().get(i).getBytes()).isEqualTo(transactions.get(i));
+    }
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/AbstractSszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/AbstractSszProgressiveListSchema.java
@@ -280,20 +280,15 @@ public abstract class AbstractSszProgressiveListSchema<
       }
     }
 
-    if (elementSchema instanceof AbstractSszPrimitiveSchema) {
-      // Primitive packing: multiple values per 32-byte leaf
-      final int bytesPerElement = elementBitSize / 8;
+    if (elementSchema instanceof final AbstractSszPrimitiveSchema<?, ?> primitiveElementSchema) {
+      // Primitive packing: multiple values per 32-byte leaf. The element schema validates
+      // constrained encodings per chunk (e.g., booleans must be 0 or 1)
       int bytesRemain = bytesSize;
       final List<LeafNode> childNodes = new ArrayList<>(bytesRemain / LeafNode.MAX_BYTE_SIZE + 1);
       while (bytesRemain > 0) {
         final int toRead = Math.min(bytesRemain, LeafNode.MAX_BYTE_SIZE);
         bytesRemain -= toRead;
-        final Bytes bytes = reader.read(toRead);
-        // Validate each element within the chunk (e.g., booleans must be 0 or 1)
-        for (int offset = 0; offset < bytes.size(); offset += bytesPerElement) {
-          elementSchema.sszDeserialize(bytes.slice(offset, bytesPerElement));
-        }
-        childNodes.add(LeafNode.create(bytes));
+        childNodes.add(primitiveElementSchema.createNodeFromSszBytes(reader.read(toRead)));
       }
       final int elementsCount = (int) (bytesSize * 8L / elementBitSize);
       final TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(childNodes);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/AbstractSszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/AbstractSszProgressiveListSchema.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.createPackedProgressiveListTree;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getLength;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getVectorNode;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.toLengthNode;
@@ -283,16 +284,9 @@ public abstract class AbstractSszProgressiveListSchema<
     if (elementSchema instanceof final AbstractSszPrimitiveSchema<?, ?> primitiveElementSchema) {
       // Primitive packing: multiple values per 32-byte leaf. The element schema validates
       // constrained encodings per chunk (e.g., booleans must be 0 or 1)
-      int bytesRemain = bytesSize;
-      final List<LeafNode> childNodes = new ArrayList<>(bytesRemain / LeafNode.MAX_BYTE_SIZE + 1);
-      while (bytesRemain > 0) {
-        final int toRead = Math.min(bytesRemain, LeafNode.MAX_BYTE_SIZE);
-        bytesRemain -= toRead;
-        childNodes.add(primitiveElementSchema.createNodeFromSszBytes(reader.read(toRead)));
-      }
       final int elementsCount = (int) (bytesSize * 8L / elementBitSize);
-      final TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(childNodes);
-      return BranchNode.create(progressiveTree, toLengthNode(elementsCount));
+      return createPackedProgressiveListTree(
+          reader.read(bytesSize), primitiveElementSchema::createNodeFromSszBytes, elementsCount);
     } else {
       // Fixed-size composite elements: one per chunk
       final int elementsCount = bytesSize / elementSchema.getSszFixedPartSize();

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/AbstractSszProgressiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/AbstractSszProgressiveListSchema.java
@@ -475,6 +475,10 @@ public abstract class AbstractSszProgressiveListSchema<
       elementSchema.storeBackingNodes(nodeStore, maxBranchLevelsSkipped, levelGIndex, levelSubtree);
     } else if (childDepth == 0) {
       // SuperNode covers entire level subtree
+      // NOTE: storing SszSuperNodes via storeLeafNode is unsound for payloads <= 32 bytes: stores
+      // assume a leaf's root equals rightPad(data) and skip persisting them (see
+      // KvStoreTreeNodeStore.storeLeafNode), which does not hold for computed-root data nodes.
+      // Left as-is: no production schema currently stores supernode-hinted structures.
       nodeStore.storeLeafNode(levelSubtree, levelGIndex);
     } else {
       final long lastUsefulGIndex =

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/ListSchemaUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/ListSchemaUtil.java
@@ -14,9 +14,14 @@
 package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
 import tech.pegasys.teku.infrastructure.ssz.tree.LeafNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.ProgressiveTreeUtil;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
 /**
@@ -46,5 +51,35 @@ public class ListSchemaUtil {
 
   public static TreeNode getVectorNode(final TreeNode listNode) {
     return listNode.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+  }
+
+  /**
+   * Builds the backing tree of a packed progressive list — BranchNode(progressiveDataTree,
+   * lengthNode) — by splitting the packed data into 32-byte leaf chunks.
+   *
+   * @param length the element count stored in the length node (bits for bitlists, elements
+   *     otherwise), independent of {@code packedBytes} size
+   */
+  public static TreeNode createPackedProgressiveListTree(
+      final Bytes packedBytes, final int length) {
+    return createPackedProgressiveListTree(packedBytes, LeafNode::create, length);
+  }
+
+  /**
+   * Variant of {@link #createPackedProgressiveListTree(Bytes, int)} taking a chunk factory so
+   * element schemas can validate constrained encodings while creating each leaf.
+   */
+  public static TreeNode createPackedProgressiveListTree(
+      final Bytes packedBytes, final Function<Bytes, LeafNode> chunkFactory, final int length) {
+    final int size = packedBytes.size();
+    final List<LeafNode> chunks = new ArrayList<>(size / LeafNode.MAX_BYTE_SIZE + 1);
+    int offset = 0;
+    while (offset < size) {
+      final int chunkSize = Math.min(LeafNode.MAX_BYTE_SIZE, size - offset);
+      chunks.add(chunkFactory.apply(packedBytes.slice(offset, chunkSize)));
+      offset += chunkSize;
+    }
+    return BranchNode.create(
+        ProgressiveTreeUtil.createProgressiveTree(chunks), toLengthNode(length));
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
@@ -120,7 +120,7 @@ public final class SszPrimitiveSchemas {
         }
 
         @Override
-        protected LeafNode createNodeFromSszBytes(final Bytes bytes) {
+        public LeafNode createNodeFromSszBytes(final Bytes bytes) {
           final byte data = bytes.get(0);
           if (data != 0 && data != 1) {
             throw new SszDeserializeException("Invalid bit value: " + bytes);
@@ -363,7 +363,7 @@ public final class SszPrimitiveSchemas {
     }
 
     @Override
-    protected LeafNode createNodeFromSszBytes(final Bytes bytes) {
+    public LeafNode createNodeFromSszBytes(final Bytes bytes) {
       for (byte current : bytes.toArrayUnsafe()) {
         if (current != 0 && current != 1) {
           throw new SszDeserializeException("Invalid serialized boolean value: " + current);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveBitlistSchema.java
@@ -15,13 +15,13 @@ package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.createPackedProgressiveListTree;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getLength;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getVectorNode;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.toLengthNode;
 import static tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil.bitsCeilToBytes;
 
 import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
@@ -241,19 +241,7 @@ public class SszProgressiveBitlistSchema implements SszBitlistSchema<SszBitlist>
 
     final int length = sszGetLengthAndValidate(bytes);
     final Bytes treeBytes = sszTruncateLeadingBit(bytes, length);
-
-    // Split into 32-byte leaf chunks
-    final List<LeafNode> chunks = new ArrayList<>();
-    int off = 0;
-    final int size = treeBytes.size();
-    while (off < size) {
-      final int chunkSize = Math.min(LeafNode.MAX_BYTE_SIZE, size - off);
-      chunks.add(LeafNode.create(treeBytes.slice(off, chunkSize)));
-      off += LeafNode.MAX_BYTE_SIZE;
-    }
-
-    final TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(chunks);
-    return BranchNode.create(progressiveTree, toLengthNode(length));
+    return createPackedProgressiveListTree(treeBytes, length);
   }
 
   @Override
@@ -411,17 +399,7 @@ public class SszProgressiveBitlistSchema implements SszBitlistSchema<SszBitlist>
     final int dataByteLen = bitsCeilToBytes(size);
     final byte[] paddedBytes =
         dataByteLen == 0 ? new byte[0] : Arrays.copyOf(bitSetBytes, dataByteLen);
-
-    final List<LeafNode> chunks = new ArrayList<>();
-    int off = 0;
-    while (off < paddedBytes.length) {
-      final int chunkSize = Math.min(LeafNode.MAX_BYTE_SIZE, paddedBytes.length - off);
-      chunks.add(LeafNode.create(Bytes.wrap(paddedBytes, off, chunkSize)));
-      off += LeafNode.MAX_BYTE_SIZE;
-    }
-
-    final TreeNode progressiveTree = ProgressiveTreeUtil.createProgressiveTree(chunks);
-    return BranchNode.create(progressiveTree, toLengthNode(size));
+    return createPackedProgressiveListTree(Bytes.wrap(paddedBytes), size);
   }
 
   private int chunksForBitCount(final int bitCount) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszSchemaHints.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszSchemaHints.java
@@ -70,6 +70,23 @@ public class SszSchemaHints {
     }
   }
 
+  /**
+   * Hint for a List[ByteList[N], M] schema to back the list with a single
+   * tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNode holding the serialized bytes,
+   * instead of a materialized tree. Requires the element schema to be a byte list schema.
+   */
+  public static final class SszPackedByteListsHint extends SszSchemaHint {
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof SszPackedByteListsHint;
+    }
+
+    @Override
+    public int hashCode() {
+      return SszPackedByteListsHint.class.hashCode();
+    }
+  }
+
   public static SszSchemaHints of(final SszSchemaHint... hints) {
     return new SszSchemaHints(Arrays.asList(hints));
   }
@@ -80,6 +97,10 @@ public class SszSchemaHints {
 
   public static SszSchemaHints sszSuperNode(final int superNodeDepth) {
     return of(new SszSuperNodeHint(superNodeDepth));
+  }
+
+  public static SszSchemaHints sszPackedByteLists() {
+    return of(new SszPackedByteListsHint());
   }
 
   private final List<SszSchemaHint> hints;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszByteListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszByteListSchema.java
@@ -17,6 +17,7 @@ import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszByteListSchemaImpl;
 
 public interface SszByteListSchema<SszListT extends SszByteList>
@@ -25,10 +26,19 @@ public interface SszByteListSchema<SszListT extends SszByteList>
   SszListT fromBytes(Bytes bytes);
 
   static SszByteListSchema<SszByteList> create(final long maxLength) {
-    return new SszByteListSchemaImpl<>(SszPrimitiveSchemas.BYTE_SCHEMA, maxLength);
+    return create(maxLength, SszSchemaHints.none());
+  }
+
+  static SszByteListSchema<SszByteList> create(final long maxLength, final SszSchemaHints hints) {
+    return new SszByteListSchemaImpl<>(SszPrimitiveSchemas.BYTE_SCHEMA, maxLength, hints);
   }
 
   static SszByteListSchema<SszByteList> createUInt8(final long maxLength) {
-    return new SszByteListSchemaImpl<>(SszPrimitiveSchemas.UINT8_SCHEMA, maxLength);
+    return createUInt8(maxLength, SszSchemaHints.none());
+  }
+
+  static SszByteListSchema<SszByteList> createUInt8(
+      final long maxLength, final SszSchemaHints hints) {
+    return new SszByteListSchemaImpl<>(SszPrimitiveSchemas.UINT8_SCHEMA, maxLength, hints);
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java
@@ -54,15 +54,18 @@ public interface SszPrimitiveListSchema<
     if (elementSchema.equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszBitlistSchema.create(maxLength);
     } else if (elementSchema.equals(SszPrimitiveSchemas.UINT64_SCHEMA)) {
-      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszUInt64ListSchema.create(maxLength);
+      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>)
+          SszUInt64ListSchema.create(maxLength, hints);
     } else if (elementSchema.equals(SszPrimitiveSchemas.BYTE_SCHEMA)) {
-      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszByteListSchema.create(maxLength);
+      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>)
+          SszByteListSchema.create(maxLength, hints);
     } else if (elementSchema.equals(SszPrimitiveSchemas.UINT8_SCHEMA)) {
-      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszByteListSchema.createUInt8(maxLength);
+      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>)
+          SszByteListSchema.createUInt8(maxLength, hints);
     } else if (elementSchema.equals(SszPrimitiveSchemas.BOOLEAN_SCHEMA)) {
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszBooleanListSchema.create(maxLength);
     } else {
-      return new SszPrimitiveListSchemaImpl<>(elementSchema, maxLength);
+      return new SszPrimitiveListSchemaImpl<>(elementSchema, maxLength, hints);
     }
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszUInt64ListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszUInt64ListSchema.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszUInt64ListSchemaImpl;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -22,6 +23,11 @@ public interface SszUInt64ListSchema<SszListT extends SszUInt64List>
     extends SszPrimitiveListSchema<UInt64, SszUInt64, SszListT> {
 
   static SszUInt64ListSchema<SszUInt64List> create(final long maxLength) {
-    return new SszUInt64ListSchemaImpl<>(maxLength);
+    return create(maxLength, SszSchemaHints.none());
+  }
+
+  static SszUInt64ListSchema<SszUInt64List> create(
+      final long maxLength, final SszSchemaHints hints) {
+    return new SszUInt64ListSchemaImpl<>(maxLength, hints);
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszByteListImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -36,7 +37,14 @@ public class SszByteListSchemaImpl<SszListT extends SszByteList>
 
   public SszByteListSchemaImpl(
       final SszPrimitiveSchema<Byte, SszByte> elementSchema, final long maxLength) {
-    super(elementSchema, maxLength);
+    this(elementSchema, maxLength, SszSchemaHints.none());
+  }
+
+  public SszByteListSchemaImpl(
+      final SszPrimitiveSchema<Byte, SszByte> elementSchema,
+      final long maxLength,
+      final SszSchemaHints hints) {
+    super(elementSchema, maxLength, hints);
     this.jsonTypeDefinition =
         elementSchema.equals(SszPrimitiveSchemas.BYTE_SCHEMA)
             ? SszPrimitiveTypeDefinitions.sszSerializedType(this, "SSZ encoded byte list")

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszPrimitiveListSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszPrimitiveListSchemaImpl.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszPrimitive;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszPrimitiveList;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszPrimitiveListImpl;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszPrimitiveListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.LeafDataNode;
@@ -38,7 +39,14 @@ public class SszPrimitiveListSchemaImpl<
 
   public SszPrimitiveListSchemaImpl(
       final SszPrimitiveSchema<ElementT, SszElementT> elementSchema, final long maxLength) {
-    super(elementSchema, maxLength);
+    this(elementSchema, maxLength, SszSchemaHints.none());
+  }
+
+  public SszPrimitiveListSchemaImpl(
+      final SszPrimitiveSchema<ElementT, SszElementT> elementSchema,
+      final long maxLength,
+      final SszSchemaHints hints) {
+    super(elementSchema, maxLength, hints);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64ListSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64ListSchemaImpl.java
@@ -17,6 +17,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszUInt64ListImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -27,6 +28,10 @@ public class SszUInt64ListSchemaImpl<SszListT extends SszUInt64List>
 
   public SszUInt64ListSchemaImpl(final long maxLength) {
     super(SszPrimitiveSchemas.UINT64_SCHEMA, maxLength);
+  }
+
+  public SszUInt64ListSchemaImpl(final long maxLength, final SszSchemaHints hints) {
+    super(SszPrimitiveSchemas.UINT64_SCHEMA, maxLength, hints);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -309,6 +309,10 @@ public abstract class AbstractSszListSchema<
       return;
     }
     final long lastUsefulGIndex = getVectorLastUsefulGIndex(rootGIndex, length, superNodeDepth);
+    // NOTE: storing SszSuperNodes via storeLeafNode is unsound for payloads <= 32 bytes: stores
+    // assume a leaf's root equals rightPad(data) and skip persisting them (see
+    // KvStoreTreeNodeStore.storeLeafNode), which does not hold for computed-root data nodes.
+    // Left as-is: no production schema currently stores supernode-hinted structures.
     final TargetDepthNodeHandler targetDepthNodeHandler =
         superNodeDepth == 0
             ? (targetDepthNode, targetDepthGIndex) ->

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.ssz.schema.impl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getLength;
 import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.getVectorNode;
@@ -30,7 +31,9 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints.SszPackedByteListsHint;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints.SszSuperNodeHint;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.LoadingUtil.ChildLoader;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.StoringUtil.TargetDepthNodeHandler;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszLengthBounds;
@@ -52,6 +55,8 @@ public abstract class AbstractSszListSchema<
   private final SszVectorSchemaImpl<ElementDataT> compatibleVectorSchema;
   private final SszLengthBounds sszLengthBounds;
   private final DeserializableTypeDefinition<SszListT> jsonTypeDefinition;
+  // null when the SszPackedByteListsHint is not present
+  private final SszByteListSchema<?> packedByteListElementSchema;
 
   protected AbstractSszListSchema(
       final SszSchema<ElementDataT> elementSchema, final long maxLength) {
@@ -63,6 +68,15 @@ public abstract class AbstractSszListSchema<
       final long maxLength,
       final SszSchemaHints hints) {
     super(maxLength, elementSchema, hints);
+    if (hints.getHint(SszPackedByteListsHint.class).isPresent()) {
+      checkArgument(
+          elementSchema instanceof SszByteListSchema,
+          "SszPackedByteListsHint requires a byte list element schema but got %s",
+          elementSchema);
+      this.packedByteListElementSchema = (SszByteListSchema<?>) elementSchema;
+    } else {
+      this.packedByteListElementSchema = null;
+    }
     this.compatibleVectorSchema =
         new SszVectorSchemaImpl<>(elementSchema, getMaxLength(), true, getHints());
     this.sszLengthBounds = computeSszLengthBounds(elementSchema, maxLength);
@@ -90,6 +104,10 @@ public abstract class AbstractSszListSchema<
 
   protected AbstractSszVectorSchema<ElementDataT, ?> getCompatibleVectorSchema() {
     return compatibleVectorSchema;
+  }
+
+  SszByteListSchema<?> getPackedByteListElementSchema() {
+    return packedByteListElementSchema;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -125,6 +125,9 @@ public abstract class AbstractSszListSchema<
 
   @Override
   public int getSszVariablePartSize(final TreeNode node) {
+    if (getVectorNode(node) instanceof SszPackedByteListsNode packedNode) {
+      return packedNode.getSszBytes().size();
+    }
     int length = getLength(node);
     SszSchema<?> elementSchema = getElementSchema();
     if (elementSchema.isFixedSize()) {
@@ -151,10 +154,14 @@ public abstract class AbstractSszListSchema<
     if (getElementSchema().equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       throw new UnsupportedOperationException(
           "BitlistImpl serialization is only supported by SszBitlistSchema");
-    } else {
-      return getCompatibleVectorSchema()
-          .sszSerializeVector(getVectorNode(node), writer, elementsCount);
     }
+    if (getVectorNode(node) instanceof SszPackedByteListsNode packedNode) {
+      final Bytes sszBytes = packedNode.getSszBytes();
+      writer.write(sszBytes);
+      return sszBytes.size();
+    }
+    return getCompatibleVectorSchema()
+        .sszSerializeVector(getVectorNode(node), writer, elementsCount);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -76,6 +76,8 @@ public abstract class AbstractSszListSchema<
           elementSchema instanceof SszByteListSchema,
           "SszPackedByteListsHint requires a byte list element schema but got %s",
           elementSchema);
+      checkArgument(
+          maxLength >= 2, "SszPackedByteListsHint requires maxLength >= 2 but got %s", maxLength);
       this.packedByteListElementSchema = (SszByteListSchema<?>) elementSchema;
     } else {
       this.packedByteListElementSchema = null;
@@ -144,10 +146,6 @@ public abstract class AbstractSszListSchema<
 
   protected AbstractSszVectorSchema<ElementDataT, ?> getCompatibleVectorSchema() {
     return compatibleVectorSchema;
-  }
-
-  SszByteListSchema<?> getPackedByteListElementSchema() {
-    return packedByteListElementSchema;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.ssz.schema.ListSchemaUtil.toLengt
 import static tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil.bitsCeilToBytes;
 
 import java.nio.ByteOrder;
+import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableArrayTypeDefinition;
@@ -85,6 +86,43 @@ public abstract class AbstractSszListSchema<
     this.jsonTypeDefinition =
         new DeserializableArrayTypeDefinition<>(
             getElementSchema().getJsonTypeDefinition(), this::createFromElements);
+  }
+
+  @Override
+  public TreeNode createTreeFromElements(final List<? extends ElementDataT> elements) {
+    if (packedByteListElementSchema == null || elements.isEmpty()) {
+      return SszListSchema.super.createTreeFromElements(elements);
+    }
+    checkArgument(
+        elements.size() <= getMaxLength(),
+        "Too many elements for this collection type (max length %s, size %s)",
+        getMaxLength(),
+        elements.size());
+    final int count = elements.size();
+    final byte[] offsetBytes = new byte[count * SSZ_LENGTH_SIZE];
+    final int[] offsets = new int[count + 1];
+    final Bytes[] parts = new Bytes[count + 1];
+    int offset = count * SSZ_LENGTH_SIZE;
+    for (int i = 0; i < count; i++) {
+      final Bytes elementSsz = elements.get(i).sszSerialize();
+      offsets[i] = offset;
+      offsetBytes[i * SSZ_LENGTH_SIZE] = (byte) offset;
+      offsetBytes[i * SSZ_LENGTH_SIZE + 1] = (byte) (offset >>> 8);
+      offsetBytes[i * SSZ_LENGTH_SIZE + 2] = (byte) (offset >>> 16);
+      offsetBytes[i * SSZ_LENGTH_SIZE + 3] = (byte) (offset >>> 24);
+      parts[i + 1] = elementSsz;
+      offset += elementSsz.size();
+    }
+    offsets[count] = offset;
+    parts[0] = Bytes.wrap(offsetBytes);
+    final SszPackedByteListsNode packedNode =
+        new SszPackedByteListsNode(
+            Bytes.wrap(parts),
+            offsets,
+            packedByteListElementSchema.treeDepth(),
+            treeDepth(),
+            this::materializePackedElement);
+    return createTree(packedNode, count);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -189,6 +189,7 @@ public abstract class AbstractSszListSchema<
 
   private int[] parsePackedOffsets(final Bytes bytes) {
     final int endOffset = bytes.size();
+    checkSsz(endOffset >= SSZ_LENGTH_SIZE, "Invalid SSZ: trying to read more bytes than available");
     final int firstElementOffset = SszType.sszBytesToLength(bytes.slice(0, SSZ_LENGTH_SIZE));
     checkSsz(firstElementOffset % SSZ_LENGTH_SIZE == 0, "Invalid first element offset");
     checkSsz(firstElementOffset > 0, "Invalid first element offset");

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints.SszPackedByteListsHint;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints.SszSuperNodeHint;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszType;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.LoadingUtil.ChildLoader;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.StoringUtil.TargetDepthNodeHandler;
@@ -41,6 +42,7 @@ import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
 import tech.pegasys.teku.infrastructure.ssz.tree.BranchNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.SszSuperNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource;
@@ -160,9 +162,57 @@ public abstract class AbstractSszListSchema<
     if (getElementSchema().equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       throw new UnsupportedOperationException(
           "BitlistImpl deserialization is only supported by SszBitlistSchema");
-    } else {
-      DeserializedData data = sszDeserializeVector(reader);
-      return createTree(data.getDataTree(), data.getChildrenCount());
+    }
+    if (packedByteListElementSchema != null) {
+      return sszDeserializePacked(reader);
+    }
+    DeserializedData data = sszDeserializeVector(reader);
+    return createTree(data.getDataTree(), data.getChildrenCount());
+  }
+
+  private TreeNode sszDeserializePacked(final SszReader reader) {
+    final int endOffset = reader.getAvailableBytes();
+    if (endOffset == 0) {
+      return createDefaultTree();
+    }
+    final Bytes bytes = reader.read(endOffset);
+    final int[] offsets = parsePackedOffsets(bytes);
+    final SszPackedByteListsNode packedNode =
+        new SszPackedByteListsNode(
+            bytes,
+            offsets,
+            packedByteListElementSchema.treeDepth(),
+            treeDepth(),
+            this::materializePackedElement);
+    return createTree(packedNode, packedNode.getElementCount());
+  }
+
+  private int[] parsePackedOffsets(final Bytes bytes) {
+    final int endOffset = bytes.size();
+    final int firstElementOffset = SszType.sszBytesToLength(bytes.slice(0, SSZ_LENGTH_SIZE));
+    checkSsz(firstElementOffset % SSZ_LENGTH_SIZE == 0, "Invalid first element offset");
+    checkSsz(firstElementOffset > 0, "Invalid first element offset");
+    checkSsz(firstElementOffset <= endOffset, "Invalid first element offset");
+    final int elementsCount = firstElementOffset / SSZ_LENGTH_SIZE;
+    checkSsz(elementsCount <= getMaxLength(), "SSZ sequence length exceeds max type length");
+    final long elementMaxSize = packedByteListElementSchema.getMaxLength();
+    final int[] offsets = new int[elementsCount + 1];
+    offsets[0] = firstElementOffset;
+    for (int i = 1; i < elementsCount; i++) {
+      offsets[i] = SszType.sszBytesToLength(bytes.slice(i * SSZ_LENGTH_SIZE, SSZ_LENGTH_SIZE));
+    }
+    offsets[elementsCount] = endOffset;
+    for (int i = 0; i < elementsCount; i++) {
+      final int size = offsets[i + 1] - offsets[i];
+      checkSsz(size >= 0, "Invalid SSZ: wrong child offsets");
+      checkSsz(size <= elementMaxSize, "SSZ element length exceeds max element type length");
+    }
+    return offsets;
+  }
+
+  private TreeNode materializePackedElement(final Bytes elementSsz) {
+    try (SszReader elementReader = SszReader.fromBytes(elementSsz)) {
+      return getElementSchema().sszDeserializeTree(elementReader);
     }
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszPrimitiveSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszPrimitiveSchema.java
@@ -169,7 +169,12 @@ public abstract class AbstractSszPrimitiveSchema<DataT, SszDataT extends SszPrim
     return createNodeFromSszBytes(bytes);
   }
 
-  protected LeafNode createNodeFromSszBytes(final Bytes bytes) {
+  /**
+   * Creates a leaf node from SSZ-encoded bytes containing one or more packed values of this type,
+   * validating value encodings where the type constrains them (e.g. booleans must be 0 or 1).
+   * Packed-list deserializers call this once per (up to 32-byte) chunk.
+   */
+  public LeafNode createNodeFromSszBytes(final Bytes bytes) {
     return LeafNode.create(bytes);
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNode.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.tree;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
+
+/// Backs an entire `List[ByteList[N], M]` vector subtree with its serialized SSZ bytes.
+///
+/// Instead of materializing per-element trees, this node retains the list's SSZ variable part
+/// (offset table + element data, typically a zero-copy slice of the incoming buffer) and computes
+/// `hashTreeRoot` by streaming merkleization with O(depth) transient memory, caching a single
+/// root. Retaining `sszBytes` pins the enclosing buffer slice; acceptable because the enclosing
+/// structure retains sibling slices anyway.
+///
+/// Navigation is virtual: `left()`/`right()` return lightweight range wrappers, element subtrees
+/// are materialized on demand via the supplied materializer (and come out spine-compressed).
+/// Updates decay this node into the fully materialized equivalent — the cold path by design.
+public class SszPackedByteListsNode implements BranchNode {
+
+  private final Bytes sszBytes;
+  private final int[] elementOffsets;
+  private final int elementDataDepth;
+  private final int depth;
+  private final Function<Bytes, TreeNode> elementMaterializer;
+  private volatile Bytes32 cachedHash = null;
+
+  public SszPackedByteListsNode(
+      final Bytes sszBytes,
+      final int[] elementOffsets,
+      final int elementDataDepth,
+      final int depth,
+      final Function<Bytes, TreeNode> elementMaterializer) {
+    checkArgument(depth >= 1 && depth < TreeUtil.ZERO_TREES.length, "Invalid depth: %s", depth);
+    checkArgument(
+        elementOffsets.length >= 2 && elementOffsets[elementOffsets.length - 1] == sszBytes.size(),
+        "Offsets must include the end sentinel");
+    checkArgument(
+        elementOffsets.length - 1 <= 1L << depth, "More elements than the tree depth allows");
+    this.sszBytes = sszBytes;
+    this.elementOffsets = elementOffsets;
+    this.elementDataDepth = elementDataDepth;
+    this.depth = depth;
+    this.elementMaterializer = elementMaterializer;
+  }
+
+  public Bytes getSszBytes() {
+    return sszBytes;
+  }
+
+  public int getElementCount() {
+    return elementOffsets.length - 1;
+  }
+
+  private Bytes elementSsz(final int index) {
+    return sszBytes.slice(elementOffsets[index], elementOffsets[index + 1] - elementOffsets[index]);
+  }
+
+  private TreeNode materializeElement(final int index) {
+    return elementMaterializer.apply(elementSsz(index));
+  }
+
+  /** The fully materialized equivalent tree (spine-compressed); used by the update decay path. */
+  public TreeNode materialize() {
+    final List<TreeNode> elements = new ArrayList<>(getElementCount());
+    for (int i = 0; i < getElementCount(); i++) {
+      elements.add(materializeElement(i));
+    }
+    return TreeUtil.createTree(elements, depth);
+  }
+
+  private TreeNode childNode(final long firstSlot, final int childDepth) {
+    if (firstSlot >= getElementCount()) {
+      return TreeUtil.ZERO_TREES[childDepth];
+    }
+    if (childDepth == 0) {
+      return materializeElement((int) firstSlot);
+    }
+    return new VirtualBranchNode(firstSlot, childDepth);
+  }
+
+  @Override
+  @NotNull
+  public TreeNode left() {
+    return childNode(0, depth - 1);
+  }
+
+  @Override
+  @NotNull
+  public TreeNode right() {
+    return childNode(1L << (depth - 1), depth - 1);
+  }
+
+  @Override
+  public BranchNode rebind(final boolean left, final TreeNode newNode) {
+    return left ? BranchNode.create(newNode, right()) : BranchNode.create(left(), newNode);
+  }
+
+  @Override
+  public TreeNode updated(final TreeUpdates newNodes) {
+    if (newNodes.isEmpty()) {
+      return this;
+    } else if (newNodes.isFinal()) {
+      return newNodes.getNode(0);
+    } else {
+      return materialize().updated(newNodes);
+    }
+  }
+
+  @Override
+  public Bytes32 hashTreeRoot() {
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash == null) {
+      cachedHash = BranchNode.super.hashTreeRoot();
+      this.cachedHash = cachedHash;
+    }
+    return cachedHash;
+  }
+
+  @Override
+  public Bytes32 hashTreeRoot(final Sha256 sha256) {
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash == null) {
+      cachedHash = subtreeRoot(sha256, 0, depth);
+      this.cachedHash = cachedHash;
+    }
+    return cachedHash;
+  }
+
+  private Bytes32 subtreeRoot(final Sha256 sha256, final long firstSlot, final int subtreeDepth) {
+    if (firstSlot >= getElementCount()) {
+      return TreeUtil.ZERO_TREES[subtreeDepth].hashTreeRoot();
+    }
+    if (subtreeDepth == 0) {
+      return elementRoot(sha256, (int) firstSlot);
+    }
+    final Bytes32 leftRoot = subtreeRoot(sha256, firstSlot, subtreeDepth - 1);
+    final Bytes32 rightRoot =
+        subtreeRoot(sha256, firstSlot + (1L << (subtreeDepth - 1)), subtreeDepth - 1);
+    return Bytes32.wrap(sha256.digest(leftRoot, rightRoot));
+  }
+
+  private Bytes32 elementRoot(final Sha256 sha256, final int index) {
+    final Bytes data = elementSsz(index);
+    final Bytes32 dataRoot = byteChunksRoot(sha256, data, 0, elementDataDepth);
+    final Bytes32 lengthRoot =
+        Bytes32.rightPad(Bytes.ofUnsignedLong(data.size(), ByteOrder.LITTLE_ENDIAN));
+    return Bytes32.wrap(sha256.digest(dataRoot, lengthRoot));
+  }
+
+  private static Bytes32 byteChunksRoot(
+      final Sha256 sha256, final Bytes data, final int firstChunk, final int chunksDepth) {
+    final int firstByte = firstChunk * LeafNode.MAX_BYTE_SIZE;
+    if (firstByte >= data.size()) {
+      return TreeUtil.ZERO_TREES[chunksDepth].hashTreeRoot();
+    }
+    if (chunksDepth == 0) {
+      return Bytes32.rightPad(
+          data.slice(firstByte, Math.min(LeafNode.MAX_BYTE_SIZE, data.size() - firstByte)));
+    }
+    final Bytes32 leftRoot = byteChunksRoot(sha256, data, firstChunk, chunksDepth - 1);
+    final Bytes32 rightRoot =
+        byteChunksRoot(sha256, data, firstChunk + (1 << (chunksDepth - 1)), chunksDepth - 1);
+    return Bytes32.wrap(sha256.digest(leftRoot, rightRoot));
+  }
+
+  @Override
+  public String toString() {
+    return "PackedByteLists[" + getElementCount() + " elements, " + sszBytes.size() + " bytes]";
+  }
+
+  /// Lazily materialized branch covering element slots `[firstSlot, firstSlot + 2^nodeDepth)`.
+  /// Stateless: roots are recomputed per call; anything holding subtree roots long-term should
+  /// materialize instead.
+  private class VirtualBranchNode implements BranchNode {
+    private final long firstSlot;
+    private final int nodeDepth;
+
+    private VirtualBranchNode(final long firstSlot, final int nodeDepth) {
+      this.firstSlot = firstSlot;
+      this.nodeDepth = nodeDepth;
+    }
+
+    @Override
+    @NotNull
+    public TreeNode left() {
+      return childNode(firstSlot, nodeDepth - 1);
+    }
+
+    @Override
+    @NotNull
+    public TreeNode right() {
+      return childNode(firstSlot + (1L << (nodeDepth - 1)), nodeDepth - 1);
+    }
+
+    @Override
+    public BranchNode rebind(final boolean left, final TreeNode newNode) {
+      return left ? BranchNode.create(newNode, right()) : BranchNode.create(left(), newNode);
+    }
+
+    @Override
+    public Bytes32 hashTreeRoot(final Sha256 sha256) {
+      return subtreeRoot(sha256, firstSlot, nodeDepth);
+    }
+
+    @Override
+    public String toString() {
+      return "PackedByteListsRange[slot " + firstSlot + ", depth " + nodeDepth + "]";
+    }
+  }
+}

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNode.java
@@ -34,7 +34,8 @@ import tech.pegasys.teku.infrastructure.crypto.Sha256;
 ///
 /// Navigation is virtual: `left()`/`right()` return lightweight range wrappers, element subtrees
 /// are materialized on demand via the supplied materializer (and come out spine-compressed).
-/// Updates decay this node into the fully materialized equivalent — the cold path by design.
+/// Both `updated` overloads decay this node into the fully materialized equivalent and apply the
+/// update there — the cold path by design.
 public class SszPackedByteListsNode implements BranchNode {
 
   private final Bytes sszBytes;
@@ -51,6 +52,10 @@ public class SszPackedByteListsNode implements BranchNode {
       final int depth,
       final Function<Bytes, TreeNode> elementMaterializer) {
     checkArgument(depth >= 1 && depth < TreeUtil.ZERO_TREES.length, "Invalid depth: %s", depth);
+    checkArgument(
+        elementDataDepth >= 0 && elementDataDepth < TreeUtil.ZERO_TREES.length,
+        "Invalid elementDataDepth: %s",
+        elementDataDepth);
     checkArgument(
         elementOffsets.length >= 2 && elementOffsets[elementOffsets.length - 1] == sszBytes.size(),
         "Offsets must include the end sentinel");
@@ -124,6 +129,15 @@ public class SszPackedByteListsNode implements BranchNode {
     } else {
       return materialize().updated(newNodes);
     }
+  }
+
+  @Override
+  public TreeNode updated(
+      final long generalizedIndex, final Function<TreeNode, TreeNode> nodeUpdater) {
+    if (GIndexUtil.gIdxIsSelf(generalizedIndex)) {
+      return nodeUpdater.apply(this);
+    }
+    return materialize().updated(generalizedIndex, nodeUpdater);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeUtil.java
@@ -113,6 +113,13 @@ public class TreeUtil {
   }
 
   public static TreeNode createTree(final List<? extends TreeNode> leafNodes, final int depth) {
+    final int packedDepth = treeDepth(leafNodes.size());
+    if (!leafNodes.isEmpty() && depth > packedDepth) {
+      // the populated leaves fit in a shallower left-aligned subtree: build only that subtree and
+      // represent the zero-padded levels above it with a single compact spine node
+      final TreeNode packedTree = createTree(leafNodes, 0, leafNodes.size(), packedDepth);
+      return ZeroPaddedSpineNode.create(packedTree, packedDepth, depth);
+    }
     return createTree(leafNodes, 0, leafNodes.size(), depth);
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ZeroPaddedSpineNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ZeroPaddedSpineNode.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.tree;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.tuweni.bytes.Bytes32;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
+
+/// Compact representation of a subtree of depth `depth` whose only non-zero content is a single
+/// child subtree of depth `childDepth` occupying the leftmost position. It is equivalent to a
+/// chain of `depth - childDepth` branch nodes where every right child is the zero subtree of the
+/// corresponding depth:
+///
+/// ```
+///              o                 <- this node (depth)
+///             / \
+///            o   Z[depth-1]
+///           / \
+///         ...  Z[childDepth+1]
+///         / \
+///     child  Z[childDepth]
+/// ```
+///
+/// This is the typical shape of a sparsely populated list tree — e.g. a short
+/// `ByteList[HUGE_LIMIT]` — where materializing the chain would cost one branch node plus one
+/// cached root per level. This node stores only the child and computes its root by folding the
+/// child root with the precomputed zero subtree roots, caching a single [Bytes32].
+///
+/// Navigation ([#get(long)], [#iterate(long, long, TreeVisitor)]) is virtual: intermediate spine
+/// levels are materialized on demand as lightweight wrappers. Updates decay the touched path into
+/// regular branch nodes, matching the previous representation.
+public class ZeroPaddedSpineNode implements BranchNode {
+
+  private final TreeNode child;
+  private final int childDepth;
+  private final int depth;
+  private volatile Bytes32 cachedHash = null;
+
+  private ZeroPaddedSpineNode(final TreeNode child, final int childDepth, final int depth) {
+    this.child = child;
+    this.childDepth = childDepth;
+    this.depth = depth;
+  }
+
+  /// Creates a node equivalent to the zero-padded chain of branch nodes from `depth` down to a
+  /// left-aligned `child` subtree of depth `childDepth`.
+  public static TreeNode create(final TreeNode child, final int childDepth, final int depth) {
+    checkArgument(
+        childDepth >= 0 && depth > childDepth && depth < TreeUtil.ZERO_TREES.length,
+        "Invalid spine depths: childDepth=%s, depth=%s",
+        childDepth,
+        depth);
+    return new ZeroPaddedSpineNode(child, childDepth, depth);
+  }
+
+  @Override
+  @NotNull
+  public TreeNode left() {
+    return depth - 1 == childDepth ? child : new ZeroPaddedSpineNode(child, childDepth, depth - 1);
+  }
+
+  @Override
+  @NotNull
+  public TreeNode right() {
+    return TreeUtil.ZERO_TREES[depth - 1];
+  }
+
+  @Override
+  public BranchNode rebind(final boolean left, final TreeNode newNode) {
+    return left ? BranchNode.create(newNode, right()) : BranchNode.create(left(), newNode);
+  }
+
+  @Override
+  public TreeNode updated(final TreeUpdates newNodes) {
+    if (newNodes.isEmpty()) {
+      return this;
+    } else if (newNodes.isFinal()) {
+      return newNodes.getNode(0);
+    } else {
+      final Pair<TreeUpdates, TreeUpdates> children = newNodes.splitAtPivot();
+      return BranchNode.create(
+          left().updated(children.getLeft()), right().updated(children.getRight()));
+    }
+  }
+
+  @Override
+  public Bytes32 hashTreeRoot() {
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash == null) {
+      cachedHash = BranchNode.super.hashTreeRoot();
+      this.cachedHash = cachedHash;
+    }
+    return cachedHash;
+  }
+
+  @Override
+  public Bytes32 hashTreeRoot(final Sha256 sha256) {
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash == null) {
+      Bytes32 root = child.hashTreeRoot(sha256);
+      for (int level = childDepth; level < depth; level++) {
+        root = Bytes32.wrap(sha256.digest(root, TreeUtil.ZERO_TREES[level].hashTreeRoot()));
+      }
+      cachedHash = root;
+      this.cachedHash = cachedHash;
+    }
+    return cachedHash;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + child + " +ZeroPaddedSpine-" + (depth - childDepth) + ")";
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
@@ -163,4 +163,23 @@ public class SszPackedByteListsSchemaTest {
     assertThat(HINTED.createFromElements(List.of()).hashTreeRoot())
         .isEqualTo(UNHINTED.createFromElements(List.of()).hashTreeRoot());
   }
+
+  @Test
+  public void storeLoad_shouldRoundTripViaMaterializedForm() {
+    final Bytes bytes = serialized(1, 0, 33, 100);
+    final SszList<SszByteList> hinted = (SszList<SszByteList>) HINTED.sszDeserialize(bytes);
+    final InMemoryStoringTreeNodeStore nodeStore = new InMemoryStoringTreeNodeStore();
+    final TreeNode node = hinted.getBackingNode();
+    HINTED.storeBackingNodes(nodeStore, 100, GIndexUtil.SELF_G_INDEX, node);
+    final TreeNode loaded =
+        HINTED.loadBackingNodes(nodeStore, node.hashTreeRoot(), GIndexUtil.SELF_G_INDEX);
+    assertThat(loaded.hashTreeRoot()).isEqualTo(node.hashTreeRoot());
+    final SszList<SszByteList> reloaded =
+        (SszList<SszByteList>) HINTED.createFromBackingNode(loaded);
+    for (int i = 0; i < hinted.size(); i++) {
+      assertThat(reloaded.get(i).getBytes()).isEqualTo(hinted.get(i).getBytes());
+    }
+    // packed form is intentionally NOT preserved across store/load
+    assertThat(vectorNode(reloaded)).isNotInstanceOf(SszPackedByteListsNode.class);
+  }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
@@ -142,4 +142,25 @@ public class SszPackedByteListsSchemaTest {
     final SszList<SszByteList> unhinted = (SszList<SszByteList>) UNHINTED.sszDeserialize(bytes);
     assertThat(hinted.sszSerialize()).isEqualTo(unhinted.sszSerialize());
   }
+
+  @Test
+  public void createFromElements_shouldProducePackedNodeAndMatchOracle() {
+    final List<SszByteList> elements =
+        List.of(
+            ELEMENT_SCHEMA.fromBytes(Bytes.of(1)),
+            ELEMENT_SCHEMA.fromBytes(Bytes.EMPTY),
+            ELEMENT_SCHEMA.fromBytes(Bytes.wrap(new byte[100])));
+    final SszList<SszByteList> hinted = (SszList<SszByteList>) HINTED.createFromElements(elements);
+    final SszList<SszByteList> unhinted =
+        (SszList<SszByteList>) UNHINTED.createFromElements(elements);
+    assertThat(vectorNode(hinted)).isInstanceOf(SszPackedByteListsNode.class);
+    assertThat(hinted.hashTreeRoot()).isEqualTo(unhinted.hashTreeRoot());
+    assertThat(hinted.sszSerialize()).isEqualTo(unhinted.sszSerialize());
+  }
+
+  @Test
+  public void createFromElements_shouldHandleEmptyList() {
+    assertThat(HINTED.createFromElements(List.of()).hashTreeRoot())
+        .isEqualTo(UNHINTED.createFromElements(List.of()).hashTreeRoot());
+  }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
@@ -15,15 +15,29 @@ package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNodeTest.elementsOfSizes;
+import static tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNodeTest.serializeElements;
 
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
+import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil;
+import tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNode;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
 public class SszPackedByteListsSchemaTest {
 
   private static final SszByteListSchema<SszByteList> ELEMENT_SCHEMA =
       SszByteListSchema.create(256);
+
+  private static final SszListSchema<SszByteList, ?> HINTED =
+      SszListSchema.create(ELEMENT_SCHEMA, 16, SszSchemaHints.sszPackedByteLists());
+  private static final SszListSchema<SszByteList, ?> UNHINTED =
+      SszListSchema.create(ELEMENT_SCHEMA, 16);
 
   @Test
   public void hint_shouldBeAcceptedForByteListElements() {
@@ -39,5 +53,73 @@ public class SszPackedByteListsSchemaTest {
                 SszListSchema.create(
                     SszPrimitiveSchemas.UINT64_SCHEMA, 16, SszSchemaHints.sszPackedByteLists()))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static Bytes serialized(final int... sizes) {
+    return serializeElements(elementsOfSizes(sizes));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static SszList<SszByteList> deserializeHinted(final Bytes bytes) {
+    return (SszList<SszByteList>) HINTED.sszDeserialize(bytes);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static SszList<SszByteList> deserializeUnhinted(final Bytes bytes) {
+    return (SszList<SszByteList>) UNHINTED.sszDeserialize(bytes);
+  }
+
+  private static TreeNode vectorNode(final SszList<SszByteList> list) {
+    return list.getBackingNode().get(GIndexUtil.LEFT_CHILD_G_INDEX);
+  }
+
+  @Test
+  public void deserialize_shouldProducePackedNodeAndMatchOracle() {
+    final Bytes bytes = serialized(1, 0, 33, 100);
+    final SszList<SszByteList> hinted = deserializeHinted(bytes);
+    final SszList<SszByteList> unhinted = deserializeUnhinted(bytes);
+    assertThat(vectorNode(hinted)).isInstanceOf(SszPackedByteListsNode.class);
+    assertThat(hinted.hashTreeRoot()).isEqualTo(unhinted.hashTreeRoot());
+    assertThat(hinted.size()).isEqualTo(4);
+    for (int i = 0; i < hinted.size(); i++) {
+      assertThat(hinted.get(i).getBytes()).isEqualTo(unhinted.get(i).getBytes());
+    }
+  }
+
+  @Test
+  public void deserialize_shouldProduceDefaultTreeForEmptyList() {
+    final SszList<SszByteList> hinted = deserializeHinted(Bytes.EMPTY);
+    assertThat(vectorNode(hinted)).isNotInstanceOf(SszPackedByteListsNode.class);
+    assertThat(hinted.hashTreeRoot())
+        .isEqualTo(UNHINTED.sszDeserialize(Bytes.EMPTY).hashTreeRoot());
+  }
+
+  @Test
+  public void deserialize_shouldRejectMalformedInputLikeOracle() {
+    // too many elements (17 > 16)
+    final Bytes tooMany = serialized(IntStream.range(0, 17).map(i -> 1).toArray());
+    assertThatThrownBy(() -> HINTED.sszDeserialize(tooMany))
+        .isInstanceOf(SszDeserializeException.class);
+    assertThatThrownBy(() -> UNHINTED.sszDeserialize(tooMany))
+        .isInstanceOf(SszDeserializeException.class);
+    // element exceeding the inner limit (257 > 256)
+    final Bytes overlongElement = serialized(257);
+    assertThatThrownBy(() -> HINTED.sszDeserialize(overlongElement))
+        .isInstanceOf(SszDeserializeException.class);
+    assertThatThrownBy(() -> UNHINTED.sszDeserialize(overlongElement))
+        .isInstanceOf(SszDeserializeException.class);
+    // misaligned first offset
+    final Bytes misaligned = Bytes.concatenate(Bytes.of(5, 0, 0, 0), Bytes.of(1));
+    assertThatThrownBy(() -> HINTED.sszDeserialize(misaligned))
+        .isInstanceOf(SszDeserializeException.class);
+    // non-monotonic offsets: two elements, second offset before first
+    final Bytes nonMonotonic =
+        Bytes.concatenate(Bytes.of(8, 0, 0, 0), Bytes.of(7, 0, 0, 0), Bytes.of(1, 2));
+    assertThatThrownBy(() -> HINTED.sszDeserialize(nonMonotonic))
+        .isInstanceOf(SszDeserializeException.class);
+    // zero first offset: rejected (deliberate deviation; matches the progressive-list fix)
+    final Bytes zeroFirstOffset = Bytes.of(0, 0, 0, 0);
+    assertThatThrownBy(() -> HINTED.sszDeserialize(zeroFirstOffset))
+        .isInstanceOf(SszDeserializeException.class);
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+
+public class SszPackedByteListsSchemaTest {
+
+  private static final SszByteListSchema<SszByteList> ELEMENT_SCHEMA =
+      SszByteListSchema.create(256);
+
+  @Test
+  public void hint_shouldBeAcceptedForByteListElements() {
+    final SszListSchema<SszByteList, ?> schema =
+        SszListSchema.create(ELEMENT_SCHEMA, 16, SszSchemaHints.sszPackedByteLists());
+    assertThat(schema.toString()).contains("SszPackedByteListsHint");
+  }
+
+  @Test
+  public void hint_shouldBeRejectedForNonByteListElements() {
+    assertThatThrownBy(
+            () ->
+                SszListSchema.create(
+                    SszPrimitiveSchemas.UINT64_SCHEMA, 16, SszSchemaHints.sszPackedByteLists()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
@@ -56,6 +56,16 @@ public class SszPackedByteListsSchemaTest {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  @Test
+  public void hint_shouldBeRejectedForMaxLengthBelowTwo() {
+    // maxLength 1 gives the outer vector a tree depth of 0, which SszPackedByteListsNode cannot
+    // represent; catch it at schema construction rather than surfacing an obscure failure on the
+    // wire-decode path.
+    assertThatThrownBy(
+            () -> SszListSchema.create(ELEMENT_SCHEMA, 1, SszSchemaHints.sszPackedByteLists()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
   private static Bytes serialized(final int... sizes) {
     return serializeElements(elementsOfSizes(sizes));
   }
@@ -138,7 +148,9 @@ public class SszPackedByteListsSchemaTest {
     final Bytes bytes = serialized(1, 0, 33, 100);
     final SszList<SszByteList> hinted = (SszList<SszByteList>) HINTED.sszDeserialize(bytes);
     assertThat(hinted.sszSerialize()).isEqualTo(bytes);
-    // a decayed (updated) list must still serialize correctly through the generic path
+    // an independently deserialized unhinted (materialized) list must serialize identically;
+    // real decay-then-serialize is covered by
+    // updated_shouldDecayThroughProductionMutationPathAndMatchUnhinted below
     final SszList<SszByteList> unhinted = (SszList<SszByteList>) UNHINTED.sszDeserialize(bytes);
     assertThat(hinted.sszSerialize()).isEqualTo(unhinted.sszSerialize());
   }
@@ -162,6 +174,33 @@ public class SszPackedByteListsSchemaTest {
   public void createFromElements_shouldHandleEmptyList() {
     assertThat(HINTED.createFromElements(List.of()).hashTreeRoot())
         .isEqualTo(UNHINTED.createFromElements(List.of()).hashTreeRoot());
+  }
+
+  @Test
+  public void updated_shouldDecayThroughProductionMutationPathAndMatchUnhinted() {
+    // Drives the production mutation flow (SszMutableList.commitChanges() ->
+    // backing.updated(TreeUpdates)) for a hinted packed list, and checks it decays to the same
+    // result as the equivalent mutation on an unhinted (already materialized) list.
+    final Bytes bytes = serialized(1, 0, 33, 100);
+    final SszList<SszByteList> committedHinted = mutateElementOne(deserializeHinted(bytes));
+    final SszList<SszByteList> committedUnhinted = mutateElementOne(deserializeUnhinted(bytes));
+
+    assertThat(committedHinted.hashTreeRoot()).isEqualTo(committedUnhinted.hashTreeRoot());
+    assertThat(committedHinted.sszSerialize()).isEqualTo(committedUnhinted.sszSerialize());
+    assertThat(committedHinted.size()).isEqualTo(committedUnhinted.size());
+    for (int i = 0; i < committedHinted.size(); i++) {
+      assertThat(committedHinted.get(i).getBytes())
+          .describedAs("element %s", i)
+          .isEqualTo(committedUnhinted.get(i).getBytes());
+    }
+    // the hinted list's vector node must have decayed into the materialized representation
+    assertThat(vectorNode(committedHinted)).isNotInstanceOf(SszPackedByteListsNode.class);
+  }
+
+  private static SszList<SszByteList> mutateElementOne(final SszList<SszByteList> list) {
+    final var mutable = list.createWritableCopy();
+    mutable.set(1, ELEMENT_SCHEMA.fromBytes(Bytes.of(9, 9, 9)));
+    return mutable.commitChanges();
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNodeTest.elementsOfSizes;
 import static tech.pegasys.teku.infrastructure.ssz.tree.SszPackedByteListsNodeTest.serializeElements;
 
+import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -121,5 +122,14 @@ public class SszPackedByteListsSchemaTest {
     final Bytes zeroFirstOffset = Bytes.of(0, 0, 0, 0);
     assertThatThrownBy(() -> HINTED.sszDeserialize(zeroFirstOffset))
         .isInstanceOf(SszDeserializeException.class);
+    // truncated input shorter than a single offset (1-3 bytes)
+    for (final Bytes truncated : List.of(Bytes.of(1), Bytes.of(1, 2), Bytes.of(1, 2, 3))) {
+      assertThatThrownBy(() -> HINTED.sszDeserialize(truncated))
+          .describedAs("hinted, %s bytes", truncated.size())
+          .isInstanceOf(SszDeserializeException.class);
+      assertThatThrownBy(() -> UNHINTED.sszDeserialize(truncated))
+          .describedAs("unhinted, %s bytes", truncated.size())
+          .isInstanceOf(SszDeserializeException.class);
+    }
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPackedByteListsSchemaTest.java
@@ -132,4 +132,14 @@ public class SszPackedByteListsSchemaTest {
           .isInstanceOf(SszDeserializeException.class);
     }
   }
+
+  @Test
+  public void serialize_shouldRoundTripByteIdentical() {
+    final Bytes bytes = serialized(1, 0, 33, 100);
+    final SszList<SszByteList> hinted = (SszList<SszByteList>) HINTED.sszDeserialize(bytes);
+    assertThat(hinted.sszSerialize()).isEqualTo(bytes);
+    // a decayed (updated) list must still serialize correctly through the generic path
+    final SszList<SszByteList> unhinted = (SszList<SszByteList>) UNHINTED.sszDeserialize(bytes);
+    assertThat(hinted.sszSerialize()).isEqualTo(unhinted.sszSerialize());
+  }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveByteListSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveByteListSchemaTest.java
@@ -17,8 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutablePrimitiveList;
@@ -40,6 +43,20 @@ class SszProgressiveByteListSchemaTest {
     assertThat(byteList).isInstanceOf(SszProgressiveByteListImpl.class);
     assertThat(byteList.size()).isEqualTo(3);
     assertThat(byteList.getBytes()).isEqualTo(bytes);
+  }
+
+  // 97 bytes (4 chunks) fills progressive levels 0-1; 193 bytes (7 chunks) reaches level 2
+  @ParameterizedTest
+  @ValueSource(ints = {97, 193})
+  void fromBytes_shouldPreserveBytesAcrossMultipleChunks(final int size) {
+    final Bytes bytes = Bytes.of(IntStream.range(0, size).map(i -> (i * 17) & 0xFF).toArray());
+    final SszByteList byteList = SCHEMA.fromBytes(bytes);
+
+    assertThat(byteList).isInstanceOf(SszProgressiveByteListImpl.class);
+    assertThat(byteList.size()).isEqualTo(size);
+    assertThat(byteList.getBytes()).isEqualTo(bytes);
+    assertThat(SCHEMA.sszDeserialize(byteList.sszSerialize()).hashTreeRoot())
+        .isEqualTo(byteList.hashTreeRoot());
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.ssz.schema.TreeNodeAssert.assertThatTreeNode;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -36,6 +37,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
 import tech.pegasys.teku.infrastructure.ssz.impl.SszContainerImpl;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBoolean;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
@@ -129,6 +131,21 @@ public class SszProgressiveListSchemaTest {
     for (int i = 0; i < 10; i++) {
       assertThat(deserialized.get(i).get()).isEqualTo(UInt64.valueOf(i));
     }
+  }
+
+  @Test
+  void sszDeserialize_shouldValidateBooleanEncodingInEveryChunk() {
+    final SszProgressiveListSchema<SszBoolean> schema =
+        SszProgressiveListSchema.create(SszPrimitiveSchemas.BOOLEAN_SCHEMA);
+
+    final byte[] valid = new byte[40];
+    Arrays.fill(valid, (byte) 1);
+    assertThat(schema.sszDeserialize(Bytes.wrap(valid)).size()).isEqualTo(40);
+
+    final byte[] invalid = valid.clone();
+    invalid[35] = 2; // second 32-byte chunk
+    assertThatThrownBy(() -> schema.sszDeserialize(Bytes.wrap(invalid)))
+        .isInstanceOf(SszDeserializeException.class);
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNodeTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNodeTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
@@ -159,5 +160,66 @@ public class SszPackedByteListsNodeTest {
 
   static List<Integer> sparseCounts() {
     return List.of(1, 2, 33, 100);
+  }
+
+  @Test
+  public void get_shouldMatchOracleForAllPositions() {
+    final List<Bytes> elements = elementsOfSizes(1, 0, 33, 100);
+    final SszPackedByteListsNode packed = node(elements, SMALL_ELEMENT, SMALL_ORACLE);
+    final TreeNode oracle = oracleVectorNode(SMALL_ORACLE, elements);
+    final int depth = SMALL_ORACLE.treeDepth();
+    // every element slot (occupied and empty) must agree by root
+    for (int slot = 0; slot < 16; slot++) {
+      final long gIndex = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, slot, depth);
+      assertThat(packed.get(gIndex).hashTreeRoot())
+          .describedAs("slot %s", slot)
+          .isEqualTo(oracle.get(gIndex).hashTreeRoot());
+    }
+    // navigation INSIDE an occupied element subtree (its length node)
+    final long elementGIndex = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 2, depth);
+    final long lengthGIndex = GIndexUtil.gIdxCompose(elementGIndex, GIndexUtil.RIGHT_CHILD_G_INDEX);
+    assertThat(packed.get(lengthGIndex).hashTreeRoot())
+        .isEqualTo(oracle.get(lengthGIndex).hashTreeRoot());
+    // intermediate branch positions
+    assertThat(packed.get(GIndexUtil.LEFT_CHILD_G_INDEX).hashTreeRoot())
+        .isEqualTo(oracle.get(GIndexUtil.LEFT_CHILD_G_INDEX).hashTreeRoot());
+    assertThat(packed.get(GIndexUtil.RIGHT_CHILD_G_INDEX).hashTreeRoot())
+        .isEqualTo(oracle.get(GIndexUtil.RIGHT_CHILD_G_INDEX).hashTreeRoot());
+  }
+
+  @Test
+  public void merkleProof_shouldMatchOracle() {
+    final List<Bytes> elements = elementsOfSizes(1, 0, 33, 100);
+    final SszPackedByteListsNode packed = node(elements, SMALL_ELEMENT, SMALL_ORACLE);
+    final TreeNode oracle = oracleVectorNode(SMALL_ORACLE, elements);
+    final long gIndex =
+        GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 2, SMALL_ORACLE.treeDepth());
+    assertThat(MerkleUtil.constructMerkleProof(packed, gIndex))
+        .isEqualTo(MerkleUtil.constructMerkleProof(oracle, gIndex));
+  }
+
+  @Test
+  public void updated_shouldDecayAndMatchOracle() {
+    final List<Bytes> elements = elementsOfSizes(1, 0, 33, 100);
+    final SszPackedByteListsNode packed = node(elements, SMALL_ELEMENT, SMALL_ORACLE);
+    final TreeNode oracle = oracleVectorNode(SMALL_ORACLE, elements);
+    final int depth = SMALL_ORACLE.treeDepth();
+    // replace element 1 with a freshly materialized different element
+    final Bytes replacementSsz = Bytes.of(9, 9, 9);
+    final TreeNode replacement =
+        node(List.of(replacementSsz), SMALL_ELEMENT, SMALL_ORACLE)
+            .get(GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 0, depth));
+    final long gIndex = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 1, depth);
+    assertThat(packed.updated(gIndex, replacement).hashTreeRoot())
+        .isEqualTo(oracle.updated(gIndex, replacement).hashTreeRoot());
+  }
+
+  @Test
+  public void iterate_shouldVisitLeavesMatchingOracleData() {
+    final List<Bytes> elements = elementsOfSizes(1, 0, 33, 100);
+    final SszPackedByteListsNode packed = node(elements, SMALL_ELEMENT, SMALL_ORACLE);
+    final TreeNode oracle = oracleVectorNode(SMALL_ORACLE, elements);
+    assertThat(TreeUtil.concatenateLeavesData(packed))
+        .isEqualTo(TreeUtil.concatenateLeavesData(oracle));
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNodeTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNodeTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
+
+public class SszPackedByteListsNodeTest {
+
+  static final SszByteListSchema<SszByteList> SMALL_ELEMENT = SszByteListSchema.create(256);
+  static final SszListSchema<SszByteList, ?> SMALL_ORACLE = SszListSchema.create(SMALL_ELEMENT, 16);
+  static final SszByteListSchema<SszByteList> HUGE_ELEMENT = SszByteListSchema.create(1L << 30);
+  static final SszListSchema<SszByteList, ?> HUGE_ORACLE =
+      SszListSchema.create(HUGE_ELEMENT, 1L << 20);
+
+  /**
+   * Builds the SSZ variable part (offset table + data) for the given element payloads. Public: also
+   * used by SszPackedByteListsSchemaTest in the schema package (Tasks 4-7).
+   */
+  public static Bytes serializeElements(final List<Bytes> elements) {
+    final int count = elements.size();
+    final byte[] offsetBytes = new byte[count * 4];
+    int offset = count * 4;
+    for (int i = 0; i < count; i++) {
+      offsetBytes[i * 4] = (byte) offset;
+      offsetBytes[i * 4 + 1] = (byte) (offset >> 8);
+      offsetBytes[i * 4 + 2] = (byte) (offset >> 16);
+      offsetBytes[i * 4 + 3] = (byte) (offset >> 24);
+      offset += elements.get(i).size();
+    }
+    final Bytes[] parts = new Bytes[count + 1];
+    parts[0] = Bytes.wrap(offsetBytes);
+    for (int i = 0; i < count; i++) {
+      parts[i + 1] = elements.get(i);
+    }
+    return Bytes.wrap(parts);
+  }
+
+  static int[] offsetsOf(final List<Bytes> elements) {
+    final int count = elements.size();
+    final int[] offsets = new int[count + 1];
+    int offset = count * 4;
+    for (int i = 0; i < count; i++) {
+      offsets[i] = offset;
+      offset += elements.get(i).size();
+    }
+    offsets[count] = offset;
+    return offsets;
+  }
+
+  static SszPackedByteListsNode node(
+      final List<Bytes> elements,
+      final SszByteListSchema<SszByteList> elementSchema,
+      final SszListSchema<SszByteList, ?> oracleSchema) {
+    final Function<Bytes, TreeNode> materializer =
+        elementSsz -> {
+          try (SszReader reader = SszReader.fromBytes(elementSsz)) {
+            return elementSchema.sszDeserializeTree(reader);
+          }
+        };
+    return new SszPackedByteListsNode(
+        serializeElements(elements),
+        offsetsOf(elements),
+        elementSchema.treeDepth(),
+        oracleSchema.treeDepth(),
+        materializer);
+  }
+
+  public static List<Bytes> elementsOfSizes(final int... sizes) {
+    return IntStream.range(0, sizes.length)
+        .mapToObj(
+            i -> {
+              final byte[] data = new byte[sizes[i]];
+              for (int j = 0; j < data.length; j++) {
+                data[j] = (byte) (i + j + 1);
+              }
+              return Bytes.wrap(data);
+            })
+        .toList();
+  }
+
+  static TreeNode oracleVectorNode(
+      final SszListSchema<SszByteList, ?> oracleSchema, final List<Bytes> elements) {
+    // left child of the unhinted list root == the materialized vector node
+    return oracleSchema
+        .sszDeserialize(serializeElements(elements))
+        .getBackingNode()
+        .get(GIndexUtil.LEFT_CHILD_G_INDEX);
+  }
+
+  static List<int[]> sizeMatrix() {
+    return List.of(
+        new int[] {0},
+        new int[] {1},
+        new int[] {31},
+        new int[] {32},
+        new int[] {33},
+        new int[] {100},
+        new int[] {0, 1, 31, 32, 33, 100},
+        new int[] {255, 256});
+  }
+
+  @ParameterizedTest
+  @MethodSource("sizeMatrix")
+  public void hashTreeRoot_shouldMatchOracle_smallSchema(final int[] sizes) {
+    final List<Bytes> elements = elementsOfSizes(sizes);
+    assertThat(node(elements, SMALL_ELEMENT, SMALL_ORACLE).hashTreeRoot())
+        .isEqualTo(oracleVectorNode(SMALL_ORACLE, elements).hashTreeRoot());
+  }
+
+  @ParameterizedTest
+  @MethodSource("sizeMatrix")
+  public void hashTreeRoot_shouldMatchOracle_hugeSchema(final int[] sizes) {
+    final List<Bytes> elements = elementsOfSizes(sizes);
+    assertThat(node(elements, HUGE_ELEMENT, HUGE_ORACLE).hashTreeRoot())
+        .isEqualTo(oracleVectorNode(HUGE_ORACLE, elements).hashTreeRoot());
+  }
+
+  @ParameterizedTest
+  @MethodSource("boundaryCounts")
+  public void hashTreeRoot_shouldMatchOracleAtFullBoundary(final int count) {
+    final List<Bytes> elements = elementsOfSizes(IntStream.range(0, count).map(i -> 3).toArray());
+    assertThat(node(elements, SMALL_ELEMENT, SMALL_ORACLE).hashTreeRoot())
+        .isEqualTo(oracleVectorNode(SMALL_ORACLE, elements).hashTreeRoot());
+  }
+
+  static List<Integer> boundaryCounts() {
+    return List.of(1, 2, 15, 16);
+  }
+
+  @ParameterizedTest
+  @MethodSource("sparseCounts")
+  public void hashTreeRoot_shouldMatchOracleForSparseHugeList(final int count) {
+    final List<Bytes> elements = elementsOfSizes(IntStream.range(0, count).map(i -> 5).toArray());
+    assertThat(node(elements, HUGE_ELEMENT, HUGE_ORACLE).hashTreeRoot())
+        .isEqualTo(oracleVectorNode(HUGE_ORACLE, elements).hashTreeRoot());
+  }
+
+  static List<Integer> sparseCounts() {
+    return List.of(1, 2, 33, 100);
+  }
+}

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNodeTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/SszPackedByteListsNodeTest.java
@@ -215,6 +215,32 @@ public class SszPackedByteListsNodeTest {
   }
 
   @Test
+  public void updated_shouldFullyMaterializeAndNotRetainPackedNode() {
+    final List<Bytes> elements = elementsOfSizes(1, 0, 33, 100);
+    final SszPackedByteListsNode packed = node(elements, SMALL_ELEMENT, SMALL_ORACLE);
+    final TreeNode oracle = oracleVectorNode(SMALL_ORACLE, elements);
+    final int depth = SMALL_ORACLE.treeDepth();
+    // replace element 1 with a freshly materialized different element
+    final Bytes replacementSsz = Bytes.of(9, 9, 9);
+    final TreeNode replacement =
+        node(List.of(replacementSsz), SMALL_ELEMENT, SMALL_ORACLE)
+            .get(GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 0, depth));
+    final long gIndex = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 1, depth);
+
+    final TreeNode result = packed.updated(gIndex, replacement);
+    final TreeNode oracleResult = oracle.updated(gIndex, replacement);
+
+    // fully materialized: no residual SszPackedByteListsNode (or lazy wrapper over it) anywhere
+    // reachable from the returned root
+    assertThat(result).isNotInstanceOf(SszPackedByteListsNode.class);
+    assertThat(result.hashTreeRoot()).isEqualTo(oracleResult.hashTreeRoot());
+    assertThat(TreeUtil.concatenateLeavesData(result))
+        .isEqualTo(TreeUtil.concatenateLeavesData(oracleResult));
+    assertThat(result.get(GIndexUtil.RIGHT_CHILD_G_INDEX).hashTreeRoot())
+        .isEqualTo(oracleResult.get(GIndexUtil.RIGHT_CHILD_G_INDEX).hashTreeRoot());
+  }
+
+  @Test
   public void iterate_shouldVisitLeavesMatchingOracleData() {
     final List<Bytes> elements = elementsOfSizes(1, 0, 33, 100);
     final SszPackedByteListsNode packed = node(elements, SMALL_ELEMENT, SMALL_ORACLE);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ZeroPaddedSpineNodeTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ZeroPaddedSpineNodeTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
+
+public class ZeroPaddedSpineNodeTest {
+
+  /**
+   * Reference implementation: the fully materialized zero-padded tree exactly as {@link
+   * TreeUtil#createTree(List, int)} built it before spine node compression was introduced.
+   */
+  private static TreeNode naiveTree(
+      final List<? extends TreeNode> leaves, final int from, final int to, final int depth) {
+    if (from == to) {
+      return TreeUtil.ZERO_TREES[depth];
+    } else if (depth == 0) {
+      return leaves.get(from);
+    } else {
+      final long index = 1L << (depth - 1);
+      final int mid = index > to - from ? to : from + (int) index;
+      return BranchNode.create(
+          naiveTree(leaves, from, mid, depth - 1), naiveTree(leaves, mid, to, depth - 1));
+    }
+  }
+
+  private static TreeNode naiveTree(final List<? extends TreeNode> leaves, final int depth) {
+    return naiveTree(leaves, 0, leaves.size(), depth);
+  }
+
+  private static List<LeafNode> leaves(final int count) {
+    return IntStream.range(0, count).mapToObj(i -> TreeTest.newTestLeaf(i + 1)).toList();
+  }
+
+  @Test
+  public void createTree_shouldWrapSparseLeavesInSpineNode() {
+    final TreeNode tree = TreeUtil.createTree(leaves(1), 25);
+    assertThat(tree).isInstanceOf(ZeroPaddedSpineNode.class);
+  }
+
+  @Test
+  public void createTree_shouldNotWrapWhenLeavesFillTheDepth() {
+    assertThat(TreeUtil.createTree(leaves(4), 2)).isNotInstanceOf(ZeroPaddedSpineNode.class);
+    assertThat(TreeUtil.createTree(leaves(3), 2)).isNotInstanceOf(ZeroPaddedSpineNode.class);
+  }
+
+  @Test
+  public void createTree_shouldReturnZeroTreeForEmptyLeaves() {
+    assertThat(TreeUtil.createTree(List.of(), 25)).isSameAs(TreeUtil.ZERO_TREES[25]);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, 1",
+    "1, 5",
+    "1, 25",
+    "2, 25",
+    "3, 6",
+    "5, 25",
+    "8, 4",
+    "100, 25",
+    "1000, 25",
+    "0, 25"
+  })
+  public void hashTreeRoot_shouldMatchFullyMaterializedTree(final int leafCount, final int depth) {
+    final List<LeafNode> leaves = leaves(leafCount);
+    final TreeNode tree = TreeUtil.createTree(leaves, depth);
+    final TreeNode naive = naiveTree(leaves, depth);
+    assertThat(tree.hashTreeRoot()).isEqualTo(naive.hashTreeRoot());
+  }
+
+  @Test
+  public void get_shouldNavigateToLeavesAndZeroSubtrees() {
+    final List<LeafNode> leaves = leaves(3);
+    final int depth = 10;
+    final TreeNode tree = TreeUtil.createTree(leaves, depth);
+
+    for (int i = 0; i < leaves.size(); i++) {
+      final long leafGIndex = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, i, depth);
+      assertThat(tree.get(leafGIndex)).isEqualTo(leaves.get(i));
+    }
+    // right child of the root is an untouched zero subtree
+    assertThat(tree.get(GIndexUtil.RIGHT_CHILD_G_INDEX).hashTreeRoot())
+        .isEqualTo(TreeUtil.ZERO_TREES[depth - 1].hashTreeRoot());
+    // a leaf position beyond the populated prefix is a zero leaf
+    final long emptyLeafGIndex = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 7, depth);
+    assertThat(tree.get(emptyLeafGIndex).hashTreeRoot())
+        .isEqualTo(LeafNode.EMPTY_LEAF.hashTreeRoot());
+  }
+
+  @Test
+  public void iterate_shouldVisitSameLeavesAsMaterializedTree() {
+    final List<LeafNode> leaves = leaves(5);
+    final int depth = 12;
+    final Bytes spineData = TreeUtil.concatenateLeavesData(TreeUtil.createTree(leaves, depth));
+    final Bytes naiveData = TreeUtil.concatenateLeavesData(naiveTree(leaves, depth));
+    assertThat(spineData).isEqualTo(naiveData);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0", "2", "7", "100"})
+  public void updated_shouldMatchMaterializedTreeUpdate(final int updatePosition) {
+    final List<LeafNode> leaves = leaves(3);
+    final int depth = 10;
+    final TreeNode tree = TreeUtil.createTree(leaves, depth);
+    final TreeNode naive = naiveTree(leaves, depth);
+
+    final long gIndex = GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, updatePosition, depth);
+    final TreeNode newLeaf = TreeTest.newTestLeaf(777);
+
+    assertThat(tree.updated(gIndex, newLeaf).hashTreeRoot())
+        .isEqualTo(naive.updated(gIndex, newLeaf).hashTreeRoot());
+  }
+
+  @Test
+  public void updated_shouldSupportBatchUpdatesAcrossTheSpine() {
+    final List<LeafNode> leaves = leaves(2);
+    final int depth = 8;
+    final TreeNode tree = TreeUtil.createTree(leaves, depth);
+    final TreeNode naive = naiveTree(leaves, depth);
+
+    final List<TreeUpdates.Update> updates = new ArrayList<>();
+    updates.add(
+        new TreeUpdates.Update(
+            GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 1, depth),
+            TreeTest.newTestLeaf(555)));
+    updates.add(
+        new TreeUpdates.Update(
+            GIndexUtil.gIdxChildGIndex(GIndexUtil.SELF_G_INDEX, 200, depth),
+            TreeTest.newTestLeaf(666)));
+
+    assertThat(tree.updated(new TreeUpdates(new ArrayList<>(updates))).hashTreeRoot())
+        .isEqualTo(naive.updated(new TreeUpdates(new ArrayList<>(updates))).hashTreeRoot());
+  }
+
+  @Test
+  public void listOfTinyByteLists_shouldRoundTripAndMatchMaterializedRoot() {
+    // degenerate case: List[ByteList[1 << 30], 1 << 20] holding many single-byte elements
+    final SszByteListSchema<SszByteList> elementSchema = SszByteListSchema.create(1L << 30);
+    final SszListSchema<SszByteList, ?> listSchema = SszListSchema.create(elementSchema, 1L << 20);
+
+    final List<SszByteList> elements =
+        IntStream.range(0, 100).mapToObj(i -> elementSchema.fromBytes(Bytes.of(i))).toList();
+    final var list = listSchema.createFromElements(elements);
+
+    // serialization round trip preserves data and root
+    final Bytes serialized = list.sszSerialize();
+    final var deserialized = listSchema.sszDeserialize(serialized);
+    assertThat(deserialized.hashTreeRoot()).isEqualTo(list.hashTreeRoot());
+    assertThat(deserialized.sszSerialize()).isEqualTo(serialized);
+    assertThat(deserialized.get(42).getBytes()).isEqualTo(Bytes.of(42));
+
+    // root matches the fully materialized reference construction
+    final List<LeafNode> elementLeaf = List.of(LeafNode.create(Bytes.of(42)));
+    final TreeNode naiveElementData = naiveTree(elementLeaf, elementSchema.treeDepth());
+    assertThat(list.get(42).getBackingNode().get(GIndexUtil.LEFT_CHILD_G_INDEX).hashTreeRoot())
+        .isEqualTo(naiveElementData.hashTreeRoot());
+  }
+}


### PR DESCRIPTION
various optimizations for progressive and non-progressive ssz

it also contains some refactoring (moved some common logic into ListSchemaUtil)

added a benchmark to compare perf between progressive and non-progressive (called "bounded")

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SSZ merkleization and deserialization for production execution payload transaction lists; behavior is heavily tested but incorrect roots or wire handling would affect consensus-critical data.
> 
> **Overview**
> Adds SSZ performance work aimed at **execution transaction lists** and **progressive** types, plus a JMH suite comparing **bounded** vs **progressive** representations.
> 
> **Packed `List[ByteList, M]` backing:** New `SszPackedByteListsHint` and `SszPackedByteListsNode` keep the list’s SSZ variable part in one buffer, compute `hashTreeRoot` by streaming merkleization, and materialize elements on demand; mutations decay to a full tree. `AbstractSszListSchema` wires hint-aware create, serialize, and deserialize. **Execution payload** `transactions` (Bellatrix through Gloas) and Heze **InclusionList** `transactions` now use `SszSchemaHints.sszPackedByteLists()`.
> 
> **Tree and deserialize refactors:** `ZeroPaddedSpineNode` compresses sparse left-aligned list trees; `TreeUtil.createTree` uses it when leaves fit a shallower depth. Packed progressive primitive lists share `ListSchemaUtil.createPackedProgressiveListTree`; boolean/bit validation runs per chunk via public `createNodeFromSszBytes`.
> 
> **Benchmarks and tests:** New `ProgressiveSszBenchmark` JMH class; unit/spec tests assert packed roots, SSZ round-trips, and oracle parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e30d136e25e541b3527def3c783f38c9b9f96c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->