### PR TITLE
Mutable progressive byte list - preserve element schema on set

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableProgressiveByteListImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszMutableProgressiveByteListImpl.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutablePrimitiveList;
 import tech.pegasys.teku.infrastructure.ssz.impl.SszMutableProgressiveListImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszProgressiveByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
@@ -35,6 +36,11 @@ public class SszMutableProgressiveByteListImpl
   }
 
   @Override
+  public void set(final int index, final SszByte value) {
+    super.set(index, getElementSchema().boxed(value.get()));
+  }
+
+  @Override
   public SszByteList commitChanges() {
     return (SszByteList) super.commitChanges();
   }
@@ -49,5 +55,10 @@ public class SszMutableProgressiveByteListImpl
   @Override
   public SszMutablePrimitiveList<Byte, SszByte> createWritableCopy() {
     throw new UnsupportedOperationException("Creating a copy from writable list is not supported");
+  }
+
+  @SuppressWarnings("unchecked")
+  private SszPrimitiveSchema<Byte, SszByte> getElementSchema() {
+    return (SszPrimitiveSchema<Byte, SszByte>) getSchema().getElementSchema();
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveByteListSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveByteListSchemaTest.java
@@ -145,6 +145,7 @@ class SszProgressiveByteListSchemaTest {
     final SszByteList updated = (SszByteList) mutable.commitChanges();
 
     assertThat(updated.getBytes()).isEqualTo(Bytes.fromHexString("0x01FF03"));
+    assertThat(updated.get(1).getSchema()).isEqualTo(SszPrimitiveSchemas.UINT8_SCHEMA);
     assertThat(UINT8_SCHEMA.sszDeserialize(updated.sszSerialize()).get(1).getSchema())
         .isEqualTo(SszPrimitiveSchemas.UINT8_SCHEMA);
   }


### PR DESCRIPTION
Tiny fix for #9772 - it will make future reference test happy

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow SSZ infrastructure change with a targeted unit test; no auth, networking, or consensus logic touched.
> 
> **Overview**
> Fixes mutable updates to **progressive byte lists** (e.g. Gloas `participation`) so replaced elements keep the list’s **element schema** (such as `UINT8`), not whatever schema the incoming `SszByte` carried.
> 
> `SszMutableProgressiveByteListImpl` now overrides `set` to store values via `getElementSchema().boxed(...)`, aligned with the UInt64 progressive list pattern. A test checks byte content and that `get(1).getSchema()` stays `UINT8_SCHEMA` after commit and round-trip SSZ deserialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe884e3c24066783a6310a10d3778ba67297817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->