### PR TITLE
Fix edge case for BlocksByRange request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 
 ### Bug Fixes
  - Fixed Beacon REST API socket retention when clients cancel pending asynchronous requests. Requests now time out after 30 seconds.
+ - Fix an edge case on BeaconBlocksByRange where a request for a single block would return an empty response instead of the block.

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -89,6 +89,26 @@ public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegra
   }
 
   @Test
+  public void shouldRespondWithSingleHotBlockWhenCountIsOne() throws Exception {
+    // Regression test for #10985: a count=1 request for an available (hot) slot must return the
+    // block at that slot rather than an empty response. This is the exact scenario from the issue:
+    // start_slot = <available hot block slot>, count = 1, step = 1.
+    final Eth2Peer peer = createPeer();
+
+    peerStorage.chainUpdater().advanceChain();
+    final SignedBlockAndState headBlock = peerStorage.chainUpdater().advanceChain();
+    peerStorage.chainUpdater().updateBestBlock(headBlock);
+
+    final List<SignedBeaconBlock> blocks = new ArrayList<>();
+    waitFor(
+        peer.requestBlocksByRange(
+            headBlock.getSlot(), UInt64.ONE, RpcResponseListener.from(blocks::add)));
+    waitFor(() -> assertThat(peer.getOutstandingRequests()).isEqualTo(0));
+
+    assertThat(blocks).containsExactly(headBlock.getBlock());
+  }
+
+  @Test
   public void requestBlocksByRangeAfterPeerDisconnectedImmediately() {
     final Eth2Peer peer = createPeer();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -196,7 +196,7 @@ public class BeaconBlocksByRangeMessageHandler
               // or a start slot strictly beyond our head. When startSlot == headSlot we must still
               // return the block at that slot, since the spec requires returning at least the first
               // block in the requested range if we have it.
-              if (count.equals(ZERO) || startSlot.isGreaterThan(headSlot)) {
+              if (count.isZero() || startSlot.isGreaterThan(headSlot)) {
                 return SafeFuture.completedFuture(initialState);
               }
               return sendNextBlock(initialState);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -192,9 +192,11 @@ public class BeaconBlocksByRangeMessageHandler
               final UInt64 headSlot = hotRoots.isEmpty() ? headBlockSlot : hotRoots.lastKey();
               final RequestState initialState =
                   new RequestState(startSlot, step, count, headSlot, hotRoots, callback);
-              // there is an edge case when startSlot == headSlot in which case we don't return
-              // anything
-              if (initialState.isComplete()) {
+              // Only short-circuit when there is genuinely nothing to send: a zero-length request
+              // or a start slot strictly beyond our head. When startSlot == headSlot we must still
+              // return the block at that slot, since the spec requires returning at least the first
+              // block in the requested range if we have it.
+              if (count.equals(ZERO) || startSlot.isGreaterThan(headSlot)) {
                 return SafeFuture.completedFuture(initialState);
               }
               return sendNextBlock(initialState);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -342,7 +342,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
     final int count = 1;
     final int skip = 1;
     withCanonicalHeadBlock(blocksWStates.get(10));
-    withAncestorRoots(startBlock, count, skip, allBlocks());
+    // getAncestorRoots for a count=1 request only returns the single root at startSlot
+    // (endSlot = startSlot + step*count - 1 == startSlot), so hotRoots.lastKey() == startSlot.
+    // This reproduces the real behaviour where startSlot == headSlot for the request state.
+    withAncestorRoots(startBlock, count, skip, hotBlocks(startBlock));
 
     requestBlocks(startBlock, count, skip);
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR fixes an edge case where we would return empty when requested a single block. Thanks @Alleysira for reporting this.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fix #10985 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow P2P RPC handler change with targeted unit and integration tests; no auth, data migration, or broad API surface impact.
> 
> **Overview**
> Fixes **BeaconBlocksByRange** returning an empty stream when a peer asks for **one block** at the **head (hot) slot** (`start_slot == head`, `count == 1`, `step == 1`), which violated spec expectations (#10985).
> 
> **`BeaconBlocksByRangeMessageHandler`** no longer treats `RequestState.isComplete()` at setup as “send nothing.” It only skips block iteration when **`count` is zero** or **`startSlot` is strictly past `headSlot`**. When `startSlot` equals the head, it still runs **`sendNextBlock`** so the block at that slot is returned.
> 
> Coverage: unit test mocks **`getAncestorRoots`** for the real `count=1` / `startSlot == headSlot` case, plus an integration regression that requests the head slot with `count=1`. Changelog entry added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832c56e23308cb39040075898cbfa526f95e5f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->