### PR TITLE
Complete deprecated blob sidecar range requests

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
@@ -20,18 +20,22 @@ import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
 import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import static tech.pegasys.teku.spec.SpecMilestone.ELECTRA;
+import static tech.pegasys.teku.spec.SpecMilestone.FULU;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.NoOpKZG;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
@@ -41,10 +45,11 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.common.statetransition.availability.AvailabilityCheckerFactory;
 
-@TestSpecContext(milestone = {CAPELLA, DENEB, ELECTRA})
+@TestSpecContext(milestone = {CAPELLA, DENEB, ELECTRA, FULU})
 public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegrationTest {
 
   private Eth2Peer peer;
+  private Spec spec;
   private SpecMilestone specMilestone;
 
   @BeforeEach
@@ -56,6 +61,7 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
             AvailabilityCheckerFactory.NOOP_DATACOLUMN_SIDECAR,
             NoOpKZG.INSTANCE);
     peer = createPeer(specContext.getSpec());
+    spec = specContext.getSpec();
     specMilestone = specContext.getSpecMilestone();
   }
 
@@ -91,9 +97,28 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
   }
 
   @TestTemplate
+  public void requestBlobSidecars_shouldCompleteAfterFuluDeprecation()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assumeThat(specMilestone).isEqualTo(FULU);
+
+    final List<BlobSidecar> blobSidecars = new ArrayList<>();
+    final UInt64 startSlot = spec.blobSidecarsDeprecationSlot().increment();
+    final SafeFuture<Void> requestFuture =
+        peer.requestBlobSidecarsByRange(
+            startSlot, UInt64.ONE, RpcResponseListener.from(blobSidecars::add));
+
+    waitFor(requestFuture);
+    assertThat(blobSidecars).isEmpty();
+    waitFor(() -> assertThat(peer.getOutstandingRequests()).isEqualTo(0));
+
+    assertThat(peer.requestMetadata().get(10, TimeUnit.SECONDS)).isNotNull();
+  }
+
+  @TestTemplate
   public void requestBlobSidecars_shouldReturnCanonicalBlobSidecarsOnDenebMilestone()
       throws ExecutionException, InterruptedException, TimeoutException {
     assumeThat(specMilestone).isGreaterThanOrEqualTo(DENEB);
+    assumeThat(specMilestone).isLessThan(FULU);
 
     // finalize chain 2 blobs per block
     finalizeChainWithBlobs(2);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -129,12 +129,19 @@ public class BlobSidecarsByRangeMessageHandler
         message.getCount(),
         startSlot);
 
+    if (!peer.approveRequest()) {
+      requestCounter.labels("rate_limited").inc();
+      return;
+    }
+
     if (startSlot.isGreaterThan(spec.blobSidecarsDeprecationSlot())) {
       LOG.trace(
           "Peer {} requested {} slots of blob sidecars starting at slot {} after Fulu. BlobSidecarsByRange v1 is deprecated and the request will be ignored.",
           peer.getId(),
           message.getCount(),
           startSlot);
+      requestCounter.labels("ignored").inc();
+      callback.completeSuccessfully();
       return;
     }
 
@@ -147,7 +154,7 @@ public class BlobSidecarsByRangeMessageHandler
     final Optional<RequestKey> maybeRequestKey =
         peer.approveBlobSidecarsRequest(callback, requestedCount);
 
-    if (!peer.approveRequest() || maybeRequestKey.isEmpty()) {
+    if (maybeRequestKey.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
       return;
     }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeFuluDeprecationTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.RequestKey;
@@ -168,16 +170,26 @@ public class BlobSidecarsByRangeFuluDeprecationTest {
 
   @Test
   public void shouldIgnoreRequestsWhenStartSlotIsAfterFulu() {
-    final UInt64 startSlot =
-        spec.computeStartSlotAtEpoch(fuluForkEpoch); // start slot at fulu boundary
+    final UInt64 startSlot = spec.blobSidecarsDeprecationSlot().increment();
     final UInt64 count = slotsPerEpoch.times(2); // count = 16
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
     final BlobSidecarsByRangeMessageHandler handler =
         new BlobSidecarsByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
+
+    when(peer.approveRequest()).thenReturn(true);
+
     handler.onIncomingMessage(protocolId, peer, request, callback);
+
+    verify(peer, times(1)).approveRequest();
+    verify(peer, never()).approveBlobSidecarsRequest(any(), anyLong());
+    verify(callback, times(1)).completeSuccessfully();
+    verify(callback, never()).respond(any());
     verifyNoInteractions(combinedChainDataClient);
-    verifyNoInteractions(callback);
+    assertEquals(
+        1,
+        metricsSystem.getLabelledCounterValue(
+            TekuMetricCategory.NETWORK, "rpc_blob_sidecars_by_range_requests_total", "ignored"));
   }
 
   public void runTestWith(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -277,6 +277,28 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   }
 
   @TestTemplate
+  public void shouldNotServeBlobSidecarsIfPeerRequestIsRateLimited() {
+    when(peer.approveRequest()).thenReturn(false);
+
+    final BlobSidecarsByRangeRequestMessage request =
+        new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
+
+    handler.onIncomingMessage(protocolId, peer, request, listener);
+
+    verify(peer, times(1)).approveRequest();
+    verify(peer, never()).approveBlobSidecarsRequest(any(), anyLong());
+    verifyNoInteractions(listener, combinedChainDataClient);
+
+    final long rateLimitedCount =
+        metricsSystem.getLabelledCounterValue(
+            TekuMetricCategory.NETWORK,
+            "rpc_blob_sidecars_by_range_requests_total",
+            "rate_limited");
+
+    assertThat(rateLimitedCount).isOne();
+  }
+
+  @TestTemplate
   public void shouldSendResourceUnavailableIfBlobSidecarsAreNotAvailable() {
 
     // current epoch is 5020


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes P2P RPC completion semantics and rate-limit ordering for a deprecated but still-advertised method; incorrect behavior could affect peer sync or request tracking on Fulu networks.
> 
> **Overview**
> **Post-Fulu `BlobSidecarsByRange` requests now finish cleanly** instead of leaving the RPC open when the start slot is past `blobSidecarsDeprecationSlot()`. The handler calls `callback.completeSuccessfully()`, records an **`ignored`** metric, and still does not serve blob sidecars or touch chain data.
> 
> **Request handling order changed:** global `peer.approveRequest()` runs **before** the Fulu deprecation branch, and blob-specific `approveBlobSidecarsRequest` is only used for non-deprecated requests. Rate-limited peers exit early with **`rate_limited`** and never hit blob quota checks.
> 
> **Tests** cover Fulu integration (empty response, request completes, outstanding requests drain), post-deprecation unit behavior (success callback, no chain client, `ignored` counter), and a dedicated case where `approveRequest()` is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926ac56ee20c0e3a68ff2a03d727411fc75e06b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->