### PR TITLE
Enable channel virtual threads by default

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeOptions.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.options;
 
+import static tech.pegasys.teku.config.BeaconNodeConfig.DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED;
+
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -27,7 +29,7 @@ public class BeaconNodeOptions {
       hidden = true,
       fallbackValue = "true",
       arity = "0..1")
-  private boolean eventChannelVirtualThreadsEnabled = true;
+  private boolean eventChannelVirtualThreadsEnabled = DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED;
 
   public void configure(final TekuConfiguration.Builder builder) {
     builder.beaconNode(b -> b.eventChannelVirtualThreadsEnabled(eventChannelVirtualThreadsEnabled));

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeOptions.java
@@ -27,7 +27,7 @@ public class BeaconNodeOptions {
       hidden = true,
       fallbackValue = "true",
       arity = "0..1")
-  private boolean eventChannelVirtualThreadsEnabled = false;
+  private boolean eventChannelVirtualThreadsEnabled = true;
 
   public void configure(final TekuConfiguration.Builder builder) {
     builder.beaconNode(b -> b.eventChannelVirtualThreadsEnabled(eventChannelVirtualThreadsEnabled));

--- a/teku/src/main/java/tech/pegasys/teku/config/BeaconNodeConfig.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/BeaconNodeConfig.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.config;
 
 public record BeaconNodeConfig(boolean eventChannelVirtualThreadsEnabled) {
 
-  public static final boolean DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED = false;
+  public static final boolean DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED = true;
 
   public static Builder builder() {
     return new Builder();

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeOptionsTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.config.BeaconNodeConfig.DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
@@ -22,9 +23,10 @@ import tech.pegasys.teku.config.TekuConfiguration;
 class BeaconNodeOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
-  void eventChannelVirtualThreads_shouldDefaultToTrue() {
+  void eventChannelVirtualThreads_shouldDefaultToConfig() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
-    assertThat(config.beaconNodeConfig().eventChannelVirtualThreadsEnabled()).isTrue();
+    assertThat(config.beaconNodeConfig().eventChannelVirtualThreadsEnabled())
+        .isEqualTo(DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeOptionsTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.config.BeaconNodeConfig.DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
@@ -23,10 +22,9 @@ import tech.pegasys.teku.config.TekuConfiguration;
 class BeaconNodeOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
-  void eventChannelVirtualThreads_shouldDefaultToConfig() {
+  void eventChannelVirtualThreads_shouldDefaultToTrue() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
-    assertThat(config.beaconNodeConfig().eventChannelVirtualThreadsEnabled())
-        .isEqualTo(DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED);
+    assertThat(config.beaconNodeConfig().eventChannelVirtualThreadsEnabled()).isTrue();
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeOptionsTest.java
@@ -22,9 +22,9 @@ import tech.pegasys.teku.config.TekuConfiguration;
 class BeaconNodeOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
-  void eventChannelVirtualThreads_shouldDefaultToFalse() {
+  void eventChannelVirtualThreads_shouldDefaultToTrue() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
-    assertThat(config.beaconNodeConfig().eventChannelVirtualThreadsEnabled()).isFalse();
+    assertThat(config.beaconNodeConfig().eventChannelVirtualThreadsEnabled()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flips default event-channel threading for every node that does not set the flag, which can change concurrency and resource use; opt-out remains available via the existing CLI switch.
> 
> **Overview**
> **Event channel virtual threads are now on by default** for beacon nodes. `DEFAULT_EVENT_CHANNEL_VIRTUAL_THREADS_ENABLED` in `BeaconNodeConfig` changes from `false` to `true`, and the hidden CLI option `--Xevent-channel-virtual-threads-enabled` picks up that constant instead of a hardcoded `false`.
> 
> Operators can still turn the behavior off with `--Xevent-channel-virtual-threads-enabled=false`. CLI tests are updated so the no-args default expects virtual threads enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e2114aad6b4ea58accbca879ecd4177a8b9eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->