### PR TITLE
Additional 7688 validations

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.gloas.block;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.config.SpecConfigGloas.BUILDER_INDEX_SELF_BUILD;
 import static tech.pegasys.teku.spec.config.SpecConfigGloas.PAYLOAD_BUILDER_VERSION;
 
@@ -69,6 +70,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
   private static final Logger LOG = LogManager.getLogger();
 
   private final PredicatesGloas predicatesGloas;
+  private final SpecConfigGloas specConfigGloas;
   private final SchemaDefinitionsGloas schemaDefinitionsGloas;
   private final MiscHelpersGloas miscHelpersGloas;
   private final BeaconStateAccessorsGloas beaconStateAccessorsGloas;
@@ -109,6 +111,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
         executionRequestsDataCodec,
         executionRequestsProcessor);
     this.predicatesGloas = predicates;
+    this.specConfigGloas = specConfig;
     this.schemaDefinitionsGloas = schemaDefinitions;
     this.miscHelpersGloas = miscHelpers;
     this.beaconStateAccessorsGloas = beaconStateAccessors;
@@ -162,7 +165,8 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       throw new BlockProcessingException(
           "The execution requests root in the latest committed bid does not match the parent execution requests in the block");
     }
-    applyParentExecutionPayload(stateGloas, requests, validatorExitContextSupplier);
+    safelyProcess(
+        () -> applyParentExecutionPayload(stateGloas, requests, validatorExitContextSupplier));
   }
 
   // apply_parent_execution_payload
@@ -170,6 +174,23 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final MutableBeaconStateGloas state,
       final ExecutionRequests requests,
       final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+    final ExecutionRequestsGloas requestsGloas = ExecutionRequestsGloas.required(requests);
+    checkArgument(
+        requests.getWithdrawals().size() <= specConfigGloas.getMaxWithdrawalRequestsPerPayload(),
+        "Too many withdrawal requests");
+    checkArgument(
+        requests.getConsolidations().size()
+            <= specConfigGloas.getMaxConsolidationRequestsPerPayload(),
+        "Too many consolidation requests");
+    checkArgument(
+        requestsGloas.getBuilderDeposits().size()
+            <= specConfigGloas.getMaxBuilderDepositRequestsPerPayload(),
+        "Too many builder deposit requests");
+    checkArgument(
+        requestsGloas.getBuilderExits().size()
+            <= specConfigGloas.getMaxBuilderExitRequestsPerPayload(),
+        "Too many builder exit requests");
+
     final ExecutionPayloadBid parentBid = state.getLatestExecutionPayloadBid();
     final UInt64 parentSlot = parentBid.getSlot();
     final UInt64 parentEpoch = miscHelpers.computeEpochAtSlot(parentSlot);
@@ -189,7 +210,6 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
         state, requests.getWithdrawals(), validatorExitContextSupplier);
     executionRequestsProcessorGloas.processConsolidationRequests(
         state, requests.getConsolidations());
-    final ExecutionRequestsGloas requestsGloas = ExecutionRequestsGloas.required(requests);
     executionRequestsProcessorGloas.processBuilderDepositRequests(
         state, requestsGloas.getBuilderDeposits());
     executionRequestsProcessorGloas.processBuilderExitRequests(
@@ -426,6 +446,32 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
       final IndexedAttestationCache indexedAttestationCache,
       final Supplier<ValidatorExitContext> validatorExitContextSupplier)
       throws BlockProcessingException {
+    final BeaconBlockBodyGloas bodyGloas = BeaconBlockBodyGloas.required(body);
+    safelyProcess(
+        () -> {
+          checkArgument(
+              body.getProposerSlashings().size() <= specConfigGloas.getMaxProposerSlashings(),
+              "Too many proposer slashings");
+          checkArgument(
+              body.getAttesterSlashings().size()
+                  <= specConfigGloas.getMaxAttesterSlashingsElectra(),
+              "Too many attester slashings");
+          checkArgument(
+              body.getAttestations().size() <= specConfigGloas.getMaxAttestationsElectra(),
+              "Too many attestations");
+          checkArgument(
+              body.getVoluntaryExits().size() <= specConfigGloas.getMaxVoluntaryExits(),
+              "Too many voluntary exits");
+          checkArgument(
+              bodyGloas.getBlsToExecutionChanges().size()
+                  <= specConfigGloas.getMaxBlsToExecutionChanges(),
+              "Too many BLS to execution changes");
+          checkArgument(
+              bodyGloas.getPayloadAttestations().size()
+                  <= specConfigGloas.getMaxPayloadAttestations(),
+              "Too many payload attestations");
+        });
+
     super.processOperationsNoValidation(
         state, body, indexedAttestationCache, validatorExitContextSupplier);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -19,14 +19,19 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
@@ -41,6 +46,21 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
       final BeaconStateAccessorsGloas beaconStateAccessors,
       final MiscHelpersGloas miscHelpers) {
     super(specConfig, schemaDefinitions, beaconStateAccessors, miscHelpers);
+  }
+
+  @Override
+  public SafeFuture<AttestationProcessingResult> isValidIndexedAttestationAsync(
+      final Fork fork,
+      final BeaconState state,
+      final IndexedAttestationLight indexedAttestation,
+      final AsyncBLSSignatureVerifier signatureVerifier) {
+    final int maxAttestingIndices =
+        specConfig.getMaxValidatorsPerCommittee() * specConfig.getMaxCommitteesPerSlot();
+    if (indexedAttestation.attestingIndices().size() > maxAttestingIndices) {
+      return SafeFuture.completedFuture(
+          AttestationProcessingResult.invalid("Too many attesting indices"));
+    }
+    return super.isValidIndexedAttestationAsync(fork, state, indexedAttestation, signatureVerifier);
   }
 
   /**

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloasTest.java
@@ -14,23 +14,43 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.block;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
+import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionRequestsSchemaGloas;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingPayment;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.BuilderPendingPaymentSchema;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BlockProcessorGloasTest {
 
   private final Spec spec = TestSpecFactory.createMinimalGloas();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final SpecConfigGloas config = SpecConfigGloas.required(spec.getGenesisSpecConfig());
+  private final ExecutionRequestsSchemaGloas executionRequestsSchema =
+      ExecutionRequestsSchemaGloas.required(
+          SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
+              .getExecutionRequestsSchema());
   private final int slotsPerEpoch = spec.getGenesisSpecConfig().getSlotsPerEpoch();
 
   private BlockProcessorGloas blockProcessor() {
@@ -71,6 +91,121 @@ class BlockProcessorGloasTest {
         state.updated(mutable -> blockProcessor().removeBuilderPendingPayment(slashing, mutable));
 
     assertThat(builderPaymentAt(result, paymentIndex)).isEqualTo(payment);
+  }
+
+  @Test
+  void applyParentExecutionPayload_rejectsTooManyBoundedRequests() {
+    assertTooManyRequestsAreRejected(
+        executionRequestsSchema.create(
+            List.of(),
+            Collections.nCopies(
+                config.getMaxWithdrawalRequestsPerPayload() + 1,
+                dataStructureUtil.randomWithdrawalRequest()),
+            List.of(),
+            List.of(),
+            List.of()),
+        "Too many withdrawal requests");
+    assertTooManyRequestsAreRejected(
+        executionRequestsSchema.create(
+            List.of(),
+            List.of(),
+            Collections.nCopies(
+                config.getMaxConsolidationRequestsPerPayload() + 1,
+                dataStructureUtil.randomConsolidationRequest()),
+            List.of(),
+            List.of()),
+        "Too many consolidation requests");
+    assertTooManyRequestsAreRejected(
+        executionRequestsSchema.create(
+            List.of(),
+            List.of(),
+            List.of(),
+            Collections.nCopies(
+                config.getMaxBuilderDepositRequestsPerPayload() + 1,
+                dataStructureUtil.randomBuilderDepositRequest()),
+            List.of()),
+        "Too many builder deposit requests");
+    assertTooManyRequestsAreRejected(
+        executionRequestsSchema.create(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            Collections.nCopies(
+                config.getMaxBuilderExitRequestsPerPayload() + 1,
+                dataStructureUtil.randomBuilderExitRequest())),
+        "Too many builder exit requests");
+  }
+
+  @Test
+  void processOperationsNoValidation_rejectsTooManyBoundedOperations() {
+    final BeaconBlockBodyGloas tooManyProposerSlashings = emptyBody();
+    when(tooManyProposerSlashings.getProposerSlashings())
+        .thenReturn(sszList(config.getMaxProposerSlashings() + 1));
+    assertTooManyOperationsAreRejected(tooManyProposerSlashings, "Too many proposer slashings");
+
+    final BeaconBlockBodyGloas tooManyAttesterSlashings = emptyBody();
+    when(tooManyAttesterSlashings.getAttesterSlashings())
+        .thenReturn(sszList(config.getMaxAttesterSlashingsElectra() + 1));
+    assertTooManyOperationsAreRejected(tooManyAttesterSlashings, "Too many attester slashings");
+
+    final BeaconBlockBodyGloas tooManyAttestations = emptyBody();
+    when(tooManyAttestations.getAttestations())
+        .thenReturn(sszList(config.getMaxAttestationsElectra() + 1));
+    assertTooManyOperationsAreRejected(tooManyAttestations, "Too many attestations");
+
+    final BeaconBlockBodyGloas tooManyVoluntaryExits = emptyBody();
+    when(tooManyVoluntaryExits.getVoluntaryExits())
+        .thenReturn(sszList(config.getMaxVoluntaryExits() + 1));
+    assertTooManyOperationsAreRejected(tooManyVoluntaryExits, "Too many voluntary exits");
+
+    final BeaconBlockBodyGloas tooManyBlsToExecutionChanges = emptyBody();
+    when(tooManyBlsToExecutionChanges.getBlsToExecutionChanges())
+        .thenReturn(sszList(config.getMaxBlsToExecutionChanges() + 1));
+    assertTooManyOperationsAreRejected(
+        tooManyBlsToExecutionChanges, "Too many BLS to execution changes");
+
+    final BeaconBlockBodyGloas tooManyPayloadAttestations = emptyBody();
+    when(tooManyPayloadAttestations.getPayloadAttestations())
+        .thenReturn(sszList(config.getMaxPayloadAttestations() + 1));
+    assertTooManyOperationsAreRejected(tooManyPayloadAttestations, "Too many payload attestations");
+  }
+
+  private void assertTooManyRequestsAreRejected(
+      final ExecutionRequests requests, final String expectedMessage) {
+    assertThatThrownBy(() -> blockProcessor().applyParentExecutionPayload(null, requests, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(expectedMessage);
+  }
+
+  private void assertTooManyOperationsAreRejected(
+      final BeaconBlockBodyGloas body, final String expectedMessage) {
+    assertThatThrownBy(() -> blockProcessor().processOperationsNoValidation(null, body, null, null))
+        .isInstanceOf(BlockProcessingException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(expectedMessage);
+  }
+
+  private BeaconBlockBodyGloas emptyBody() {
+    final BeaconBlockBodyGloas body = mock(BeaconBlockBodyGloas.class);
+    when(body.toVersionGloas()).thenReturn(Optional.of(body));
+    when(body.getProposerSlashings()).thenReturn(sszList(0));
+    when(body.getAttesterSlashings()).thenReturn(sszList(0));
+    when(body.getAttestations()).thenReturn(sszList(0));
+    when(body.getVoluntaryExits()).thenReturn(sszList(0));
+    when(body.getBlsToExecutionChanges()).thenReturn(sszList(0));
+    when(body.getPayloadAttestations()).thenReturn(sszList(0));
+    return body;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends SszData> SszList<T> sszList(final int size) {
+    return mock(
+        SszList.class,
+        invocation ->
+            invocation.getMethod().getName().equals("size")
+                ? size
+                : Answers.RETURNS_DEFAULTS.answer(invocation));
   }
 
   private BeaconState stateWithPaymentAt(


### PR DESCRIPTION
EIP-7688 will make some types unbounded so, previously ssz enforced limits now become explicit as per spec (part of alpha.12 release)

related to #9772 

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus block-processing validation paths; incorrect limits or wiring could reject valid blocks or accept invalid ones, but scope is bounded checks aligned with spec config and is covered by new unit tests.
> 
> **Overview**
> Adds **explicit Gloas/EIP-7688 limit checks** where SSZ may no longer enforce list bounds, so oversized blocks and parent execution requests are rejected during state transition instead of relying on schema limits alone.
> 
> In **`BlockProcessorGloas`**, parent execution payload application now rejects withdrawal, consolidation, and builder deposit/exit request lists above the configured per-payload maximums. **`processOperationsNoValidation`** gains upfront checks on proposer slashings, attester slashings, attestations, voluntary exits, BLS-to-execution changes, and payload attestations against **`SpecConfigGloas`** limits (wrapped in **`safelyProcess`** so failures surface as **`BlockProcessingException`**). **`applyParentExecutionPayload`** is also invoked through **`safelyProcess`** from **`processParentExecutionPayload`**.
> 
> **`AttestationUtilGloas`** overrides async indexed attestation validation to reject attestations whose attesting index count exceeds **`maxValidatorsPerCommittee * maxCommitteesPerSlot`**, returning an invalid **`AttestationProcessingResult`** before delegating to Electra.
> 
> **`BlockProcessorGloasTest`** adds coverage that over-limit execution requests throw **`IllegalArgumentException`** and over-limit block body operation counts throw **`BlockProcessingException`** with the expected messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5861df8f8a9e284eedc7efed6e7cc1469ebe0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->