### PR TITLE
allow builders to bid on multiple branches

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -33,7 +33,7 @@ public class Constants {
   public static final int MAX_SLOTS_TO_TRACK_BUILDERS_BIDS = 10;
   // Preferences are published for the next epoch and need to persist until that epoch completes
   public static final int MAX_SLOTS_TO_TRACK_PROPOSER_PREFERENCES = 64;
-  // Maximum number of (slot, parentBlockHash) combinations to cache the highest bid values for
+  // Maximum number of (slot, parentBlockHash, parentBlockRoot) combinations to cache highest bids
   public static final int HIGHEST_BID_SET_SIZE = 10;
   // Target 2 different attestation data (aggregators normally agree) for two slots
   public static final int VALID_ATTESTATION_DATA_SET_SIZE = 2 * 64 * 2;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -138,14 +138,15 @@ public interface ReadOnlyForkChoiceStrategy {
   boolean shouldExtendPayload(ReadOnlyStore store, SlotAndBlockRoot slotAndBlockRoot);
 
   /**
-   * Returns whether block production should build on the FULL variant of {@code head}.
+   * Returns whether block production at {@code slot} should build on the FULL variant of {@code
+   * head}.
    *
    * <p>Pre-Gloas follows the existing {@link #shouldExtendPayload(ReadOnlyStore, SlotAndBlockRoot)}
    * decision. Gloas overrides this to account for PTC votes that signal data unavailability or an
    * untimely payload.
    */
   boolean shouldBuildOnFull(
-      final ReadOnlyStore store, final UInt64 currentSlot, final ForkChoiceNode head);
+      final ReadOnlyStore store, final UInt64 slot, final ForkChoiceNode head);
 
   default Optional<Boolean> getPayloadTimelinessVote(
       final Bytes32 blockRoot, final int ptcPosition) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -565,8 +565,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
 
     @Override
     public boolean shouldBuildOnFull(
-        final ReadOnlyStore store, final UInt64 currentSlot, final ForkChoiceNode head) {
-      return shouldExtendPayload(store, new SlotAndBlockRoot(currentSlot, head.blockRoot()));
+        final ReadOnlyStore store, final UInt64 slot, final ForkChoiceNode head) {
+      return shouldExtendPayload(store, new SlotAndBlockRoot(slot, head.blockRoot()));
     }
 
     @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -173,8 +173,8 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
 
   @Override
   public boolean shouldBuildOnFull(
-      final ReadOnlyStore store, final UInt64 currentSlot, final ForkChoiceNode head) {
-    return shouldExtendPayload(store, new SlotAndBlockRoot(currentSlot, head.blockRoot()));
+      final ReadOnlyStore store, final UInt64 slot, final ForkChoiceNode head) {
+    return shouldExtendPayload(store, new SlotAndBlockRoot(slot, head.blockRoot()));
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -49,9 +49,9 @@ public class ExecutionPayloadBidGossipValidator {
   private final GossipValidationHelper gossipValidationHelper;
   private final SigningRootUtil signingRootUtil;
   private final int minBidIncrementPercentage;
-  private final Map<UInt64, Set<UInt64>> seenExecutionPayloadBids =
+  private final Map<UInt64, Set<BuilderAndParent>> seenExecutionPayloadBids =
       LimitedMap.createSynchronizedLRU(MAX_SLOTS_TO_TRACK_BUILDERS_BIDS);
-  private final Map<SlotAndBlockHash, UInt64> highestBids =
+  private final Map<BidParent, UInt64> highestBids =
       LimitedMap.createSynchronizedLRU(HIGHEST_BID_SET_SIZE);
 
   private final ProposerPreferencesManager proposerPreferencesManager;
@@ -123,15 +123,19 @@ public class ExecutionPayloadBidGossipValidator {
     }
 
     /*
-     * [IGNORE] this is the first signed bid seen with a valid signature from the given builder for this slot.
+     * [IGNORE] this is the first signed bid seen with a valid signature from the given builder for the tuple
+     * (bid.slot, bid.parent_block_hash, bid.parent_block_root).
      */
-    if (seenExecutionPayloadBids
-        .getOrDefault(bid.getSlot(), Set.of())
-        .contains(bid.getBuilderIndex())) {
+    final BuilderAndParent builderAndParent =
+        new BuilderAndParent(
+            bid.getBuilderIndex(), bid.getParentBlockHash(), bid.getParentBlockRoot());
+    if (seenExecutionPayloadBids.getOrDefault(bid.getSlot(), Set.of()).contains(builderAndParent)) {
       LOG.trace(
-          "Already received a bid from builder with index {} at slot {}",
+          "Already received a bid from builder with index {} at slot {} for parent hash {} and parent root {}",
           bid.getBuilderIndex(),
-          bid.getSlot());
+          bid.getSlot(),
+          bid.getParentBlockHash(),
+          bid.getParentBlockRoot());
       return completedFuture(
           ignore(
               "Already received a bid from builder with index %s at slot %s",
@@ -139,7 +143,8 @@ public class ExecutionPayloadBidGossipValidator {
     }
 
     /*
-     * [IGNORE] this bid is the highest value bid seen for the corresponding slot and the given parent block hash.
+     * [IGNORE] this bid is the highest value bid seen for the tuple
+     * (bid.slot, bid.parent_block_hash, bid.parent_block_root).
      *
      * Note: Implementations SHOULD include DoS prevention measures to
      * mitigate spam from malicious builders submitting numerous bids with minimal value increments.
@@ -147,8 +152,8 @@ public class ExecutionPayloadBidGossipValidator {
      * minimum threshold, or (2) forwarding only the highest observed bid at regular time intervals.
      *
      */
-    final SlotAndBlockHash bidValueKey =
-        new SlotAndBlockHash(bid.getSlot(), bid.getParentBlockHash());
+    final BidParent bidValueKey =
+        new BidParent(bid.getSlot(), bid.getParentBlockHash(), bid.getParentBlockRoot());
     final UInt64 existingBidValue = highestBids.getOrDefault(bidValueKey, UInt64.ZERO);
     if (!existingBidValue.isZero()) {
       final UInt64 minRequiredBid = calculateMinimumRequiredBid(existingBidValue);
@@ -202,7 +207,16 @@ public class ExecutionPayloadBidGossipValidator {
     }
 
     /*
-     * [IGNORE] bid.parent_block_root is the hash tree root of a known beacon block in fork choice.
+     * [IGNORE] The bid is compatible with the current head branch, i.e.
+     * is_bid_compatible_with_head(store, bid) returns True.
+     */
+    if (!gossipValidationHelper.isBidCompatibleWithHead(bid)) {
+      LOG.trace("Bid is not compatible with the current head branch");
+      return completedFuture(ignore("Bid is not compatible with the current head branch"));
+    }
+
+    /*
+     * Retrieve the bid's parent block slot for the remaining validation rules.
      */
     final Optional<UInt64> maybeParentBlockSlot =
         gossipValidationHelper.getSlotForBlockRoot(bid.getParentBlockRoot());
@@ -298,11 +312,13 @@ public class ExecutionPayloadBidGossipValidator {
 
               if (!seenExecutionPayloadBids
                   .computeIfAbsent(bid.getSlot(), __ -> ConcurrentHashMap.newKeySet())
-                  .add(bid.getBuilderIndex())) {
+                  .add(builderAndParent)) {
                 LOG.trace(
-                    "Another payload execution bid from Builder with index {} already processed while validating bid for slot {}",
+                    "Another payload execution bid from Builder with index {} already processed while validating bid for slot {}, parent hash {}, and parent root {}",
                     bid.getBuilderIndex(),
-                    bid.getSlot());
+                    bid.getSlot(),
+                    bid.getParentBlockHash(),
+                    bid.getParentBlockRoot());
                 return ignore(
                     "Another payload execution bid from Builder with index %s already processed while validating bid for slot %s",
                     bid.getBuilderIndex(), bid.getSlot());
@@ -431,5 +447,7 @@ public class ExecutionPayloadBidGossipValidator {
     return gasLimit.equals(minGasLimit);
   }
 
-  record SlotAndBlockHash(UInt64 slot, Bytes32 blockHash) {}
+  record BuilderAndParent(UInt64 builderIndex, Bytes32 parentBlockHash, Bytes32 parentBlockRoot) {}
+
+  record BidParent(UInt64 slot, Bytes32 parentBlockHash, Bytes32 parentBlockRoot) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -27,7 +27,10 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -39,6 +42,7 @@ import tech.pegasys.teku.spec.logic.common.util.AttestationValidationResult;
 import tech.pegasys.teku.spec.logic.common.util.DataColumnSidecarUtil;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.BeaconStateAccessorsGloas;
 import tech.pegasys.teku.spec.logic.versions.gloas.helpers.PredicatesGloas;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipValidationHelper {
@@ -301,6 +305,49 @@ public class GossipValidationHelper {
   public Optional<UInt64> getGasLimitForExecutionPayload(
       final Bytes32 blockRoot, final Bytes32 blockHash) {
     return recentChainData.getExecutionGasLimitForBlockRootAndHash(blockRoot, blockHash);
+  }
+
+  public boolean isBidCompatibleWithHead(final ExecutionPayloadBid bid) {
+    final Optional<ChainHead> maybeHead = recentChainData.getChainHead();
+    if (maybeHead.isEmpty()) {
+      return false;
+    }
+
+    final ChainHead head = maybeHead.get();
+    final ReadOnlyStore store = recentChainData.getStore();
+    final Optional<SignedBeaconBlock> maybeHeadBlock = store.getBlockIfAvailable(head.getRoot());
+    if (maybeHeadBlock.isEmpty()) {
+      return false;
+    }
+    final Optional<ExecutionPayloadBid> maybeHeadBid =
+        maybeHeadBlock
+            .get()
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .map(SignedExecutionPayloadBid::getMessage);
+    if (maybeHeadBid.isEmpty()) {
+      // A pre-Gloas head has no bid, so the first Gloas bid builds on its execution payload
+      return bid.getParentBlockRoot().equals(head.getRoot())
+          && bid.getParentBlockHash().equals(head.getExecutionBlockHash());
+    }
+
+    final ExecutionPayloadBid headBid = maybeHeadBid.get();
+    final boolean buildsOnParentBlock = bid.getParentBlockRoot().equals(head.getParentRoot());
+    final boolean buildsOnParentPayload =
+        bid.getParentBlockHash().equals(headBid.getParentBlockHash());
+    if (buildsOnParentBlock && buildsOnParentPayload) {
+      return true;
+    }
+    if (!bid.getParentBlockRoot().equals(head.getRoot())) {
+      return false;
+    }
+
+    final boolean buildsOnHeadPayload = bid.getParentBlockHash().equals(headBid.getBlockHash());
+    if (getForkChoiceStrategy().shouldBuildOnFull(store, bid.getSlot(), head.getForkChoiceNode())) {
+      return buildsOnHeadPayload;
+    }
+    return buildsOnParentPayload;
   }
 
   private static InternalValidationResult reject(final String reason) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
@@ -108,6 +108,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.isSlotCurrentOrNext(slot)).thenReturn(true);
     when(gossipValidationHelper.getGasLimitForExecutionPayload(parentBlockRoot, parentBlockHash))
         .thenReturn(Optional.of(bid.getGasLimit()));
+    when(gossipValidationHelper.isBidCompatibleWithHead(any())).thenReturn(true);
     when(gossipValidationHelper.getSlotForBlockRoot(parentBlockRoot))
         .thenReturn(Optional.of(slot.decrement()));
     when(gossipValidationHelper.getParentStateInBlockEpoch(slot.decrement(), parentBlockRoot, slot))
@@ -263,6 +264,46 @@ public class ExecutionPayloadBidGossipValidatorTest {
   }
 
   @TestTemplate
+  void shouldAcceptBidsFromSameBuilderForDifferentParentBlockRoots() {
+    assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(ACCEPT);
+
+    final SignedExecutionPayloadBid bidForDifferentParent =
+        signedBidForParent(
+            parentBlockHash, dataStructureUtil.randomBytes32(), builderIndex, bid.getValue());
+    mockBidValidation(bidForDifferentParent);
+
+    assertThatSafeFuture(bidValidator.validate(bidForDifferentParent)).isCompletedWithValue(ACCEPT);
+  }
+
+  @TestTemplate
+  void shouldAcceptBidsFromSameBuilderForDifferentParentBlockHashes() {
+    assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(ACCEPT);
+
+    final SignedExecutionPayloadBid bidForDifferentParent =
+        signedBidForParent(
+            dataStructureUtil.randomBytes32(), parentBlockRoot, builderIndex, bid.getValue());
+    mockBidValidation(bidForDifferentParent);
+
+    assertThatSafeFuture(bidValidator.validate(bidForDifferentParent)).isCompletedWithValue(ACCEPT);
+  }
+
+  @TestTemplate
+  void shouldTrackHighestBidsSeparatelyForDifferentParentBlockRoots() {
+    final UInt64 bidValue = UInt64.valueOf(1_000_000_000);
+    final SignedExecutionPayloadBid firstBid =
+        signedBidForParent(parentBlockHash, parentBlockRoot, builderIndex, bidValue);
+    final SignedExecutionPayloadBid bidForDifferentParentRoot =
+        signedBidForParent(
+            parentBlockHash, dataStructureUtil.randomBytes32(), builderIndex.plus(1), bidValue);
+    mockBidValidation(firstBid);
+    mockBidValidation(bidForDifferentParentRoot);
+
+    assertThatSafeFuture(bidValidator.validate(firstBid)).isCompletedWithValue(ACCEPT);
+    assertThatSafeFuture(bidValidator.validate(bidForDifferentParentRoot))
+        .isCompletedWithValue(ACCEPT);
+  }
+
+  @TestTemplate
   void shouldNotCacheHigherBidIfInvalid() {
     final UInt64 lowerValue = UInt64.valueOf(10_000);
     final SignedExecutionPayloadBid lowerValueBid = bidFromBuilder(builderIndex, lowerValue);
@@ -304,6 +345,14 @@ public class ExecutionPayloadBidGossipValidatorTest {
             saveForFuture(
                 "Gas limit for parent execution payload with block hash %s is unavailable. The bid will be saved for future processing",
                 parentBlockHash));
+  }
+
+  @TestTemplate
+  void shouldIgnore_whenBidIsNotCompatibleWithHead() {
+    when(gossipValidationHelper.isBidCompatibleWithHead(bid)).thenReturn(false);
+
+    assertThatSafeFuture(bidValidator.validate(signedBid))
+        .isCompletedWithValue(ignore("Bid is not compatible with the current head branch"));
   }
 
   @TestTemplate
@@ -467,39 +516,24 @@ public class ExecutionPayloadBidGossipValidatorTest {
     for (int i = 0; i < MAX_SLOTS_TO_TRACK_BUILDERS_BIDS + 1; i++) {
       final UInt64 bidValue = UInt64.valueOf(1000 + i);
       final SignedExecutionPayloadBid bid =
-          dataStructureUtil.randomSignedExecutionPayloadBid(
-              dataStructureUtil.randomExecutionPayloadBid(
-                  dataStructureUtil.randomBytes32(),
-                  startSlot.plus(i),
-                  sameBuilder,
-                  bidValue,
-                  UInt64.ZERO));
+          signedBidForParent(
+              parentBlockHash, parentBlockRoot, startSlot.plus(i), sameBuilder, bidValue);
       mockBidValidation(bid, sameBuilder, bidValue);
       assertThatSafeFuture(bidValidator.validate(bid)).isCompletedWithValue(ACCEPT);
     }
 
     // Submit another bid for slot 100 which has been evicted and should be accepted
     final SignedExecutionPayloadBid bidForEvictedSlot =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                dataStructureUtil.randomBytes32(),
-                startSlot,
-                sameBuilder,
-                UInt64.valueOf(2000),
-                UInt64.ZERO));
+        signedBidForParent(
+            parentBlockHash, parentBlockRoot, startSlot, sameBuilder, UInt64.valueOf(2000));
     mockBidValidation(bidForEvictedSlot, sameBuilder, UInt64.valueOf(2000));
     assertThatSafeFuture(bidValidator.validate(bidForEvictedSlot)).isCompletedWithValue(ACCEPT);
 
     // Submit another bid for most recent slot which is still in cache and should be ignored
     final UInt64 cachedSlot = startSlot.plus(MAX_SLOTS_TO_TRACK_BUILDERS_BIDS);
     final SignedExecutionPayloadBid bidForCachedSlot =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                dataStructureUtil.randomBytes32(),
-                cachedSlot,
-                sameBuilder,
-                UInt64.valueOf(3000),
-                UInt64.ZERO));
+        signedBidForParent(
+            parentBlockHash, parentBlockRoot, cachedSlot, sameBuilder, UInt64.valueOf(3000));
     mockBidValidation(bidForCachedSlot, sameBuilder, UInt64.valueOf(3000));
     assertThatSafeFuture(bidValidator.validate(bidForCachedSlot))
         .isCompletedWithValue(
@@ -513,9 +547,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     // First bid with known value
     final UInt64 firstBidValue = UInt64.valueOf(10000);
     final SignedExecutionPayloadBid firstBid =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                parentBlockHash, slot, builderIndex, firstBidValue, UInt64.ZERO));
+        signedBidForParent(parentBlockHash, parentBlockRoot, builderIndex, firstBidValue);
     mockBidValidation(firstBid, builderIndex, firstBidValue);
     assertThatSafeFuture(bidValidator.validate(firstBid)).isCompletedWithValue(ACCEPT);
 
@@ -524,9 +556,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
         firstBidValue.times(100 + MIN_BID_INCREMENT_PERCENTAGE).dividedBy(100);
     final UInt64 differentBuilderIndex = builderIndex.plus(1);
     final SignedExecutionPayloadBid secondBid =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                parentBlockHash, slot, differentBuilderIndex, secondBidValue, UInt64.ZERO));
+        signedBidForParent(parentBlockHash, parentBlockRoot, differentBuilderIndex, secondBidValue);
 
     mockBidValidation(secondBid, differentBuilderIndex, secondBidValue);
     assertThatSafeFuture(bidValidator.validate(secondBid)).isCompletedWithValue(ACCEPT);
@@ -537,9 +567,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     // First bid with known value
     final UInt64 firstBidValue = UInt64.valueOf(1_000_000_000);
     final SignedExecutionPayloadBid firstBid =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                parentBlockHash, slot, builderIndex, firstBidValue, UInt64.ZERO));
+        signedBidForParent(parentBlockHash, parentBlockRoot, builderIndex, firstBidValue);
     mockBidValidation(firstBid, builderIndex, firstBidValue);
     assertThatSafeFuture(bidValidator.validate(firstBid)).isCompletedWithValue(ACCEPT);
 
@@ -548,9 +576,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
         firstBidValue.times(200 + MIN_BID_INCREMENT_PERCENTAGE).dividedBy(200);
     final UInt64 differentBuilderIndex = builderIndex.plus(1);
     final SignedExecutionPayloadBid secondBid =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                parentBlockHash, slot, differentBuilderIndex, secondBidValue, UInt64.ZERO));
+        signedBidForParent(parentBlockHash, parentBlockRoot, differentBuilderIndex, secondBidValue);
 
     final UInt64 minIncrement = firstBidValue.times(MIN_BID_INCREMENT_PERCENTAGE).dividedBy(100);
     final UInt64 minRequiredBid = firstBidValue.plus(minIncrement);
@@ -571,9 +597,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     // First bid with known value
     final UInt64 firstBidValue = UInt64.valueOf(10000);
     final SignedExecutionPayloadBid firstBid =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                parentBlockHash, slot, builderIndex, firstBidValue, UInt64.ZERO));
+        signedBidForParent(parentBlockHash, parentBlockRoot, builderIndex, firstBidValue);
     mockBidValidation(firstBid, builderIndex, firstBidValue);
     assertThatSafeFuture(bidValidator.validate(firstBid)).isCompletedWithValue(ACCEPT);
 
@@ -582,9 +606,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
         firstBidValue.times(100 + (5 * MIN_BID_INCREMENT_PERCENTAGE)).dividedBy(100);
     final UInt64 differentBuilderIndex = builderIndex.plus(1);
     final SignedExecutionPayloadBid secondBid =
-        dataStructureUtil.randomSignedExecutionPayloadBid(
-            dataStructureUtil.randomExecutionPayloadBid(
-                parentBlockHash, slot, differentBuilderIndex, secondBidValue, UInt64.ZERO));
+        signedBidForParent(parentBlockHash, parentBlockRoot, differentBuilderIndex, secondBidValue);
 
     mockBidValidation(secondBid, differentBuilderIndex, secondBidValue);
     assertThatSafeFuture(bidValidator.validate(secondBid)).isCompletedWithValue(ACCEPT);
@@ -622,9 +644,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
   private SignedExecutionPayloadBid bidFromBuilder(
       final UInt64 builderIndex, final UInt64 bidValue) {
-    return dataStructureUtil.randomSignedExecutionPayloadBid(
-        dataStructureUtil.randomExecutionPayloadBid(
-            parentBlockHash, slot, builderIndex, bidValue, UInt64.ZERO));
+    return signedBidForParent(parentBlockHash, parentBlockRoot, builderIndex, bidValue);
   }
 
   private SignedExecutionPayloadBid signedBidWithGasLimit(final UInt64 gasLimit) {
@@ -644,6 +664,38 @@ public class ExecutionPayloadBidGossipValidatorTest {
                 bid.getBlobKzgCommitments(),
                 bid.getExecutionRequestsRoot());
     return dataStructureUtil.randomSignedExecutionPayloadBid(bidWithGasLimit);
+  }
+
+  private SignedExecutionPayloadBid signedBidForParent(
+      final Bytes32 parentHash,
+      final Bytes32 parentRoot,
+      final UInt64 builderIndex,
+      final UInt64 value) {
+    return signedBidForParent(parentHash, parentRoot, bid.getSlot(), builderIndex, value);
+  }
+
+  private SignedExecutionPayloadBid signedBidForParent(
+      final Bytes32 parentHash,
+      final Bytes32 parentRoot,
+      final UInt64 slot,
+      final UInt64 builderIndex,
+      final UInt64 value) {
+    final ExecutionPayloadBid bidForParent =
+        bid.getSchema()
+            .create(
+                parentHash,
+                parentRoot,
+                bid.getBlockHash(),
+                bid.getPrevRandao(),
+                bid.getFeeRecipient(),
+                bid.getGasLimit(),
+                builderIndex,
+                slot,
+                value,
+                bid.getExecutionPayment(),
+                bid.getBlobKzgCommitments(),
+                bid.getExecutionRequestsRoot());
+    return dataStructureUtil.randomSignedExecutionPayloadBid(bidForParent);
   }
 
   private void mockProposerPreferences(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelperTest.java
@@ -42,17 +42,22 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.ExecutionPayloadBid;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.fulu.BeaconStateSchemaFulu;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.datastructures.state.versions.gloas.Builder;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.ChainUpdater;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -336,6 +341,137 @@ public class GossipValidationHelperTest {
   }
 
   @TestTemplate
+  void isBidCompatibleWithHead_shouldAcceptBidBuildingOnHeadParent(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final BidCompatibility bidCompatibility = createBidCompatibility();
+    final ExecutionPayloadBid bid =
+        createBidForParent(
+            bidCompatibility.headBid(),
+            bidCompatibility.headBid().getParentBlockHash(),
+            bidCompatibility.headBlock().getParentRoot(),
+            bidCompatibility.headBlock().getSlot());
+
+    assertThat(bidCompatibility.helper().isBidCompatibleWithHead(bid)).isTrue();
+  }
+
+  @TestTemplate
+  void isBidCompatibleWithHead_shouldAcceptBidBuildingOnFullHead(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final BidCompatibility bidCompatibility = createBidCompatibility();
+    final UInt64 bidSlot = bidCompatibility.headBlock().getSlot().plus(ONE);
+    final ExecutionPayloadBid bid =
+        createBidForParent(
+            bidCompatibility.headBid(),
+            bidCompatibility.headBid().getBlockHash(),
+            bidCompatibility.headBlock().getRoot(),
+            bidSlot);
+    when(bidCompatibility
+            .strategy()
+            .shouldBuildOnFull(bidCompatibility.store(), bidSlot, bidCompatibility.headNode()))
+        .thenReturn(true);
+
+    assertThat(bidCompatibility.helper().isBidCompatibleWithHead(bid)).isTrue();
+  }
+
+  @TestTemplate
+  void isBidCompatibleWithHead_shouldAcceptBidBuildingOnEmptyHead(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final BidCompatibility bidCompatibility = createBidCompatibility();
+    final UInt64 bidSlot = bidCompatibility.headBlock().getSlot().plus(ONE);
+    final ExecutionPayloadBid bid =
+        createBidForParent(
+            bidCompatibility.headBid(),
+            bidCompatibility.headBid().getParentBlockHash(),
+            bidCompatibility.headBlock().getRoot(),
+            bidSlot);
+
+    assertThat(bidCompatibility.helper().isBidCompatibleWithHead(bid)).isTrue();
+  }
+
+  @TestTemplate
+  void isBidCompatibleWithHead_shouldRejectWrongPayloadForFullHead(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final BidCompatibility bidCompatibility = createBidCompatibility();
+    final UInt64 bidSlot = bidCompatibility.headBlock().getSlot().plus(ONE);
+    final ExecutionPayloadBid bid =
+        createBidForParent(
+            bidCompatibility.headBid(),
+            bidCompatibility.headBid().getParentBlockHash(),
+            bidCompatibility.headBlock().getRoot(),
+            bidSlot);
+    when(bidCompatibility
+            .strategy()
+            .shouldBuildOnFull(bidCompatibility.store(), bidSlot, bidCompatibility.headNode()))
+        .thenReturn(true);
+
+    assertThat(bidCompatibility.helper().isBidCompatibleWithHead(bid)).isFalse();
+  }
+
+  @TestTemplate
+  void isBidCompatibleWithHead_shouldRejectBidForUnrelatedBlock(final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final BidCompatibility bidCompatibility = createBidCompatibility();
+    final ExecutionPayloadBid bid =
+        createBidForParent(
+            bidCompatibility.headBid(),
+            bidCompatibility.headBid().getParentBlockHash(),
+            dataStructureUtil.randomBytes32(),
+            bidCompatibility.headBlock().getSlot().plus(ONE));
+
+    assertThat(bidCompatibility.helper().isBidCompatibleWithHead(bid)).isFalse();
+  }
+
+  @TestTemplate
+  void isBidCompatibleWithHead_shouldRejectWhenHeadBlockIsUnavailable(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final BidCompatibility bidCompatibility = createBidCompatibility();
+    final ExecutionPayloadBid bid =
+        createBidForParent(
+            bidCompatibility.headBid(),
+            bidCompatibility.headBid().getBlockHash(),
+            bidCompatibility.headBlock().getRoot(),
+            bidCompatibility.headBlock().getSlot().plus(ONE));
+    when(bidCompatibility.store().getBlockIfAvailable(bidCompatibility.headBlock().getRoot()))
+        .thenReturn(Optional.empty());
+
+    assertThat(bidCompatibility.helper().isBidCompatibleWithHead(bid)).isFalse();
+  }
+
+  @TestTemplate
+  void isBidCompatibleWithHead_shouldUseExecutionHashForPreGloasHead(
+      final SpecContext specContext) {
+    specContext.assumeGloasActive();
+    final Spec forkTransitionSpec = TestSpecFactory.createMinimalWithGloasForkEpoch(ONE);
+    final UInt64 firstGloasSlot = forkTransitionSpec.computeStartSlotAtEpoch(ONE);
+    final SignedBeaconBlock preGloasHead =
+        new DataStructureUtil(forkTransitionSpec)
+            .randomSignedBeaconBlock(firstGloasSlot.minus(ONE));
+    final Bytes32 executionBlockHash = dataStructureUtil.randomBytes32();
+    final ExecutionPayloadBid template = dataStructureUtil.randomExecutionPayloadBid();
+    final ExecutionPayloadBid compatibleBid =
+        createBidForParent(template, executionBlockHash, preGloasHead.getRoot(), firstGloasSlot);
+    final ExecutionPayloadBid incompatibleBid =
+        createBidForParent(
+            template, dataStructureUtil.randomBytes32(), preGloasHead.getRoot(), firstGloasSlot);
+
+    final ChainHead chainHead = mock(ChainHead.class);
+    final RecentChainData recentChainData = mock(RecentChainData.class);
+    final UpdatableStore store = mock(UpdatableStore.class);
+    when(chainHead.getRoot()).thenReturn(preGloasHead.getRoot());
+    when(chainHead.getExecutionBlockHash()).thenReturn(executionBlockHash);
+    when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(recentChainData.getStore()).thenReturn(store);
+    when(store.getBlockIfAvailable(preGloasHead.getRoot())).thenReturn(Optional.of(preGloasHead));
+    final GossipValidationHelper helper =
+        new GossipValidationHelper(
+            forkTransitionSpec, recentChainData, storageSystem.getMetricsSystem());
+
+    assertThat(helper.isBidCompatibleWithHead(compatibleBid)).isTrue();
+    assertThat(helper.isBidCompatibleWithHead(incompatibleBid)).isFalse();
+  }
+
+  @TestTemplate
   void getParentStateInBlockEpoch_shouldComputeCorrectly() {
     final UInt64 firstSlotAtEpoch1 = spec.computeStartSlotAtEpoch(ONE);
 
@@ -603,4 +739,61 @@ public class GossipValidationHelperTest {
         new GossipValidationHelper(spec, recentChainDataMock, storageSystem.getMetricsSystem());
     assertThat(gossipValidationHelperMocked.isSlotCurrent(slot)).isEqualTo(expectedResult);
   }
+
+  private BidCompatibility createBidCompatibility() {
+    final SignedBeaconBlock headBlock = dataStructureUtil.randomSignedBeaconBlock(UInt64.ONE);
+    final ExecutionPayloadBid headBid =
+        headBlock
+            .getMessage()
+            .getBody()
+            .getOptionalSignedExecutionPayloadBid()
+            .orElseThrow()
+            .getMessage();
+    final ForkChoiceNode headNode = ForkChoiceNode.createFull(headBlock.getRoot());
+    final ChainHead chainHead = mock(ChainHead.class);
+    final RecentChainData recentChainData = mock(RecentChainData.class);
+    final UpdatableStore store = mock(UpdatableStore.class);
+    final ReadOnlyForkChoiceStrategy strategy = mock(ReadOnlyForkChoiceStrategy.class);
+    when(chainHead.getRoot()).thenReturn(headBlock.getRoot());
+    when(chainHead.getParentRoot()).thenReturn(headBlock.getParentRoot());
+    when(chainHead.getExecutionBlockHash()).thenReturn(headBid.getBlockHash());
+    when(chainHead.getForkChoiceNode()).thenReturn(headNode);
+    when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(recentChainData.getStore()).thenReturn(store);
+    when(recentChainData.getForkChoiceStrategy()).thenReturn(Optional.of(strategy));
+    when(store.getBlockIfAvailable(headBlock.getRoot())).thenReturn(Optional.of(headBlock));
+    final GossipValidationHelper helper =
+        new GossipValidationHelper(spec, recentChainData, storageSystem.getMetricsSystem());
+    return new BidCompatibility(helper, store, strategy, headNode, headBlock, headBid);
+  }
+
+  private ExecutionPayloadBid createBidForParent(
+      final ExecutionPayloadBid template,
+      final Bytes32 parentBlockHash,
+      final Bytes32 parentBlockRoot,
+      final UInt64 slot) {
+    return template
+        .getSchema()
+        .create(
+            parentBlockHash,
+            parentBlockRoot,
+            template.getBlockHash(),
+            template.getPrevRandao(),
+            template.getFeeRecipient(),
+            template.getGasLimit(),
+            template.getBuilderIndex(),
+            slot,
+            template.getValue(),
+            template.getExecutionPayment(),
+            template.getBlobKzgCommitments(),
+            template.getExecutionRequestsRoot());
+  }
+
+  private record BidCompatibility(
+      GossipValidationHelper helper,
+      UpdatableStore store,
+      ReadOnlyForkChoiceStrategy strategy,
+      ForkChoiceNode headNode,
+      SignedBeaconBlock headBlock,
+      ExecutionPayloadBid headBid) {}
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModel.java
@@ -128,7 +128,7 @@ interface ForkChoiceModel {
   boolean shouldBuildOnFull(
       ProtoArray protoArray,
       BlockNodeVariantsIndex blockNodeIndex,
-      UInt64 currentSlot,
+      UInt64 slot,
       ForkChoiceNode head);
 
   /**

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
@@ -637,7 +637,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   /**
-   * Spec mapping: `should_build_on_full(store, head)`.
+   * Spec mapping: `should_build_on_full(store, head, slot)`.
    *
    * <p>The proposer calls this after fork choice has selected a non-pending head, before choosing
    * whether block production should use the parent's FULL payload variant or reorg to its EMPTY
@@ -653,7 +653,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   public boolean shouldBuildOnFull(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
-      final UInt64 currentSlot,
+      final UInt64 slot,
       final ForkChoiceNode head) {
     checkArgument(
         head.payloadStatus() != ForkChoicePayloadStatus.PAYLOAD_STATUS_PENDING,
@@ -673,7 +673,7 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
         .orElse(true)) {
       return false;
     }
-    if (!headIsFromPreviousSlot(head, protoArray, currentSlot)) {
+    if (!headIsFromPreviousSlot(head, protoArray, slot)) {
       return true;
     }
     if (payloadDataAvailability(headNodeVariants.get(), false)) {
@@ -686,11 +686,11 @@ class ForkChoiceModelGloas implements ForkChoiceModel {
   }
 
   private boolean headIsFromPreviousSlot(
-      final ForkChoiceNode head, final ProtoArray protoArray, final UInt64 currentSlot) {
+      final ForkChoiceNode head, final ProtoArray protoArray, final UInt64 slot) {
     return protoArray
         .getNode(head)
         .map(ProtoNode::getBlockSlot)
-        .map(blockSlot -> blockSlot.plus(1).equals(currentSlot))
+        .map(blockSlot -> blockSlot.plus(1).equals(slot))
         .orElse(false);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelPhase0.java
@@ -172,7 +172,7 @@ class ForkChoiceModelPhase0 implements ForkChoiceModel {
   public boolean shouldBuildOnFull(
       final ProtoArray protoArray,
       final BlockNodeVariantsIndex blockNodeIndex,
-      final UInt64 currentSlot,
+      final UInt64 slot,
       final ForkChoiceNode head) {
     return false;
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -491,11 +491,10 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
 
   @Override
   public boolean shouldBuildOnFull(
-      final ReadOnlyStore store, final UInt64 currentSlot, final ForkChoiceNode head) {
+      final ReadOnlyStore store, final UInt64 slot, final ForkChoiceNode head) {
     protoArrayLock.readLock().lock();
     try {
-      return getForkChoiceModel(currentSlot)
-          .shouldBuildOnFull(protoArray, blockNodeIndex, currentSlot, head);
+      return getForkChoiceModel(slot).shouldBuildOnFull(protoArray, blockNodeIndex, slot, head);
     } finally {
       protoArrayLock.readLock().unlock();
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -1397,10 +1397,8 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   private boolean shouldBuildOnFull(
-      final GloasPayloadDecisionFixture fixture,
-      final UInt64 currentSlot,
-      final ForkChoiceNode head) {
-    return fixture.strategy().shouldBuildOnFull(fixture.store(), currentSlot, head);
+      final GloasPayloadDecisionFixture fixture, final UInt64 slot, final ForkChoiceNode head) {
+    return fixture.strategy().shouldBuildOnFull(fixture.store(), slot, head);
   }
 
   private IntSet ptcPositions(final int count) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Allow builders to bid on multiple branches

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #11019 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which execution payload bids are gossiped and cached during forks; incorrect head-compatibility logic could drop valid bids or accept bids on stale branches.
> 
> **Overview**
> **Execution payload bid gossip** now treats each branch separately: deduplication and highest-bid tracking use **(slot, parent_block_hash, parent_block_root)** (and builder + parents for “already seen”), so the same builder can bid on different forks without one branch blocking another.
> 
> Adds **`GossipValidationHelper.isBidCompatibleWithHead`**, wired into **`ExecutionPayloadBidGossipValidator`**, so bids that do not extend the current head’s beacon/payload lineage (including Gloas **FULL vs EMPTY** via **`shouldBuildOnFull(store, bid.slot, head)`**) are **ignored** instead of accepted.
> 
> Renames **`shouldBuildOnFull`**’s slot parameter from `currentSlot` to **`slot`** across fork-choice APIs/implementations so compatibility checks use the **bid slot**, not an ambiguous “current” slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db530dad6138700225953ec4bfae707c2ae7d40d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->