### PR TITLE
Fix isAttestationSameSlot in GLOAS

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -318,18 +318,23 @@ public class BeaconStateAccessorsGloas extends BeaconStateAccessorsFulu {
       final boolean headRootMatches,
       final AttestationData data,
       final BeaconState state) {
+    final boolean isAttestationSameSlot = isAttestationSameSlot(state, data);
+    if (isAttestationSameSlot) {
+      checkArgument(data.getIndex().isZero(), "Index must be set to zero");
+    }
+
     if (!isMatchingTarget || !headRootMatches) {
       return false;
     }
-    if (isAttestationSameSlot(state, data)) {
-      checkArgument(data.getIndex().isZero(), "Index must be set to zero");
+
+    if (isAttestationSameSlot) {
       return true;
-    } else {
-      final int slotIndex = data.getSlot().mod(config.getSlotsPerHistoricalRoot()).intValue();
-      final boolean payloadIndex =
-          BeaconStateGloas.required(state).getExecutionPayloadAvailability().get(slotIndex).get();
-      return data.getIndex().intValue() == (payloadIndex ? 1 : 0);
     }
+
+    final int slotIndex = data.getSlot().mod(config.getSlotsPerHistoricalRoot()).intValue();
+    final boolean payloadIndex =
+        BeaconStateGloas.required(state).getExecutionPayloadAvailability().get(slotIndex).get();
+    return data.getIndex().intValue() == (payloadIndex ? 1 : 0);
   }
 
   /**

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloasTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.gloas.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.spec.config.SpecConfigGloas;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestation;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedPayloadAttestationLight;
 import tech.pegasys.teku.spec.datastructures.state.BeaconStateTestBuilder;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -90,6 +92,22 @@ public class BeaconStateAccessorsGloasTest {
     final Optional<BLSPublicKey> index =
         beaconStateAccessors.getBuilderPubKey(state, UInt64.valueOf(999));
     assertThat(index).isEmpty();
+  }
+
+  @Test
+  void computeIsMatchingHead_shouldRejectNonZeroIndexForSameSlotWhenTargetDoesNotMatch() {
+    final BeaconState state = dataStructureUtil.randomBeaconState();
+    final AttestationData data =
+        new AttestationData(
+            UInt64.ZERO,
+            UInt64.ONE,
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomCheckpoint(),
+            dataStructureUtil.randomCheckpoint());
+
+    assertThatThrownBy(() -> beaconStateAccessors.computeIsMatchingHead(false, false, data, state))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Index must be set to zero");
   }
 
   // EIP-8061 churn limit coverage --------------------------------------------------------------


### PR DESCRIPTION
fixes https://github.com/Consensys/teku-internal/issues/305

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GLOAS attestation head-matching and participation logic; the change only tightens validation order for same-slot attestations but could reject blocks that previously slipped through without the index check.
> 
> **Overview**
> **GLOAS `computeIsMatchingHead` now validates same-slot attestation index before target/head checks.**
> 
> For attestations classified as same-slot via `isAttestationSameSlot`, the **index must be zero** is enforced with `checkArgument` **up front**, instead of only after target and head roots already match. Invalid same-slot attestations with a non-zero index therefore fail immediately rather than being treated as a non-matching head and skipping validation.
> 
> Control flow is refactored so the early return on failed target/head match happens after that check; payload-index matching for non–same-slot attestations is unchanged.
> 
> A unit test asserts that `computeIsMatchingHead(false, false, …)` still throws when slot is zero and index is non-zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa10edc62568d93086ca235f7a4e0725d279584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->