### PR TITLE
Introduce IndexedPayloadAttestationLight

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedPayloadAttestationLight.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedPayloadAttestationLight.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import java.util.List;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
+
+public record IndexedPayloadAttestationLight(
+    List<UInt64> attestingIndices, PayloadAttestationData data, BLSSignature signature) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.gloas.BeaconBlockBodyGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
@@ -39,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequests;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionRequestsDataCodec;
 import tech.pegasys.teku.spec.datastructures.execution.versions.gloas.ExecutionRequestsGloas;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedPayloadAttestationLight;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
@@ -465,7 +465,7 @@ public class BlockProcessorGloas extends BlockProcessorFulu {
         throw new BlockProcessingException("Attestation is NOT for the previous slot");
       }
       // Verify signature
-      final IndexedPayloadAttestation indexedPayloadAttestation =
+      final IndexedPayloadAttestationLight indexedPayloadAttestation =
           beaconStateAccessorsGloas.getIndexedPayloadAttestation(state, payloadAttestation);
 
       if (!attestationUtilGloas.isValidIndexedPayloadAttestation(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -30,15 +30,14 @@ import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszVector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64Vector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedPayloadAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
@@ -177,32 +176,22 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
    *
    * <p>Return the indexed payload attestation corresponding to ``payload_attestation``.
    */
-  public IndexedPayloadAttestation getIndexedPayloadAttestation(
+  public IndexedPayloadAttestationLight getIndexedPayloadAttestation(
       final BeaconState state, final PayloadAttestation payloadAttestation) {
     final UInt64 slot = payloadAttestation.getData().getSlot();
     final IntList ptc = getPtc(state, slot);
     final SszBitvector aggregationBits = payloadAttestation.getAggregationBits();
-    final IntList attestingIndices = new IntArrayList();
+    final List<UInt64> attestingIndices = new ArrayList<>();
     for (int i = 0; i < ptc.size(); i++) {
       if (aggregationBits.isSet(i)) {
         final int index = ptc.getInt(i);
-        attestingIndices.add(index);
+        attestingIndices.add(UInt64.valueOf(index));
       }
     }
-    final SszUInt64List sszAttestingIndices =
-        attestingIndices
-            .intStream()
-            .sorted()
-            .mapToObj(idx -> SszUInt64.of(UInt64.valueOf(idx)))
-            .collect(
-                schemaDefinitions
-                    .getIndexedPayloadAttestationSchema()
-                    .getAttestingIndicesSchema()
-                    .collector());
-    return schemaDefinitions
-        .getIndexedPayloadAttestationSchema()
-        .create(
-            sszAttestingIndices, payloadAttestation.getData(), payloadAttestation.getSignature());
+    attestingIndices.sort(UInt64::compareTo);
+
+    return new IndexedPayloadAttestationLight(
+        attestingIndices, payloadAttestation.getData(), payloadAttestation.getSignature());
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/AttestationUtilGloas.java
@@ -23,8 +23,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
-import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.IndexedPayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedPayloadAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
@@ -50,9 +50,9 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
    * signature.
    */
   public boolean isValidIndexedPayloadAttestation(
-      final BeaconState state, final IndexedPayloadAttestation attestation) {
+      final BeaconState state, final IndexedPayloadAttestationLight attestation) {
     // Verify indices are non-empty and sorted
-    final List<UInt64> indices = attestation.getAttestingIndices().asListUnboxed();
+    final List<UInt64> indices = attestation.attestingIndices();
     if (indices.isEmpty() || !Comparators.isInOrder(indices, UInt64::compareTo)) {
       return false;
     }
@@ -65,11 +65,11 @@ public class AttestationUtilGloas extends AttestationUtilElectra {
         beaconStateAccessors.getDomain(
             state.getForkInfo(),
             Domain.PTC_ATTESTER,
-            miscHelpers.computeEpochAtSlot(attestation.getData().getSlot()));
-    final Bytes signingRoot = miscHelpers.computeSigningRoot(attestation.getData(), domain);
+            miscHelpers.computeEpochAtSlot(attestation.data().getSlot()));
+    final Bytes signingRoot = miscHelpers.computeSigningRoot(attestation.data(), domain);
     return specConfig
         .getBLSSignatureVerifier()
-        .verify(pubKeys, signingRoot, attestation.getSignature());
+        .verify(pubKeys, signingRoot, attestation.signature());
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -24,12 +26,17 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigGloas;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedPayloadAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.BeaconStateTestBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BeaconStateAccessorsGloasTest {
@@ -142,6 +149,52 @@ public class BeaconStateAccessorsGloasTest {
     assertThat(beaconStateAccessors.getExitChurnLimit(state)).isEqualTo(expectedExit);
     assertThat(beaconStateAccessors.getConsolidationChurnLimit(state))
         .isNotEqualTo(beaconStateAccessors.getExitChurnLimit(state));
+  }
+
+  @Test
+  public void getIndexedPayloadAttestation_selectsPtcMembersForSetBitsAndSortsIndices() {
+    final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
+    final UInt64 slot = state.getSlot();
+    final IntList ptc = beaconStateAccessors.getPtc(state, slot);
+
+    // Set the first three PTC positions; their validator indices are not necessarily ascending, so
+    // this also exercises the sort.
+    final PayloadAttestation payloadAttestation = payloadAttestation(slot, 0, 1, 2);
+
+    final IndexedPayloadAttestationLight indexed =
+        beaconStateAccessors.getIndexedPayloadAttestation(state, payloadAttestation);
+
+    final List<UInt64> expected =
+        IntStream.of(ptc.getInt(0), ptc.getInt(1), ptc.getInt(2))
+            .mapToObj(UInt64::valueOf)
+            .sorted()
+            .toList();
+    assertThat(indexed.attestingIndices()).containsExactlyElementsOf(expected);
+    assertThat(indexed.attestingIndices()).isSorted();
+    assertThat(indexed.data()).isEqualTo(payloadAttestation.getData());
+    assertThat(indexed.signature()).isEqualTo(payloadAttestation.getSignature());
+  }
+
+  @Test
+  public void getIndexedPayloadAttestation_returnsEmptyIndicesWhenNoBitsSet() {
+    final BeaconStateGloas state = BeaconStateGloas.required(dataStructureUtil.randomBeaconState());
+    final PayloadAttestation payloadAttestation = payloadAttestation(state.getSlot());
+
+    final IndexedPayloadAttestationLight indexed =
+        beaconStateAccessors.getIndexedPayloadAttestation(state, payloadAttestation);
+
+    assertThat(indexed.attestingIndices()).isEmpty();
+  }
+
+  private PayloadAttestation payloadAttestation(final UInt64 slot, final int... setBits) {
+    final PayloadAttestationSchema schema =
+        SchemaDefinitionsGloas.required(spec.getGenesisSchemaDefinitions())
+            .getPayloadAttestationSchema();
+    final PayloadAttestationData data = dataStructureUtil.randomPayloadAttestationData(slot);
+    return schema.create(
+        schema.getAggregationBitsSchema().ofBits(setBits),
+        data,
+        dataStructureUtil.randomSignature());
   }
 
   private SpecConfigGloas configGloas() {


### PR DESCRIPTION
## What
Replaces the SSZ-backed `IndexedPayloadAttestation` with a lightweight plain-record `IndexedPayloadAttestationLight` on the payload-attestation processing path, mirroring the existing `IndexedAttestationLight` pattern.

Closes #10743.

## Why
`IndexedPayloadAttestation` is built for BLS signature verification during block processing. It is never serialized, stored, or gossiped. The SSZ tree-node backing is pure overhead for that use.

## Changes
- Add `IndexedPayloadAttestationLight`.
- `BeaconStateAccessorsGloas.getIndexedPayloadAttestation` builds and returns the light record.
- `AttestationUtilGloas.isValidIndexedPayloadAttestation` consumes the light record.
- `BlockProcessorGloas` threads the light form through.
- SSZ `IndexedPayloadAttestation` container + schema retained for consensus-spec reference/property tests.
- Add unit coverage for `getIndexedPayloadAttestation` (bit-selection + sorting).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of an in-memory verification path with equivalent validation logic and new unit tests; no wire format or consensus type changes on the hot path.
> 
> **Overview**
> GLOAS **payload attestation** handling no longer builds a transient SSZ `IndexedPayloadAttestation` during block processing. It now uses a plain **`IndexedPayloadAttestationLight`** record (`attestingIndices`, `data`, `signature`), aligned with the existing `IndexedAttestationLight` approach.
> 
> **`BeaconStateAccessorsGloas.getIndexedPayloadAttestation`** maps PTC aggregation bits to validator indices in a `List<UInt64>`, sorts them, and returns the light record instead of materializing an SSZ list via schema collectors. **`AttestationUtilGloas.isValidIndexedPayloadAttestation`** and **`BlockProcessorGloas.processPayloadAttestations`** are updated to consume that type; BLS and index checks are the same, only the carrier type changed.
> 
> The SSZ **`IndexedPayloadAttestation`** container and schema are **unchanged** for consensus-spec / property tests. **`BeaconStateAccessorsGloasTest`** adds coverage for bit selection, sorting, and empty aggregation bits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c877a8156dea547d017c57b367bbee49f93c1786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->