### PR TITLE
increased cache size to a more reasonable size for current mainnet state

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -36,7 +36,7 @@ public class StorageConfiguration {
   public static final boolean DEFAULT_ROCKSDB_BLOB_DB_ENABLED = false;
   public static final int DEFAULT_STATE_REBUILD_TIMEOUT_SECONDS = 120;
   public static final long DEFAULT_STORAGE_FREQUENCY = 2048L;
-  public static final int DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE = 100_000;
+  public static final int DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE = 5_000_000;
   public static final Duration DEFAULT_BLOCK_PRUNING_INTERVAL = Duration.ofMinutes(15);
   public static final int DEFAULT_BLOCK_PRUNING_LIMIT = 5000;
   public static final Duration DEFAULT_BLOBS_PRUNING_INTERVAL = Duration.ofMinutes(1);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -187,8 +187,9 @@ public class KvStoreDatabase implements Database {
       final boolean storeNonCanonicalBlocks,
       final int maxKnownNodeCacheSize,
       final Spec spec) {
-    final V4FinalizedStateStorageLogic<SchemaCombinedTreeState> finalizedStateStorageLogic =
+    final V4FinalizedStateTreeStorageLogic finalizedStateStorageLogic =
         new V4FinalizedStateTreeStorageLogic(metricsSystem, spec, maxKnownNodeCacheSize);
+    finalizedStateStorageLogic.populateCacheFromExistingDb(db, schema);
     return create(
         db,
         schema,

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
@@ -67,6 +67,20 @@ public class V4FinalizedStateTreeStorageLogic
             "Number of finalized states stored");
   }
 
+  public void populateCacheFromExistingDb(
+      final KvStoreAccessor db, final SchemaCombinedTreeState schema) {
+    LOG.info("Rebuilding finalized state branch node cache from existing database...");
+    final long startMs = System.currentTimeMillis();
+    try (final Stream<Bytes32> keys =
+        db.streamKeys(schema.getColumnFinalizedStateMerkleTreeBranches())) {
+      keys.forEach(knownStoredBranchesCache::add);
+    }
+    LOG.info(
+        "Rebuilt finalized state branch cache with {} entries in {}ms",
+        knownStoredBranchesCache.size(),
+        System.currentTimeMillis() - startMs);
+  }
+
   @Override
   public Optional<BeaconState> getLatestAvailableFinalizedState(
       final KvStoreAccessor db, final SchemaCombinedTreeState dbSchema, final UInt64 maxSlot) {
@@ -150,10 +164,11 @@ public class V4FinalizedStateTreeStorageLogic
               state.getBackingNode());
       statesStored++;
       LOG.debug(
-          "Wrote finalized state delta slot={} root={} branchNodes={} leafNodes={}",
+          "Wrote finalized state delta slot={} root={} branchNodes={} skipped={} leafNodes={}",
           state.getSlot(),
           state.hashTreeRoot(),
           nodeStore.getStoredBranchNodeCount() - branchesBefore,
+          nodeStore.getSkippedBranchNodeCount(),
           nodeStore.getStoredLeafNodeCount() - leavesBefore);
     }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -656,7 +656,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .dataStorageMode(PRUNE)
                     .dataStorageFrequency(StorageConfiguration.DEFAULT_STORAGE_FREQUENCY)
                     .dataStorageCreateDbVersion(DatabaseVersion.DEFAULT_VERSION)
-                    .maxKnownNodeCacheSize(100_000))
+                    .maxKnownNodeCacheSize(StorageConfiguration.DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE))
         .data(b -> b.dataBasePath(dataPath))
         .p2p(
             b ->


### PR DESCRIPTION
Also warm cache on startup so that it doesnt take several epochs to warm the cache.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes finalized-state storage caching and default memory footprint on startup; behavior is performance-oriented but touches hot finalized DB paths.
> 
> **Overview**
> Raises the default **max known node cache** from 100k to **5M** so the finalized beacon state Merkle branch cache can cover mainnet-scale state trees without constant eviction.
> 
> On database open, **`populateCacheFromExistingDb`** now scans existing finalized state branch keys in RocksDB and pre-fills `knownStoredBranchesCache`, so the node does not need several epochs of finalization to rebuild cache effectiveness after restart.
> 
> Startup logs report cache size and rebuild duration; finalized state write debug logging also includes **skipped** branch node counts. CLI test expectations use `StorageConfiguration.DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE` instead of a hardcoded value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee40da802c652bd81e0c5394e0cfb623b9b0db48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->