### PR TITLE
update validation result for fee recipient mismatch to ignore instead of reject

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -105,7 +105,7 @@ public class ExecutionPayloadBidGossipValidator {
      */
     if (!bid.getFeeRecipient().equals(proposerPreferences.get().getFeeRecipient())) {
       return completedFuture(
-          reject(
+          ignore(
               "Bid fee_recipient %s does not match proposer preferences fee_recipient %s",
               bid.getFeeRecipient(), proposerPreferences.get().getFeeRecipient()));
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
@@ -163,7 +163,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
   }
 
   @TestTemplate
-  void shouldReject_whenFeeRecipientDoesNotMatchProposerPreferences() {
+  void shouldIgnore_whenFeeRecipientDoesNotMatchProposerPreferences() {
     final ProposerPreferences mismatchedPreferences = mock(ProposerPreferences.class);
     when(mismatchedPreferences.getFeeRecipient()).thenReturn(dataStructureUtil.randomEth1Address());
     when(mismatchedPreferences.getTargetGasLimit()).thenReturn(bid.getGasLimit());
@@ -171,7 +171,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
         .thenReturn(Optional.of(mismatchedPreferences));
 
     assertThatSafeFuture(bidValidator.validate(signedBid))
-        .isCompletedWithValueMatching(InternalValidationResult::isReject);
+        .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
   }
 
   @TestTemplate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
changed in the spec here: https://github.com/ethereum/consensus-specs/pull/5429, present in the new spec release

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in gossip validation only; mismatched fee-recipient bids are dropped quietly rather than treated as invalid, with no auth or persistence impact.
> 
> **Overview**
> Updates **execution payload bid** gossip validation to match the latest consensus spec: when `bid.fee_recipient` does not match the proposer’s `SignedProposerPreferences` for that slot, the node now returns **ignore** instead of **reject**.
> 
> The unit test was renamed and its expectation was updated from reject to ignore for that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58bb5fffd21a8798833f445677f796134c64c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->