### PR TITLE
Improve incoming RPC handling under QUIC

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandler.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnSidecarsByRootRequestMessage;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnsByRootIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarArchiveReconstructor;
@@ -131,29 +132,32 @@ public class DataColumnSidecarsByRootMessageHandler
     completionCallback.onCompletion(
         () -> dataColumnSidecarArchiveReconstructor.onRequestCompleted(messageId));
 
-    SafeFuture.collectAll(
-            message.stream()
-                .map(
-                    byRootIdentifier -> {
-                      if (byRootIdentifier.getColumns().stream()
-                          .noneMatch(myCustodyColumns::contains)) {
-                        // we don't custody any of the requested columns
-                        return SafeFuture.completedFuture(0L);
-                      }
-                      return resolveBlockRootSlot(byRootIdentifier.getBlockRoot())
-                          .thenCompose(
-                              maybeSlot ->
-                                  retrieveAndRespondForBlockRoot(
-                                      byRootIdentifier.getBlockRoot(),
-                                      maybeSlot,
-                                      byRootIdentifier.getColumns(),
-                                      myCustodyColumns,
-                                      messageId,
-                                      completionCallback));
-                    }))
+    SafeFuture<Long> responseFuture = SafeFuture.completedFuture(0L);
+    for (final DataColumnsByRootIdentifier byRootIdentifier : message) {
+      responseFuture =
+          responseFuture.thenCompose(
+              sentSoFar -> {
+                if (byRootIdentifier.getColumns().stream().noneMatch(myCustodyColumns::contains)) {
+                  // we don't custody any of the requested columns
+                  return SafeFuture.completedFuture(sentSoFar);
+                }
+                return resolveBlockRootSlot(byRootIdentifier.getBlockRoot())
+                    .thenCompose(
+                        maybeSlot ->
+                            retrieveAndRespondForBlockRoot(
+                                byRootIdentifier.getBlockRoot(),
+                                maybeSlot,
+                                byRootIdentifier.getColumns(),
+                                myCustodyColumns,
+                                messageId,
+                                completionCallback))
+                    .thenApply(sent -> sentSoFar + sent);
+              });
+    }
+
+    responseFuture
         .thenAccept(
-            counts -> {
-              final long sent = counts.stream().mapToLong(Long::longValue).sum();
+            sent -> {
               if (sent != requestedDataColumnSidecarsCount) {
                 peer.adjustDataColumnSidecarsRequest(maybeRequestKey.get(), sent);
               }
@@ -231,15 +235,22 @@ public class DataColumnSidecarsByRootMessageHandler
     final UInt64 slot = maybeSlot.get();
     return validateMinimumRequestEpoch(blockRoot, slot)
         .thenCompose(
-            __ ->
-                SafeFuture.collectAll(
-                        columns.stream()
-                            .filter(myCustodyColumns::contains)
-                            .map(column -> new DataColumnSlotAndIdentifier(slot, blockRoot, column))
-                            .map(
-                                identifier ->
-                                    retrieveAndRespondForColumn(identifier, messageId, callback)))
-                    .thenApply(counts -> counts.stream().mapToLong(Long::longValue).sum()));
+            __ -> {
+              SafeFuture<Long> responseFuture = SafeFuture.completedFuture(0L);
+              for (final UInt64 column : columns) {
+                if (!myCustodyColumns.contains(column)) {
+                  continue;
+                }
+                final DataColumnSlotAndIdentifier identifier =
+                    new DataColumnSlotAndIdentifier(slot, blockRoot, column);
+                responseFuture =
+                    responseFuture.thenCompose(
+                        sentSoFar ->
+                            retrieveAndRespondForColumn(identifier, messageId, callback)
+                                .thenApply(sent -> sentSoFar + sent));
+              }
+              return responseFuture;
+            });
   }
 
   private SafeFuture<Long> retrieveAndRespondForColumn(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandler.java
@@ -148,6 +148,6 @@ public class Eth2IncomingRequestHandler<
   }
 
   private RpcResponseCallback<TResponse> createResponseCallback(final RpcStream rpcStream) {
-    return new RpcResponseCallback<>(rpcStream, responseEncoder);
+    return new RpcResponseCallback<>(rpcStream, responseEncoder, asyncRunner, protocolId);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandler.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue.QueueIsFullExc
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
+import tech.pegasys.teku.networking.p2p.rpc.StreamTimeoutException;
 
 public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMessageHandler<I, O> {
   private static final Logger LOG = LogManager.getLogger();
@@ -68,7 +69,8 @@ public abstract class PeerRequiredLocalMessageHandler<I, O> implements LocalMess
     // peer sent STOP_SENDING) is not a ClosedChannelException so it must be matched separately.
     if (rootCause instanceof StreamClosedException
         || rootCause instanceof ClosedChannelException
-        || rootCause instanceof ChannelOutputShutdownException) {
+        || rootCause instanceof ChannelOutputShutdownException
+        || rootCause instanceof StreamTimeoutException) {
       LOG.trace("Stream closed while sending requested {}", type, error);
       callback.completeWithUnexpectedError(error);
       return;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallback.java
@@ -13,11 +13,15 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.core;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.RootCauseExceptionHandler;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
@@ -25,21 +29,32 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ServerErrorExcept
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
+import tech.pegasys.teku.networking.p2p.rpc.StreamTimeoutException;
 
 class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback<TResponse> {
   private static final Logger LOG = LogManager.getLogger();
+
+  @VisibleForTesting static final Duration RESPONSE_WRITE_TIMEOUT = Duration.ofSeconds(10);
+
   private final RpcResponseEncoder<TResponse, ?> responseEncoder;
   private final RpcStream rpcStream;
+  private final AsyncRunner asyncRunner;
+  private final String protocolId;
 
   public RpcResponseCallback(
-      final RpcStream rpcStream, final RpcResponseEncoder<TResponse, ?> responseEncoder) {
+      final RpcStream rpcStream,
+      final RpcResponseEncoder<TResponse, ?> responseEncoder,
+      final AsyncRunner asyncRunner,
+      final String protocolId) {
     this.rpcStream = rpcStream;
     this.responseEncoder = responseEncoder;
+    this.asyncRunner = asyncRunner;
+    this.protocolId = protocolId;
   }
 
   @Override
   public SafeFuture<Void> respond(final TResponse data) {
-    return rpcStream.writeBytes(responseEncoder.encodeSuccessfulResponse(data));
+    return writeWithTimeout(responseEncoder.encodeSuccessfulResponse(data));
   }
 
   @Override
@@ -48,6 +63,12 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
         .thenRun(this::completeSuccessfully)
         .finish(
             RootCauseExceptionHandler.builder()
+                .addCatch(
+                    StreamClosedException.class,
+                    err -> LOG.trace("Failed to write because stream was closed", err))
+                .addCatch(
+                    StreamTimeoutException.class,
+                    err -> LOG.trace("Failed to write because response write timed out", err))
                 .addCatch(
                     ClosedChannelException.class,
                     err -> LOG.trace("Failed to write because channel was closed", err))
@@ -69,10 +90,20 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
   public void completeWithErrorResponse(final RpcException error) {
     LOG.debug("Responding to RPC request with error: {}", error.getErrorMessageString());
     try {
-      rpcStream
-          .writeBytes(responseEncoder.encodeErrorResponse(error))
+      writeWithTimeout(responseEncoder.encodeErrorResponse(error))
           .finish(
               RootCauseExceptionHandler.builder()
+                  .addCatch(
+                      StreamClosedException.class,
+                      err ->
+                          LOG.trace(
+                              "Failed to write error response because stream was closed", err))
+                  .addCatch(
+                      StreamTimeoutException.class,
+                      err ->
+                          LOG.trace(
+                              "Failed to write error response because response write timed out",
+                              err))
                   .addCatch(
                       ClosedChannelException.class,
                       err ->
@@ -94,6 +125,31 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
     rpcStream.closeWriteStream().finishDebug(LOG);
   }
 
+  private SafeFuture<Void> writeWithTimeout(final Bytes responseBytes) {
+    final SafeFuture<Void> writeFuture;
+    try {
+      writeFuture = rpcStream.writeBytes(responseBytes);
+    } catch (final Throwable t) {
+      return SafeFuture.failedFuture(t);
+    }
+    final SafeFuture.Interruptor timeoutInterruptor =
+        SafeFuture.createInterruptor(
+            asyncRunner.getDelayedFuture(RESPONSE_WRITE_TIMEOUT),
+            () ->
+                new RpcTimeoutException(
+                    "Timed out waiting for response write for protocol " + protocolId,
+                    RESPONSE_WRITE_TIMEOUT));
+    return writeFuture
+        .orInterrupt(timeoutInterruptor)
+        .catchAndRethrow(
+            error -> {
+              if (Throwables.getRootCause(error) instanceof RpcTimeoutException) {
+                LOG.debug("Timed out writing RPC response for {}. Closing stream.", protocolId);
+                rpcStream.closeAbruptly().finishDebug(LOG);
+              }
+            });
+  }
+
   @Override
   public void completeWithUnexpectedError(final Throwable error) {
     if (error instanceof PeerDisconnectedException) {
@@ -109,8 +165,9 @@ class RpcResponseCallback<TResponse extends SszData> implements ResponseCallback
     final Throwable rootCause = Throwables.getRootCause(error);
     if (rootCause instanceof StreamClosedException
         || rootCause instanceof ClosedChannelException
-        || rootCause instanceof ChannelOutputShutdownException) {
-      LOG.trace("Not sending RPC response as the stream is already closed", error);
+        || rootCause instanceof ChannelOutputShutdownException
+        || rootCause instanceof StreamTimeoutException) {
+      LOG.trace("Not sending RPC response as the stream is already closed or timed out", error);
       rpcStream.closeAbruptly().finishTrace(LOG);
       return;
     }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootMessageHandlerTest.java
@@ -396,6 +396,41 @@ public class DataColumnSidecarsByRootMessageHandlerTest {
   }
 
   @TestTemplate
+  public void shouldWaitForPreviousResponseWriteBeforeSendingNextSidecar() {
+    final DataColumnsByRootIdentifier[] dataColumnsByRootIdentifiers =
+        generateDataColumnsByRootIdentifiers(2, 1);
+    final List<DataColumnSidecar> generatedSidecars =
+        IntStream.range(0, 2).mapToObj(__ -> dataStructureUtil.randomDataColumnSidecar()).toList();
+    final SafeFuture<Void> firstWriteFuture = new SafeFuture<>();
+
+    when(callback.respond(any())).thenReturn(firstWriteFuture).thenReturn(SafeFuture.COMPLETE);
+    when(combinedChainDataClient.getSidecar(any()))
+        .thenAnswer(
+            invocation -> {
+              final DataColumnSlotAndIdentifier slotAndIdentifier = invocation.getArgument(0);
+              for (int i = 0; i < 2; ++i) {
+                if (dataColumnsByRootIdentifiers[i]
+                    .getBlockRoot()
+                    .equals(slotAndIdentifier.blockRoot())) {
+                  return SafeFuture.completedFuture(Optional.of(generatedSidecars.get(i)));
+                }
+              }
+              throw new RuntimeException("Should never get here");
+            });
+
+    handler.onIncomingMessage(
+        protocolId, peer, messageSchema.of(dataColumnsByRootIdentifiers), callback);
+
+    verify(callback, times(1)).respond(any());
+    verify(callback, never()).completeSuccessfully();
+
+    firstWriteFuture.complete(null);
+
+    verify(callback, times(2)).respond(any());
+    verify(callback).completeSuccessfully();
+  }
+
+  @TestTemplate
   public void shouldTryToReconstructArchiveDataColumnSidecars() {
     final DataColumnsByRootIdentifier[] dataColumnsByRootIdentifiers =
         generateDataColumnsByRootIdentifiers(4, 1);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/PeerRequiredLocalMessageHandlerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.infrastructure.logging.LogCaptor;
@@ -65,6 +66,21 @@ class PeerRequiredLocalMessageHandlerTest {
       handler.handleError(error, callback, "thingy");
 
       assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+    verify(callback).completeWithUnexpectedError(error);
+  }
+
+  @Test
+  void shouldHandleStreamTimeoutAsExpectedStreamClose() {
+    final Throwable error = new RpcTimeoutException("Timed out writing response", Duration.ZERO);
+
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(PeerRequiredLocalMessageHandler.class, Level.TRACE)) {
+      handler.handleError(error, callback, "thingy");
+
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+      assertThat(logCaptor.getTraceLogs())
+          .anySatisfy(log -> assertThat(log).contains("Stream closed while sending requested"));
     }
     verify(callback).completeWithUnexpectedError(error);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/RpcResponseCallbackTest.java
@@ -22,17 +22,22 @@ import static org.mockito.Mockito.when;
 
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
 import org.apache.logging.log4j.Level;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 
 class RpcResponseCallbackTest {
 
+  private static final String PROTOCOL_ID = "/eth2/beacon_chain/req/test/1/ssz_snappy";
+
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final RpcStream rpcStream = mock(RpcStream.class);
 
   @SuppressWarnings("unchecked")
@@ -41,7 +46,24 @@ class RpcResponseCallbackTest {
   private final SszData data = mock(SszData.class);
 
   private final RpcResponseCallback<SszData> callback =
-      new RpcResponseCallback<>(rpcStream, responseEncoder);
+      new RpcResponseCallback<>(rpcStream, responseEncoder, asyncRunner, PROTOCOL_ID);
+
+  @Test
+  void shouldCloseStreamWhenResponseWriteDoesNotComplete() {
+    final SafeFuture<Void> writeFuture = new SafeFuture<>();
+    when(responseEncoder.encodeSuccessfulResponse(data)).thenReturn(Bytes.EMPTY);
+    when(rpcStream.writeBytes(any())).thenReturn(writeFuture);
+    when(rpcStream.closeAbruptly()).thenReturn(SafeFuture.COMPLETE);
+
+    final SafeFuture<Void> responseFuture = callback.respond(data);
+
+    assertThat(responseFuture).isNotDone();
+
+    asyncRunner.executeQueuedActions();
+
+    verify(rpcStream).closeAbruptly();
+    assertThat(responseFuture).isCompletedExceptionally();
+  }
 
   @Test
   void shouldNotLogErrorWhenWriteFailsWithStopSending() {
@@ -108,6 +130,20 @@ class RpcResponseCallbackTest {
   }
 
   @Test
+  void completeWithUnexpectedErrorShouldNotWriteErrorResponseWhenStreamTimedOut() {
+    when(rpcStream.closeAbruptly()).thenReturn(SafeFuture.COMPLETE);
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.completeWithUnexpectedError(
+          new RpcTimeoutException("No response write", Duration.ZERO));
+
+      verify(rpcStream, never()).writeBytes(any());
+      verify(rpcStream).closeAbruptly();
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
   void completeWithUnexpectedErrorShouldWriteErrorResponseForUnexpectedError() {
     when(responseEncoder.encodeErrorResponse(any())).thenReturn(Bytes.EMPTY);
     when(rpcStream.writeBytes(any())).thenReturn(SafeFuture.COMPLETE);
@@ -136,6 +172,17 @@ class RpcResponseCallbackTest {
   @Test
   void completeWithErrorResponseShouldNotLogErrorWhenWriteFailsWithClosedChannel() {
     failErrorResponseWriteWith(new ClosedChannelException());
+
+    try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
+      callback.completeWithErrorResponse(new RpcException.ServerErrorException());
+
+      assertThat(logCaptor.getErrorLogs()).isEmpty();
+    }
+  }
+
+  @Test
+  void completeWithErrorResponseShouldNotLogErrorWhenWriteFailsWithStreamClosed() {
+    failErrorResponseWriteWith(new StreamClosedException());
 
     try (final LogCaptor logCaptor = LogCaptor.forClass(RpcResponseCallback.class, Level.TRACE)) {
       callback.completeWithErrorResponse(new RpcException.ServerErrorException());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core P2P req/resp write paths and data-column serving order; behavior changes under slow peers but is defensive (timeouts, sequencing) rather than protocol-breaking.
> 
> **Overview**
> Hardens **incoming req/resp** so slow or stuck QUIC writes do not pile up work or spam errors, and so multi-chunk replies are sent in order.
> 
> **`RpcResponseCallback`** now wraps every response write (success and error) in a **10s timeout** via `AsyncRunner`; on timeout it fails the write future, **closes the stream abruptly**, and treats **`StreamTimeoutException`** like other expected close cases (trace logging, no server-error retry). **`Eth2IncomingRequestHandler`** passes `asyncRunner` and `protocolId` into the callback. **`PeerRequiredLocalMessageHandler`** maps stream timeouts to the same quiet “stream closed while sending” path as `STOP_SENDING` / closed channel.
> 
> **`DataColumnSidecarsByRootMessageHandler`** stops using parallel `collectAll` for roots and columns; it **chains** `retrieveAndRespond` steps with `thenCompose` so each **`callback.respond()`** completes before the next sidecar is sent—covered by a new test that blocks the first write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769bfb55fc4c46ea7ce7fa82095c4093860da377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->