### PR TITLE
Remove deprecated BeaconChainUtil use from TransitionBenchmark

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -105,7 +105,7 @@ public abstract class TransitionBenchmark {
             transitionBlockValidator,
             new StubMetricsSystem());
     chainBuilder = ChainBuilder.create(spec, validatorKeys);
-    chainUpdater = new ChainUpdater(recentChainData, chainBuilder);
+    chainUpdater = new ChainUpdater(recentChainData, chainBuilder, spec);
     chainUpdater.initializeGenesis(false);
 
     blockImporter =

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -42,13 +42,14 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
+import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityFactory;
@@ -62,9 +63,8 @@ public abstract class TransitionBenchmark {
   Spec spec;
   WeakSubjectivityValidator wsValidator;
   RecentChainData recentChainData;
-
-  @SuppressWarnings("deprecation")
-  BeaconChainUtil localChain;
+  ChainBuilder chainBuilder;
+  ChainUpdater chainUpdater;
 
   BlockImporter blockImporter;
   Iterator<SignedBeaconBlock> blockIterator;
@@ -75,7 +75,6 @@ public abstract class TransitionBenchmark {
   int validatorsCount;
 
   @Setup(Level.Trial)
-  @SuppressWarnings("deprecation")
   public void init() throws Exception {
     spec =
         TestSpecFactory.createMainnetAltair(
@@ -105,8 +104,9 @@ public abstract class TransitionBenchmark {
             new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             new StubMetricsSystem());
-    localChain = BeaconChainUtil.create(spec, recentChainData, validatorKeys, false);
-    localChain.initializeStorage();
+    chainBuilder = ChainBuilder.create(spec, validatorKeys);
+    chainUpdater = new ChainUpdater(recentChainData, chainBuilder);
+    chainUpdater.initializeGenesis(false);
 
     blockImporter =
         new BlockImporter(
@@ -136,7 +136,7 @@ public abstract class TransitionBenchmark {
       block = prefetchedBlock;
       prefetchedBlock = null;
     }
-    localChain.setSlot(block.getSlot());
+    chainUpdater.setCurrentSlot(block.getSlot());
     lastResult = blockImporter.importBlock(block).join();
     if (!lastResult.isSuccessful()) {
       throw new RuntimeException("Unable to import block: " + lastResult);


### PR DESCRIPTION
## Fixed Issue(s)
https://github.com/Consensys/teku/issues/9934

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only test harness change with no production or security impact; behavior should match the previous deprecated helper usage.
> 
> **Overview**
> **`TransitionBenchmark`** no longer uses deprecated **`BeaconChainUtil`** for JMH state-transition benchmarks.
> 
> Setup now uses **`ChainBuilder`** plus **`ChainUpdater`**: genesis is initialized via **`chainUpdater.initializeGenesis(false)`** instead of **`localChain.initializeStorage()`**, and each imported block advances the harness with **`chainUpdater.setCurrentSlot(...)`** instead of **`localChain.setSlot(...)`**. Related **`@SuppressWarnings("deprecation")`** annotations were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcba80c63ca96f6b1a1444ed087b9263a23daf24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->