### PR TITLE
PoC BeaconChainController tests

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -769,7 +769,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     initStoredLatestCanonicalBlockUpdater();
   }
 
-  private void initKeyValueStore() {
+  protected void initKeyValueStore() {
     keyValueStore =
         new FileKeyValueStore(beaconDataDirectory.resolve(KEY_VALUE_STORE_SUBDIRECTORY));
   }
@@ -930,7 +930,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     }
   }
 
-  private void initDasSamplerManager() {
+  protected void initDasSamplerManager() {
     if (spec.isMilestoneSupported(SpecMilestone.FULU)) {
       LOG.info("Activated DAS Sampler Manager for Fulu");
       this.dasSamplerManager =

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainControllerTest.java
@@ -14,15 +14,31 @@
 package tech.pegasys.teku.services.beaconchain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
+import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
+import tech.pegasys.teku.statetransition.execution.ExecutionPayloadBidManager;
+import tech.pegasys.teku.statetransition.execution.ProposerPreferencesManager;
+import tech.pegasys.teku.statetransition.execution.ReceivedExecutionPayloadEventsChannel;
+import tech.pegasys.teku.statetransition.util.PoolFactory;
+import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 class BeaconChainControllerTest {
@@ -100,6 +116,54 @@ class BeaconChainControllerTest {
     when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(currentEpoch));
 
     assertThat(controller.isSafeToDeactivateDenebFeatures()).isTrue();
+  }
+
+  @Test
+  void initExecutionPayloadBidManager_subscribesToEventChannelsWhenGloasSupported() {
+    final BeaconChainController controller = createController(TestSpecFactory.createMinimalGloas());
+    final EventChannels eventChannels = mock(EventChannels.class);
+
+    controller.gossipValidationHelper = mock(GossipValidationHelper.class);
+    controller.proposerPreferencesManager = mock(ProposerPreferencesManager.class);
+    controller.beaconConfig = mock(BeaconChainConfiguration.class, RETURNS_DEEP_STUBS);
+    controller.poolFactory = mock(PoolFactory.class);
+    controller.eventChannels = eventChannels;
+
+    controller.initExecutionPayloadBidManager();
+
+    verify(eventChannels).subscribe(eq(SlotEventsChannel.class), any());
+    verify(eventChannels).subscribe(eq(ReceivedBlockEventsChannel.class), any());
+    verify(eventChannels).subscribe(eq(ReceivedExecutionPayloadEventsChannel.class), any());
+    verify(controller.proposerPreferencesManager).subscribeOperationAdded(any());
+    assertThat(controller.executionPayloadBidManager).isNotEqualTo(ExecutionPayloadBidManager.NOOP);
+  }
+
+  @Test
+  void initExecutionPayloadBidManager_doesNothingWhenGloasNotSupported() {
+    final BeaconChainController controller = createController(TestSpecFactory.createMinimalFulu());
+    final EventChannels eventChannels = mock(EventChannels.class);
+    controller.eventChannels = eventChannels;
+
+    controller.initExecutionPayloadBidManager();
+
+    verifyNoInteractions(eventChannels);
+    assertThat(controller.executionPayloadBidManager).isEqualTo(ExecutionPayloadBidManager.NOOP);
+  }
+
+  @Test
+  void initAll_initialisesExecutionPayloadBidManagerBeforeValidatorApiHandlerConsumesIt() {
+    // initValidatorApiHandler() builds the block factory (BlockOperationSelectorFactory) and the
+    // ValidatorApiHandler, both consuming executionPayloadBidManager. It must therefore run after
+    // initExecutionPayloadBidManager(), otherwise those consumers capture a null manager. This
+    // pins that ordering in initAll(): reordering the two calls fails the test.
+    final BeaconChainController controller = mock(BeaconChainController.class);
+    doCallRealMethod().when(controller).initAll();
+
+    controller.initAll();
+
+    final InOrder inOrder = inOrder(controller);
+    inOrder.verify(controller).initExecutionPayloadBidManager();
+    inOrder.verify(controller).initValidatorApiHandler();
   }
 
   private Spec createFuluSpecWithRetentionPeriod(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Looking on a way we could test BeaconChainController in order to:
- verify event channel and other types of subscriptions
- verify call order to avoid regression when something is null at the place it's used

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
