### PR TITLE
Update get_indexed_payload_attestation specref anchor

### DIFF
--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -5185,7 +5185,7 @@
 - name: get_indexed_payload_attestation#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
-      search: public IndexedPayloadAttestation getIndexedPayloadAttestation(
+      search: public IndexedPayloadAttestationLight getIndexedPayloadAttestation(
   spec: |
     <spec fn="get_indexed_payload_attestation" fork="gloas" hash="0e516ffb">
     def get_indexed_payload_attestation(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
#10964 changed the return type of `getIndexedPayloadAttestation` to `IndexedPayloadAttestationLight` but missed to change the signature in `search:` in `specrefs/functions.yml` for `get_indexed_payload_attestation`. This lead to CI failure in `check-specrefs`. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/specref metadata only; no runtime or consensus logic changes.
> 
> **Overview**
> Updates the **`get_indexed_payload_attestation#gloas`** specref in `specrefs/functions.yml` so its `search:` anchor matches the current Java implementation.
> 
> The anchor string now looks for `public IndexedPayloadAttestationLight getIndexedPayloadAttestation(` instead of `IndexedPayloadAttestation`, restoring **`check-specrefs`** after the return type change in #10964.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebdadb5c9ffd162ebbe4eb572e0013a8c9a18375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->