### PR TITLE
fix for jreleaser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,12 @@ buildscript {
 	repositories {
 		mavenCentral()
 	}
+	// JReleaser 1.23.0 uses GpgObjectSigner from JGit 5.x/6.x, which was removed in JGit 7.x.
+	// Spotless 8.7.0 pulls in JGit 7.7.0, which wins resolution and breaks jreleaserFullRelease.
+	// Spotless does not use ratchetFrom, so it never actually calls JGit at runtime.
+	configurations.classpath.resolutionStrategy {
+		force 'org.eclipse.jgit:org.eclipse.jgit:5.13.5.202508271544-r'
+	}
 	dependencies {
 		classpath 'io.consensys.protocols:license-reporter:1.2.0'
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix for jreleaser so we can publish there hopefully


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only dependency resolution on the buildscript classpath; no runtime Teku code changes, with a documented rationale that Spotless does not need JGit 7 at runtime.
> 
> **Overview**
> Adds a **buildscript classpath resolution strategy** that **forces** `org.eclipse.jgit:org.eclipse.jgit:5.13.5.202508271544-r`, with comments explaining the conflict: **JReleaser 1.23.0** depends on **JGit 5.x/6.x** APIs (e.g. `GpgObjectSigner`) removed in **JGit 7.x**, while **Spotless 8.7.0** transitively pulls **JGit 7.7.0** and wins resolution—breaking **`jreleaserFullRelease`** / Maven Central publish. Spotless is not using `ratchetFrom`, so pinning JGit on the buildscript classpath is considered safe for Spotless at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbd80cb58033d04244d90278a5f18ecadce413d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->