### PR TITLE
tweaks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -87,7 +87,10 @@ public class AttestationValidator {
       return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
     }
     return singleOrAggregateAttestationChecks(
-            signatureVerifier, validatableAttestation, validatableAttestation.getReceivedSubnetId())
+            signatureVerifier,
+            validatableAttestation,
+            validatableAttestation.getReceivedSubnetId(),
+            true)
         .thenApply(InternalValidationResultWithState::getResult)
         .thenPeek(
             result -> {
@@ -116,6 +119,19 @@ public class AttestationValidator {
       final AsyncBLSSignatureVerifier signatureVerifier,
       final ValidatableAttestation validatableAttestation,
       final OptionalInt receivedOnSubnetId) {
+    // Aggregate validation path: preserve legacy behaviour where a future-slot attestation is
+    // deferred without running signature verification here. The aggregate wrapper uses a batch
+    // verifier that is flushed separately, so verifying (and optimistically caching) the signature
+    // here would leave an unverified signature cached if the deferral short-circuits the flush.
+    return singleOrAggregateAttestationChecks(
+        signatureVerifier, validatableAttestation, receivedOnSubnetId, false);
+  }
+
+  SafeFuture<InternalValidationResultWithState> singleOrAggregateAttestationChecks(
+      final AsyncBLSSignatureVerifier signatureVerifier,
+      final ValidatableAttestation validatableAttestation,
+      final OptionalInt receivedOnSubnetId,
+      final boolean verifyFutureSlotAttestationSignature) {
 
     Attestation attestation = validatableAttestation.getAttestation();
     final AttestationData data = attestation.getData();
@@ -165,10 +181,20 @@ public class AttestationValidator {
             gossipValidationHelper.getCurrentTimeMillis());
 
     if (slotInclusionGossipValidationResult.isPresent()) {
-      return switch (slotInclusionGossipValidationResult.get()) {
-        case IGNORE -> completedFuture(InternalValidationResultWithState.ignore());
-        case SAVE_FOR_FUTURE -> completedFuture(InternalValidationResultWithState.saveForFuture());
-      };
+      if (slotInclusionGossipValidationResult.get() == SlotInclusionGossipValidationResult.IGNORE) {
+        return completedFuture(InternalValidationResultWithState.ignore());
+      }
+      // SAVE_FOR_FUTURE: a future-slot attestation is deferred rather than accepted for gossip.
+      // When requested, we still verify its signature so that a bogus signature is rejected and its
+      // sender penalised, rather than being deferred with a penalty-free Ignore verdict and later
+      // forcing a BLS verification in the fork choice path for free. Only an invalid signature
+      // rejects here; every other gossip check simply defers (fork choice re-validates the rest
+      // once the attestation's slot arrives). A verified signature is cached so fork choice does
+      // not re-verify it.
+      if (!verifyFutureSlotAttestationSignature) {
+        return completedFuture(InternalValidationResultWithState.saveForFuture());
+      }
+      return checkFutureSlotAttestationSignature(validatableAttestation, signatureVerifier);
     }
 
     // [REJECT] The block being voted for (attestation.data.beacon_block_root) passes validation.
@@ -274,6 +300,42 @@ public class AttestationValidator {
                         validatableAttestation.saveCommitteeShufflingSeedAndCommitteesSize(state);
                         return InternalValidationResultWithState.accept(state);
                       });
+            });
+  }
+
+  /**
+   * Verifies the signature of a future-slot attestation and always defers it (SAVE_FOR_FUTURE),
+   * rejecting only when the signature is invalid. The remaining gossip checks are intentionally
+   * skipped here: they either only apply to attestations eligible for immediate propagation, or are
+   * re-validated by fork choice when the attestation's slot arrives. Rejecting solely on an invalid
+   * signature keeps the peer penalty limited to provably-invalid messages, matching how other
+   * clients score future-slot attestations, while still avoiding a penalty-free BLS verification in
+   * the fork choice path.
+   */
+  private SafeFuture<InternalValidationResultWithState> checkFutureSlotAttestationSignature(
+      final ValidatableAttestation validatableAttestation,
+      final AsyncBLSSignatureVerifier signatureVerifier) {
+    final AttestationData data = validatableAttestation.getAttestation().getData();
+    // The signature can't be verified without the block being voted for and its state; defer.
+    if (!gossipValidationHelper.isBlockAvailable(data.getBeaconBlockRoot())) {
+      return completedFuture(InternalValidationResultWithState.saveForFuture());
+    }
+    return gossipValidationHelper
+        .getStateForAttestationValidation(data)
+        .thenCompose(
+            maybeState -> {
+              if (maybeState.isEmpty()) {
+                return completedFuture(InternalValidationResultWithState.saveForFuture());
+              }
+              return spec.isValidIndexedAttestation(
+                      maybeState.get(), validatableAttestation, signatureVerifier)
+                  .thenApply(
+                      signatureResult ->
+                          signatureResult.isSuccessful()
+                              ? InternalValidationResultWithState.saveForFuture()
+                              : InternalValidationResultWithState.reject(
+                                  "Attestation is not a valid indexed attestation: %s",
+                                  signatureResult.getInvalidReason()));
             });
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/Phase0AttestationValidatorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
@@ -363,5 +364,73 @@ public class Phase0AttestationValidatorTest extends AbstractAttestationValidator
                     expectedSubnetId)))
         .matches(
             rejected("descend from target block"), "Rejected does not descend from target block");
+  }
+
+  @Test
+  public void shouldRejectFutureSlotAttestationWithInvalidSignature() {
+    // A future-slot attestation with a bogus signature must be rejected (so the sender is
+    // penalised) rather than deferred with a penalty-free Ignore verdict, which would force a
+    // signature verification in the fork choice path for free.
+    final StateAndBlockSummary blockAndState = storageSystem.getChainHead();
+    final Attestation attestation = attestationGenerator.validAttestation(blockAndState, ONE);
+    assertThat(attestation.getData().getSlot()).isEqualTo(ONE);
+
+    final AsyncBLSSignatureVerifier signatureVerifier = mock(AsyncBLSSignatureVerifier.class);
+    when(signatureVerifier.verify(anyList(), any(Bytes.class), any()))
+        .thenReturn(SafeFuture.completedFuture(false));
+    final AttestationValidator validator =
+        new AttestationValidator(
+            spec, signatureVerifier, gossipValidationHelper, invalidBlockRoots);
+
+    final int subnetId = spec.computeSubnetForAttestation(blockAndState.getState(), attestation);
+    chainUpdater.setCurrentSlot(ZERO);
+
+    assertThat(
+            validator
+                .validate(ValidatableAttestation.fromNetwork(spec, attestation, subnetId))
+                .join()
+                .code())
+        .isEqualTo(REJECT);
+    // The signature was actually verified at gossip time, giving a REJECT verdict that penalises
+    // the sender.
+    verify(signatureVerifier).verify(anyList(), any(Bytes.class), any());
+  }
+
+  @Test
+  public void shouldVerifyAndCacheSignatureForValidFutureSlotAttestation() {
+    // A valid future-slot attestation is still only deferred (SAVE_FOR_FUTURE), but its signature
+    // is verified and cached here so the fork choice path does not re-verify it.
+    final StateAndBlockSummary blockAndState = storageSystem.getChainHead();
+    final Attestation attestation = attestationGenerator.validAttestation(blockAndState, ONE);
+    assertThat(attestation.getData().getSlot()).isEqualTo(ONE);
+    chainUpdater.setCurrentSlot(ZERO);
+
+    final ValidatableAttestation validatableAttestation =
+        ValidatableAttestation.fromNetwork(
+            spec,
+            attestation,
+            spec.computeSubnetForAttestation(blockAndState.getState(), attestation));
+
+    assertThat(validator.validate(validatableAttestation).join().code()).isEqualTo(SAVE_FOR_FUTURE);
+    assertThat(validatableAttestation.isValidIndexedAttestation()).isTrue();
+  }
+
+  @Test
+  public void shouldDeferFutureSlotAttestationOnWrongSubnetWhenSignatureIsValid() {
+    // A future-slot attestation is only rejected for an invalid signature; other gossip failures
+    // (here, the wrong subnet) defer rather than penalise the sender. Contrast with
+    // shouldRejectAttestationsSentOnTheWrongSubnet, which rejects an in-window attestation.
+    final StateAndBlockSummary blockAndState = storageSystem.getChainHead();
+    final Attestation attestation = attestationGenerator.validAttestation(blockAndState, ONE);
+    assertThat(attestation.getData().getSlot()).isEqualTo(ONE);
+    final int subnetId = spec.computeSubnetForAttestation(blockAndState.getState(), attestation);
+    chainUpdater.setCurrentSlot(ZERO);
+
+    assertThat(
+            validator
+                .validate(ValidatableAttestation.fromNetwork(spec, attestation, subnetId + 1))
+                .join()
+                .code())
+        .isEqualTo(SAVE_FOR_FUTURE);
   }
 }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetwork.java
@@ -48,6 +48,7 @@ public class LibP2PNetwork implements P2PNetwork<Peer> {
   private static final Logger LOG = LogManager.getLogger();
   static final int REMOTE_OPEN_STREAMS_RATE_LIMIT = 256;
   static final int REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT = 256;
+  static final int MAXIMUM_ACTIVE_INBOUND_RPC_STREAMS = 128;
 
   private final PrivKey privKey;
   private final NodeId nodeId;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.libp2p;
 
+import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.MAXIMUM_ACTIVE_INBOUND_RPC_STREAMS;
 import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_OPEN_STREAMS_RATE_LIMIT;
 import static tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.REMOTE_PARALLEL_OPEN_STREAMS_COUNT_LIMIT;
 
@@ -49,6 +50,7 @@ import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNetwork.PrivateKeyProvider;
 import tech.pegasys.teku.networking.p2p.libp2p.gossip.GossipTopicFilter;
 import tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetwork;
 import tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetworkBuilder;
+import tech.pegasys.teku.networking.p2p.libp2p.rpc.InboundRpcStreamLimiter;
 import tech.pegasys.teku.networking.p2p.libp2p.rpc.RpcHandler;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.networking.p2p.network.PeerHandler;
@@ -289,7 +291,11 @@ public class LibP2PNetworkBuilder {
   }
 
   protected List<? extends RpcHandler<?, ?, ?>> createRpcHandlers() {
-    return rpcMethods.stream().map(m -> new RpcHandler<>(asyncRunner, m, metricsSystem)).toList();
+    final InboundRpcStreamLimiter inboundRpcStreamLimiter =
+        new InboundRpcStreamLimiter(MAXIMUM_ACTIVE_INBOUND_RPC_STREAMS);
+    return rpcMethods.stream()
+        .map(m -> new RpcHandler<>(asyncRunner, m, metricsSystem, inboundRpcStreamLimiter))
+        .toList();
   }
 
   protected LibP2PGossipNetwork createGossipNetwork() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/InboundRpcStreamLimiter.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/InboundRpcStreamLimiter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.libp2p.rpc;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Limits the number of active inbound RPC streams across every transport and connection. */
+public class InboundRpcStreamLimiter {
+
+  private final int maximumActiveStreams;
+  private final AtomicInteger activeStreams = new AtomicInteger();
+
+  public InboundRpcStreamLimiter(final int maximumActiveStreams) {
+    if (maximumActiveStreams < 1) {
+      throw new IllegalArgumentException("Maximum active inbound RPC streams must be positive");
+    }
+    this.maximumActiveStreams = maximumActiveStreams;
+  }
+
+  public boolean tryAcquire() {
+    int currentActiveStreams;
+    do {
+      currentActiveStreams = activeStreams.get();
+      if (currentActiveStreams >= maximumActiveStreams) {
+        return false;
+      }
+    } while (!activeStreams.compareAndSet(currentActiveStreams, currentActiveStreams + 1));
+    return true;
+  }
+
+  public void release() {
+    final int remainingStreams = activeStreams.decrementAndGet();
+    if (remainingStreams < 0) {
+      activeStreams.incrementAndGet();
+      throw new IllegalStateException("Released an inbound RPC stream that was not acquired");
+    }
+  }
+
+  public int getMaximumActiveStreams() {
+    return maximumActiveStreams;
+  }
+
+  int getActiveStreams() {
+    return activeStreams.get();
+  }
+}

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandler.java
@@ -70,6 +70,7 @@ public class RpcHandler<
 
   private final AsyncRunner asyncRunner;
   private final RpcMethod<TOutgoingHandler, TRequest, TRespHandler> rpcMethod;
+  private final InboundRpcStreamLimiter inboundRpcStreamLimiter;
 
   final Counter rpcRequestsTotalCounter;
   final Counter rpcRequestsFailedCounter;
@@ -78,9 +79,11 @@ public class RpcHandler<
   public RpcHandler(
       final AsyncRunner asyncRunner,
       final RpcMethod<TOutgoingHandler, TRequest, TRespHandler> rpcMethod,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final InboundRpcStreamLimiter inboundRpcStreamLimiter) {
     this.asyncRunner = asyncRunner;
     this.rpcMethod = rpcMethod;
+    this.inboundRpcStreamLimiter = inboundRpcStreamLimiter;
 
     rpcRequestsTotalCounter =
         metricsSystem.createCounter(
@@ -206,13 +209,37 @@ public class RpcHandler<
     final Connection connection = streamChannel.getConnection();
     final NodeId nodeId = new LibP2PNodeId(connection.secureSession().getRemoteId());
 
-    final Controller<TOutgoingHandler> controller = new Controller<>(nodeId, streamChannel);
-    if (!channel.isInitiator()) {
-      controller.setIncomingRequestHandler(
-          rpcMethod.createIncomingRequestHandler(selectedProtocol));
+    final boolean isIncomingStream = !channel.isInitiator();
+    if (isIncomingStream && !inboundRpcStreamLimiter.tryAcquire()) {
+      LOG.debug(
+          "Rejecting inbound RPC stream for protocol {} from {} because the global active stream limit of {} has been reached",
+          selectedProtocol,
+          nodeId,
+          inboundRpcStreamLimiter.getMaximumActiveStreams());
+      ignoreFuture(streamChannel.close());
+      return SafeFuture.failedFuture(
+          new IllegalStateException("Maximum active inbound RPC streams reached"));
     }
-    channel.pushHandler(controller);
-    return controller.activeFuture;
+
+    try {
+      final Controller<TOutgoingHandler> controller =
+          new Controller<>(
+              nodeId,
+              streamChannel,
+              isIncomingStream ? inboundRpcStreamLimiter::release : () -> {});
+      if (isIncomingStream) {
+        controller.setIncomingRequestHandler(
+            rpcMethod.createIncomingRequestHandler(selectedProtocol));
+      }
+      channel.pushHandler(controller);
+      return controller.activeFuture;
+    } catch (final Throwable t) {
+      if (isIncomingStream) {
+        inboundRpcStreamLimiter.release();
+      }
+      ignoreFuture(streamChannel.close());
+      return SafeFuture.failedFuture(t);
+    }
   }
 
   static class Controller<TOutgoingHandler extends RpcRequestHandler>
@@ -221,6 +248,7 @@ public class RpcHandler<
 
     private final NodeId nodeId;
     private final Stream p2pStream;
+    private final Runnable releaseStreamPermit;
     private Optional<TOutgoingHandler> outgoingRequestHandler = Optional.empty();
     private Optional<RpcRequestHandler> rpcRequestHandler = Optional.empty();
     private RpcStream rpcStream;
@@ -228,9 +256,11 @@ public class RpcHandler<
 
     protected final SafeFuture<Controller<TOutgoingHandler>> activeFuture = new SafeFuture<>();
 
-    private Controller(final NodeId nodeId, final Stream p2pStream) {
+    private Controller(
+        final NodeId nodeId, final Stream p2pStream, final Runnable releaseStreamPermit) {
       this.nodeId = nodeId;
       this.p2pStream = p2pStream;
+      this.releaseStreamPermit = releaseStreamPermit;
     }
 
     @Override
@@ -321,6 +351,7 @@ public class RpcHandler<
         runHandler(h -> h.closed(nodeId, rpcStream));
       } finally {
         rpcRequestHandler = Optional.empty();
+        releaseStreamPermit.run();
       }
     }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/InboundRpcStreamLimiterTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/InboundRpcStreamLimiterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.p2p.libp2p.rpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import org.junit.jupiter.api.Test;
+
+class InboundRpcStreamLimiterTest {
+
+  @Test
+  void shouldLimitActiveStreamsAndAllowNewStreamsAfterRelease() {
+    final InboundRpcStreamLimiter limiter = new InboundRpcStreamLimiter(2);
+
+    assertThat(limiter.tryAcquire()).isTrue();
+    assertThat(limiter.tryAcquire()).isTrue();
+    assertThat(limiter.tryAcquire()).isFalse();
+    assertThat(limiter.getActiveStreams()).isEqualTo(2);
+
+    limiter.release();
+
+    assertThat(limiter.tryAcquire()).isTrue();
+    assertThat(limiter.getActiveStreams()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldRejectNonPositiveLimits() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new InboundRpcStreamLimiter(0));
+  }
+
+  @Test
+  void shouldRejectReleaseWithoutAcquisition() {
+    final InboundRpcStreamLimiter limiter = new InboundRpcStreamLimiter(1);
+
+    assertThatIllegalStateException().isThrownBy(limiter::release);
+  }
+}

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandlerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/rpc/RpcHandlerTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.p2p.libp2p.rpc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -24,10 +25,13 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 
 import io.libp2p.core.Connection;
 import io.libp2p.core.ConnectionClosedException;
+import io.libp2p.core.PeerId;
 import io.libp2p.core.Stream;
 import io.libp2p.core.StreamPromise;
 import io.libp2p.core.multistream.ProtocolBinding;
 import io.libp2p.core.mux.StreamMuxer.Session;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -55,11 +59,14 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.
 @SuppressWarnings("unchecked")
 public class RpcHandlerTest {
 
+  private static final PeerId REMOTE_PEER_ID =
+      PeerId.fromBase58("16Uiu2HAmFxCpRh2nZevFR3KGXJ3jhpixMYFSuawqKZyZYHrYoiK5");
+
   StubAsyncRunner asyncRunner = new StubAsyncRunner();
   RpcMethod<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> rpcMethod = mock(RpcMethod.class);
   StubMetricsSystem metricsSystem = new StubMetricsSystem();
   RpcHandler<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> rpcHandler =
-      new RpcHandler<>(asyncRunner, rpcMethod, metricsSystem);
+      new RpcHandler<>(asyncRunner, rpcMethod, metricsSystem, new InboundRpcStreamLimiter(128));
 
   Connection connection = mock(Connection.class);
   Session session = mock(Session.class);
@@ -86,6 +93,97 @@ public class RpcHandlerTest {
     when(controller.getRpcStream()).thenReturn(rpcStream);
     when(rpcStream.writeBytes(any())).thenReturn(writeFuture);
     when(stream.getProtocol()).thenReturn(protocolIdFuture);
+  }
+
+  @Test
+  void shouldRejectInboundStreamsAtLimitAndReleasePermitWhenStreamCloses() {
+    final InboundRpcStreamLimiter limiter = new InboundRpcStreamLimiter(1);
+    final RpcHandler<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> handler =
+        createRpcHandler(limiter);
+    final RpcRequestHandler requestHandler = mock(RpcRequestHandler.class);
+    when(rpcMethod.createIncomingRequestHandler(protocolId)).thenReturn(requestHandler);
+
+    final Stream firstStream = createP2PStream(false);
+    final AtomicReference<Controller<RpcRequestHandler>> firstController =
+        captureController(firstStream);
+    final SafeFuture<Controller<RpcRequestHandler>> firstInit =
+        handler.initChannel(firstStream, protocolId);
+    final ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+    firstController.get().channelActive(context);
+
+    assertThat(firstInit).isCompletedWithValue(firstController.get());
+    assertThat(limiter.getActiveStreams()).isOne();
+
+    final Stream rejectedStream = createP2PStream(false);
+    final SafeFuture<Controller<RpcRequestHandler>> rejectedInit =
+        handler.initChannel(rejectedStream, protocolId);
+
+    assertThatSafeFuture(rejectedInit).isCompletedExceptionallyWith(IllegalStateException.class);
+    verify(rejectedStream).close();
+    assertThat(limiter.getActiveStreams()).isOne();
+
+    firstController.get().handlerRemoved(context);
+
+    assertThat(limiter.getActiveStreams()).isZero();
+
+    final Stream replacementStream = createP2PStream(false);
+    final AtomicReference<Controller<RpcRequestHandler>> replacementController =
+        captureController(replacementStream);
+    final SafeFuture<Controller<RpcRequestHandler>> replacementInit =
+        handler.initChannel(replacementStream, protocolId);
+    replacementController.get().channelActive(context);
+
+    assertThat(replacementInit).isCompletedWithValue(replacementController.get());
+    assertThat(limiter.getActiveStreams()).isOne();
+    verify(replacementStream, never()).close();
+
+    replacementController.get().handlerRemoved(context);
+    assertThat(limiter.getActiveStreams()).isZero();
+  }
+
+  @Test
+  void shouldReleaseInboundPermitWhenHandlerInitializationFails() {
+    final InboundRpcStreamLimiter limiter = new InboundRpcStreamLimiter(1);
+    final RpcHandler<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> handler =
+        createRpcHandler(limiter);
+    final Stream inboundStream = createP2PStream(false);
+    when(rpcMethod.createIncomingRequestHandler(protocolId))
+        .thenThrow(new IllegalArgumentException("Invalid protocol"));
+
+    final SafeFuture<Controller<RpcRequestHandler>> initFuture =
+        handler.initChannel(inboundStream, protocolId);
+
+    assertThatSafeFuture(initFuture).isCompletedExceptionallyWith(IllegalArgumentException.class);
+    assertThat(limiter.getActiveStreams()).isZero();
+    verify(inboundStream).close();
+  }
+
+  @Test
+  void shouldNotApplyInboundLimitToOutboundStreams() {
+    final InboundRpcStreamLimiter limiter = new InboundRpcStreamLimiter(1);
+    assertThat(limiter.tryAcquire()).isTrue();
+    final RpcHandler<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> handler =
+        createRpcHandler(limiter);
+    final Stream outboundStream = createP2PStream(true);
+    final AtomicReference<Controller<RpcRequestHandler>> outboundController =
+        captureController(outboundStream);
+    final ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+
+    final SafeFuture<Controller<RpcRequestHandler>> initFuture =
+        handler.initChannel(outboundStream, protocolId);
+    outboundController.get().channelActive(context);
+
+    assertThat(initFuture).isCompletedWithValue(outboundController.get());
+    assertThat(limiter.getActiveStreams()).isOne();
+    verify(outboundStream, never()).close();
+    verify(rpcMethod, never()).createIncomingRequestHandler(any());
+
+    outboundController.get().handlerRemoved(context);
+
+    assertThat(limiter.getActiveStreams()).isOne();
+
+    limiter.release();
+    assertThat(limiter.getActiveStreams()).isZero();
   }
 
   @Test
@@ -405,5 +503,35 @@ public class RpcHandlerTest {
   private void assertRequestsFailedCounterValue(final long expectedValue) {
     assertThat(metricsSystem.getCounterValue(TekuMetricCategory.LIBP2P, "rpc_requests_failed"))
         .isEqualTo(expectedValue);
+  }
+
+  private RpcHandler<RpcRequestHandler, RpcRequest, RpcResponseHandler<?>> createRpcHandler(
+      final InboundRpcStreamLimiter limiter) {
+    return new RpcHandler<>(asyncRunner, rpcMethod, new StubMetricsSystem(), limiter);
+  }
+
+  private Stream createP2PStream(final boolean initiator) {
+    final Stream p2pStream = mock(Stream.class);
+    final io.libp2p.core.security.SecureChannel.Session secureSession =
+        mock(io.libp2p.core.security.SecureChannel.Session.class);
+    when(p2pStream.isInitiator()).thenReturn(initiator);
+    when(p2pStream.getConnection()).thenReturn(connection);
+    when(p2pStream.close()).thenReturn(CompletableFuture.completedFuture(Unit.INSTANCE));
+    when(connection.secureSession()).thenReturn(secureSession);
+    when(secureSession.getRemoteId()).thenReturn(REMOTE_PEER_ID);
+    return p2pStream;
+  }
+
+  private AtomicReference<Controller<RpcRequestHandler>> captureController(final Stream p2pStream) {
+    final AtomicReference<Controller<RpcRequestHandler>> capturedController =
+        new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              capturedController.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(p2pStream)
+        .pushHandler(any(ChannelHandler.class));
+    return capturedController;
   }
 }


### PR DESCRIPTION

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect gossip peer scoring and attestation signature caching on a hot path, plus global RPC stream admission that could drop legitimate inbound sync traffic under load.
> 
> **Overview**
> This PR tightens **gossip attestation handling** and adds a **libp2p inbound RPC backpressure** guard.
> 
> For attestations whose slot is not yet in the propagation window, gossip validation can now **verify BLS signatures early** (while still returning `SAVE_FOR_FUTURE`). Invalid signatures are **rejected** so peers can be penalized; valid ones are **cached** so fork choice does not pay for verification later. The **aggregate** validation path keeps the old behavior (defer without verifying here) to avoid caching unverified signatures when batch verification is flushed separately. Other gossip failures on future-slot messages (e.g. wrong subnet) still **defer** rather than reject.
> 
> On networking, a shared **`InboundRpcStreamLimiter`** (cap **128** active inbound RPC streams globally) is wired into all `RpcHandler` instances. Inbound streams acquire a permit at `initChannel`, release on close or init failure; outbound streams are unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845c80099c8043defda6fbd2792696431dc6c6ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->