### PR TITLE
Add Aircompressor enabled logging

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -19,6 +19,8 @@ import static tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig.DEFAUL
 import java.time.Duration;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.networking.eth2.gossip.config.Eth2Context;
 import tech.pegasys.teku.networking.eth2.gossip.config.GossipConfigurator;
@@ -32,6 +34,8 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigFulu;
 
 public class P2PConfig {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   public static final int DEFAULT_PEER_BLOCKS_RATE_LIMIT = 500;
   // 250 MB per peer per minute (~ 4.16 MB/s)
@@ -352,6 +356,13 @@ public class P2PConfig {
 
     public P2PConfig build() {
       validate();
+
+      if (gossipSnappyAircompressorEnabled) {
+        LOG.info("Experimental aircompressor Snappy encoding is enabled for gossip");
+      }
+      if (rpcSnappyAircompressorEnabled) {
+        LOG.info("Experimental aircompressor Snappy encoding is enabled for RPC");
+      }
 
       final GossipConfigurator gossipConfigurator =
           isGossipScoringEnabled


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We will remove it once it defaults to true. But currently we need a way to understand it was really enabled on nodes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change at config build; no P2P encoding or wire-format behavior is modified.
> 
> **Overview**
> Adds **startup INFO logs** in `P2PConfig.Builder.build()` so operators can confirm experimental **aircompressor Snappy** encoding is active for **gossip** and/or **RPC** when those flags are turned on.
> 
> Wires in a Log4j `Logger` on `P2PConfig`; encoding selection and defaults are unchanged—this is observability only until aircompressor becomes the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf4228cd3d8fcd50c188db772c3ead0a5123988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->