### PR TITLE
update logs

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.validation;
 
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
 import static tech.pegasys.teku.spec.config.Constants.HIGHEST_BID_SET_SIZE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_SLOTS_TO_TRACK_BUILDERS_BIDS;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
@@ -154,12 +155,18 @@ public class ExecutionPayloadBidGossipValidator {
 
       if (bid.getValue().isLessThan(minRequiredBid)) {
         LOG.trace(
-            "Bid value {} does not meet minimum increment threshold ({}%). Current highest: {}, minimum required: {}",
-            bid.getValue(), minBidIncrementPercentage, existingBidValue, minRequiredBid);
+            "Bid value {} ETH does not meet minimum increment threshold ({}%). Current highest: {} ETH, minimum required: {} ETH",
+            gweiToEth(bid.getValue()),
+            minBidIncrementPercentage,
+            gweiToEth(existingBidValue),
+            gweiToEth(minRequiredBid));
         return completedFuture(
             ignore(
-                "Bid value %s does not meet minimum increment threshold (%s%%). Current highest: %s, minimum required: %s",
-                bid.getValue(), minBidIncrementPercentage, existingBidValue, minRequiredBid));
+                "Bid value %s ETH does not meet minimum increment threshold (%s%%). Current highest: %s ETH, minimum required: %s ETH",
+                gweiToEth(bid.getValue()),
+                minBidIncrementPercentage,
+                gweiToEth(existingBidValue),
+                gweiToEth(minRequiredBid)));
       }
     }
 
@@ -285,12 +292,12 @@ public class ExecutionPayloadBidGossipValidator {
               if (!gossipValidationHelper.builderHasEnoughBalanceForBid(
                   bid.getValue(), bid.getBuilderIndex(), state, bid.getSlot())) {
                 LOG.trace(
-                    "Bid value {} exceeds builder with index {} excess balance",
-                    bid.getValue(),
+                    "Bid value {} ETH exceeds builder with index {} excess balance",
+                    gweiToEth(bid.getValue()),
                     bid.getBuilderIndex());
                 return ignore(
-                    "Bid value %s exceeds builder with index %s excess balance",
-                    bid.getValue(), bid.getBuilderIndex());
+                    "Bid value %s ETH exceeds builder with index %s excess balance",
+                    gweiToEth(bid.getValue()), bid.getBuilderIndex());
               }
 
               /*
@@ -328,11 +335,17 @@ public class ExecutionPayloadBidGossipValidator {
               if (!wasBidAccepted(bidValue, existingBidRef.get(), actualHighestBid)) {
                 final UInt64 minRequired = calculateMinimumRequiredBid(actualHighestBid);
                 LOG.trace(
-                    "Bid value {} does not meet minimum increment threshold ({}%) due to concurrent update. Current highest: {}, minimum required: {}",
-                    bidValue, minBidIncrementPercentage, actualHighestBid, minRequired);
+                    "Bid value {} ETH does not meet minimum increment threshold ({}%) due to concurrent update. Current highest: {} ETH, minimum required: {} ETH",
+                    gweiToEth(bidValue),
+                    minBidIncrementPercentage,
+                    gweiToEth(actualHighestBid),
+                    gweiToEth(minRequired));
                 return ignore(
-                    "Bid value %s does not meet minimum increment threshold (%s%%) due to concurrent update. Current highest: %s, minimum required: %s",
-                    bidValue, minBidIncrementPercentage, actualHighestBid, minRequired);
+                    "Bid value %s ETH does not meet minimum increment threshold (%s%%) due to concurrent update. Current highest: %s ETH, minimum required: %s ETH",
+                    gweiToEth(bidValue),
+                    minBidIncrementPercentage,
+                    gweiToEth(actualHighestBid),
+                    gweiToEth(minRequired));
               }
 
               return ACCEPT;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -96,9 +96,14 @@ public class ExecutionPayloadBidGossipValidator {
     final Optional<ProposerPreferences> proposerPreferences =
         proposerPreferencesManager.getProposerPreferences(bid.getSlot());
     if (proposerPreferences.isEmpty()) {
+      LOG.trace(
+          "No proposer preferences available at slot {}. The bid from the builder with index {} will be saved for future processing.",
+          bid.getSlot(),
+          bid.getBuilderIndex());
       return completedFuture(
           saveForFuture(
-              "No proposer preferences available. The bid will be saved for future processing."));
+              "No proposer preferences available at slot %s. The bid from the builder with index %s will be saved for future processing.",
+              bid.getSlot(), bid.getBuilderIndex()));
     }
 
     /*
@@ -106,9 +111,13 @@ public class ExecutionPayloadBidGossipValidator {
      * SignedProposerPreferences associated with bid.slot
      */
     if (!bid.getFeeRecipient().equals(proposerPreferences.get().getFeeRecipient())) {
+      LOG.trace(
+          "Bid fee recipient {} does not match proposer preferences fee recipient {}",
+          bid.getFeeRecipient(),
+          proposerPreferences.get().getFeeRecipient());
       return completedFuture(
           ignore(
-              "Bid fee_recipient %s does not match proposer preferences fee_recipient %s",
+              "Bid fee recipient %s does not match proposer preferences fee recipient %s",
               bid.getFeeRecipient(), proposerPreferences.get().getFeeRecipient()));
     }
 
@@ -118,6 +127,10 @@ public class ExecutionPayloadBidGossipValidator {
     if (seenExecutionPayloadBids
         .getOrDefault(bid.getSlot(), Set.of())
         .contains(bid.getBuilderIndex())) {
+      LOG.trace(
+          "Already received a bid from builder with index {} at slot {}",
+          bid.getBuilderIndex(),
+          bid.getSlot());
       return completedFuture(
           ignore(
               "Already received a bid from builder with index %s at slot %s",
@@ -182,9 +195,14 @@ public class ExecutionPayloadBidGossipValidator {
     final UInt64 parentGasLimit = maybeParentGasLimit.get();
     final UInt64 targetGasLimit = proposerPreferences.get().getTargetGasLimit();
     if (!isGasLimitTargetCompatible(parentGasLimit, bid.getGasLimit(), targetGasLimit)) {
+      LOG.trace(
+          "Bid gas limit {} is not compatible with parent gas limit {} and proposer preferences target gas limit {}",
+          bid.getGasLimit(),
+          parentGasLimit,
+          targetGasLimit);
       return completedFuture(
           ignore(
-              "Bid gas_limit %s is not compatible with parent gas_limit %s and proposer preferences target_gas_limit %s",
+              "Bid gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
               bid.getGasLimit(), parentGasLimit, targetGasLimit));
     }
 
@@ -239,11 +257,11 @@ public class ExecutionPayloadBidGossipValidator {
                   gossipValidationHelper.getRandaoMixForCurrentEpoch(state, bid.getSlot());
               if (!bid.getPrevRandao().equals(expectedRandaoMix)) {
                 LOG.trace(
-                    "Bid prev_randao {} does not match expected RANDAO mix {}",
+                    "Bid prev randao {} does not match expected RANDAO mix {}",
                     bid.getPrevRandao(),
                     expectedRandaoMix);
                 return reject(
-                    "Bid prev_randao %s does not match expected RANDAO mix %s",
+                    "Bid prev randao %s does not match expected RANDAO mix %s",
                     bid.getPrevRandao(), expectedRandaoMix);
               }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -156,10 +156,10 @@ public class ExecutionPayloadBidGossipValidator {
       if (bid.getValue().isLessThan(minRequiredBid)) {
         LOG.trace(
             "Bid value {} ETH does not meet minimum increment threshold ({}%). Current highest: {} ETH, minimum required: {} ETH",
-            gweiToEth(bid.getValue()),
-            minBidIncrementPercentage,
-            gweiToEth(existingBidValue),
-            gweiToEth(minRequiredBid));
+            () -> gweiToEth(bid.getValue()),
+            () -> minBidIncrementPercentage,
+            () -> gweiToEth(existingBidValue),
+            () -> gweiToEth(minRequiredBid));
         return completedFuture(
             ignore(
                 "Bid value %s ETH does not meet minimum increment threshold (%s%%). Current highest: %s ETH, minimum required: %s ETH",
@@ -293,8 +293,8 @@ public class ExecutionPayloadBidGossipValidator {
                   bid.getValue(), bid.getBuilderIndex(), state, bid.getSlot())) {
                 LOG.trace(
                     "Bid value {} ETH exceeds builder with index {} excess balance",
-                    gweiToEth(bid.getValue()),
-                    bid.getBuilderIndex());
+                    () -> gweiToEth(bid.getValue()),
+                    bid::getBuilderIndex);
                 return ignore(
                     "Bid value %s ETH exceeds builder with index %s excess balance",
                     gweiToEth(bid.getValue()), bid.getBuilderIndex());
@@ -336,10 +336,10 @@ public class ExecutionPayloadBidGossipValidator {
                 final UInt64 minRequired = calculateMinimumRequiredBid(actualHighestBid);
                 LOG.trace(
                     "Bid value {} ETH does not meet minimum increment threshold ({}%) due to concurrent update. Current highest: {} ETH, minimum required: {} ETH",
-                    gweiToEth(bidValue),
-                    minBidIncrementPercentage,
-                    gweiToEth(actualHighestBid),
-                    gweiToEth(minRequired));
+                    () -> gweiToEth(bidValue),
+                    () -> minBidIncrementPercentage,
+                    () -> gweiToEth(actualHighestBid),
+                    () -> gweiToEth(minRequired));
                 return ignore(
                     "Bid value %s ETH does not meet minimum increment threshold (%s%%) due to concurrent update. Current highest: %s ETH, minimum required: %s ETH",
                     gweiToEth(bidValue),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
@@ -162,7 +162,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
             saveForFuture(
-                "No proposer preferences available. The bid will be saved for future processing."));
+                "No proposer preferences available at slot %s. The bid from the builder with index %s will be saved for future processing.",
+                slot, builderIndex));
   }
 
   @TestTemplate
@@ -176,7 +177,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
             ignore(
-                "Bid fee_recipient %s does not match proposer preferences fee_recipient %s",
+                "Bid fee recipient %s does not match proposer preferences fee recipient %s",
                 bid.getFeeRecipient(), mismatchedPreferences.getFeeRecipient()));
   }
 
@@ -193,7 +194,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     assertThatSafeFuture(bidValidator.validate(bidWithGasLimit))
         .isCompletedWithValue(
             ignore(
-                "Bid gas_limit %s is not compatible with parent gas_limit %s and proposer preferences target_gas_limit %s",
+                "Bid gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
                 bidWithGasLimit.getMessage().getGasLimit(), parentGasLimit, targetGasLimit));
   }
 
@@ -223,7 +224,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     assertThatSafeFuture(bidValidator.validate(bidWithGasLimit))
         .isCompletedWithValue(
             ignore(
-                "Bid gas_limit %s is not compatible with parent gas_limit %s and proposer preferences target_gas_limit %s",
+                "Bid gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
                 bidGasLimit, parentGasLimit, targetGasLimit));
   }
 
@@ -344,7 +345,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
             reject(
-                "Bid prev_randao %s does not match expected RANDAO mix %s",
+                "Bid prev randao %s does not match expected RANDAO mix %s",
                 bid.getPrevRandao(), incorrectRandaoMix));
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.logging.Converter.gweiToEth;
 import static tech.pegasys.teku.spec.config.Constants.MAX_SLOTS_TO_TRACK_BUILDERS_BIDS;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ignore;
@@ -361,14 +362,17 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
   @TestTemplate
   void shouldIgnore_whenBuilderHasInsufficientBalance() {
+    final UInt64 bidValue = UInt64.valueOf(1_000_000_000);
+    final SignedExecutionPayloadBid insufficientBalanceBid = bidFromBuilder(builderIndex, bidValue);
+    mockBidValidation(insufficientBalanceBid, builderIndex, bidValue);
     when(gossipValidationHelper.builderHasEnoughBalanceForBid(
-            bid.getValue(), builderIndex, postState, slot))
+            bidValue, builderIndex, postState, slot))
         .thenReturn(false);
-    assertThatSafeFuture(bidValidator.validate(signedBid))
+    assertThatSafeFuture(bidValidator.validate(insufficientBalanceBid))
         .isCompletedWithValue(
             ignore(
-                "Bid value %s exceeds builder with index %s excess balance",
-                bid.getValue(), builderIndex));
+                "Bid value %s ETH exceeds builder with index %s excess balance",
+                gweiToEth(bidValue), builderIndex));
   }
 
   @TestTemplate
@@ -533,7 +537,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
   @TestTemplate
   void shouldIgnore_whenBidBelowMinimumIncrementThreshold() {
     // First bid with known value
-    final UInt64 firstBidValue = UInt64.valueOf(10000);
+    final UInt64 firstBidValue = UInt64.valueOf(1_000_000_000);
     final SignedExecutionPayloadBid firstBid =
         dataStructureUtil.randomSignedExecutionPayloadBid(
             dataStructureUtil.randomExecutionPayloadBid(
@@ -550,7 +554,6 @@ public class ExecutionPayloadBidGossipValidatorTest {
             dataStructureUtil.randomExecutionPayloadBid(
                 parentBlockHash, slot, differentBuilderIndex, secondBidValue, UInt64.ZERO));
 
-    // Calculate what the minimum required bid would be
     final UInt64 minIncrement = firstBidValue.times(MIN_BID_INCREMENT_PERCENTAGE).dividedBy(100);
     final UInt64 minRequiredBid = firstBidValue.plus(minIncrement);
 
@@ -558,8 +561,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
     assertThatSafeFuture(bidValidator.validate(secondBid))
         .isCompletedWithValue(
             ignore(
-                "Bid value %s does not meet minimum increment threshold (%s%%). Current highest: %s, minimum required: %s",
-                secondBidValue, MIN_BID_INCREMENT_PERCENTAGE, firstBidValue, minRequiredBid));
+                "Bid value %s ETH does not meet minimum increment threshold (%s%%). Current highest: %s ETH, minimum required: %s ETH",
+                gweiToEth(secondBidValue),
+                MIN_BID_INCREMENT_PERCENTAGE,
+                gweiToEth(firstBidValue),
+                gweiToEth(minRequiredBid)));
   }
 
   @TestTemplate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add logs and update wording

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and string-formatting only; gossip validation rules and outcomes are unchanged.
> 
> **Overview**
> Improves **observability** and **readability** when execution payload bids are ignored or deferred in `ExecutionPayloadBidGossipValidator`.
> 
> Adds **trace** logs for paths that previously only returned validation results (missing proposer preferences, fee recipient mismatch, duplicate builder bid per slot, gas limit incompatibility). The “save for later” case when preferences are missing now includes **slot** and **builder index** in both the log and the returned message.
> 
> User-facing ignore/reject/save-for-future strings drop spec-style underscores (`fee_recipient`, `gas_limit`, `prev_randao`) in favor of plain wording. **Bid amounts** in minimum-increment and excess-balance messages—and matching trace lines—are shown in **ETH** via `gweiToEth` instead of raw gwei, with lazy suppliers on trace where appropriate.
> 
> Tests are updated to assert the new message text and ETH formatting; one insufficient-balance test uses an explicit bid value aligned with the new expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d150673df7967a869c27e48d161a18b29779d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->