### PR TITLE
Warm Gradle dependencies for CI test shards

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -12,6 +12,19 @@ runs:
   using: "composite"
   steps:
 
+    - name: Ensure zstd is available
+      shell: bash
+      run: |
+        if ! command -v zstd > /dev/null 2>&1; then
+          if [ "$(id -u)" -eq 0 ]; then
+            apt=(apt-get)
+          else
+            apt=(sudo apt-get)
+          fi
+          "${apt[@]}" update
+          "${apt[@]}" install --yes --no-install-recommends zstd
+        fi
+
     - name: Set up JDK 25
       uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,11 +218,6 @@ jobs:
         shell: bash
         run: |
           ./gradlew clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava compilePropertyTestJava resolveCiDependencies assemble
-      - name: Cache resolved Gradle dependencies
-        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: ~/.gradle/caches/modules-2
-          key: ci-gradle-dependencies-${{ github.run_id }}
       - name: Upload distribution tar
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -625,12 +620,6 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           gradle-cache-read-only: 'true'
-      - name: Restore resolved Gradle dependencies
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: ~/.gradle/caches/modules-2
-          key: ci-gradle-dependencies-${{ github.run_id }}
-          fail-on-cache-miss: true
       - name: Download assemble-output
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,12 @@ jobs:
       - name: Assemble
         shell: bash
         run: |
-          ./gradlew clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava compilePropertyTestJava resolveCiJacocoDependencies assemble
+          ./gradlew clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava compilePropertyTestJava resolveCiDependencies assemble
+      - name: Cache resolved Gradle dependencies
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ~/.gradle/caches/modules-2
+          key: ci-gradle-dependencies-${{ github.run_id }}
       - name: Upload distribution tar
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -586,7 +591,7 @@ jobs:
       - name: CompileReferenceTests
         shell: bash
         run: |
-          ./gradlew --no-daemon --parallel compileReferenceTestJava resolveCiJacocoDependencies
+          ./gradlew --no-daemon --parallel compileReferenceTestJava resolveCiDependencies
       - name: Caching reference tests
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
@@ -620,6 +625,12 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           gradle-cache-read-only: 'true'
+      - name: Restore resolved Gradle dependencies
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ~/.gradle/caches/modules-2
+          key: ci-gradle-dependencies-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Download assemble-output
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -68,13 +68,6 @@ jobs:
         with:
           gradle-cache-read-only: 'true'
 
-      - name: Restore resolved Gradle dependencies
-        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: ~/.gradle/caches/modules-2
-          key: ci-gradle-dependencies-${{ inputs.assemble_output_run_id }}
-          fail-on-cache-miss: true
-
       # only acceptance tests need the docker login
       # 4.0.0
       - name: Login to dockerhub

--- a/.github/workflows/matrix-tests-template.yml
+++ b/.github/workflows/matrix-tests-template.yml
@@ -68,6 +68,13 @@ jobs:
         with:
           gradle-cache-read-only: 'true'
 
+      - name: Restore resolved Gradle dependencies
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ~/.gradle/caches/modules-2
+          key: ci-gradle-dependencies-${{ inputs.assemble_output_run_id }}
+          fail-on-cache-miss: true
+
       # only acceptance tests need the docker login
       # 4.0.0
       - name: Login to dockerhub

--- a/build.gradle
+++ b/build.gradle
@@ -1107,13 +1107,19 @@ tasks.register('manifestDocker') {
 	}
 }
 
-def ciJacocoConfigurations = [
+def ciDependencyConfigurations = [
 	'jacocoAgent',
 	'jacocoAnt',
+	'runtimeClasspath',
+	'testRuntimeClasspath',
+	'integrationTestRuntimeClasspath',
+	'acceptanceTestRuntimeClasspath',
+	'propertyTestRuntimeClasspath',
+	'referenceTestRuntimeClasspath',
 ]
 
-def resolveCiJacocoConfigurations = { targetProject ->
-	ciJacocoConfigurations.each { configurationName ->
+def resolveCiDependencyConfigurations = { targetProject ->
+	ciDependencyConfigurations.each { configurationName ->
 		def configuration = targetProject.configurations.findByName(configurationName)
 		if (configuration != null && configuration.canBeResolved) {
 			logger.info("Resolving ${targetProject.path}:${configurationName}")
@@ -1429,23 +1435,23 @@ subprojects {
 		jvmArgs '--enable-native-access=ALL-UNNAMED'
 	}
 
-	tasks.register('resolveCiJacocoDependencies') {
+	tasks.register('resolveCiDependencies') {
 		group = 'build setup'
-		description = 'Resolves Jacoco configurations used by CI shards to warm the Gradle cache.'
+		description = 'Resolves test runtime configurations used by CI shards to warm the Gradle cache.'
 
 		doLast {
-			resolveCiJacocoConfigurations(project)
+			resolveCiDependencyConfigurations(project)
 		}
 	}
 }
 
-tasks.register('resolveCiJacocoDependencies') {
+tasks.register('resolveCiDependencies') {
 	group = 'build setup'
-	description = 'Resolves Jacoco configurations used by CI shards to warm the Gradle cache.'
-	dependsOn subprojects.collect { it.tasks.named('resolveCiJacocoDependencies') }
+	description = 'Resolves test runtime configurations used by CI shards to warm the Gradle cache.'
+	dependsOn subprojects.collect { it.tasks.named('resolveCiDependencies') }
 
 	doLast {
-		resolveCiJacocoConfigurations(project)
+		resolveCiDependencyConfigurations(project)
 	}
 }
 


### PR DESCRIPTION
should alleviate:

```
* What went wrong:
A problem occurred evaluating project ':fuzz'.
> Could not resolve all files for configuration ':fuzz:runtimeClasspath'.
   > Could not resolve io.consensys.protocols:jc-kzg-4844:2.1.8.
     Required by:
         project ':fuzz' > project :ethereum:spec > project :infrastructure:kzg
      > Could not resolve io.consensys.protocols:jc-kzg-4844:2.1.8.
         > Could not get resource 'https://repo.maven.apache.org/maven2/io/consensys/protocols/jc-kzg-4844/2.1.8/jc-kzg-4844-2.1.8.pom'.
            > Could not GET 'https://repo.maven.apache.org/maven2/io/consensys/protocols/jc-kzg-4844/2.1.8/jc-kzg-4844-2.1.8.pom'. Received status code 403 from server: Forbidden
> There are 2 more failures with identical causes.
```

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows, composite prepare setup, and Gradle cache-warming tasks with no application or security logic touched.
> 
> **Overview**
> CI assemble and reference-test prep now run **`resolveCiDependencies`** instead of the JaCoCo-only warmup task, so the shared Gradle cache is populated with **runtime and test runtime classpaths** (unit, integration, acceptance, property, reference) before matrix shards run with read-only cache.
> 
> In **`build.gradle`**, the warmup task is renamed and its resolved configuration list is expanded beyond `jacocoAgent` / `jacocoAnt` to include those classpath configurations across subprojects.
> 
> The **prepare** composite action installs **`zstd`** on runners when it is missing (via `apt-get`, with `sudo` when needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1054e90573c6ee5cafbaba24d52732838ffa734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->