### PR TITLE
Set `blobDataAvailable` correctly for PTC

### DIFF
--- a/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integration-test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -71,6 +71,7 @@ import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
 import tech.pegasys.teku.statetransition.datacolumns.CustodyGroupCountManager;
+import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
@@ -231,6 +232,7 @@ public class ValidatorApiHandlerIntegrationTest {
             blockProductionPerformanceFactory,
             blockPublisher,
             payloadAttestationPool,
+            DataAvailabilitySampler.NOOP,
             executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -677,8 +677,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
               final SignedBeaconBlock block = maybeBlock.get();
               final boolean payloadPresent =
                   executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(block.getRoot());
-              final boolean blobDataAvailable =
-                  dataAvailabilitySampler.isDataAvailable(slot, block.getRoot());
+              final boolean blobDataAvailable = dataAvailabilitySampler.isDataAvailable(block);
               final PayloadAttestationData payloadAttestationData =
                   SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
                       .getPayloadAttestationDataSchema()

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -109,6 +109,7 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
+import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager.RemoteBidOrigin;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
@@ -171,6 +172,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
   private final ProposersDataManager proposersDataManager;
   private final BlockPublisher blockPublisher;
   private final PayloadAttestationPool payloadAttestationPool;
+  private final DataAvailabilitySampler dataAvailabilitySampler;
   private final ExecutionPayloadManager executionPayloadManager;
   private final ExecutionPayloadFactory executionPayloadFactory;
   private final ExecutionPayloadPublisher executionPayloadPublisher;
@@ -203,6 +205,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
           blockProductionAndPublishingPerformanceFactory,
       final BlockPublisher blockPublisher,
       final PayloadAttestationPool payloadAttestationPool,
+      final DataAvailabilitySampler dataAvailabilitySampler,
       final ExecutionPayloadManager executionPayloadManager,
       final ExecutionPayloadFactory executionPayloadFactory,
       final ExecutionPayloadPublisher executionPayloadPublisher,
@@ -231,6 +234,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
     this.proposersDataManager = proposersDataManager;
     this.blockPublisher = blockPublisher;
     this.payloadAttestationPool = payloadAttestationPool;
+    this.dataAvailabilitySampler = dataAvailabilitySampler;
     this.executionPayloadManager = executionPayloadManager;
     this.executionPayloadFactory = executionPayloadFactory;
     this.executionPayloadPublisher = executionPayloadPublisher;
@@ -673,12 +677,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel, SlotEventsChann
               final SignedBeaconBlock block = maybeBlock.get();
               final boolean payloadPresent =
                   executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(block.getRoot());
-              // if execution payload is in the store, blob data is available
               final boolean blobDataAvailable =
-                  combinedChainDataClient
-                      .getStore()
-                      .getExecutionPayloadIfAvailable(block.getRoot())
-                      .isPresent();
+                  dataAvailabilitySampler.isDataAvailable(slot, block.getRoot());
               final PayloadAttestationData payloadAttestationData =
                   SchemaDefinitionsGloas.required(spec.atSlot(slot).getSchemaDefinitions())
                       .getPayloadAttestationDataSchema()

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -1499,6 +1499,7 @@ class ValidatorApiHandlerTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
     when(executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(block.getRoot()))
         .thenReturn(true);
+    when(dataAvailabilitySampler.isDataAvailable(block)).thenReturn(true);
 
     final Optional<PayloadAttestationData> result =
         SafeFutureAssert.safeJoin(validatorApiHandler.createPayloadAttestationData(newSlot));
@@ -1509,30 +1510,7 @@ class ValidatorApiHandlerTest {
               assertThat(payloadAttestationData.getBeaconBlockRoot()).isEqualTo(block.getRoot());
               assertThat(payloadAttestationData.getSlot()).isEqualTo(newSlot);
               assertThat(payloadAttestationData.isPayloadPresent()).isTrue();
-              assertThat(payloadAttestationData.isBlobDataAvailable()).isFalse();
-            });
-  }
-
-  @Test
-  public void createPayloadAttestationData_shouldSetPayloadPresentFalseWhenPayloadWasNotEarly() {
-    final UInt64 newSlot = UInt64.valueOf(25);
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(newSlot);
-
-    when(chainDataClient.getBlockAtSlotExact(eq(newSlot)))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
-    when(executionPayloadManager.isExecutionPayloadSeenBeforeDeadline(block.getRoot()))
-        .thenReturn(false);
-
-    final Optional<PayloadAttestationData> result =
-        SafeFutureAssert.safeJoin(validatorApiHandler.createPayloadAttestationData(newSlot));
-
-    assertThat(result)
-        .hasValueSatisfying(
-            payloadAttestationData -> {
-              assertThat(payloadAttestationData.getBeaconBlockRoot()).isEqualTo(block.getRoot());
-              assertThat(payloadAttestationData.getSlot()).isEqualTo(newSlot);
-              assertThat(payloadAttestationData.isPayloadPresent()).isFalse();
-              assertThat(payloadAttestationData.isBlobDataAvailable()).isFalse();
+              assertThat(payloadAttestationData.isBlobDataAvailable()).isTrue();
             });
   }
 
@@ -1548,6 +1526,7 @@ class ValidatorApiHandlerTest {
 
     assertThat(result).isEmpty();
     verify(executionPayloadManager, never()).isExecutionPayloadSeenBeforeDeadline(any());
+    verify(dataAvailabilitySampler, never()).isDataAvailable(any());
   }
 
   @Test

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -122,6 +122,7 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
+import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
 import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
@@ -171,6 +172,8 @@ class ValidatorApiHandlerTest {
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
   private final PayloadAttestationPool payloadAttestationPool = mock(PayloadAttestationPool.class);
+  private final DataAvailabilitySampler dataAvailabilitySampler =
+      mock(DataAvailabilitySampler.class);
   private final ExecutionPayloadManager executionPayloadManager =
       mock(ExecutionPayloadManager.class);
   private final ExecutionPayloadFactory executionPayloadFactory =
@@ -239,6 +242,7 @@ class ValidatorApiHandlerTest {
             blockProductionPerformanceFactory,
             blockPublisher,
             payloadAttestationPool,
+            dataAvailabilitySampler,
             executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,
@@ -534,6 +538,7 @@ class ValidatorApiHandlerTest {
             blockProductionPerformanceFactory,
             blockPublisher,
             payloadAttestationPool,
+            dataAvailabilitySampler,
             executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -77,6 +77,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
+import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
 import tech.pegasys.teku.statetransition.execution.ExecutionPayloadManager;
@@ -344,6 +345,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             blockProductionAndPublishingFactory,
             blockPublisher,
             payloadAttestationPool,
+            DataAvailabilitySampler.NOOP,
             executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasPreSampler.java
@@ -95,7 +95,7 @@ public class DasPreSampler {
                 sampler
                     .checkDataAvailability(block.getSlot(), block.getRoot())
                     .finish(
-                        succ ->
+                        ignored ->
                             LOG.debug(
                                 "DasPreSampler: success pre-sampling block {} ({})",
                                 block.getSlot(),

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -41,7 +41,7 @@ public interface DasSamplerBasic extends DataAvailabilitySampler, SlotEventsChan
         }
 
         @Override
-        public boolean isDataAvailable(final UInt64 slot, final Bytes32 blockRoot) {
+        public boolean isDataAvailable(final SignedBeaconBlock block) {
           return false;
         }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -42,7 +42,7 @@ public interface DasSamplerBasic extends DataAvailabilitySampler, SlotEventsChan
 
         @Override
         public boolean isDataAvailable(final SignedBeaconBlock block) {
-          return false;
+          return true;
         }
 
         @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -41,6 +41,11 @@ public interface DasSamplerBasic extends DataAvailabilitySampler, SlotEventsChan
         }
 
         @Override
+        public boolean isDataAvailable(final UInt64 slot, final Bytes32 blockRoot) {
+          return false;
+        }
+
+        @Override
         public SamplingEligibilityStatus checkSamplingEligibility(final BeaconBlock block) {
           return SamplingEligibilityStatus.NOT_REQUIRED_NO_BLOBS;
         }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
@@ -337,6 +337,17 @@ public class DasSamplerBasicImpl implements DasSamplerBasic, SlotEventsChannel {
     return true;
   }
 
+  @Override
+  public boolean isDataAvailable(final UInt64 slot, final Bytes32 blockRoot) {
+    if (isDataAvailabilityAlreadySatisfied(slot, blockRoot)) {
+      return true;
+    }
+    final DataColumnSamplingTracker tracker = recentlySampledColumnsByRoot.get(blockRoot);
+    return tracker != null
+        && tracker.completionFuture().isDone()
+        && !tracker.completionFuture().isCompletedExceptionally();
+  }
+
   private boolean isInCustodyPeriod(final BeaconBlock block) {
     final MiscHelpersFulu miscHelpersFulu =
         MiscHelpersFulu.required(spec.atSlot(block.getSlot()).miscHelpers());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
@@ -339,6 +339,7 @@ public class DasSamplerBasicImpl implements DasSamplerBasic, SlotEventsChannel {
 
   @Override
   public boolean isDataAvailable(final SignedBeaconBlock block) {
+    // if there are no blobs for this block, consider the data as available
     if (!hasBlobs(block.getMessage())) {
       return true;
     }
@@ -346,9 +347,7 @@ public class DasSamplerBasicImpl implements DasSamplerBasic, SlotEventsChannel {
       return true;
     }
     final DataColumnSamplingTracker tracker = recentlySampledColumnsByRoot.get(block.getRoot());
-    return tracker != null
-        && tracker.completionFuture().isDone()
-        && !tracker.completionFuture().isCompletedExceptionally();
+    return tracker != null && tracker.completionFuture().isCompletedNormally();
   }
 
   private boolean isInCustodyPeriod(final BeaconBlock block) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
@@ -338,11 +338,14 @@ public class DasSamplerBasicImpl implements DasSamplerBasic, SlotEventsChannel {
   }
 
   @Override
-  public boolean isDataAvailable(final UInt64 slot, final Bytes32 blockRoot) {
-    if (isDataAvailabilityAlreadySatisfied(slot, blockRoot)) {
+  public boolean isDataAvailable(final SignedBeaconBlock block) {
+    if (isDataAvailabilityAlreadySatisfied(block.getSlot(), block.getRoot())) {
       return true;
     }
-    final DataColumnSamplingTracker tracker = recentlySampledColumnsByRoot.get(blockRoot);
+    if (!hasBlobs(block.getMessage())) {
+      return true;
+    }
+    final DataColumnSamplingTracker tracker = recentlySampledColumnsByRoot.get(block.getRoot());
     return tracker != null
         && tracker.completionFuture().isDone()
         && !tracker.completionFuture().isCompletedExceptionally();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasicImpl.java
@@ -339,10 +339,10 @@ public class DasSamplerBasicImpl implements DasSamplerBasic, SlotEventsChannel {
 
   @Override
   public boolean isDataAvailable(final SignedBeaconBlock block) {
-    if (isDataAvailabilityAlreadySatisfied(block.getSlot(), block.getRoot())) {
+    if (!hasBlobs(block.getMessage())) {
       return true;
     }
-    if (!hasBlobs(block.getMessage())) {
+    if (isDataAvailabilityAlreadySatisfied(block.getSlot(), block.getRoot())) {
       return true;
     }
     final DataColumnSamplingTracker tracker = recentlySampledColumnsByRoot.get(block.getRoot());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
@@ -40,26 +40,27 @@ public interface DataAvailabilitySampler
   DataAvailabilitySampler NOOP =
       new DataAvailabilitySampler() {
         @Override
-        public SafeFuture<List<UInt64>> checkDataAvailability(UInt64 slot, Bytes32 blockRoot) {
+        public SafeFuture<List<UInt64>> checkDataAvailability(
+            final UInt64 slot, final Bytes32 blockRoot) {
           return SafeFuture.completedFuture(List.of());
         }
 
         @Override
         public boolean isDataAvailable(final SignedBeaconBlock block) {
-          return false;
+          return true;
         }
 
         @Override
         public void flush() {}
 
         @Override
-        public SamplingEligibilityStatus checkSamplingEligibility(BeaconBlock block) {
+        public SamplingEligibilityStatus checkSamplingEligibility(final BeaconBlock block) {
           return SamplingEligibilityStatus.NOT_REQUIRED_OLD_EPOCH;
         }
 
         @Override
         public void onNewValidatedDataColumnSidecar(
-            final DataColumnSlotAndIdentifier columnId, RemoteOrigin origin) {}
+            final DataColumnSlotAndIdentifier columnId, final RemoteOrigin origin) {}
 
         @Override
         public void onNewBlock(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
@@ -45,6 +45,11 @@ public interface DataAvailabilitySampler
         }
 
         @Override
+        public boolean isDataAvailable(final UInt64 slot, final Bytes32 blockRoot) {
+          return false;
+        }
+
+        @Override
         public void flush() {}
 
         @Override
@@ -75,6 +80,9 @@ public interface DataAvailabilitySampler
    * the {@link #flush()} method
    */
   SafeFuture<List<UInt64>> checkDataAvailability(UInt64 slot, Bytes32 blockRoot);
+
+  /** Returns true if data availability has already been confirmed for the given block. */
+  boolean isDataAvailable(UInt64 slot, Bytes32 blockRoot);
 
   /**
    * Immediately initiates sampling. When doing batch sampling it would be more effective to invoke

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataAvailabilitySampler.java
@@ -45,7 +45,7 @@ public interface DataAvailabilitySampler
         }
 
         @Override
-        public boolean isDataAvailable(final UInt64 slot, final Bytes32 blockRoot) {
+        public boolean isDataAvailable(final SignedBeaconBlock block) {
           return false;
         }
 
@@ -82,7 +82,7 @@ public interface DataAvailabilitySampler
   SafeFuture<List<UInt64>> checkDataAvailability(UInt64 slot, Bytes32 blockRoot);
 
   /** Returns true if data availability has already been confirmed for the given block. */
-  boolean isDataAvailable(UInt64 slot, Bytes32 blockRoot);
+  boolean isDataAvailable(SignedBeaconBlock block);
 
   /**
    * Immediately initiates sampling. When doing batch sampling it would be more effective to invoke

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1910,6 +1910,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             blockProductionPerformanceFactory,
             blockPublisher,
             payloadAttestationPool,
+            dataAvailabilitySampler,
             executionPayloadManager,
             executionPayloadFactory,
             executionPayloadPublisher,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
In cases when payload is absent, we also vote payload availability is absent regardless of the actual availability. This PR fixes this by using a real data availability checker.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how PTC validators vote on blob data availability, which affects consensus-related attestation data; logic is localized to payload attestation creation and reuses existing DAS state.
> 
> **Overview**
> **Payload attestation (PTC) duties** now set `blobDataAvailable` using **`DataAvailabilitySampler.isDataAvailable(block)`** instead of treating execution-payload presence in the store as blob availability.
> 
> `ValidatorApiHandler` takes a new **`DataAvailabilitySampler`** dependency (wired from **`BeaconChainController`** with the live sampler; tests use **`NOOP`**). **`createPayloadAttestationData`** still uses **`ExecutionPayloadManager`** for `payloadPresent`, but blob availability is independent of whether the payload envelope is in the store—fixing cases where payload is absent but blob availability should still be reported correctly.
> 
> The sampler API gains **`isDataAvailable(SignedBeaconBlock)`**, implemented in **`DasSamplerBasicImpl`** (no blobs → available; already satisfied on chain → available; otherwise completed DAS sampling tracker). **`DataAvailabilitySampler.NOOP`** and **`DasSamplerBasic.NOOP`** always return true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd3d77371a202664fdc28d36e14b3e7c590e4dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->