### PR TITLE
Update ethspecify version

### DIFF
--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -14,6 +14,10 @@ specrefs:
     - presets.yml
 
   exceptions:
+    configs:
+      # Not implemented: heze
+      - MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS#heze
+
     constants:
       # Not defined as a constant, unnecessary
       - BASIS_POINTS#phase0
@@ -24,18 +28,8 @@ specrefs:
       # No light client support
       - MAX_REQUEST_LIGHT_CLIENT_UPDATES
 
-      # Constants in the KZG library
-      - BYTES_PER_COMMITMENT
-      - BYTES_PER_PROOF
-      - FIAT_SHAMIR_PROTOCOL_DOMAIN
-      - G1_POINT_AT_INFINITY
+      # Constant in the KZG library
       - G2_POINT_AT_INFINITY
-      - KZG_ENDIANNESS
-      - KZG_SETUP_G2_LENGTH
-      - KZG_SETUP_G2_MONOMIAL
-      - PRIMITIVE_ROOT_OF_UNITY
-      - RANDOM_CHALLENGE_KZG_BATCH_DOMAIN
-      - RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN
 
       # Not defined, implemented differently
       - PTC_TIMELINESS_INDEX#gloas
@@ -95,59 +89,6 @@ specrefs:
 
       # Will not implement: Deprecated
       - get_pow_block_at_terminal_total_difficulty#bellatrix
-
-      # Functions implemented by KZG library for EIP-4844
-      - bit_reversal_permutation#deneb
-      - blob_to_kzg_commitment#deneb
-      - blob_to_polynomial#deneb
-      - bls_field_to_bytes#deneb
-      - bytes_to_bls_field#deneb
-      - bytes_to_kzg_commitment#deneb
-      - bytes_to_kzg_proof#deneb
-      - compute_blob_kzg_proof#deneb
-      - compute_challenge#deneb
-      - compute_kzg_proof#deneb
-      - compute_kzg_proof_impl#deneb
-      - compute_powers#deneb
-      - compute_quotient_eval_within_domain#deneb
-      - compute_roots_of_unity#deneb
-      - evaluate_polynomial_in_evaluation_form#deneb
-      - g1_lincomb#deneb
-      - hash_to_bls_field#deneb
-      - is_power_of_two#deneb
-      - reverse_bits#deneb
-      - validate_kzg_g1#deneb
-      - verify_blob_kzg_proof#deneb
-      - verify_blob_kzg_proof_batch#deneb
-      - verify_kzg_proof#deneb
-      - verify_kzg_proof_batch#deneb
-      - verify_kzg_proof_impl#deneb
-
-      # Functions implemented by KZG library for EIP-7594
-      - _fft_field#fulu
-      - add_polynomialcoeff#fulu
-      - cell_to_coset_evals#fulu
-      - compute_cells#fulu
-      - compute_cells_and_kzg_proofs#fulu
-      - compute_cells_and_kzg_proofs_polynomialcoeff#fulu
-      - compute_kzg_proof_multi_impl#fulu
-      - compute_verify_cell_kzg_proof_batch_challenge#fulu
-      - construct_vanishing_polynomial#fulu
-      - coset_evals_to_cell#fulu
-      - coset_fft_field#fulu
-      - coset_for_cell#fulu
-      - coset_shift_for_cell#fulu
-      - divide_polynomialcoeff#fulu
-      - evaluate_polynomialcoeff#fulu
-      - fft_field#fulu
-      - interpolate_polynomialcoeff#fulu
-      - multiply_polynomialcoeff#fulu
-      - polynomial_eval_to_coeff#fulu
-      - recover_cells_and_kzg_proofs#fulu
-      - recover_polynomialcoeff#fulu
-      - vanishing_polynomialcoeff#fulu
-      - verify_cell_kzg_proof_batch#fulu
-      - verify_cell_kzg_proof_batch_impl#fulu
 
       # No light client support
       - apply_light_client_update
@@ -216,6 +157,8 @@ specrefs:
 
       # Not implemented: gloas
       - get_proposer_head#gloas
+      - is_bid_compatible_with_head#gloas
+      - is_valid_dependent_root#gloas
 
       # Not implemented yet: EIP-7688 progressive SSZ transition
       - upgrade_attestation_to_gloas#gloas

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -3,8 +3,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "AGGREGATE_DUE_BPS:"
   spec: |
-    <spec config_var="AGGREGATE_DUE_BPS" fork="phase0" hash="7eaa811a">
-    AGGREGATE_DUE_BPS: uint64 = 6667
+    <spec config_var="AGGREGATE_DUE_BPS" fork="phase0" hash="84cdd00d">
+    AGGREGATE_DUE_BPS: Uint64 = 6667
     </spec>
 
 - name: AGGREGATE_DUE_BPS_GLOAS#gloas
@@ -12,8 +12,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "AGGREGATE_DUE_BPS_GLOAS:"
   spec: |
-    <spec config_var="AGGREGATE_DUE_BPS_GLOAS" fork="gloas" hash="34aa3164">
-    AGGREGATE_DUE_BPS_GLOAS: uint64 = 5000
+    <spec config_var="AGGREGATE_DUE_BPS_GLOAS" fork="gloas" hash="fd72ee55">
+    AGGREGATE_DUE_BPS_GLOAS: Uint64 = 5000
     </spec>
 
 - name: ALTAIR_FORK_EPOCH#altair
@@ -40,8 +40,8 @@
       search: "^ATTESTATION_DUE_BPS:"
       regex: true
   spec: |
-    <spec config_var="ATTESTATION_DUE_BPS" fork="phase0" hash="929dd1c9">
-    ATTESTATION_DUE_BPS: uint64 = 3333
+    <spec config_var="ATTESTATION_DUE_BPS" fork="phase0" hash="8d6a7c50">
+    ATTESTATION_DUE_BPS: Uint64 = 3333
     </spec>
 
 - name: ATTESTATION_DUE_BPS_GLOAS#gloas
@@ -49,8 +49,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_DUE_BPS_GLOAS:"
   spec: |
-    <spec config_var="ATTESTATION_DUE_BPS_GLOAS" fork="gloas" hash="3863c1ef">
-    ATTESTATION_DUE_BPS_GLOAS: uint64 = 2500
+    <spec config_var="ATTESTATION_DUE_BPS_GLOAS" fork="gloas" hash="c1414076">
+    ATTESTATION_DUE_BPS_GLOAS: Uint64 = 2500
     </spec>
 
 - name: ATTESTATION_PROPAGATION_SLOT_RANGE#phase0
@@ -58,8 +58,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_PROPAGATION_SLOT_RANGE:"
   spec: |
-    <spec config_var="ATTESTATION_PROPAGATION_SLOT_RANGE" fork="phase0" hash="40bcdb02">
-    ATTESTATION_PROPAGATION_SLOT_RANGE = 32
+    <spec config_var="ATTESTATION_PROPAGATION_SLOT_RANGE" fork="phase0" hash="3b24805b">
+    ATTESTATION_PROPAGATION_SLOT_RANGE: Slot = 32
     </spec>
 
 - name: ATTESTATION_SUBNET_COUNT#phase0
@@ -67,8 +67,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_SUBNET_COUNT:"
   spec: |
-    <spec config_var="ATTESTATION_SUBNET_COUNT" fork="phase0" hash="1c8c0a1b">
-    ATTESTATION_SUBNET_COUNT = 64
+    <spec config_var="ATTESTATION_SUBNET_COUNT" fork="phase0" hash="0bf2c282">
+    ATTESTATION_SUBNET_COUNT: Uint64 = 64
     </spec>
 
 - name: ATTESTATION_SUBNET_EXTRA_BITS#phase0
@@ -76,8 +76,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ATTESTATION_SUBNET_EXTRA_BITS:"
   spec: |
-    <spec config_var="ATTESTATION_SUBNET_EXTRA_BITS" fork="phase0" hash="e233b5ba">
-    ATTESTATION_SUBNET_EXTRA_BITS = 0
+    <spec config_var="ATTESTATION_SUBNET_EXTRA_BITS" fork="phase0" hash="c6453717">
+    ATTESTATION_SUBNET_EXTRA_BITS: Uint64 = 0
     </spec>
 
 - name: BALANCE_PER_ADDITIONAL_CUSTODY_GROUP#fulu
@@ -130,8 +130,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BLOB_SIDECAR_SUBNET_COUNT:"
   spec: |
-    <spec config_var="BLOB_SIDECAR_SUBNET_COUNT" fork="deneb" hash="03cc9976">
-    BLOB_SIDECAR_SUBNET_COUNT = 6
+    <spec config_var="BLOB_SIDECAR_SUBNET_COUNT" fork="deneb" hash="b0065991">
+    BLOB_SIDECAR_SUBNET_COUNT: Uint64 = 6
     </spec>
 
 - name: BLOB_SIDECAR_SUBNET_COUNT_ELECTRA#electra
@@ -139,8 +139,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "BLOB_SIDECAR_SUBNET_COUNT_ELECTRA:"
   spec: |
-    <spec config_var="BLOB_SIDECAR_SUBNET_COUNT_ELECTRA" fork="electra" hash="37ca2860">
-    BLOB_SIDECAR_SUBNET_COUNT_ELECTRA = 9
+    <spec config_var="BLOB_SIDECAR_SUBNET_COUNT_ELECTRA" fork="electra" hash="28e0f7b4">
+    BLOB_SIDECAR_SUBNET_COUNT_ELECTRA: Uint64 = 9
     </spec>
 
 - name: CAPELLA_FORK_EPOCH#capella
@@ -167,8 +167,8 @@
       search: "^CHURN_LIMIT_QUOTIENT:"
       regex: true
   spec: |
-    <spec config_var="CHURN_LIMIT_QUOTIENT" fork="phase0" hash="a43a1d33">
-    CHURN_LIMIT_QUOTIENT: uint64 = 65536
+    <spec config_var="CHURN_LIMIT_QUOTIENT" fork="phase0" hash="72355a28">
+    CHURN_LIMIT_QUOTIENT: Uint64 = 65536
     </spec>
 
 - name: CHURN_LIMIT_QUOTIENT_GLOAS#gloas
@@ -176,8 +176,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CHURN_LIMIT_QUOTIENT_GLOAS:"
   spec: |
-    <spec config_var="CHURN_LIMIT_QUOTIENT_GLOAS" fork="gloas" hash="fe8d5d9f">
-    CHURN_LIMIT_QUOTIENT_GLOAS: uint64 = 32768
+    <spec config_var="CHURN_LIMIT_QUOTIENT_GLOAS" fork="gloas" hash="8251a638">
+    CHURN_LIMIT_QUOTIENT_GLOAS: Uint64 = 32768
     </spec>
 
 - name: CONFIRMATION_BYZANTINE_THRESHOLD#phase0
@@ -185,8 +185,8 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
       search: CONFIRMATION_BYZANTINE_THRESHOLD =
   spec: |
-    <spec config_var="CONFIRMATION_BYZANTINE_THRESHOLD" fork="phase0" hash="60de2e33">
-    CONFIRMATION_BYZANTINE_THRESHOLD: uint64 = 25
+    <spec config_var="CONFIRMATION_BYZANTINE_THRESHOLD" fork="phase0" hash="340aaaea">
+    CONFIRMATION_BYZANTINE_THRESHOLD: Uint64 = 25
     </spec>
 
 - name: CONSOLIDATION_CHURN_LIMIT_QUOTIENT#gloas
@@ -194,8 +194,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CONSOLIDATION_CHURN_LIMIT_QUOTIENT:"
   spec: |
-    <spec config_var="CONSOLIDATION_CHURN_LIMIT_QUOTIENT" fork="gloas" hash="03f92b84">
-    CONSOLIDATION_CHURN_LIMIT_QUOTIENT: uint64 = 65536
+    <spec config_var="CONSOLIDATION_CHURN_LIMIT_QUOTIENT" fork="gloas" hash="4e807e2c">
+    CONSOLIDATION_CHURN_LIMIT_QUOTIENT: Uint64 = 65536
     </spec>
 
 - name: CONTRIBUTION_DUE_BPS#altair
@@ -203,8 +203,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CONTRIBUTION_DUE_BPS:"
   spec: |
-    <spec config_var="CONTRIBUTION_DUE_BPS" fork="altair" hash="a3808203">
-    CONTRIBUTION_DUE_BPS: uint64 = 6667
+    <spec config_var="CONTRIBUTION_DUE_BPS" fork="altair" hash="cfa5c39f">
+    CONTRIBUTION_DUE_BPS: Uint64 = 6667
     </spec>
 
 - name: CONTRIBUTION_DUE_BPS_GLOAS#gloas
@@ -212,8 +212,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "CONTRIBUTION_DUE_BPS_GLOAS:"
   spec: |
-    <spec config_var="CONTRIBUTION_DUE_BPS_GLOAS" fork="gloas" hash="0ead2ac1">
-    CONTRIBUTION_DUE_BPS_GLOAS: uint64 = 5000
+    <spec config_var="CONTRIBUTION_DUE_BPS_GLOAS" fork="gloas" hash="d21d5478">
+    CONTRIBUTION_DUE_BPS_GLOAS: Uint64 = 5000
     </spec>
 
 - name: CUSTODY_REQUIREMENT#fulu
@@ -222,8 +222,8 @@
       search: "^CUSTODY_REQUIREMENT:"
       regex: true
   spec: |
-    <spec config_var="CUSTODY_REQUIREMENT" fork="fulu" hash="3ed53d1d">
-    CUSTODY_REQUIREMENT: uint64 = 4
+    <spec config_var="CUSTODY_REQUIREMENT" fork="fulu" hash="380eb77b">
+    CUSTODY_REQUIREMENT: Uint64 = 4
     </spec>
 
 - name: DATA_COLUMN_SIDECAR_SUBNET_COUNT#fulu
@@ -231,8 +231,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "DATA_COLUMN_SIDECAR_SUBNET_COUNT:"
   spec: |
-    <spec config_var="DATA_COLUMN_SIDECAR_SUBNET_COUNT" fork="fulu" hash="4b4dd06b">
-    DATA_COLUMN_SIDECAR_SUBNET_COUNT: uint64 = 128
+    <spec config_var="DATA_COLUMN_SIDECAR_SUBNET_COUNT" fork="fulu" hash="1344504d">
+    DATA_COLUMN_SIDECAR_SUBNET_COUNT: Uint64 = 128
     </spec>
 
 - name: DENEB_FORK_EPOCH#deneb
@@ -251,6 +251,33 @@
   spec: |
     <spec config_var="DENEB_FORK_VERSION" fork="deneb" hash="da95e3b9">
     DENEB_FORK_VERSION: Version = '0x04000000'
+    </spec>
+
+- name: DEPOSIT_CHAIN_ID#phase0
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
+      search: "DEPOSIT_CHAIN_ID:"
+  spec: |
+    <spec config_var="DEPOSIT_CHAIN_ID" fork="phase0" hash="59033cad">
+    DEPOSIT_CHAIN_ID: Uint64 = 1
+    </spec>
+
+- name: DEPOSIT_CONTRACT_ADDRESS#phase0
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
+      search: "DEPOSIT_CONTRACT_ADDRESS:"
+  spec: |
+    <spec config_var="DEPOSIT_CONTRACT_ADDRESS" fork="phase0" hash="552d8348">
+    DEPOSIT_CONTRACT_ADDRESS: ExecutionAddress = '0x00000000219ab540356cBB839Cbe05303d7705Fa'
+    </spec>
+
+- name: DEPOSIT_NETWORK_ID#phase0
+  sources:
+    - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
+      search: "DEPOSIT_NETWORK_ID:"
+  spec: |
+    <spec config_var="DEPOSIT_NETWORK_ID" fork="phase0" hash="02da2a1a">
+    DEPOSIT_NETWORK_ID: Uint64 = 1
     </spec>
 
 - name: EJECTION_BALANCE#phase0
@@ -285,8 +312,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "EPOCHS_PER_SUBNET_SUBSCRIPTION:"
   spec: |
-    <spec config_var="EPOCHS_PER_SUBNET_SUBSCRIPTION" fork="phase0" hash="1b832329">
-    EPOCHS_PER_SUBNET_SUBSCRIPTION = 256
+    <spec config_var="EPOCHS_PER_SUBNET_SUBSCRIPTION" fork="phase0" hash="6ab5401b">
+    EPOCHS_PER_SUBNET_SUBSCRIPTION: Epoch = 256
     </spec>
 
 - name: ETH1_FOLLOW_DISTANCE#phase0
@@ -294,8 +321,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "ETH1_FOLLOW_DISTANCE:"
   spec: |
-    <spec config_var="ETH1_FOLLOW_DISTANCE" fork="phase0" hash="2f5ba1a0">
-    ETH1_FOLLOW_DISTANCE: uint64 = 2048
+    <spec config_var="ETH1_FOLLOW_DISTANCE" fork="phase0" hash="e4685f37">
+    ETH1_FOLLOW_DISTANCE: Uint64 = 2048
     </spec>
 
 - name: FULU_FORK_EPOCH#fulu
@@ -321,8 +348,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "GENESIS_DELAY:"
   spec: |
-    <spec config_var="GENESIS_DELAY" fork="phase0" hash="c50c75f1">
-    GENESIS_DELAY: uint64 = 604800
+    <spec config_var="GENESIS_DELAY" fork="phase0" hash="15d020f0">
+    GENESIS_DELAY: Uint64 = 604800
     </spec>
 
 - name: GENESIS_FORK_VERSION#phase0
@@ -375,8 +402,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "INACTIVITY_SCORE_BIAS:"
   spec: |
-    <spec config_var="INACTIVITY_SCORE_BIAS" fork="altair" hash="c84c24a9">
-    INACTIVITY_SCORE_BIAS: uint64 = 4
+    <spec config_var="INACTIVITY_SCORE_BIAS" fork="altair" hash="27a17e68">
+    INACTIVITY_SCORE_BIAS: Uint64 = 4
     </spec>
 
 - name: INACTIVITY_SCORE_RECOVERY_RATE#altair
@@ -384,8 +411,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "INACTIVITY_SCORE_RECOVERY_RATE:"
   spec: |
-    <spec config_var="INACTIVITY_SCORE_RECOVERY_RATE" fork="altair" hash="d7876320">
-    INACTIVITY_SCORE_RECOVERY_RATE: uint64 = 16
+    <spec config_var="INACTIVITY_SCORE_RECOVERY_RATE" fork="altair" hash="e1b07db3">
+    INACTIVITY_SCORE_RECOVERY_RATE: Uint64 = 16
     </spec>
 
 - name: INCLUSION_LIST_DUE_BPS#heze
@@ -393,8 +420,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "INCLUSION_LIST_DUE_BPS:"
   spec: |
-    <spec config_var="INCLUSION_LIST_DUE_BPS" fork="heze" hash="dec96f13">
-    INCLUSION_LIST_DUE_BPS: uint64 = 6667
+    <spec config_var="INCLUSION_LIST_DUE_BPS" fork="heze" hash="2b6a4401">
+    INCLUSION_LIST_DUE_BPS: Uint64 = 6667
     </spec>
 
 - name: MAXIMUM_GOSSIP_CLOCK_DISPARITY#phase0
@@ -402,8 +429,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAXIMUM_GOSSIP_CLOCK_DISPARITY:"
   spec: |
-    <spec config_var="MAXIMUM_GOSSIP_CLOCK_DISPARITY" fork="phase0" hash="12990b53">
-    MAXIMUM_GOSSIP_CLOCK_DISPARITY = 500
+    <spec config_var="MAXIMUM_GOSSIP_CLOCK_DISPARITY" fork="phase0" hash="4455f907">
+    MAXIMUM_GOSSIP_CLOCK_DISPARITY: Uint64 = 500
     </spec>
 
 - name: MAX_BLOBS_PER_BLOCK#deneb
@@ -412,8 +439,8 @@
       search: "^MAX_BLOBS_PER_BLOCK:"
       regex: true
   spec: |
-    <spec config_var="MAX_BLOBS_PER_BLOCK" fork="deneb" hash="3e0b5383">
-    MAX_BLOBS_PER_BLOCK: uint64 = 6
+    <spec config_var="MAX_BLOBS_PER_BLOCK" fork="deneb" hash="da6a82cc">
+    MAX_BLOBS_PER_BLOCK: Uint64 = 6
     </spec>
 
 - name: MAX_BLOBS_PER_BLOCK_ELECTRA#electra
@@ -421,8 +448,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_BLOBS_PER_BLOCK_ELECTRA:"
   spec: |
-    <spec config_var="MAX_BLOBS_PER_BLOCK_ELECTRA" fork="electra" hash="0d8ea1c9">
-    MAX_BLOBS_PER_BLOCK_ELECTRA: uint64 = 9
+    <spec config_var="MAX_BLOBS_PER_BLOCK_ELECTRA" fork="electra" hash="a03f0ed9">
+    MAX_BLOBS_PER_BLOCK_ELECTRA: Uint64 = 9
     </spec>
 
 - name: MAX_BYTES_PER_INCLUSION_LIST#heze
@@ -430,8 +457,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_BYTES_PER_INCLUSION_LIST:"
   spec: |
-    <spec config_var="MAX_BYTES_PER_INCLUSION_LIST" fork="heze" hash="9202c516">
-    MAX_BYTES_PER_INCLUSION_LIST = 8192
+    <spec config_var="MAX_BYTES_PER_INCLUSION_LIST" fork="heze" hash="1d503ddc">
+    MAX_BYTES_PER_INCLUSION_LIST: Uint64 = 8192
     </spec>
 
 - name: MAX_PAYLOAD_SIZE#phase0
@@ -439,8 +466,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_PAYLOAD_SIZE:"
   spec: |
-    <spec config_var="MAX_PAYLOAD_SIZE" fork="phase0" hash="7f1566fb">
-    MAX_PAYLOAD_SIZE = 10485760
+    <spec config_var="MAX_PAYLOAD_SIZE" fork="phase0" hash="51a340f4">
+    MAX_PAYLOAD_SIZE: Uint64 = 10485760
     </spec>
 
 - name: MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT#deneb
@@ -448,8 +475,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT:"
   spec: |
-    <spec config_var="MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT" fork="deneb" hash="c4d9b0bb">
-    MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT: uint64 = 8
+    <spec config_var="MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT" fork="deneb" hash="3d7eeec7">
+    MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT: Uint64 = 8
     </spec>
 
 - name: MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS#gloas
@@ -475,8 +502,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_BLOCKS:"
   spec: |
-    <spec config_var="MAX_REQUEST_BLOCKS" fork="phase0" hash="a9ae6c77">
-    MAX_REQUEST_BLOCKS = 1024
+    <spec config_var="MAX_REQUEST_BLOCKS" fork="phase0" hash="300478e3">
+    MAX_REQUEST_BLOCKS: Uint64 = 1024
     </spec>
 
 - name: MAX_REQUEST_BLOCKS_DENEB#deneb
@@ -484,8 +511,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_BLOCKS_DENEB:"
   spec: |
-    <spec config_var="MAX_REQUEST_BLOCKS_DENEB" fork="deneb" hash="8318964a">
-    MAX_REQUEST_BLOCKS_DENEB = 128
+    <spec config_var="MAX_REQUEST_BLOCKS_DENEB" fork="deneb" hash="0a5779c5">
+    MAX_REQUEST_BLOCKS_DENEB: Uint64 = 128
     </spec>
 
 - name: MAX_REQUEST_INCLUSION_LIST#heze
@@ -493,8 +520,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_INCLUSION_LIST:"
   spec: |
-    <spec config_var="MAX_REQUEST_INCLUSION_LIST" fork="heze" hash="0d52ccf4">
-    MAX_REQUEST_INCLUSION_LIST = 16
+    <spec config_var="MAX_REQUEST_INCLUSION_LIST" fork="heze" hash="b64ddfd1">
+    MAX_REQUEST_INCLUSION_LIST: Uint64 = 16
     </spec>
 
 - name: MAX_REQUEST_PAYLOADS#gloas
@@ -502,8 +529,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MAX_REQUEST_PAYLOADS:"
   spec: |
-    <spec config_var="MAX_REQUEST_PAYLOADS" fork="gloas" hash="23399ee5">
-    MAX_REQUEST_PAYLOADS = 128
+    <spec config_var="MAX_REQUEST_PAYLOADS" fork="gloas" hash="cb92d98e">
+    MAX_REQUEST_PAYLOADS: Uint64 = 128
     </spec>
 
 - name: MESSAGE_DOMAIN_INVALID_SNAPPY#phase0
@@ -529,8 +556,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_BUILDER_WITHDRAWABILITY_DELAY:"
   spec: |
-    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="be7f8473">
-    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 64
+    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="1ad08a7c">
+    MIN_BUILDER_WITHDRAWABILITY_DELAY: Epoch = 64
     </spec>
 
 - name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS#deneb
@@ -538,8 +565,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS:"
   spec: |
-    <spec config_var="MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS" fork="deneb" hash="3df9114c">
-    MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS = 4096
+    <spec config_var="MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS" fork="deneb" hash="1832eb33">
+    MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS: Epoch = 4096
     </spec>
 
 - name: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS#fulu
@@ -547,8 +574,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS:"
   spec: |
-    <spec config_var="MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS" fork="fulu" hash="b717a22d">
-    MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS: uint64 = 4096
+    <spec config_var="MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS" fork="fulu" hash="1ca47aad">
+    MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS: Epoch = 4096
     </spec>
 
 - name: MIN_GENESIS_ACTIVE_VALIDATOR_COUNT#phase0
@@ -556,8 +583,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT:"
   spec: |
-    <spec config_var="MIN_GENESIS_ACTIVE_VALIDATOR_COUNT" fork="phase0" hash="7715513b">
-    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: uint64 = 16384
+    <spec config_var="MIN_GENESIS_ACTIVE_VALIDATOR_COUNT" fork="phase0" hash="d86e0ccc">
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: Uint64 = 16384
     </spec>
 
 - name: MIN_GENESIS_TIME#phase0
@@ -565,8 +592,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_GENESIS_TIME:"
   spec: |
-    <spec config_var="MIN_GENESIS_TIME" fork="phase0" hash="75c06876">
-    MIN_GENESIS_TIME: uint64 = 1606824000
+    <spec config_var="MIN_GENESIS_TIME" fork="phase0" hash="3abe635d">
+    MIN_GENESIS_TIME: Uint64 = 1606824000
     </spec>
 
 - name: MIN_PER_EPOCH_CHURN_LIMIT#phase0
@@ -574,8 +601,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_PER_EPOCH_CHURN_LIMIT:"
   spec: |
-    <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT" fork="phase0" hash="ff24b223">
-    MIN_PER_EPOCH_CHURN_LIMIT: uint64 = 4
+    <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT" fork="phase0" hash="33e3586b">
+    MIN_PER_EPOCH_CHURN_LIMIT: Uint64 = 4
     </spec>
 
 - name: MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA#electra
@@ -587,13 +614,20 @@
     MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA: Gwei = 128000000000
     </spec>
 
+- name: MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS#heze
+  sources: []
+  spec: |
+    <spec config_var="MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS" fork="heze" hash="4bab088f">
+    MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS: Slot = 1
+    </spec>
+
 - name: MIN_VALIDATOR_WITHDRAWABILITY_DELAY#phase0
   sources:
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "MIN_VALIDATOR_WITHDRAWABILITY_DELAY:"
   spec: |
-    <spec config_var="MIN_VALIDATOR_WITHDRAWABILITY_DELAY" fork="phase0" hash="5c4eeded">
-    MIN_VALIDATOR_WITHDRAWABILITY_DELAY: uint64 = 256
+    <spec config_var="MIN_VALIDATOR_WITHDRAWABILITY_DELAY" fork="phase0" hash="5c286670">
+    MIN_VALIDATOR_WITHDRAWABILITY_DELAY: Epoch = 256
     </spec>
 
 - name: NUMBER_OF_CUSTODY_GROUPS#fulu
@@ -601,8 +635,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "NUMBER_OF_CUSTODY_GROUPS:"
   spec: |
-    <spec config_var="NUMBER_OF_CUSTODY_GROUPS" fork="fulu" hash="ef65e821">
-    NUMBER_OF_CUSTODY_GROUPS: uint64 = 128
+    <spec config_var="NUMBER_OF_CUSTODY_GROUPS" fork="fulu" hash="3b8dd1d5">
+    NUMBER_OF_CUSTODY_GROUPS: Uint64 = 128
     </spec>
 
 - name: PAYLOAD_ATTESTATION_DUE_BPS#gloas
@@ -610,8 +644,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "PAYLOAD_ATTESTATION_DUE_BPS:"
   spec: |
-    <spec config_var="PAYLOAD_ATTESTATION_DUE_BPS" fork="gloas" hash="17307d0e">
-    PAYLOAD_ATTESTATION_DUE_BPS: uint64 = 7500
+    <spec config_var="PAYLOAD_ATTESTATION_DUE_BPS" fork="gloas" hash="d5ffbe84">
+    PAYLOAD_ATTESTATION_DUE_BPS: Uint64 = 7500
     </spec>
 
 - name: PAYLOAD_DUE_BPS#gloas
@@ -619,8 +653,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "PAYLOAD_DUE_BPS:"
   spec: |
-    <spec config_var="PAYLOAD_DUE_BPS" fork="gloas" hash="07d2a783">
-    PAYLOAD_DUE_BPS: uint64 = 5000
+    <spec config_var="PAYLOAD_DUE_BPS" fork="gloas" hash="8f8ebf70">
+    PAYLOAD_DUE_BPS: Uint64 = 5000
     </spec>
 
 - name: PROPOSER_REORG_CUTOFF_BPS#phase0
@@ -628,8 +662,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "PROPOSER_REORG_CUTOFF_BPS:"
   spec: |
-    <spec config_var="PROPOSER_REORG_CUTOFF_BPS" fork="phase0" hash="a487cc43">
-    PROPOSER_REORG_CUTOFF_BPS: uint64 = 1667
+    <spec config_var="PROPOSER_REORG_CUTOFF_BPS" fork="phase0" hash="c554bd23">
+    PROPOSER_REORG_CUTOFF_BPS: Uint64 = 1667
     </spec>
 
 - name: PROPOSER_SCORE_BOOST#phase0
@@ -637,8 +671,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "PROPOSER_SCORE_BOOST:"
   spec: |
-    <spec config_var="PROPOSER_SCORE_BOOST" fork="phase0" hash="fbc878c6">
-    PROPOSER_SCORE_BOOST: uint64 = 40
+    <spec config_var="PROPOSER_SCORE_BOOST" fork="phase0" hash="5ac38798">
+    PROPOSER_SCORE_BOOST: Uint64 = 40
     </spec>
 
 - name: REORG_HEAD_WEIGHT_THRESHOLD#phase0
@@ -646,8 +680,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "REORG_HEAD_WEIGHT_THRESHOLD:"
   spec: |
-    <spec config_var="REORG_HEAD_WEIGHT_THRESHOLD" fork="phase0" hash="d4ecaa84">
-    REORG_HEAD_WEIGHT_THRESHOLD: uint64 = 20
+    <spec config_var="REORG_HEAD_WEIGHT_THRESHOLD" fork="phase0" hash="402a5acb">
+    REORG_HEAD_WEIGHT_THRESHOLD: Uint64 = 20
     </spec>
 
 - name: REORG_MAX_EPOCHS_SINCE_FINALIZATION#phase0
@@ -664,8 +698,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "REORG_PARENT_WEIGHT_THRESHOLD:"
   spec: |
-    <spec config_var="REORG_PARENT_WEIGHT_THRESHOLD" fork="phase0" hash="cb81e3da">
-    REORG_PARENT_WEIGHT_THRESHOLD: uint64 = 160
+    <spec config_var="REORG_PARENT_WEIGHT_THRESHOLD" fork="phase0" hash="3f4de3d8">
+    REORG_PARENT_WEIGHT_THRESHOLD: Uint64 = 160
     </spec>
 
 - name: SAMPLES_PER_SLOT#fulu
@@ -673,8 +707,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SAMPLES_PER_SLOT:"
   spec: |
-    <spec config_var="SAMPLES_PER_SLOT" fork="fulu" hash="dfbcb295">
-    SAMPLES_PER_SLOT: uint64 = 8
+    <spec config_var="SAMPLES_PER_SLOT" fork="fulu" hash="ecb8eaf2">
+    SAMPLES_PER_SLOT: Uint64 = 8
     </spec>
 
 - name: SECONDS_PER_ETH1_BLOCK#phase0
@@ -682,8 +716,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SECONDS_PER_ETH1_BLOCK:"
   spec: |
-    <spec config_var="SECONDS_PER_ETH1_BLOCK" fork="phase0" hash="90c9f3d1">
-    SECONDS_PER_ETH1_BLOCK: uint64 = 14
+    <spec config_var="SECONDS_PER_ETH1_BLOCK" fork="phase0" hash="0c643d31">
+    SECONDS_PER_ETH1_BLOCK: Uint64 = 14
     </spec>
 
 - name: SHARD_COMMITTEE_PERIOD#phase0
@@ -691,8 +725,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SHARD_COMMITTEE_PERIOD:"
   spec: |
-    <spec config_var="SHARD_COMMITTEE_PERIOD" fork="phase0" hash="5d0e85a4">
-    SHARD_COMMITTEE_PERIOD: uint64 = 256
+    <spec config_var="SHARD_COMMITTEE_PERIOD" fork="phase0" hash="87d0ca70">
+    SHARD_COMMITTEE_PERIOD: Epoch = 256
     </spec>
 
 - name: SLOT_DURATION_MS#phase0
@@ -700,8 +734,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SLOT_DURATION_MS:"
   spec: |
-    <spec config_var="SLOT_DURATION_MS" fork="phase0" hash="b6d4ba6d">
-    SLOT_DURATION_MS: uint64 = 12000
+    <spec config_var="SLOT_DURATION_MS" fork="phase0" hash="6c1935e7">
+    SLOT_DURATION_MS: Uint64 = 12000
     </spec>
 
 - name: SUBNETS_PER_NODE#phase0
@@ -709,8 +743,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SUBNETS_PER_NODE:"
   spec: |
-    <spec config_var="SUBNETS_PER_NODE" fork="phase0" hash="4799f8f3">
-    SUBNETS_PER_NODE = 2
+    <spec config_var="SUBNETS_PER_NODE" fork="phase0" hash="d8a1cb61">
+    SUBNETS_PER_NODE: Uint64 = 2
     </spec>
 
 - name: SYNC_MESSAGE_DUE_BPS#altair
@@ -718,8 +752,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SYNC_MESSAGE_DUE_BPS:"
   spec: |
-    <spec config_var="SYNC_MESSAGE_DUE_BPS" fork="altair" hash="791b29d8">
-    SYNC_MESSAGE_DUE_BPS: uint64 = 3333
+    <spec config_var="SYNC_MESSAGE_DUE_BPS" fork="altair" hash="21b16e07">
+    SYNC_MESSAGE_DUE_BPS: Uint64 = 3333
     </spec>
 
 - name: SYNC_MESSAGE_DUE_BPS_GLOAS#gloas
@@ -727,8 +761,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "SYNC_MESSAGE_DUE_BPS_GLOAS:"
   spec: |
-    <spec config_var="SYNC_MESSAGE_DUE_BPS_GLOAS" fork="gloas" hash="47f14d95">
-    SYNC_MESSAGE_DUE_BPS_GLOAS: uint64 = 2500
+    <spec config_var="SYNC_MESSAGE_DUE_BPS_GLOAS" fork="gloas" hash="b70fe65b">
+    SYNC_MESSAGE_DUE_BPS_GLOAS: Uint64 = 2500
     </spec>
 
 - name: TERMINAL_BLOCK_HASH#bellatrix
@@ -745,8 +779,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH:"
   spec: |
-    <spec config_var="TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH" fork="bellatrix" hash="81928369">
-    TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH = 18446744073709551615
+    <spec config_var="TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH" fork="bellatrix" hash="331e75a1">
+    TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: Epoch = 18446744073709551615
     </spec>
 
 - name: TERMINAL_TOTAL_DIFFICULTY#bellatrix
@@ -754,8 +788,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "TERMINAL_TOTAL_DIFFICULTY:"
   spec: |
-    <spec config_var="TERMINAL_TOTAL_DIFFICULTY" fork="bellatrix" hash="e0f3a816">
-    TERMINAL_TOTAL_DIFFICULTY = 58750000000000000000000
+    <spec config_var="TERMINAL_TOTAL_DIFFICULTY" fork="bellatrix" hash="7fb79a4e">
+    TERMINAL_TOTAL_DIFFICULTY: Uint256 = 58750000000000000000000
     </spec>
 
 - name: VALIDATOR_CUSTODY_REQUIREMENT#fulu
@@ -763,6 +797,6 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml
       search: "VALIDATOR_CUSTODY_REQUIREMENT:"
   spec: |
-    <spec config_var="VALIDATOR_CUSTODY_REQUIREMENT" fork="fulu" hash="4dfc4457">
-    VALIDATOR_CUSTODY_REQUIREMENT = 8
+    <spec config_var="VALIDATOR_CUSTODY_REQUIREMENT" fork="fulu" hash="87f04d3e">
+    VALIDATOR_CUSTODY_REQUIREMENT: Uint64 = 8
     </spec>

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -1,8 +1,8 @@
 - name: ATTESTATION_TIMELINESS_INDEX#gloas
   sources: []
   spec: |
-    <spec constant_var="ATTESTATION_TIMELINESS_INDEX" fork="gloas" hash="7d373fc8">
-    ATTESTATION_TIMELINESS_INDEX = 0
+    <spec constant_var="ATTESTATION_TIMELINESS_INDEX" fork="gloas" hash="7b99e379">
+    ATTESTATION_TIMELINESS_INDEX: Uint64 = 0
     </spec>
 
 - name: BASE_REWARDS_PER_EPOCH#phase0
@@ -10,24 +10,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
       search: BASE_REWARDS_PER_EPOCH =
   spec: |
-    <spec constant_var="BASE_REWARDS_PER_EPOCH" fork="phase0" hash="395f7528">
-    BASE_REWARDS_PER_EPOCH: uint64 = 4
+    <spec constant_var="BASE_REWARDS_PER_EPOCH" fork="phase0" hash="a1ff205c">
+    BASE_REWARDS_PER_EPOCH: Uint64 = 4
     </spec>
 
 - name: BASIS_POINTS#phase0
   sources: []
   spec: |
-    <spec constant_var="BASIS_POINTS" fork="phase0" hash="cb0c8561">
-    BASIS_POINTS: uint64 = 10000
-    </spec>
-
-- name: BLS_MODULUS#deneb
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
-      search: private Integer computeAttestationSubnetPrefixBits()
-  spec: |
-    <spec constant_var="BLS_MODULUS" fork="deneb" hash="dfa6ff32">
-    BLS_MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513
+    <spec constant_var="BASIS_POINTS" fork="phase0" hash="b1cae846">
+    BASIS_POINTS: Uint64 = 10000
     </spec>
 
 - name: BLS_WITHDRAWAL_PREFIX#phase0
@@ -62,8 +53,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
       search: BUILDER_INDEX_FLAG =
   spec: |
-    <spec constant_var="BUILDER_INDEX_FLAG" fork="gloas" hash="e9dca70d">
-    BUILDER_INDEX_FLAG: uint64 = 2**40
+    <spec constant_var="BUILDER_INDEX_FLAG" fork="gloas" hash="c8f0a318">
+    BUILDER_INDEX_FLAG: Uint64 = 2**40
     </spec>
 
 - name: BUILDER_INDEX_SELF_BUILD#gloas
@@ -80,8 +71,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
       search: BUILDER_PAYMENT_THRESHOLD_DENOMINATOR =
   spec: |
-    <spec constant_var="BUILDER_PAYMENT_THRESHOLD_DENOMINATOR" fork="gloas" hash="2b5e020f">
-    BUILDER_PAYMENT_THRESHOLD_DENOMINATOR: uint64 = 10
+    <spec constant_var="BUILDER_PAYMENT_THRESHOLD_DENOMINATOR" fork="gloas" hash="db4e9377">
+    BUILDER_PAYMENT_THRESHOLD_DENOMINATOR: Uint64 = 10
     </spec>
 
 - name: BUILDER_PAYMENT_THRESHOLD_NUMERATOR#gloas
@@ -89,8 +80,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
       search: BUILDER_PAYMENT_THRESHOLD_NUMERATOR =
   spec: |
-    <spec constant_var="BUILDER_PAYMENT_THRESHOLD_NUMERATOR" fork="gloas" hash="f7d031d3">
-    BUILDER_PAYMENT_THRESHOLD_NUMERATOR: uint64 = 6
+    <spec constant_var="BUILDER_PAYMENT_THRESHOLD_NUMERATOR" fork="gloas" hash="da1a0f54">
+    BUILDER_PAYMENT_THRESHOLD_NUMERATOR: Uint64 = 6
     </spec>
 
 - name: BUILDER_WITHDRAWAL_PREFIX#gloas
@@ -102,27 +93,13 @@
     BUILDER_WITHDRAWAL_PREFIX: Bytes1 = '0xB0'
     </spec>
 
-- name: BYTES_PER_COMMITMENT#deneb
-  sources: []
-  spec: |
-    <spec constant_var="BYTES_PER_COMMITMENT" fork="deneb" hash="c46710b5">
-    BYTES_PER_COMMITMENT: uint64 = 48
-    </spec>
-
 - name: BYTES_PER_FIELD_ELEMENT#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
       search: BYTES_PER_FIELD_ELEMENT =
   spec: |
-    <spec constant_var="BYTES_PER_FIELD_ELEMENT" fork="deneb" hash="4563f0ce">
-    BYTES_PER_FIELD_ELEMENT: uint64 = 32
-    </spec>
-
-- name: BYTES_PER_PROOF#deneb
-  sources: []
-  spec: |
-    <spec constant_var="BYTES_PER_PROOF" fork="deneb" hash="7fec794e">
-    BYTES_PER_PROOF: uint64 = 48
+    <spec constant_var="BYTES_PER_FIELD_ELEMENT" fork="deneb" hash="096a1b57">
+    BYTES_PER_FIELD_ELEMENT: Uint64 = 32
     </spec>
 
 - name: COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR#phase0
@@ -130,8 +107,8 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
       search: COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR =
   spec: |
-    <spec constant_var="COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR" fork="phase0" hash="e8e1efcf">
-    COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR: uint64 = 5
+    <spec constant_var="COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR" fork="phase0" hash="0e734eab">
+    COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR: Uint64 = 5
     </spec>
 
 - name: COMPOUNDING_WITHDRAWAL_PREFIX#electra
@@ -159,8 +136,8 @@
     - file: ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/DepositConstants.java
       search: DEPOSIT_CONTRACT_TREE_DEPTH =
   spec: |
-    <spec constant_var="DEPOSIT_CONTRACT_TREE_DEPTH" fork="phase0" hash="5763e551">
-    DEPOSIT_CONTRACT_TREE_DEPTH: uint64 = 2**5
+    <spec constant_var="DEPOSIT_CONTRACT_TREE_DEPTH" fork="phase0" hash="3e8a5b9a">
+    DEPOSIT_CONTRACT_TREE_DEPTH: Uint64 = 2**5
     </spec>
 
 - name: DEPOSIT_REQUEST_TYPE#electra
@@ -351,8 +328,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/EthConstants.java
       search: ETH_TO_GWEI =
   spec: |
-    <spec constant_var="ETH_TO_GWEI" fork="phase0" hash="37392e73">
-    ETH_TO_GWEI: uint64 = 10**9
+    <spec constant_var="ETH_TO_GWEI" fork="phase0" hash="a9c1d610">
+    ETH_TO_GWEI: Uint64 = 10**9
     </spec>
 
 - name: FAR_FUTURE_EPOCH#phase0
@@ -364,27 +341,13 @@
     FAR_FUTURE_EPOCH: Epoch = 2**64 - 1
     </spec>
 
-- name: FIAT_SHAMIR_PROTOCOL_DOMAIN#deneb
-  sources: []
-  spec: |
-    <spec constant_var="FIAT_SHAMIR_PROTOCOL_DOMAIN" fork="deneb" hash="b1198e8c">
-    FIAT_SHAMIR_PROTOCOL_DOMAIN = b'FSBLOBVERIFY_V1_'
-    </spec>
-
 - name: FULL_EXIT_REQUEST_AMOUNT#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
       search: FULL_EXIT_REQUEST_AMOUNT =
   spec: |
-    <spec constant_var="FULL_EXIT_REQUEST_AMOUNT" fork="electra" hash="4f49380e">
-    FULL_EXIT_REQUEST_AMOUNT: uint64 = 0
-    </spec>
-
-- name: G1_POINT_AT_INFINITY#deneb
-  sources: []
-  spec: |
-    <spec constant_var="G1_POINT_AT_INFINITY" fork="deneb" hash="974ad898">
-    G1_POINT_AT_INFINITY: Bytes48 = b'\xc0' + b'\x00' * 47
+    <spec constant_var="FULL_EXIT_REQUEST_AMOUNT" fork="electra" hash="d177bb89">
+    FULL_EXIT_REQUEST_AMOUNT: Gwei = 0
     </spec>
 
 - name: G2_POINT_AT_INFINITY#altair
@@ -417,29 +380,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
       search: JUSTIFICATION_BITS_LENGTH =
   spec: |
-    <spec constant_var="JUSTIFICATION_BITS_LENGTH" fork="phase0" hash="e7ec73ea">
-    JUSTIFICATION_BITS_LENGTH: uint64 = 4
-    </spec>
-
-- name: KZG_ENDIANNESS#deneb
-  sources: []
-  spec: |
-    <spec constant_var="KZG_ENDIANNESS" fork="deneb" hash="b67e714d">
-    KZG_ENDIANNESS = 'big'
-    </spec>
-
-- name: KZG_SETUP_G2_LENGTH#deneb
-  sources: []
-  spec: |
-    <spec constant_var="KZG_SETUP_G2_LENGTH" fork="deneb" hash="6435c362">
-    KZG_SETUP_G2_LENGTH: uint64 = 65
-    </spec>
-
-- name: KZG_SETUP_G2_MONOMIAL#deneb
-  sources: []
-  spec: |
-    <spec constant_var="KZG_SETUP_G2_MONOMIAL" fork="deneb" hash="4e0f802f">
-    KZG_SETUP_G2_MONOMIAL: Vector[G2Point, KZG_SETUP_G2_LENGTH] = ['0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8', '0xb5bfd7dd8cdeb128843bc287230af38926187075cbfbefa81009a2ce615ac53d2914e5870cb452d2afaaab24f3499f72185cbfee53492714734429b7b38608e23926c911cceceac9a36851477ba4c60b087041de621000edc98edada20c1def2', '0xb5337ba0ce5d37224290916e268e2060e5c14f3f9fc9e1ec3af5a958e7a0303122500ce18f1a4640bf66525bd10e763501fe986d86649d8d45143c08c3209db3411802c226e9fe9a55716ac4a0c14f9dcef9e70b2bb309553880dc5025eab3cc', '0xb3c1dcdc1f62046c786f0b82242ef283e7ed8f5626f72542aa2c7a40f14d9094dd1ebdbd7457ffdcdac45fd7da7e16c51200b06d791e5e43e257e45efdf0bd5b06cd2333beca2a3a84354eb48662d83aef5ecf4e67658c851c10b13d8d87c874', '0x954d91c7688983382609fca9e211e461f488a5971fd4e40d7e2892037268eacdfd495cfa0a7ed6eb0eb11ac3ae6f651716757e7526abe1e06c64649d80996fd3105c20c4c94bc2b22d97045356fe9d791f21ea6428ac48db6f9e68e30d875280', '0x88a6b6bb26c51cf9812260795523973bb90ce80f6820b6c9048ab366f0fb96e48437a7f7cb62aedf64b11eb4dfefebb0147608793133d32003cb1f2dc47b13b5ff45f1bb1b2408ea45770a08dbfaec60961acb8119c47b139a13b8641e2c9487', '0x85cd7be9728bd925d12f47fb04b32d9fad7cab88788b559f053e69ca18e463113ecc8bbb6dbfb024835f901b3a957d3108d6770fb26d4c8be0a9a619f6e3a4bf15cbfd48e61593490885f6cee30e4300c5f9cf5e1c08e60a2d5b023ee94fcad0', '0x80477dba360f04399821a48ca388c0fa81102dd15687fea792ee8c1114e00d1bc4839ad37ac58900a118d863723acfbe08126ea883be87f50e4eabe3b5e72f5d9e041db8d9b186409fd4df4a7dde38c0e0a3b1ae29b098e5697e7f110b6b27e4', '0xb7a6aec08715a9f8672a2b8c367e407be37e59514ac19dd4f0942a68007bba3923df22da48702c63c0d6b3efd3c2d04e0fe042d8b5a54d562f9f33afc4865dcbcc16e99029e25925580e87920c399e710d438ac1ce3a6dc9b0d76c064a01f6f7', '0xac1b001edcea02c8258aeffbf9203114c1c874ad88dae1184fadd7d94cd09053649efd0ca413400e6e9b5fa4eac33261000af88b6bd0d2abf877a4f0355d2fb4d6007adb181695201c5432e50b850b51b3969f893bddf82126c5a71b042b7686', '0x90043fda4de53fb364fab2c04be5296c215599105ecff0c12e4917c549257125775c29f2507124d15f56e30447f367db0596c33237242c02d83dfd058735f1e3c1ff99069af55773b6d51d32a68bf75763f59ec4ee7267932ae426522b8aaab6', '0xa8660ce853e9dc08271bf882e29cd53397d63b739584dda5263da4c7cc1878d0cf6f3e403557885f557e184700575fee016ee8542dec22c97befe1d10f414d22e84560741cdb3e74c30dda9b42eeaaf53e27822de2ee06e24e912bf764a9a533', '0x8fe3921a96d0d065e8aa8fce9aa42c8e1461ca0470688c137be89396dd05103606dab6cdd2a4591efd6addf72026c12e065da7be276dee27a7e30afa2bd81c18f1516e7f068f324d0bad9570b95f6bd02c727cd2343e26db0887c3e4e26dceda', '0x8ae1ad97dcb9c192c9a3933541b40447d1dc4eebf380151440bbaae1e120cc5cdf1bcea55180b128d8e180e3af623815191d063cc0d7a47d55fb7687b9d87040bf7bc1a7546b07c61db5ccf1841372d7c2fe4a5431ffff829f3c2eb590b0b710', '0x8c2fa96870a88150f7876c931e2d3cc2adeaaaf5c73ef5fa1cf9dfa0991ae4819f9321af7e916e5057d87338e630a2f21242c29d76963cf26035b548d2a63d8ad7bd6efefa01c1df502cbdfdfe0334fb21ceb9f686887440f713bf17a89b8081', '0xb9aa98e2f02bb616e22ee5dd74c7d1049321ac9214d093a738159850a1dbcc7138cb8d26ce09d8296368fd5b291d74fa17ac7cc1b80840fdd4ee35e111501e3fa8485b508baecda7c1ab7bd703872b7d64a2a40b3210b6a70e8a6ffe0e5127e3', '0x9292db67f8771cdc86854a3f614a73805bf3012b48f1541e704ea4015d2b6b9c9aaed36419769c87c49f9e3165f03edb159c23b3a49c4390951f78e1d9b0ad997129b17cdb57ea1a6638794c0cca7d239f229e589c5ae4f9fe6979f7f8cba1d7', '0x91cd9e86550f230d128664f7312591fee6a84c34f5fc7aed557bcf986a409a6de722c4330453a305f06911d2728626e611acfdf81284f77f60a3a1595053a9479964fd713117e27c0222cc679674b03bc8001501aaf9b506196c56de29429b46', '0xa9516b73f605cc31b89c68b7675dc451e6364595243d235339437f556cf22d745d4250c1376182273be2d99e02c10eee047410a43eff634d051aeb784e76cb3605d8e079b9eb6ad1957dfdf77e1cd32ce4a573c9dfcc207ca65af6eb187f6c3d', '0xa9667271f7d191935cc8ad59ef3ec50229945faea85bfdfb0d582090f524436b348aaa0183b16a6231c00332fdac2826125b8c857a2ed9ec66821cfe02b3a2279be2412441bc2e369b255eb98614e4be8490799c4df22f18d47d24ec70bba5f7', '0xa4371144d2aa44d70d3cb9789096d3aa411149a6f800cb46f506461ee8363c8724667974252f28aea61b6030c05930ac039c1ee64bb4bd56532a685cae182bf2ab935eee34718cffcb46cae214c77aaca11dbb1320faf23c47247db1da04d8dc', '0x89a7eb441892260b7e81168c386899cd84ffc4a2c5cad2eae0d1ab9e8b5524662e6f660fe3f8bfe4c92f60b060811bc605b14c5631d16709266886d7885a5eb5930097127ec6fb2ebbaf2df65909cf48f253b3d5e22ae48d3e9a2fd2b01f447e', '0x9648c42ca97665b5eccb49580d8532df05eb5a68db07f391a2340769b55119eaf4c52fe4f650c09250fa78a76c3a1e271799b8333cc2628e3d4b4a6a3e03da1f771ecf6516dd63236574a7864ff07e319a6f11f153406280d63af9e2b5713283', '0x9663bf6dd446ea7a90658ee458578d4196dc0b175ef7fcfa75f44d41670850774c2e46c5a6be132a2c072a3c0180a24f0305d1acac49d2d79878e5cda80c57feda3d01a6af12e78b5874e2a4b3717f11c97503b41a4474e2e95b179113726199', '0xb212aeb4814e0915b432711b317923ed2b09e076aaf558c3ae8ef83f9e15a83f9ea3f47805b2750ab9e8106cb4dc6ad003522c84b03dc02829978a097899c773f6fb31f7fe6b8f2d836d96580f216fec20158f1590c3e0d7850622e15194db05', '0x925f005059bf07e9ceccbe66c711b048e236ade775720d0fe479aebe6e23e8af281225ad18e62458dc1b03b42ad4ca290d4aa176260604a7aad0d9791337006fbdebe23746f8060d42876f45e4c83c3643931392fde1cd13ff8bddf8111ef974', '0x9553edb22b4330c568e156a59ef03b26f5c326424f830fe3e8c0b602f08c124730ffc40bc745bec1a22417adb22a1a960243a10565c2be3066bfdb841d1cd14c624cd06e0008f4beb83f972ce6182a303bee3fcbcabc6cfe48ec5ae4b7941bfc', '0x935f5a404f0a78bdcce709899eda0631169b366a669e9b58eacbbd86d7b5016d044b8dfc59ce7ed8de743ae16c2343b50e2f925e88ba6319e33c3fc76b314043abad7813677b4615c8a97eb83cc79de4fedf6ccbcfa4d4cbf759a5a84e4d9742', '0xa5b014ab936eb4be113204490e8b61cd38d71da0dec7215125bcd131bf3ab22d0a32ce645bca93e7b3637cf0c2db3d6601a0ddd330dc46f9fae82abe864ffc12d656c88eb50c20782e5bb6f75d18760666f43943abb644b881639083e122f557', '0x935b7298ae52862fa22bf03bfc1795b34c70b181679ae27de08a9f5b4b884f824ef1b276b7600efa0d2f1d79e4a470d51692fd565c5cf8343dd80e5d3336968fc21c09ba9348590f6206d4424eb229e767547daefa98bc3aa9f421158dee3f2a', '0x9830f92446e708a8f6b091cc3c38b653505414f8b6507504010a96ffda3bcf763d5331eb749301e2a1437f00e2415efb01b799ad4c03f4b02de077569626255ac1165f96ea408915d4cf7955047620da573e5c439671d1fa5c833fb11de7afe6', '0x840dcc44f673fff3e387af2bb41e89640f2a70bcd2b92544876daa92143f67c7512faf5f90a04b7191de01f3e2b1bde00622a20dc62ca23bbbfaa6ad220613deff43908382642d4d6a86999f662efd64b1df448b68c847cfa87630a3ffd2ec76', '0x92950c895ed54f7f876b2fda17ecc9c41b7accfbdd42c210cc5b475e0737a7279f558148531b5c916e310604a1de25a80940c94fe5389ae5d6a5e9c371be67bceea1877f5401725a6595bcf77ece60905151b6dfcb68b75ed2e708c73632f4fd', '0x8010246bf8e94c25fd029b346b5fbadb404ef6f44a58fd9dd75acf62433d8cc6db66974f139a76e0c26dddc1f329a88214dbb63276516cf325c7869e855d07e0852d622c332ac55609ba1ec9258c45746a2aeb1af0800141ee011da80af175d4', '0xb0f1bad257ebd187bdc3f37b23f33c6a5d6a8e1f2de586080d6ada19087b0e2bf23b79c1b6da1ee82271323f5bdf3e1b018586b54a5b92ab6a1a16bb3315190a3584a05e6c37d5ca1e05d702b9869e27f513472bcdd00f4d0502a107773097da', '0x9636d24f1ede773ce919f309448dd7ce023f424afd6b4b69cb98c2a988d849a283646dc3e469879daa1b1edae91ae41f009887518e7eb5578f88469321117303cd3ac2d7aee4d9cb5f82ab9ae3458e796dfe7c24284b05815acfcaa270ff22e2', '0xb373feb5d7012fd60578d7d00834c5c81df2a23d42794fed91aa9535a4771fde0341c4da882261785e0caca40bf83405143085e7f17e55b64f6c5c809680c20b050409bf3702c574769127c854d27388b144b05624a0e24a1cbcc4d08467005b', '0xb15680648949ce69f82526e9b67d9b55ce5c537dc6ab7f3089091a9a19a6b90df7656794f6edc87fb387d21573ffc847062623685931c2790a508cbc8c6b231dd2c34f4d37d4706237b1407673605a604bcf6a50cc0b1a2db20485e22b02c17e', '0x8817e46672d40c8f748081567b038a3165f87994788ec77ee8daea8587f5540df3422f9e120e94339be67f186f50952504cb44f61e30a5241f1827e501b2de53c4c64473bcc79ab887dd277f282fbfe47997a930dd140ac08b03efac88d81075', '0xa6e4ef6c1d1098f95aae119905f87eb49b909d17f9c41bcfe51127aa25fee20782ea884a7fdf7d5e9c245b5a5b32230b07e0dbf7c6743bf52ee20e2acc0b269422bd6cf3c07115df4aa85b11b2c16630a07c974492d9cdd0ec325a3fabd95044', '0x8634aa7c3d00e7f17150009698ce440d8e1b0f13042b624a722ace68ead870c3d2212fbee549a2c190e384d7d6ac37ce14ab962c299ea1218ef1b1489c98906c91323b94c587f1d205a6edd5e9d05b42d591c26494a6f6a029a2aadb5f8b6f67', '0x821a58092900bdb73decf48e13e7a5012a3f88b06288a97b855ef51306406e7d867d613d9ec738ebacfa6db344b677d21509d93f3b55c2ebf3a2f2a6356f875150554c6fff52e62e3e46f7859be971bf7dd9d5b3e1d799749c8a97c2e04325df', '0x8dba356577a3a388f782e90edb1a7f3619759f4de314ad5d95c7cc6e197211446819c4955f99c5fc67f79450d2934e3c09adefc91b724887e005c5190362245eec48ce117d0a94d6fa6db12eda4ba8dde608fbbd0051f54dcf3bb057adfb2493', '0xa32a690dc95c23ed9fb46443d9b7d4c2e27053a7fcc216d2b0020a8cf279729c46114d2cda5772fd60a97016a07d6c5a0a7eb085a18307d34194596f5b541cdf01b2ceb31d62d6b55515acfd2b9eec92b27d082fbc4dc59fc63b551eccdb8468', '0xa040f7f4be67eaf0a1d658a3175d65df21a7dbde99bfa893469b9b43b9d150fc2e333148b1cb88cfd0447d88fa1a501d126987e9fdccb2852ecf1ba907c2ca3d6f97b055e354a9789854a64ecc8c2e928382cf09dda9abde42bbdf92280cdd96', '0x864baff97fa60164f91f334e0c9be00a152a416556b462f96d7c43b59fe1ebaff42f0471d0bf264976f8aa6431176eb905bd875024cf4f76c13a70bede51dc3e47e10b9d5652d30d2663b3af3f08d5d11b9709a0321aba371d2ef13174dcfcaf', '0x95a46f32c994133ecc22db49bad2c36a281d6b574c83cfee6680b8c8100466ca034b815cfaedfbf54f4e75188e661df901abd089524e1e0eb0bf48d48caa9dd97482d2e8c1253e7e8ac250a32fd066d5b5cb08a8641bdd64ecfa48289dca83a3', '0xa2cce2be4d12144138cb91066e0cd0542c80b478bf467867ebef9ddaf3bd64e918294043500bf5a9f45ee089a8d6ace917108d9ce9e4f41e7e860cbce19ac52e791db3b6dde1c4b0367377b581f999f340e1d6814d724edc94cb07f9c4730774', '0xb145f203eee1ac0a1a1731113ffa7a8b0b694ef2312dabc4d431660f5e0645ef5838e3e624cfe1228cfa248d48b5760501f93e6ab13d3159fc241427116c4b90359599a4cb0a86d0bb9190aa7fabff482c812db966fd2ce0a1b48cb8ac8b3bca', '0xadabe5d215c608696e03861cbd5f7401869c756b3a5aadc55f41745ad9478145d44393fec8bb6dfc4ad9236dc62b9ada0f7ca57fe2bae1b71565dbf9536d33a68b8e2090b233422313cc96afc7f1f7e0907dc7787806671541d6de8ce47c4cd0', '0xae7845fa6b06db53201c1080e01e629781817f421f28956589c6df3091ec33754f8a4bd4647a6bb1c141ac22731e3c1014865d13f3ed538dcb0f7b7576435133d9d03be655f8fbb4c9f7d83e06d1210aedd45128c2b0c9bab45a9ddde1c862a5', '0x9159eaa826a24adfa7adf6e8d2832120ebb6eccbeb3d0459ffdc338548813a2d239d22b26451fda98cc0c204d8e1ac69150b5498e0be3045300e789bcb4e210d5cd431da4bdd915a21f407ea296c20c96608ded0b70d07188e96e6c1a7b9b86b', '0xa9fc6281e2d54b46458ef564ffaed6944bff71e389d0acc11fa35d3fcd8e10c1066e0dde5b9b6516f691bb478e81c6b20865281104dcb640e29dc116daae2e884f1fe6730d639dbe0e19a532be4fb337bf52ae8408446deb393d224eee7cfa50', '0x84291a42f991bfb36358eedead3699d9176a38f6f63757742fdbb7f631f2c70178b1aedef4912fed7b6cf27e88ddc7eb0e2a6aa4b999f3eb4b662b93f386c8d78e9ac9929e21f4c5e63b12991fcde93aa64a735b75b535e730ff8dd2abb16e04', '0xa1b7fcacae181495d91765dfddf26581e8e39421579c9cbd0dd27a40ea4c54af3444a36bf85a11dda2114246eaddbdd619397424bb1eb41b5a15004b902a590ede5742cd850cf312555be24d2df8becf48f5afba5a8cd087cb7be0a521728386', '0x92feaaf540dbd84719a4889a87cdd125b7e995a6782911931fef26da9afcfbe6f86aaf5328fe1f77631491ce6239c5470f44c7791506c6ef1626803a5794e76d2be0af92f7052c29ac6264b7b9b51f267ad820afc6f881460521428496c6a5f1', '0xa525c925bfae1b89320a5054acc1fa11820f73d0cf28d273092b305467b2831fab53b6daf75fb926f332782d50e2522a19edcd85be5eb72f1497193c952d8cd0bcc5d43b39363b206eae4cb1e61668bde28a3fb2fc1e0d3d113f6dfadb799717', '0x98752bb6f5a44213f40eda6aa4ff124057c1b13b6529ab42fe575b9afa66e59b9c0ed563fb20dff62130c436c3e905ee17dd8433ba02c445b1d67182ab6504a90bbe12c26a754bbf734665c622f76c62fe2e11dd43ce04fd2b91a8463679058b', '0xa9aa9a84729f7c44219ff9e00e651e50ddea3735ef2a73fdf8ed8cd271961d8ed7af5cd724b713a89a097a3fe65a3c0202f69458a8b4c157c62a85668b12fc0d3957774bc9b35f86c184dd03bfefd5c325da717d74192cc9751c2073fe9d170e', '0xb221c1fd335a4362eff504cd95145f122bf93ea02ae162a3fb39c75583fc13a932d26050e164da97cff3e91f9a7f6ff80302c19dd1916f24acf6b93b62f36e9665a8785413b0c7d930c7f1668549910f849bca319b00e59dd01e5dec8d2edacc', '0xa71e2b1e0b16d754b848f05eda90f67bedab37709550171551050c94efba0bfc282f72aeaaa1f0330041461f5e6aa4d11537237e955e1609a469d38ed17f5c2a35a1752f546db89bfeff9eab78ec944266f1cb94c1db3334ab48df716ce408ef', '0xb990ae72768779ba0b2e66df4dd29b3dbd00f901c23b2b4a53419226ef9232acedeb498b0d0687c463e3f1eead58b20b09efcefa566fbfdfe1c6e48d32367936142d0a734143e5e63cdf86be7457723535b787a9cfcfa32fe1d61ad5a2617220', '0x8d27e7fbff77d5b9b9bbc864d5231fecf817238a6433db668d5a62a2c1ee1e5694fdd90c3293c06cc0cb15f7cbeab44d0d42be632cb9ff41fc3f6628b4b62897797d7b56126d65b694dcf3e298e3561ac8813fbd7296593ced33850426df42db', '0xa92039a08b5502d5b211a7744099c9f93fa8c90cedcb1d05e92f01886219dd464eb5fb0337496ad96ed09c987da4e5f019035c5b01cc09b2a18b8a8dd419bc5895388a07e26958f6bd26751929c25f89b8eb4a299d822e2d26fec9ef350e0d3c', '0x92dcc5a1c8c3e1b28b1524e3dd6dbecd63017c9201da9dbe077f1b82adc08c50169f56fc7b5a3b28ec6b89254de3e2fd12838a761053437883c3e01ba616670cea843754548ef84bcc397de2369adcca2ab54cd73c55dc68d87aec3fc2fe4f10']
+    <spec constant_var="JUSTIFICATION_BITS_LENGTH" fork="phase0" hash="fe924a00">
+    JUSTIFICATION_BITS_LENGTH: Uint64 = 4
     </spec>
 
 - name: MAX_CONCURRENT_REQUESTS#phase0
@@ -447,15 +389,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: MAX_CONCURRENT_REQUESTS =
   spec: |
-    <spec constant_var="MAX_CONCURRENT_REQUESTS" fork="phase0" hash="f5ff241b">
-    MAX_CONCURRENT_REQUESTS = 2
+    <spec constant_var="MAX_CONCURRENT_REQUESTS" fork="phase0" hash="7c6a01b0">
+    MAX_CONCURRENT_REQUESTS: Uint64 = 2
     </spec>
 
 - name: MAX_REQUEST_LIGHT_CLIENT_UPDATES#altair
   sources: []
   spec: |
-    <spec constant_var="MAX_REQUEST_LIGHT_CLIENT_UPDATES" fork="altair" hash="aa7e3917">
-    MAX_REQUEST_LIGHT_CLIENT_UPDATES = 2**7
+    <spec constant_var="MAX_REQUEST_LIGHT_CLIENT_UPDATES" fork="altair" hash="4fc19d9c">
+    MAX_REQUEST_LIGHT_CLIENT_UPDATES: Uint64 = 2**7
     </spec>
 
 - name: NODE_ID_BITS#phase0
@@ -463,15 +405,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: NODE_ID_BITS =
   spec: |
-    <spec constant_var="NODE_ID_BITS" fork="phase0" hash="57dab5f1">
-    NODE_ID_BITS = 256
+    <spec constant_var="NODE_ID_BITS" fork="phase0" hash="8197d7fc">
+    NODE_ID_BITS: Uint64 = 256
     </spec>
 
 - name: NUM_BLOCK_TIMELINESS_DEADLINES#gloas
   sources: []
   spec: |
-    <spec constant_var="NUM_BLOCK_TIMELINESS_DEADLINES" fork="gloas" hash="c4e721d9">
-    NUM_BLOCK_TIMELINESS_DEADLINES = 2
+    <spec constant_var="NUM_BLOCK_TIMELINESS_DEADLINES" fork="gloas" hash="f820cf58">
+    NUM_BLOCK_TIMELINESS_DEADLINES: Uint64 = 2
     </spec>
 
 - name: PARTICIPATION_FLAG_WEIGHTS#altair
@@ -488,8 +430,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloas.java
       search: PAYLOAD_BUILDER_VERSION = 0
   spec: |
-    <spec constant_var="PAYLOAD_BUILDER_VERSION" fork="gloas" hash="96275869">
-    PAYLOAD_BUILDER_VERSION: uint8 = 0
+    <spec constant_var="PAYLOAD_BUILDER_VERSION" fork="gloas" hash="70d3d5ec">
+    PAYLOAD_BUILDER_VERSION: Uint8 = 0
     </spec>
 
 - name: PAYLOAD_STATUS_EMPTY#gloas
@@ -549,41 +491,20 @@
     PAYLOAD_STATUS_VALID: PayloadValidationStatus = 0
     </spec>
 
-- name: PRIMITIVE_ROOT_OF_UNITY#deneb
-  sources: []
-  spec: |
-    <spec constant_var="PRIMITIVE_ROOT_OF_UNITY" fork="deneb" hash="004e6753">
-    PRIMITIVE_ROOT_OF_UNITY = 7
-    </spec>
-
 - name: PROPOSER_WEIGHT#altair
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: PROPOSER_WEIGHT =
   spec: |
-    <spec constant_var="PROPOSER_WEIGHT" fork="altair" hash="4dcb6f6c">
-    PROPOSER_WEIGHT: uint64 = 8
+    <spec constant_var="PROPOSER_WEIGHT" fork="altair" hash="285814bb">
+    PROPOSER_WEIGHT: Uint64 = 8
     </spec>
 
 - name: PTC_TIMELINESS_INDEX#gloas
   sources: []
   spec: |
-    <spec constant_var="PTC_TIMELINESS_INDEX" fork="gloas" hash="ffca13bd">
-    PTC_TIMELINESS_INDEX = 1
-    </spec>
-
-- name: RANDOM_CHALLENGE_KZG_BATCH_DOMAIN#deneb
-  sources: []
-  spec: |
-    <spec constant_var="RANDOM_CHALLENGE_KZG_BATCH_DOMAIN" fork="deneb" hash="a994f6c6">
-    RANDOM_CHALLENGE_KZG_BATCH_DOMAIN = b'RCKZGBATCH___V1_'
-    </spec>
-
-- name: RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN#fulu
-  sources: []
-  spec: |
-    <spec constant_var="RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN" fork="fulu" hash="907a9534">
-    RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN = b'RCKZGCBATCH__V1_'
+    <spec constant_var="PTC_TIMELINESS_INDEX" fork="gloas" hash="73fb7372">
+    PTC_TIMELINESS_INDEX: Uint64 = 1
     </spec>
 
 - name: SAFETY_DECAY#phase0
@@ -591,8 +512,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/weaksubjectivity/WeakSubjectivityCalculator.java
       search: public static final UInt64 SAFETY_DECAY =
   spec: |
-    <spec constant_var="SAFETY_DECAY" fork="phase0" hash="298e03fe">
-    SAFETY_DECAY: uint64 = 10
+    <spec constant_var="SAFETY_DECAY" fork="phase0" hash="a14d04b9">
+    SAFETY_DECAY: Uint64 = 10
     </spec>
 
 - name: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY#bellatrix
@@ -600,8 +521,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY =
   spec: |
-    <spec constant_var="SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY" fork="bellatrix" hash="87b7dd5b">
-    SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY = 128
+    <spec constant_var="SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY" fork="bellatrix" hash="ea89f23b">
+    SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY: Slot = 128
     </spec>
 
 - name: SYNC_COMMITTEE_SUBNET_COUNT#altair
@@ -609,8 +530,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/NetworkConstants.java
       search: SYNC_COMMITTEE_SUBNET_COUNT =
   spec: |
-    <spec constant_var="SYNC_COMMITTEE_SUBNET_COUNT" fork="altair" hash="9b41920c">
-    SYNC_COMMITTEE_SUBNET_COUNT: uint64 = 2**2
+    <spec constant_var="SYNC_COMMITTEE_SUBNET_COUNT" fork="altair" hash="28eeefc6">
+    SYNC_COMMITTEE_SUBNET_COUNT: Uint64 = 2**2
     </spec>
 
 - name: SYNC_REWARD_WEIGHT#altair
@@ -618,8 +539,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: SYNC_REWARD_WEIGHT =
   spec: |
-    <spec constant_var="SYNC_REWARD_WEIGHT" fork="altair" hash="ea70c5e0">
-    SYNC_REWARD_WEIGHT: uint64 = 2
+    <spec constant_var="SYNC_REWARD_WEIGHT" fork="altair" hash="4e877b1b">
+    SYNC_REWARD_WEIGHT: Uint64 = 2
     </spec>
 
 - name: TARGET_AGGREGATORS_PER_COMMITTEE#phase0
@@ -627,8 +548,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ValidatorConstants.java
       search: TARGET_AGGREGATORS_PER_COMMITTEE =
   spec: |
-    <spec constant_var="TARGET_AGGREGATORS_PER_COMMITTEE" fork="phase0" hash="3a65ef1c">
-    TARGET_AGGREGATORS_PER_COMMITTEE = 2**4
+    <spec constant_var="TARGET_AGGREGATORS_PER_COMMITTEE" fork="phase0" hash="a1e0ac44">
+    TARGET_AGGREGATORS_PER_COMMITTEE: Uint64 = 2**4
     </spec>
 
 - name: TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE#altair
@@ -636,8 +557,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ValidatorConstants.java
       search: TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE =
   spec: |
-    <spec constant_var="TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE" fork="altair" hash="76404bd9">
-    TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: uint64 = 2**4
+    <spec constant_var="TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE" fork="altair" hash="342d32fe">
+    TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: Uint64 = 2**4
     </spec>
 
 - name: TIMELY_HEAD_FLAG_INDEX#altair
@@ -645,8 +566,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
       search: TIMELY_HEAD_FLAG_INDEX =
   spec: |
-    <spec constant_var="TIMELY_HEAD_FLAG_INDEX" fork="altair" hash="a01306fb">
-    TIMELY_HEAD_FLAG_INDEX = 2
+    <spec constant_var="TIMELY_HEAD_FLAG_INDEX" fork="altair" hash="2f0404ec">
+    TIMELY_HEAD_FLAG_INDEX: Uint64 = 2
     </spec>
 
 - name: TIMELY_HEAD_WEIGHT#altair
@@ -654,8 +575,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: TIMELY_HEAD_WEIGHT =
   spec: |
-    <spec constant_var="TIMELY_HEAD_WEIGHT" fork="altair" hash="d6f53c91">
-    TIMELY_HEAD_WEIGHT: uint64 = 14
+    <spec constant_var="TIMELY_HEAD_WEIGHT" fork="altair" hash="5dbf2ae7">
+    TIMELY_HEAD_WEIGHT: Uint64 = 14
     </spec>
 
 - name: TIMELY_SOURCE_FLAG_INDEX#altair
@@ -663,8 +584,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
       search: TIMELY_SOURCE_FLAG_INDEX =
   spec: |
-    <spec constant_var="TIMELY_SOURCE_FLAG_INDEX" fork="altair" hash="57f25239">
-    TIMELY_SOURCE_FLAG_INDEX = 0
+    <spec constant_var="TIMELY_SOURCE_FLAG_INDEX" fork="altair" hash="67dc0832">
+    TIMELY_SOURCE_FLAG_INDEX: Uint64 = 0
     </spec>
 
 - name: TIMELY_SOURCE_WEIGHT#altair
@@ -672,8 +593,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: TIMELY_SOURCE_WEIGHT =
   spec: |
-    <spec constant_var="TIMELY_SOURCE_WEIGHT" fork="altair" hash="9cf6e565">
-    TIMELY_SOURCE_WEIGHT: uint64 = 14
+    <spec constant_var="TIMELY_SOURCE_WEIGHT" fork="altair" hash="0fa0a586">
+    TIMELY_SOURCE_WEIGHT: Uint64 = 14
     </spec>
 
 - name: TIMELY_TARGET_FLAG_INDEX#altair
@@ -681,8 +602,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/ParticipationFlags.java
       search: TIMELY_TARGET_FLAG_INDEX =
   spec: |
-    <spec constant_var="TIMELY_TARGET_FLAG_INDEX" fork="altair" hash="32530e5a">
-    TIMELY_TARGET_FLAG_INDEX = 1
+    <spec constant_var="TIMELY_TARGET_FLAG_INDEX" fork="altair" hash="4955ac70">
+    TIMELY_TARGET_FLAG_INDEX: Uint64 = 1
     </spec>
 
 - name: TIMELY_TARGET_WEIGHT#altair
@@ -690,8 +611,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: TIMELY_TARGET_WEIGHT =
   spec: |
-    <spec constant_var="TIMELY_TARGET_WEIGHT" fork="altair" hash="5413dfe8">
-    TIMELY_TARGET_WEIGHT: uint64 = 26
+    <spec constant_var="TIMELY_TARGET_WEIGHT" fork="altair" hash="1c8b9efd">
+    TIMELY_TARGET_WEIGHT: Uint64 = 26
     </spec>
 
 - name: UINT256_MAX#fulu
@@ -699,8 +620,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: UInt256.MAX_VALUE
   spec: |
-    <spec constant_var="UINT256_MAX" fork="fulu" hash="57a47f45">
-    UINT256_MAX: uint256 = 2**256 - 1
+    <spec constant_var="UINT256_MAX" fork="fulu" hash="a6028f55">
+    UINT256_MAX: Uint256 = 2**256 - 1
     </spec>
 
 - name: UINT64_MAX#phase0
@@ -708,8 +629,8 @@
     - file: infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
       search: MAX_VALUE = new UInt64(-1L)
   spec: |
-    <spec constant_var="UINT64_MAX" fork="phase0" hash="0efe6bd6">
-    UINT64_MAX: uint64 = 2**64 - 1
+    <spec constant_var="UINT64_MAX" fork="phase0" hash="1138f03a">
+    UINT64_MAX: Uint64 = 2**64 - 1
     </spec>
 
 - name: UINT64_MAX_SQRT#phase0
@@ -717,8 +638,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
       search: UInt64 MAX_SQRT = UInt64.valueOf(4294967295L);
   spec: |
-    <spec constant_var="UINT64_MAX_SQRT" fork="phase0" hash="28d7e92a">
-    UINT64_MAX_SQRT: uint64 = 4294967295
+    <spec constant_var="UINT64_MAX_SQRT" fork="phase0" hash="6481b982">
+    UINT64_MAX_SQRT: Uint64 = 4294967295
     </spec>
 
 - name: UNSET_DEPOSIT_REQUESTS_START_INDEX#electra
@@ -726,8 +647,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
       search: UNSET_DEPOSIT_REQUESTS_START_INDEX =
   spec: |
-    <spec constant_var="UNSET_DEPOSIT_REQUESTS_START_INDEX" fork="electra" hash="5eb703dc">
-    UNSET_DEPOSIT_REQUESTS_START_INDEX: uint64 = 2**64 - 1
+    <spec constant_var="UNSET_DEPOSIT_REQUESTS_START_INDEX" fork="electra" hash="8365c845">
+    UNSET_DEPOSIT_REQUESTS_START_INDEX: Uint64 = 2**64 - 1
     </spec>
 
 - name: VERSIONED_HASH_VERSION_KZG#deneb
@@ -744,8 +665,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/IncentivizationWeights.java
       search: WEIGHT_DENOMINATOR =
   spec: |
-    <spec constant_var="WEIGHT_DENOMINATOR" fork="altair" hash="0d498a82">
-    WEIGHT_DENOMINATOR: uint64 = 64
+    <spec constant_var="WEIGHT_DENOMINATOR" fork="altair" hash="2515d882">
+    WEIGHT_DENOMINATOR: Uint64 = 64
     </spec>
 
 - name: WITHDRAWAL_REQUEST_TYPE#electra

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -28,9 +28,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/phase0/AttestationPhase0Schema.java
   spec: |
-    <spec container="Attestation" fork="phase0" hash="5fc71dce">
+    <spec container="Attestation" fork="phase0" hash="d0523528">
     class Attestation(Container):
-        aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE]
+        aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
         data: AttestationData
         signature: BLSSignature
     </spec>
@@ -42,14 +42,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectraSchema.java
   spec: |
-    <spec container="Attestation" fork="electra" hash="05913162">
+    <spec container="Attestation" fork="electra" hash="36145004">
     class Attestation(Container):
         # [Modified in Electra:EIP7549]
         aggregation_bits: AggregationBits
         data: AttestationData
         signature: BLSSignature
         # [New in Electra:EIP7549]
-        committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]
+        committee_bits: BitVector[MAX_COMMITTEES_PER_SLOT]
     </spec>
 
 - name: AttestationData#phase0
@@ -317,9 +317,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0Impl.java
   spec: |
-    <spec container="BeaconState" fork="phase0" hash="05beaa1c">
+    <spec container="BeaconState" fork="phase0" hash="28d6a433">
     class BeaconState(Container):
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -329,14 +329,14 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
         balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
         previous_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
         current_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
@@ -350,9 +350,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltair.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltairImpl.java
   spec: |
-    <spec container="BeaconState" fork="altair" hash="8de7d5fb">
+    <spec container="BeaconState" fork="altair" hash="8f9563b2">
     class BeaconState(Container):
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -362,7 +362,7 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
         balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
@@ -371,12 +371,12 @@
         previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
         # [Modified in Altair]
         current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
         # [New in Altair]
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
         # [New in Altair]
         current_sync_committee: SyncCommittee
         # [New in Altair]
@@ -391,9 +391,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrixImpl.java
   spec: |
-    <spec container="BeaconState" fork="bellatrix" hash="e5633a51">
+    <spec container="BeaconState" fork="bellatrix" hash="605f8b59">
     class BeaconState(Container):
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -403,18 +403,18 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
         balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
         previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
         current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [New in Bellatrix]
@@ -429,9 +429,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapellaImpl.java
   spec: |
-    <spec container="BeaconState" fork="capella" hash="245ba83b">
+    <spec container="BeaconState" fork="capella" hash="cd669bb4">
     class BeaconState(Container):
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -441,18 +441,18 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
         balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
         previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
         current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Capella]
@@ -473,9 +473,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/MutableBeaconStateDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/MutableBeaconStateDenebImpl.java
   spec: |
-    <spec container="BeaconState" fork="deneb" hash="32fd9dc4">
+    <spec container="BeaconState" fork="deneb" hash="09a74ef7">
     class BeaconState(Container):
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -485,18 +485,18 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
         balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
         previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
         current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Deneb:EIP4844]
@@ -514,9 +514,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/MutableBeaconStateElectra.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/electra/MutableBeaconStateElectraImpl.java
   spec: |
-    <spec container="BeaconState" fork="electra" hash="55e40daf">
+    <spec container="BeaconState" fork="electra" hash="d2b13d5a">
     class BeaconState(Container):
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -526,18 +526,18 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
         balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
         previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
         current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         latest_execution_payload_header: ExecutionPayloadHeader
@@ -545,7 +545,7 @@
         next_withdrawal_validator_index: ValidatorIndex
         historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
         # [New in Electra:EIP6110]
-        deposit_requests_start_index: uint64
+        deposit_requests_start_index: Uint64
         # [New in Electra:EIP7251]
         deposit_balance_to_consume: Gwei
         # [New in Electra:EIP7251]
@@ -572,9 +572,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/MutableBeaconStateFulu.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/fulu/MutableBeaconStateFuluImpl.java
   spec: |
-    <spec container="BeaconState" fork="fulu" hash="0923b253">
+    <spec container="BeaconState" fork="fulu" hash="5735dc82">
     class BeaconState(Container):
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -584,25 +584,25 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
         balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
         randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
         slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
         previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
         current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         latest_execution_payload_header: ExecutionPayloadHeader
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
         historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
-        deposit_requests_start_index: uint64
+        deposit_requests_start_index: Uint64
         deposit_balance_to_consume: Gwei
         exit_balance_to_consume: Gwei
         earliest_exit_epoch: Epoch
@@ -623,9 +623,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/gloas/MutableBeaconStateGloasImpl.java
   spec: |
-    <spec container="BeaconState" fork="gloas" hash="14b204a8">
+    <spec container="BeaconState" fork="gloas" hash="8a133a4f">
     class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
-        genesis_time: uint64
+        genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
@@ -635,7 +635,7 @@
         historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
         eth1_data: Eth1Data
         eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
-        eth1_deposit_index: uint64
+        eth1_deposit_index: Uint64
         # [Modified in Gloas:EIP7688]
         validators: ProgressiveList[Validator]
         # [Modified in Gloas:EIP7688]
@@ -646,12 +646,12 @@
         previous_epoch_participation: ProgressiveList[ParticipationFlags]
         # [Modified in Gloas:EIP7688]
         current_epoch_participation: ProgressiveList[ParticipationFlags]
-        justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
         # [Modified in Gloas:EIP7688]
-        inactivity_scores: ProgressiveList[uint64]
+        inactivity_scores: ProgressiveList[Uint64]
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Gloas:EIP7732]
@@ -661,7 +661,7 @@
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
         historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
-        deposit_requests_start_index: uint64
+        deposit_requests_start_index: Uint64
         deposit_balance_to_consume: Gwei
         exit_balance_to_consume: Gwei
         earliest_exit_epoch: Epoch
@@ -679,7 +679,7 @@
         # [New in Gloas:EIP7732]
         next_withdrawal_builder_index: BuilderIndex
         # [New in Gloas:EIP7732]
-        execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
+        execution_payload_availability: BitVector[SLOTS_PER_HISTORICAL_ROOT]
         # [New in Gloas:EIP7732]
         builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
         # [New in Gloas:EIP7732]
@@ -721,10 +721,10 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/gloas/Builder.java
   spec: |
-    <spec container="Builder" fork="gloas" hash="ae177179">
+    <spec container="Builder" fork="gloas" hash="c95d3cd2">
     class Builder(Container):
         pubkey: BLSPubkey
-        version: uint8
+        version: Uint8
         execution_address: ExecutionAddress
         balance: Gwei
         deposit_epoch: Epoch
@@ -900,33 +900,33 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/DepositRequest.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/DepositRequestSchema.java
   spec: |
-    <spec container="DepositRequest" fork="electra" hash="3af9895d">
+    <spec container="DepositRequest" fork="electra" hash="f51e4afe">
     class DepositRequest(Container):
         pubkey: BLSPubkey
         withdrawal_credentials: Bytes32
         amount: Gwei
         signature: BLSSignature
-        index: uint64
+        index: Uint64
     </spec>
 
 - name: Eth1Block#phase0
   sources: []
   spec: |
-    <spec container="Eth1Block" fork="phase0" hash="0a5c6b45">
+    <spec container="Eth1Block" fork="phase0" hash="587ddda8">
     class Eth1Block(Container):
-        timestamp: uint64
+        timestamp: Uint64
         deposit_root: Root
-        deposit_count: uint64
+        deposit_count: Uint64
     </spec>
 
 - name: Eth1Data#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1Data.java
   spec: |
-    <spec container="Eth1Data" fork="phase0" hash="1d7be228">
+    <spec container="Eth1Data" fork="phase0" hash="e4ca9042">
     class Eth1Data(Container):
         deposit_root: Root
-        deposit_count: uint64
+        deposit_count: Uint64
         block_hash: Hash32
     </spec>
 
@@ -936,7 +936,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadBuilderBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadSchemaBellatrix.java
   spec: |
-    <spec container="ExecutionPayload" fork="bellatrix" hash="da4d8580">
+    <spec container="ExecutionPayload" fork="bellatrix" hash="4c14e8c9">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
@@ -944,12 +944,12 @@
         receipts_root: Bytes32
         logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
         prev_randao: Bytes32
-        block_number: uint64
-        gas_limit: uint64
-        gas_used: uint64
-        timestamp: uint64
+        block_number: Uint64
+        gas_limit: Uint64
+        gas_used: Uint64
+        timestamp: Uint64
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-        base_fee_per_gas: uint256
+        base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     </spec>
@@ -961,7 +961,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadBuilderCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadSchemaCapella.java
   spec: |
-    <spec container="ExecutionPayload" fork="capella" hash="5533cb47">
+    <spec container="ExecutionPayload" fork="capella" hash="78dd6037">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
@@ -969,12 +969,12 @@
         receipts_root: Bytes32
         logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
         prev_randao: Bytes32
-        block_number: uint64
-        gas_limit: uint64
-        gas_used: uint64
-        timestamp: uint64
+        block_number: Uint64
+        gas_limit: Uint64
+        gas_used: Uint64
+        timestamp: Uint64
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-        base_fee_per_gas: uint256
+        base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
         # [New in Capella]
@@ -988,7 +988,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadBuilderDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadSchemaDeneb.java
   spec: |
-    <spec container="ExecutionPayload" fork="deneb" hash="974f7cc9">
+    <spec container="ExecutionPayload" fork="deneb" hash="548fc639">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
@@ -996,19 +996,19 @@
         receipts_root: Bytes32
         logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
         prev_randao: Bytes32
-        block_number: uint64
-        gas_limit: uint64
-        gas_used: uint64
-        timestamp: uint64
+        block_number: Uint64
+        gas_limit: Uint64
+        gas_used: Uint64
+        timestamp: Uint64
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-        base_fee_per_gas: uint256
+        base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
         withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
         # [New in Deneb:EIP4844]
-        blob_gas_used: uint64
+        blob_gas_used: Uint64
         # [New in Deneb:EIP4844]
-        excess_blob_gas: uint64
+        excess_blob_gas: Uint64
     </spec>
 
 - name: ExecutionPayload#gloas
@@ -1018,7 +1018,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadBuilderGloas.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/gloas/ExecutionPayloadSchemaGloas.java
   spec: |
-    <spec container="ExecutionPayload" fork="gloas" hash="0bee8801">
+    <spec container="ExecutionPayload" fork="gloas" hash="e985ae4c">
     class ExecutionPayload(ProgressiveContainer(active_fields=[1] * 19)):  # type: ignore
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
@@ -1026,23 +1026,23 @@
         receipts_root: Bytes32
         logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
         prev_randao: Bytes32
-        block_number: uint64
-        gas_limit: uint64
-        gas_used: uint64
-        timestamp: uint64
+        block_number: Uint64
+        gas_limit: Uint64
+        gas_used: Uint64
+        timestamp: Uint64
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-        base_fee_per_gas: uint256
+        base_fee_per_gas: Uint256
         block_hash: Hash32
         # [Modified in Gloas:EIP7688]
         transactions: ProgressiveList[Transaction]
         # [Modified in Gloas:EIP7688]
         withdrawals: ProgressiveList[Withdrawal]
-        blob_gas_used: uint64
-        excess_blob_gas: uint64
+        blob_gas_used: Uint64
+        excess_blob_gas: Uint64
         # [New in Gloas:EIP7928]
         block_access_list: BlockAccessList
         # [New in Gloas:EIP7843]
-        slot_number: uint64
+        slot_number: Uint64
     </spec>
 
 - name: ExecutionPayloadBid#gloas
@@ -1050,14 +1050,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBid.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ExecutionPayloadBidSchema.java
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="7465947d">
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="3bc16ac1">
     class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):  # type: ignore
         parent_block_hash: Hash32
         parent_block_root: Root
         block_hash: Hash32
         prev_randao: Bytes32
         fee_recipient: ExecutionAddress
-        gas_limit: uint64
+        gas_limit: Uint64
         builder_index: BuilderIndex
         slot: Slot
         value: Gwei
@@ -1086,7 +1086,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderBuilderBellatrix.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/bellatrix/ExecutionPayloadHeaderSchemaBellatrix.java
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="bellatrix" hash="08fc7165">
+    <spec container="ExecutionPayloadHeader" fork="bellatrix" hash="a3ed912a">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
@@ -1094,12 +1094,12 @@
         receipts_root: Bytes32
         logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
         prev_randao: Bytes32
-        block_number: uint64
-        gas_limit: uint64
-        gas_used: uint64
-        timestamp: uint64
+        block_number: Uint64
+        gas_limit: Uint64
+        gas_used: Uint64
+        timestamp: Uint64
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-        base_fee_per_gas: uint256
+        base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
     </spec>
@@ -1111,7 +1111,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderBuilderCapella.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/ExecutionPayloadHeaderSchemaCapella.java
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="capella" hash="5f481de3">
+    <spec container="ExecutionPayloadHeader" fork="capella" hash="521fff4a">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
@@ -1119,12 +1119,12 @@
         receipts_root: Bytes32
         logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
         prev_randao: Bytes32
-        block_number: uint64
-        gas_limit: uint64
-        gas_used: uint64
-        timestamp: uint64
+        block_number: Uint64
+        gas_limit: Uint64
+        gas_used: Uint64
+        timestamp: Uint64
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-        base_fee_per_gas: uint256
+        base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
         # [New in Capella]
@@ -1138,7 +1138,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderBuilderDeneb.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/deneb/ExecutionPayloadHeaderSchemaDeneb.java
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="deneb" hash="957fa918">
+    <spec container="ExecutionPayloadHeader" fork="deneb" hash="48bef01c">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
@@ -1146,19 +1146,19 @@
         receipts_root: Bytes32
         logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
         prev_randao: Bytes32
-        block_number: uint64
-        gas_limit: uint64
-        gas_used: uint64
-        timestamp: uint64
+        block_number: Uint64
+        gas_limit: Uint64
+        gas_used: Uint64
+        timestamp: Uint64
         extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-        base_fee_per_gas: uint256
+        base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
         withdrawals_root: Root
         # [New in Deneb:EIP4844]
-        blob_gas_used: uint64
+        blob_gas_used: Uint64
         # [New in Deneb:EIP4844]
-        excess_blob_gas: uint64
+        excess_blob_gas: Uint64
     </spec>
 
 - name: ExecutionRequests#electra
@@ -1448,9 +1448,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestation.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationSchema.java
   spec: |
-    <spec container="PayloadAttestation" fork="gloas" hash="688576d4">
+    <spec container="PayloadAttestation" fork="gloas" hash="f239524c">
     class PayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
-        aggregation_bits: Bitvector[PTC_SIZE]
+        aggregation_bits: BitVector[PTC_SIZE]
         data: PayloadAttestationData
         signature: BLSSignature
     </spec>
@@ -1460,12 +1460,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationData.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/PayloadAttestationDataSchema.java
   spec: |
-    <spec container="PayloadAttestationData" fork="gloas" hash="9f1b7f92">
+    <spec container="PayloadAttestationData" fork="gloas" hash="739fcbbb">
     class PayloadAttestationData(Container):
         beacon_block_root: Root
         slot: Slot
-        payload_present: boolean
-        blob_data_available: boolean
+        payload_present: Boolean
+        blob_data_available: Boolean
     </spec>
 
 - name: PayloadAttestationMessage#gloas
@@ -1484,9 +1484,9 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/PendingAttestation.java
   spec: |
-    <spec container="PendingAttestation" fork="phase0" hash="e0a37cea">
+    <spec container="PendingAttestation" fork="phase0" hash="fb34e482">
     class PendingAttestation(Container):
-        aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE]
+        aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
         data: AttestationData
         inclusion_delay: Slot
         proposer_index: ValidatorIndex
@@ -1530,11 +1530,11 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/PowBlock.java
   spec: |
-    <spec container="PowBlock" fork="bellatrix" hash="c6c8739a">
+    <spec container="PowBlock" fork="bellatrix" hash="a3b91158">
     class PowBlock(Container):
         block_hash: Hash32
         parent_hash: Hash32
-        total_difficulty: uint256
+        total_difficulty: Uint256
     </spec>
 
 - name: ProposerPreferences#gloas
@@ -1542,13 +1542,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ProposerPreferences.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/epbs/versions/gloas/ProposerPreferencesSchema.java
   spec: |
-    <spec container="ProposerPreferences" fork="gloas" hash="305cd154">
+    <spec container="ProposerPreferences" fork="gloas" hash="43f09631">
     class ProposerPreferences(Container):
         dependent_root: Root
         proposal_slot: Slot
         validator_index: ValidatorIndex
         fee_recipient: ExecutionAddress
-        target_gas_limit: uint64
+        target_gas_limit: Uint64
     </spec>
 
 - name: ProposerSlashing#phase0
@@ -1707,9 +1707,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregate.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregateSchema.java
   spec: |
-    <spec container="SyncAggregate" fork="altair" hash="51e247e5">
+    <spec container="SyncAggregate" fork="altair" hash="4cdfb6ae">
     class SyncAggregate(Container):
-        sync_committee_bits: Bitvector[SYNC_COMMITTEE_SIZE]
+        sync_committee_bits: BitVector[SYNC_COMMITTEE_SIZE]
         sync_committee_signature: BLSSignature
     </spec>
 
@@ -1718,10 +1718,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncAggregatorSelectionData.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncAggregatorSelectionDataSchema.java
   spec: |
-    <spec container="SyncAggregatorSelectionData" fork="altair" hash="990a8a7f">
+    <spec container="SyncAggregatorSelectionData" fork="altair" hash="ea5dd5f9">
     class SyncAggregatorSelectionData(Container):
         slot: Slot
-        subcommittee_index: uint64
+        subcommittee_index: Uint64
     </spec>
 
 - name: SyncCommittee#altair
@@ -1739,12 +1739,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContribution.java
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContributionSchema.java
   spec: |
-    <spec container="SyncCommitteeContribution" fork="altair" hash="9f9b0125">
+    <spec container="SyncCommitteeContribution" fork="altair" hash="ee2e8fe5">
     class SyncCommitteeContribution(Container):
         slot: Slot
         beacon_block_root: Root
-        subcommittee_index: uint64
-        aggregation_bits: Bitvector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]
+        subcommittee_index: Uint64
+        aggregation_bits: BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]
         signature: BLSSignature
     </spec>
 
@@ -1765,12 +1765,12 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
   spec: |
-    <spec container="Validator" fork="phase0" hash="54f88c17">
+    <spec container="Validator" fork="phase0" hash="d767a9f4">
     class Validator(Container):
         pubkey: BLSPubkey
         withdrawal_credentials: Bytes32
         effective_balance: Gwei
-        slashed: boolean
+        slashed: Boolean
         activation_eligibility_epoch: Epoch
         activation_epoch: Epoch
         exit_epoch: Epoch

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -2,10 +2,10 @@
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/BlobParameters.java
   spec: |
-    <spec dataclass="BlobParameters" fork="fulu" hash="a4575aa8">
+    <spec dataclass="BlobParameters" fork="fulu" hash="f813ec73">
     class BlobParameters:
         epoch: Epoch
-        max_blobs_per_block: uint64
+        max_blobs_per_block: Uint64
     </spec>
 
 - name: BlobsBundle#deneb
@@ -42,10 +42,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
       search: record ExpectedWithdrawals(
   spec: |
-    <spec dataclass="ExpectedWithdrawals" fork="capella" hash="dc92aac5">
+    <spec dataclass="ExpectedWithdrawals" fork="capella" hash="0a0b25b7">
     class ExpectedWithdrawals:
         withdrawals: Sequence[Withdrawal]
-        processed_sweep_withdrawals_count: uint64
+        processed_sweep_withdrawals_count: Uint64
     </spec>
 
 - name: ExpectedWithdrawals#electra
@@ -53,12 +53,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
       search: record ExpectedWithdrawals(
   spec: |
-    <spec dataclass="ExpectedWithdrawals" fork="electra" hash="562f3317">
+    <spec dataclass="ExpectedWithdrawals" fork="electra" hash="2c82cb0e">
     class ExpectedWithdrawals:
         withdrawals: Sequence[Withdrawal]
         # [New in Electra:EIP7251]
-        processed_partial_withdrawals_count: uint64
-        processed_sweep_withdrawals_count: uint64
+        processed_partial_withdrawals_count: Uint64
+        processed_sweep_withdrawals_count: Uint64
     </spec>
 
 - name: ExpectedWithdrawals#gloas
@@ -66,15 +66,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/withdrawals/WithdrawalsHelpers.java
       search: record ExpectedWithdrawals(
   spec: |
-    <spec dataclass="ExpectedWithdrawals" fork="gloas" hash="b4970d87">
+    <spec dataclass="ExpectedWithdrawals" fork="gloas" hash="254d1735">
     class ExpectedWithdrawals:
         withdrawals: Sequence[Withdrawal]
         # [New in Gloas:EIP7732]
-        processed_builder_withdrawals_count: uint64
-        processed_partial_withdrawals_count: uint64
+        processed_builder_withdrawals_count: Uint64
+        processed_partial_withdrawals_count: Uint64
         # [New in Gloas:EIP7732]
-        processed_builders_sweep_count: uint64
-        processed_sweep_withdrawals_count: uint64
+        processed_builders_sweep_count: Uint64
+        processed_sweep_withdrawals_count: Uint64
     </spec>
 
 - name: FastConfirmationStore#phase0
@@ -130,10 +130,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
   spec: |
-    <spec dataclass="GetPayloadResponse" fork="capella" hash="72cc3a23">
+    <spec dataclass="GetPayloadResponse" fork="capella" hash="b7032282">
     class GetPayloadResponse:
         execution_payload: ExecutionPayload
-        block_value: uint256
+        block_value: Uint256
     </spec>
 
 - name: GetPayloadResponse#deneb
@@ -141,10 +141,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV3Response.java
   spec: |
-    <spec dataclass="GetPayloadResponse" fork="deneb" hash="56d9f50e">
+    <spec dataclass="GetPayloadResponse" fork="deneb" hash="a8a0a123">
     class GetPayloadResponse:
         execution_payload: ExecutionPayload
-        block_value: uint256
+        block_value: Uint256
         # [New in Deneb:EIP4844]
         blobs_bundle: BlobsBundle
     </spec>
@@ -154,10 +154,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV4Response.java
   spec: |
-    <spec dataclass="GetPayloadResponse" fork="electra" hash="4ad01138">
+    <spec dataclass="GetPayloadResponse" fork="electra" hash="fce0ff0d">
     class GetPayloadResponse:
         execution_payload: ExecutionPayload
-        block_value: uint256
+        block_value: Uint256
         blobs_bundle: BlobsBundle
         # [New in Electra]
         execution_requests: Sequence[bytes]
@@ -168,10 +168,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV5Response.java
   spec: |
-    <spec dataclass="GetPayloadResponse" fork="fulu" hash="3ed4ae9e">
+    <spec dataclass="GetPayloadResponse" fork="fulu" hash="44a5186e">
     class GetPayloadResponse:
         execution_payload: ExecutionPayload
-        block_value: uint256
+        block_value: Uint256
         # [Modified in Fulu:EIP7594]
         blobs_bundle: BlobsBundle
         execution_requests: Sequence[bytes]
@@ -190,7 +190,7 @@
 - name: LatestMessage#gloas
   sources: []
   spec: |
-    <spec dataclass="LatestMessage" fork="gloas" style="diff" hash="b67faaf5">
+    <spec dataclass="LatestMessage" fork="gloas" style="diff" hash="72ed3236">
     --- phase0
     +++ gloas
     @@ -1,4 +1,5 @@
@@ -199,13 +199,13 @@
     -    epoch: Epoch
     +    slot: Slot
          root: Root
-    +    payload_present: boolean
+    +    payload_present: Boolean
     </spec>
 
 - name: LightClientStore#altair
   sources: []
   spec: |
-    <spec dataclass="LightClientStore" fork="altair" hash="20909eb7">
+    <spec dataclass="LightClientStore" fork="altair" hash="edeb2c0a">
     class LightClientStore:
         # Header that is finalized
         finalized_header: LightClientHeader
@@ -217,14 +217,14 @@
         # Most recent available reasonably-safe header
         optimistic_header: LightClientHeader
         # Max number of active participants in a sync committee (used to calculate safety threshold)
-        previous_max_active_participants: uint64
-        current_max_active_participants: uint64
+        previous_max_active_participants: Uint64
+        current_max_active_participants: Uint64
     </spec>
 
 - name: LightClientStore#capella
   sources: []
   spec: |
-    <spec dataclass="LightClientStore" fork="capella" style="diff" hash="7ea8bc0f">
+    <spec dataclass="LightClientStore" fork="capella" style="diff" hash="de5160cf">
 
     </spec>
 
@@ -276,9 +276,9 @@
   sources:
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV1.java
   spec: |
-    <spec dataclass="PayloadAttributes" fork="bellatrix" hash="e399ff61">
+    <spec dataclass="PayloadAttributes" fork="bellatrix" hash="7c9497a8">
     class PayloadAttributes:
-        timestamp: uint64
+        timestamp: Uint64
         prev_randao: Bytes32
         suggested_fee_recipient: ExecutionAddress
     </spec>
@@ -287,9 +287,9 @@
   sources:
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
   spec: |
-    <spec dataclass="PayloadAttributes" fork="capella" hash="9de39844">
+    <spec dataclass="PayloadAttributes" fork="capella" hash="c0c3dd95">
     class PayloadAttributes:
-        timestamp: uint64
+        timestamp: Uint64
         prev_randao: Bytes32
         suggested_fee_recipient: ExecutionAddress
         # [New in Capella]
@@ -300,9 +300,9 @@
   sources:
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
   spec: |
-    <spec dataclass="PayloadAttributes" fork="deneb" hash="54f3a64b">
+    <spec dataclass="PayloadAttributes" fork="deneb" hash="9e6f75bd">
     class PayloadAttributes:
-        timestamp: uint64
+        timestamp: Uint64
         prev_randao: Bytes32
         suggested_fee_recipient: ExecutionAddress
         withdrawals: Sequence[Withdrawal]
@@ -314,34 +314,34 @@
   sources:
     - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV4.java
   spec: |
-    <spec dataclass="PayloadAttributes" fork="gloas" hash="4bf8c42f">
+    <spec dataclass="PayloadAttributes" fork="gloas" hash="67f80e43">
     class PayloadAttributes:
-        timestamp: uint64
+        timestamp: Uint64
         prev_randao: Bytes32
         suggested_fee_recipient: ExecutionAddress
         withdrawals: Sequence[Withdrawal]
         parent_beacon_block_root: Root
         # [New in Gloas:EIP7843]
-        slot_number: uint64
+        slot_number: Uint64
         # [New in Gloas]
-        target_gas_limit: uint64
+        target_gas_limit: Uint64
     </spec>
 
 - name: Seen#deneb
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="deneb" hash="a87605be">
+    <spec dataclass="Seen" fork="deneb" hash="23e6b8c9">
     class Seen:
         proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
         aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        aggregate_data_roots: Dict[Root, Set[Tuple[boolean, ...]]]
+        aggregate_data_roots: Dict[Root, Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
-        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
+        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         # [New in Deneb]
         blob_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, BlobIndex]]
@@ -350,19 +350,19 @@
 - name: Seen#electra
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="electra" hash="283bf511">
+    <spec dataclass="Seen" fork="electra" hash="d07ba019">
     class Seen:
         proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
         aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
         # [Modified in Electra:EIP7549]
-        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[boolean, ...]]]
+        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
-        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
+        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         blob_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, BlobIndex]]
     </spec>
@@ -370,18 +370,18 @@
 - name: Seen#fulu
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="fulu" hash="9104c2b0">
+    <spec dataclass="Seen" fork="fulu" hash="0c9400e0">
     class Seen:
         proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
         aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[boolean, ...]]]
+        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
-        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
+        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         # [Modified in Fulu:EIP7594]
         # Removed `blob_sidecar_tuples`
@@ -394,18 +394,18 @@
 - name: Seen#gloas
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="gloas" hash="d0d3cc97">
+    <spec dataclass="Seen" fork="gloas" hash="e2e5bf67">
     class Seen:
         proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
         aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[boolean, ...]]]
+        aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
         attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
-        sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
-        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
+        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
+        sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
         data_column_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, ColumnIndex]]
     </spec>
@@ -413,10 +413,10 @@
 - name: Store#phase0
   sources: []
   spec: |
-    <spec dataclass="Store" fork="phase0" hash="4b8a2508">
+    <spec dataclass="Store" fork="phase0" hash="7fed6bfc">
     class Store:
-        time: uint64
-        genesis_time: uint64
+        time: Uint64
+        genesis_time: Uint64
         justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
         unrealized_justified_checkpoint: Checkpoint
@@ -425,7 +425,7 @@
         equivocating_indices: Set[ValidatorIndex]
         blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
         block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-        block_timeliness: Dict[Root, boolean] = field(default_factory=dict)
+        block_timeliness: Dict[Root, Boolean] = field(default_factory=dict)
         checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
         latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
         unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
@@ -434,21 +434,21 @@
 - name: Store#gloas
   sources: []
   spec: |
-    <spec dataclass="Store" fork="gloas" style="diff" hash="e6e32c2d">
+    <spec dataclass="Store" fork="gloas" style="diff" hash="7e0cbbb8">
     --- phase0
     +++ gloas
     @@ -9,7 +9,12 @@
          equivocating_indices: Set[ValidatorIndex]
          blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
          block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-    -    block_timeliness: Dict[Root, boolean] = field(default_factory=dict)
-    +    block_timeliness: Dict[Root, list[boolean]] = field(default_factory=dict)
+    -    block_timeliness: Dict[Root, Boolean] = field(default_factory=dict)
+    +    block_timeliness: Dict[Root, list[Boolean]] = field(default_factory=dict)
          checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
          latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
          unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
     +    payloads: Dict[Root, ExecutionPayloadEnvelope] = field(default_factory=dict)
-    +    payload_timeliness_vote: Dict[Root, list[Optional[boolean]]] = field(default_factory=dict)
-    +    payload_data_availability_vote: Dict[Root, list[Optional[boolean]]] = field(
+    +    payload_timeliness_vote: Dict[Root, list[Optional[Boolean]]] = field(default_factory=dict)
+    +    payload_data_availability_vote: Dict[Root, list[Optional[Boolean]]] = field(
     +        default_factory=dict
     +    )
     </spec>

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1,34 +1,15 @@
-- name: _fft_field#fulu
-  sources: []
-  spec: |
-    <spec fn="_fft_field" fork="fulu" hash="b79a8171">
-    def _fft_field(
-        vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement]
-    ) -> Sequence[BLSFieldElement]:
-        if len(vals) == 1:
-            return vals
-        L = _fft_field(vals[::2], roots_of_unity[::2])
-        R = _fft_field(vals[1::2], roots_of_unity[::2])
-        o = [BLSFieldElement(0) for _ in vals]
-        for i, (x, y) in enumerate(zip(L, R, strict=True)):
-            y_times_root = y * roots_of_unity[i]
-            o[i] = x + y_times_root
-            o[i + len(L)] = x - y_times_root
-        return o
-    </spec>
-
 - name: add_builder_to_registry#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
       search: public void addBuilderToRegistry(
   spec: |
-    <spec fn="add_builder_to_registry" fork="gloas" hash="21ceace9">
+    <spec fn="add_builder_to_registry" fork="gloas" hash="41b49d46">
     def add_builder_to_registry(
         state: BeaconState,
         pubkey: BLSPubkey,
-        version: uint8,
+        version: Uint8,
         execution_address: ExecutionAddress,
-        amount: uint64,
+        amount: Uint64,
         slot: Slot,
     ) -> None:
         set_or_append_list(
@@ -59,29 +40,14 @@
         return flags | flag
     </spec>
 
-- name: add_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="add_polynomialcoeff" fork="fulu" hash="8ee8eea9">
-    def add_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoeff:
-        """
-        Sum the coefficient form polynomials ``a`` and ``b``.
-        """
-        a, b = (a, b) if len(a) >= len(b) else (b, a)
-        length_a, length_b = len(a), len(b)
-        return PolynomialCoeff([
-            a[i] + (b[i] if i < length_b else BLSFieldElement(0)) for i in range(length_a)
-        ])
-    </spec>
-
 - name: add_validator_to_registry#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
       search: public void addValidatorToRegistry(
   spec: |
-    <spec fn="add_validator_to_registry" fork="phase0" hash="53699dc0">
+    <spec fn="add_validator_to_registry" fork="phase0" hash="a560c497">
     def add_validator_to_registry(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
     ) -> None:
         state.validators.append(get_validator_from_deposit(pubkey, withdrawal_credentials, amount))
         state.balances.append(amount)
@@ -92,9 +58,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
       search: public void addValidatorToRegistry(
   spec: |
-    <spec fn="add_validator_to_registry" fork="altair" hash="18054f42">
+    <spec fn="add_validator_to_registry" fork="altair" hash="af19a79a">
     def add_validator_to_registry(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
     ) -> None:
         index = get_index_for_new_validator(state)
         validator = get_validator_from_deposit(pubkey, withdrawal_credentials, amount)
@@ -103,7 +69,7 @@
         # [New in Altair]
         set_or_append_list(state.previous_epoch_participation, index, ParticipationFlags(0b0000_0000))
         set_or_append_list(state.current_epoch_participation, index, ParticipationFlags(0b0000_0000))
-        set_or_append_list(state.inactivity_scores, index, uint64(0))
+        set_or_append_list(state.inactivity_scores, index, Uint64(0))
     </spec>
 
 - name: add_validator_to_registry#electra
@@ -113,7 +79,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public Validator getValidatorFromDeposit(
   spec: |
-    <spec fn="add_validator_to_registry" fork="electra" style="diff" hash="7970ce24">
+    <spec fn="add_validator_to_registry" fork="electra" style="diff" hash="ae623765">
 
     </spec>
 
@@ -137,12 +103,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
       search: public void applyDeposit(
   spec: |
-    <spec fn="apply_deposit" fork="phase0" hash="a53ef920">
+    <spec fn="apply_deposit" fork="phase0" hash="e1dde87c">
     def apply_deposit(
         state: BeaconState,
         pubkey: BLSPubkey,
         withdrawal_credentials: Bytes32,
-        amount: uint64,
+        amount: Uint64,
         signature: BLSSignature,
     ) -> None:
         validator_pubkeys = [v.pubkey for v in state.validators]
@@ -169,12 +135,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
       search: public void applyDeposit(
   spec: |
-    <spec fn="apply_deposit" fork="electra" hash="6259bfc5">
+    <spec fn="apply_deposit" fork="electra" hash="28ef20ed">
     def apply_deposit(
         state: BeaconState,
         pubkey: BLSPubkey,
         withdrawal_credentials: Bytes32,
-        amount: uint64,
+        amount: Uint64,
         signature: BLSSignature,
     ) -> None:
         validator_pubkeys = [v.pubkey for v in state.validators]
@@ -328,48 +294,6 @@
                 decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
     </spec>
 
-- name: bit_reversal_permutation#deneb
-  sources: []
-  spec: |
-    <spec fn="bit_reversal_permutation" fork="deneb" hash="fac0c3df">
-    def bit_reversal_permutation(sequence: Sequence[T]) -> Sequence[T]:
-        """
-        Return a copy with bit-reversed permutation. The permutation is an involution (inverts itself).
-
-        The input and output are a sequence of generic type ``T`` objects.
-        """
-        return [sequence[reverse_bits(i, len(sequence))] for i in range(len(sequence))]
-    </spec>
-
-- name: blob_to_kzg_commitment#deneb
-  sources: []
-  spec: |
-    <spec fn="blob_to_kzg_commitment" fork="deneb" hash="7242a6a3">
-    def blob_to_kzg_commitment(blob: Blob) -> KZGCommitment:
-        """
-        Public method.
-        """
-        assert len(blob) == BYTES_PER_BLOB
-        return g1_lincomb(bit_reversal_permutation(KZG_SETUP_G1_LAGRANGE), blob_to_polynomial(blob))
-    </spec>
-
-- name: blob_to_polynomial#deneb
-  sources: []
-  spec: |
-    <spec fn="blob_to_polynomial" fork="deneb" hash="2e36fb31">
-    def blob_to_polynomial(blob: Blob) -> Polynomial:
-        """
-        Convert a blob to list of BLS field scalars.
-        """
-        polynomial = Polynomial()
-        for i in range(FIELD_ELEMENTS_PER_BLOB):
-            value = bytes_to_bls_field(
-                blob[i * BYTES_PER_FIELD_ELEMENT : (i + 1) * BYTES_PER_FIELD_ELEMENT]
-            )
-            polynomial[i] = value
-        return polynomial
-    </spec>
-
 - name: block_to_light_client_header#altair
   sources: []
   spec: |
@@ -454,63 +378,17 @@
              )
     </spec>
 
-- name: bls_field_to_bytes#deneb
-  sources: []
-  spec: |
-    <spec fn="bls_field_to_bytes" fork="deneb" hash="2b84ce7c">
-    def bls_field_to_bytes(x: BLSFieldElement) -> Bytes32:
-        return int.to_bytes(int(x), 32, KZG_ENDIANNESS)
-    </spec>
-
-- name: bytes_to_bls_field#deneb
-  sources: []
-  spec: |
-    <spec fn="bytes_to_bls_field" fork="deneb" hash="0cfd397d">
-    def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
-        """
-        Convert untrusted bytes to a trusted and validated BLS scalar field element.
-        This function does not accept inputs greater than the BLS modulus.
-        """
-        field_element = int.from_bytes(b, KZG_ENDIANNESS)
-        assert field_element < BLS_MODULUS
-        return BLSFieldElement(field_element)
-    </spec>
-
-- name: bytes_to_kzg_commitment#deneb
-  sources: []
-  spec: |
-    <spec fn="bytes_to_kzg_commitment" fork="deneb" hash="2d0ccdc3">
-    def bytes_to_kzg_commitment(b: Bytes48) -> KZGCommitment:
-        """
-        Convert untrusted bytes into a trusted and validated KZGCommitment.
-        """
-        validate_kzg_g1(b)
-        return KZGCommitment(b)
-    </spec>
-
-- name: bytes_to_kzg_proof#deneb
-  sources: []
-  spec: |
-    <spec fn="bytes_to_kzg_proof" fork="deneb" hash="fcf9a902">
-    def bytes_to_kzg_proof(b: Bytes48) -> KZGProof:
-        """
-        Convert untrusted bytes into a trusted and validated KZGProof.
-        """
-        validate_kzg_g1(b)
-        return KZGProof(b)
-    </spec>
-
 - name: bytes_to_uint64#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
       search: public static UInt64 bytesToUInt64(
   spec: |
-    <spec fn="bytes_to_uint64" fork="phase0" hash="3099d397">
-    def bytes_to_uint64(data: bytes) -> uint64:
+    <spec fn="bytes_to_uint64" fork="phase0" hash="bfd0e8ff">
+    def bytes_to_uint64(data: bytes) -> Uint64:
         """
         Return the integer deserialization of ``data`` interpreted as ``ENDIANNESS``-endian.
         """
-        return uint64(int.from_bytes(data, ENDIANNESS))
+        return Uint64(int.from_bytes(data, ENDIANNESS))
     </spec>
 
 - name: calculate_committee_fraction#phase0
@@ -518,8 +396,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 calculateCommitteeFraction(
   spec: |
-    <spec fn="calculate_committee_fraction" fork="phase0" hash="782b50e9">
-    def calculate_committee_fraction(state: BeaconState, committee_percent: uint64) -> Gwei:
+    <spec fn="calculate_committee_fraction" fork="phase0" hash="9c7034ee">
+    def calculate_committee_fraction(state: BeaconState, committee_percent: Uint64) -> Gwei:
         committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
         return Gwei((committee_weight * committee_percent) // 100)
     </spec>
@@ -539,22 +417,6 @@
         if builder_balance < min_balance:
             return False
         return builder_balance - min_balance >= bid_amount
-    </spec>
-
-- name: cell_to_coset_evals#fulu
-  sources: []
-  spec: |
-    <spec fn="cell_to_coset_evals" fork="fulu" hash="db38f921">
-    def cell_to_coset_evals(cell: Cell) -> CosetEvals:
-        """
-        Convert an untrusted ``Cell`` into a trusted ``CosetEvals``.
-        """
-        evals = CosetEvals()
-        for i in range(FIELD_ELEMENTS_PER_CELL):
-            start = i * BYTES_PER_FIELD_ELEMENT
-            end = (i + 1) * BYTES_PER_FIELD_ELEMENT
-            evals[i] = bytes_to_bls_field(cell[start:end])
-        return evals
     </spec>
 
 - name: check_if_validator_active#phase0
@@ -616,12 +478,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
       search: private Integer computeAttestationSubnetPrefixBits()
   spec: |
-    <spec fn="compute_attestation_subnet_prefix_bits" fork="phase0" hash="5adb201b">
-    def compute_attestation_subnet_prefix_bits() -> uint64:
+    <spec fn="compute_attestation_subnet_prefix_bits" fork="phase0" hash="e5f8c95b">
+    def compute_attestation_subnet_prefix_bits() -> Uint64:
         """
         Return the number of NodeId bits to use when mapping to a subscribed subnet.
         """
-        return uint64(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)
+        return Uint64(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)
     </spec>
 
 - name: compute_balance_weighted_selection#gloas
@@ -629,12 +491,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public IntList computeBalanceWeightedSelection(
   spec: |
-    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="e5dff16e">
+    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="1338c915">
     def compute_balance_weighted_selection(
         state: BeaconState,
         indices: Sequence[ValidatorIndex],
         seed: Bytes32,
-        size: uint64,
+        size: Uint64,
         shuffle_indices: bool,
     ) -> Sequence[ValidatorIndex]:
         """
@@ -644,11 +506,11 @@
         ``indices`` is traversed in order. The returned list can contain duplicates.
         """
         MAX_RANDOM_VALUE = 2**16 - 1
-        total = uint64(len(indices))
+        total = Uint64(len(indices))
         assert total > 0
         effective_balances = [state.validators[index].effective_balance for index in indices]
         selected: List[ValidatorIndex] = []
-        i = uint64(0)
+        i = Uint64(0)
         while len(selected) < size:
             offset = i % 16 * 2
             if offset == 0:
@@ -663,108 +525,6 @@
                 selected.append(indices[next_index])
             i += 1
         return selected
-    </spec>
-
-- name: compute_blob_kzg_proof#deneb
-  sources: []
-  spec: |
-    <spec fn="compute_blob_kzg_proof" fork="deneb" hash="b35a2651">
-    def compute_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes48) -> KZGProof:
-        """
-        Given a blob, return the KZG proof that is used to verify it against the commitment.
-        This method does not verify that the commitment is correct with respect to `blob`.
-        Public method.
-        """
-        assert len(blob) == BYTES_PER_BLOB
-        assert len(commitment_bytes) == BYTES_PER_COMMITMENT
-        commitment = bytes_to_kzg_commitment(commitment_bytes)
-        polynomial = blob_to_polynomial(blob)
-        evaluation_challenge = compute_challenge(blob, commitment)
-        proof, _ = compute_kzg_proof_impl(polynomial, evaluation_challenge)
-        return proof
-    </spec>
-
-- name: compute_cells#fulu
-  sources: []
-  spec: |
-    <spec fn="compute_cells" fork="fulu" hash="20f94f5f">
-    def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
-        """
-        Given a blob, extend it and return all the cells of the extended blob.
-
-        Public method.
-        """
-        assert len(blob) == BYTES_PER_BLOB
-
-        polynomial = blob_to_polynomial(blob)
-        polynomial_coeff = polynomial_eval_to_coeff(polynomial)
-
-        cells = []
-        for i in range(CELLS_PER_EXT_BLOB):
-            coset = coset_for_cell(CellIndex(i))
-            ys = CosetEvals([evaluate_polynomialcoeff(polynomial_coeff, z) for z in coset])
-            cells.append(coset_evals_to_cell(CosetEvals(ys)))
-        return cells
-    </spec>
-
-- name: compute_cells_and_kzg_proofs#fulu
-  sources: []
-  spec: |
-    <spec fn="compute_cells_and_kzg_proofs" fork="fulu" hash="0751dcee">
-    def compute_cells_and_kzg_proofs(
-        blob: Blob,
-    ) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
-        """
-        Compute all the cell proofs for an extended blob. This is an inefficient O(n^2) algorithm,
-        for performant implementation the FK20 algorithm that runs in O(n log n) should be
-        used instead.
-
-        Public method.
-        """
-        assert len(blob) == BYTES_PER_BLOB
-
-        polynomial = blob_to_polynomial(blob)
-        polynomial_coeff = polynomial_eval_to_coeff(polynomial)
-        return compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff)
-    </spec>
-
-- name: compute_cells_and_kzg_proofs_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="compute_cells_and_kzg_proofs_polynomialcoeff" fork="fulu" hash="954c9e52">
-    def compute_cells_and_kzg_proofs_polynomialcoeff(
-        polynomial_coeff: PolynomialCoeff,
-    ) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
-        """
-        Helper function which computes cells/proofs for a polynomial in coefficient form.
-        """
-        cells, proofs = [], []
-        for i in range(CELLS_PER_EXT_BLOB):
-            coset = coset_for_cell(CellIndex(i))
-            proof, ys = compute_kzg_proof_multi_impl(polynomial_coeff, coset)
-            cells.append(coset_evals_to_cell(CosetEvals(ys)))
-            proofs.append(proof)
-        return cells, proofs
-    </spec>
-
-- name: compute_challenge#deneb
-  sources: []
-  spec: |
-    <spec fn="compute_challenge" fork="deneb" hash="137cf666">
-    def compute_challenge(blob: Blob, commitment: KZGCommitment) -> BLSFieldElement:
-        """
-        Return the Fiat-Shamir challenge required by the rest of the protocol.
-        """
-
-        # Append the degree of the polynomial as a domain separator
-        degree_poly = int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 16, KZG_ENDIANNESS)
-        data = FIAT_SHAMIR_PROTOCOL_DOMAIN + degree_poly
-
-        data += blob
-        data += commitment
-
-        # Transcript has been prepared: time to create the challenge
-        return hash_to_bls_field(data)
     </spec>
 
 - name: compute_columns_for_custody_group#fulu
@@ -786,17 +546,17 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public IntList computeCommittee(
   spec: |
-    <spec fn="compute_committee" fork="phase0" hash="eb55fdd0">
+    <spec fn="compute_committee" fork="phase0" hash="23ad35aa">
     def compute_committee(
-        indices: Sequence[ValidatorIndex], seed: Bytes32, index: uint64, count: uint64
+        indices: Sequence[ValidatorIndex], seed: Bytes32, index: Uint64, count: Uint64
     ) -> Sequence[ValidatorIndex]:
         """
         Return the committee corresponding to ``indices``, ``seed``, ``index``, and committee ``count``.
         """
         start = (len(indices) * index) // count
-        end = (len(indices) * uint64(index + 1)) // count
+        end = (len(indices) * Uint64(index + 1)) // count
         return [
-            indices[compute_shuffled_index(uint64(i), uint64(len(indices)), seed)]
+            indices[compute_shuffled_index(Uint64(i), Uint64(len(indices)), seed)]
             for i in range(start, end)
         ]
     </spec>
@@ -1017,7 +777,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public Bytes4 computeForkDigest(
   spec: |
-    <spec fn="compute_fork_digest" fork="fulu" hash="14f1febd">
+    <spec fn="compute_fork_digest" fork="fulu" hash="49e03649">
     def compute_fork_digest(
         genesis_validators_root: Root,
         epoch: Epoch,
@@ -1043,8 +803,8 @@
                 xor(
                     base_digest,
                     hash(
-                        uint_to_bytes(uint64(blob_parameters.epoch))
-                        + uint_to_bytes(uint64(blob_parameters.max_blobs_per_block))
+                        uint_to_bytes(Uint64(blob_parameters.epoch))
+                        + uint_to_bytes(Uint64(blob_parameters.max_blobs_per_block))
                     ),
                 )
             )[:4]
@@ -1280,93 +1040,6 @@
         return Gwei(min_honest_ffg_support + remaining_honest_ffg_weight)
     </spec>
 
-- name: compute_kzg_proof#deneb
-  sources: []
-  spec: |
-    <spec fn="compute_kzg_proof" fork="deneb" hash="84fcdaa4">
-    def compute_kzg_proof(blob: Blob, z_bytes: Bytes32) -> Tuple[KZGProof, Bytes32]:
-        """
-        Compute KZG proof at point `z` for the polynomial represented by `blob`.
-        Do this by computing the quotient polynomial in evaluation form: q(x) = (p(x) - p(z)) / (x - z).
-        Public method.
-        """
-        assert len(blob) == BYTES_PER_BLOB
-        assert len(z_bytes) == BYTES_PER_FIELD_ELEMENT
-        polynomial = blob_to_polynomial(blob)
-        proof, y = compute_kzg_proof_impl(polynomial, bytes_to_bls_field(z_bytes))
-        return proof, int(y).to_bytes(BYTES_PER_FIELD_ELEMENT, KZG_ENDIANNESS)
-    </spec>
-
-- name: compute_kzg_proof_impl#deneb
-  sources: []
-  spec: |
-    <spec fn="compute_kzg_proof_impl" fork="deneb" hash="07a3b4d9">
-    def compute_kzg_proof_impl(
-        polynomial: Polynomial, z: BLSFieldElement
-    ) -> Tuple[KZGProof, BLSFieldElement]:
-        """
-        Helper function for `compute_kzg_proof()` and `compute_blob_kzg_proof()`.
-        """
-        roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB))
-
-        # For all x_i, compute p(x_i) - p(z)
-        y = evaluate_polynomial_in_evaluation_form(polynomial, z)
-        polynomial_shifted = [p - y for p in polynomial]
-
-        # For all x_i, compute (x_i - z)
-        denominator_poly = [x - z for x in roots_of_unity_brp]
-
-        # Compute the quotient polynomial directly in evaluation form
-        quotient_polynomial = [BLSFieldElement(0)] * FIELD_ELEMENTS_PER_BLOB
-        for i, (a, b) in enumerate(zip(polynomial_shifted, denominator_poly, strict=True)):
-            if b == BLSFieldElement(0):
-                # The denominator is zero hence `z` is a root of unity: we must handle it as a special case
-                quotient_polynomial[i] = compute_quotient_eval_within_domain(
-                    roots_of_unity_brp[i], polynomial, y
-                )
-            else:
-                # Compute: q(x_i) = (p(x_i) - p(z)) / (x_i - z).
-                quotient_polynomial[i] = a / b
-
-        return KZGProof(
-            g1_lincomb(bit_reversal_permutation(KZG_SETUP_G1_LAGRANGE), quotient_polynomial)
-        ), y
-    </spec>
-
-- name: compute_kzg_proof_multi_impl#fulu
-  sources: []
-  spec: |
-    <spec fn="compute_kzg_proof_multi_impl" fork="fulu" hash="6fd3df17">
-    def compute_kzg_proof_multi_impl(
-        polynomial_coeff: PolynomialCoeff, zs: Coset
-    ) -> Tuple[KZGProof, CosetEvals]:
-        """
-        Compute a KZG multi-evaluation proof for a set of `k` points.
-
-        This is done by committing to the following quotient polynomial:
-            Q(X) = f(X) - I(X) / Z(X)
-        Where:
-            - I(X) is the degree `k-1` polynomial that agrees with f(x) at all `k` points
-            - Z(X) is the degree `k` polynomial that evaluates to zero on all `k` points
-
-        We further note that since the degree of I(X) is less than the degree of Z(X),
-        the computation can be simplified in monomial form to Q(X) = f(X) / Z(X).
-        """
-
-        # For all points, compute the evaluation of those points
-        ys = CosetEvals([evaluate_polynomialcoeff(polynomial_coeff, z) for z in zs])
-
-        # Compute Z(X)
-        denominator_poly = vanishing_polynomialcoeff(zs)
-
-        # Compute the quotient polynomial directly in monomial form
-        quotient_polynomial = divide_polynomialcoeff(polynomial_coeff, denominator_poly)
-
-        return KZGProof(
-            g1_lincomb(KZG_SETUP_G1_MONOMIAL[: len(quotient_polynomial)], quotient_polynomial)
-        ), ys
-    </spec>
-
 - name: compute_matrix#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -1374,7 +1047,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<List<MatrixEntry>> computeExtendedMatrix(
   spec: |
-    <spec fn="compute_matrix" fork="fulu" hash="87e3f29c">
+    <spec fn="compute_matrix" fork="fulu" hash="fe9651c4">
     def compute_matrix(blobs: Sequence[Blob]) -> Sequence[MatrixEntry]:
         """
         Return the full, flattened sequence of matrix entries.
@@ -1384,7 +1057,7 @@
         """
         matrix = []
         for blob_index, blob in enumerate(blobs):
-            cells, proofs = compute_cells_and_kzg_proofs(blob)
+            cells, proofs = kzg.compute_cells_and_kzg_proofs(blob)
             for cell_index, (cell, proof) in enumerate(zip(cells, proofs, strict=True)):
                 matrix.append(
                     MatrixEntry(
@@ -1402,12 +1075,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/DenebBuilder.java
       search: private Integer computeMaxRequestBlobSidecars(
   spec: |
-    <spec fn="compute_max_request_blob_sidecars" fork="deneb" hash="c05cd1d6">
-    def compute_max_request_blob_sidecars() -> uint64:
+    <spec fn="compute_max_request_blob_sidecars" fork="deneb" hash="1da7d02f">
+    def compute_max_request_blob_sidecars() -> Uint64:
         """
         Return the maximum number of blob sidecars in a single request.
         """
-        return uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK)
+        return Uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK)
     </spec>
 
 - name: compute_max_request_blob_sidecars#electra
@@ -1415,13 +1088,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
       search: private Integer computeMaxRequestBlobSidecars(
   spec: |
-    <spec fn="compute_max_request_blob_sidecars" fork="electra" hash="38243cb4">
-    def compute_max_request_blob_sidecars() -> uint64:
+    <spec fn="compute_max_request_blob_sidecars" fork="electra" hash="55ed3dd7">
+    def compute_max_request_blob_sidecars() -> Uint64:
         """
         Return the maximum number of blob sidecars in a single request.
         """
         # [Modified in Electra:EIP7691]
-        return uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK_ELECTRA)
+        return Uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK_ELECTRA)
     </spec>
 
 - name: compute_max_request_data_column_sidecars#fulu
@@ -1429,12 +1102,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/FuluBuilder.java
       search: private Integer computeMaxRequestDataColumnSidecars(
   spec: |
-    <spec fn="compute_max_request_data_column_sidecars" fork="fulu" hash="5f2f149d">
-    def compute_max_request_data_column_sidecars() -> uint64:
+    <spec fn="compute_max_request_data_column_sidecars" fork="fulu" hash="f04fc25b">
+    def compute_max_request_data_column_sidecars() -> Uint64:
         """
         Return the maximum number of data column sidecars in a single request.
         """
-        return uint64(MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS)
+        return Uint64(MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS)
     </spec>
 
 - name: compute_merkle_branch_root#phase0
@@ -1442,9 +1115,9 @@
     - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
       search: Bytes32 hashTreeRoot(Sha256 sha256);
   spec: |
-    <spec fn="compute_merkle_branch_root" fork="phase0" hash="ff67a3de">
+    <spec fn="compute_merkle_branch_root" fork="phase0" hash="f05490d6">
     def compute_merkle_branch_root(
-        leaf: Bytes32, branch: Sequence[Bytes32], depth: uint64, index: uint64
+        leaf: Bytes32, branch: Sequence[Bytes32], depth: Uint64, index: Uint64
     ) -> Root:
         """
         Return the Merkle root obtained by hashing ``leaf`` at ``index`` with ``branch``.
@@ -1472,12 +1145,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
       search: private Integer computeMinEpochsForBlockRequests()
   spec: |
-    <spec fn="compute_min_epochs_for_block_requests" fork="phase0" hash="90b21de3">
-    def compute_min_epochs_for_block_requests() -> uint64:
+    <spec fn="compute_min_epochs_for_block_requests" fork="phase0" hash="bfc43a5c">
+    def compute_min_epochs_for_block_requests() -> Uint64:
         """
         Return the minimum epoch range over which a node must serve blocks.
         """
-        return uint64(MIN_VALIDATOR_WITHDRAWABILITY_DELAY + CHURN_LIMIT_QUOTIENT // 2)
+        return Uint64(MIN_VALIDATOR_WITHDRAWABILITY_DELAY + CHURN_LIMIT_QUOTIENT // 2)
     </spec>
 
 - name: compute_new_state_root#phase0
@@ -1502,7 +1175,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/PooledAttestationWithData.java
       search: public Attestation toAttestation(
   spec: |
-    <spec fn="compute_on_chain_aggregate" fork="electra" hash="70c27acf">
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="a1d5aa73">
     def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
         aggregates = sorted(
             network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0]
@@ -1518,7 +1191,7 @@
 
         committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
         committee_flags = [(index in committee_indices) for index in range(MAX_COMMITTEES_PER_SLOT)]
-        committee_bits = Bitvector[MAX_COMMITTEES_PER_SLOT](committee_flags)
+        committee_bits = BitVector[MAX_COMMITTEES_PER_SLOT](committee_flags)
 
         return Attestation(
             aggregation_bits=aggregation_bits,
@@ -1528,28 +1201,12 @@
         )
     </spec>
 
-- name: compute_powers#deneb
-  sources: []
-  spec: |
-    <spec fn="compute_powers" fork="deneb" hash="fb1c0187">
-    def compute_powers(x: BLSFieldElement, n: uint64) -> Sequence[BLSFieldElement]:
-        """
-        Return ``x`` to power of [0, n-1], if n > 0. When n==0, an empty array is returned.
-        """
-        current_power = BLSFieldElement(1)
-        powers = []
-        for _ in range(n):
-            powers.append(current_power)
-            current_power = current_power * x
-        return powers
-    </spec>
-
 - name: compute_proposer_index#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public int computeProposerIndex(
   spec: |
-    <spec fn="compute_proposer_index" fork="phase0" hash="865ac464">
+    <spec fn="compute_proposer_index" fork="phase0" hash="744c1f45">
     def compute_proposer_index(
         state: BeaconState, indices: Sequence[ValidatorIndex], seed: Bytes32
     ) -> ValidatorIndex:
@@ -1558,11 +1215,11 @@
         """
         assert len(indices) > 0
         MAX_RANDOM_BYTE = 2**8 - 1
-        i = uint64(0)
-        total = uint64(len(indices))
+        i = Uint64(0)
+        total = Uint64(len(indices))
         while True:
             candidate_index = indices[compute_shuffled_index(i % total, total, seed)]
-            random_byte = hash(seed + uint_to_bytes(uint64(i // 32)))[i % 32]
+            random_byte = hash(seed + uint_to_bytes(Uint64(i // 32)))[i % 32]
             effective_balance = state.validators[candidate_index].effective_balance
             if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
                 return candidate_index
@@ -1574,7 +1231,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public int computeProposerIndex(
   spec: |
-    <spec fn="compute_proposer_index" fork="electra" hash="b54f4930">
+    <spec fn="compute_proposer_index" fork="electra" hash="a0261e7d">
     def compute_proposer_index(
         state: BeaconState, indices: Sequence[ValidatorIndex], seed: Bytes32
     ) -> ValidatorIndex:
@@ -1584,8 +1241,8 @@
         assert len(indices) > 0
         # [Modified in Electra]
         MAX_RANDOM_VALUE = 2**16 - 1
-        i = uint64(0)
-        total = uint64(len(indices))
+        i = Uint64(0)
+        total = Uint64(len(indices))
         while True:
             candidate_index = indices[compute_shuffled_index(i % total, total, seed)]
             # [Modified in Electra]
@@ -1698,49 +1355,6 @@
             update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
     </spec>
 
-- name: compute_quotient_eval_within_domain#deneb
-  sources: []
-  spec: |
-    <spec fn="compute_quotient_eval_within_domain" fork="deneb" hash="b1df34e2">
-    def compute_quotient_eval_within_domain(
-        z: BLSFieldElement, polynomial: Polynomial, y: BLSFieldElement
-    ) -> BLSFieldElement:
-        """
-        Given `y == p(z)` for a polynomial `p(x)`, compute `q(z)`: the KZG quotient polynomial evaluated at `z` for the
-        special case where `z` is in roots of unity.
-
-        For more details, read https://dankradfeist.de/ethereum/2021/06/18/pcs-multiproofs.html section "Dividing
-        when one of the points is zero". The code below computes q(x_m) for the roots of unity special case.
-        """
-        roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB))
-        result = BLSFieldElement(0)
-        for i, omega_i in enumerate(roots_of_unity_brp):
-            if omega_i == z:  # skip the evaluation point in the sum
-                continue
-
-            f_i = polynomial[i] - y
-            numerator = f_i * omega_i
-            denominator = z * (z - omega_i)
-            result += numerator / denominator
-
-        return result
-    </spec>
-
-- name: compute_roots_of_unity#deneb
-  sources: []
-  spec: |
-    <spec fn="compute_roots_of_unity" fork="deneb" hash="647fd611">
-    def compute_roots_of_unity(order: uint64) -> Sequence[BLSFieldElement]:
-        """
-        Return roots of unity of ``order``.
-        """
-        assert (BLS_MODULUS - 1) % int(order) == 0
-        root_of_unity = BLSFieldElement(
-            pow(PRIMITIVE_ROOT_OF_UNITY, (BLS_MODULUS - 1) // int(order), BLS_MODULUS)
-        )
-        return compute_powers(root_of_unity, order)
-    </spec>
-
 - name: compute_safety_threshold#phase0
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
@@ -1776,8 +1390,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public int computeShuffledIndex(
   spec: |
-    <spec fn="compute_shuffled_index" fork="phase0" hash="f85577f7">
-    def compute_shuffled_index(index: uint64, index_count: uint64, seed: Bytes32) -> uint64:
+    <spec fn="compute_shuffled_index" fork="phase0" hash="8f95af5d">
+    def compute_shuffled_index(index: Uint64, index_count: Uint64, seed: Bytes32) -> Uint64:
         """
         Return the shuffled index corresponding to ``seed`` (and ``index_count``).
         """
@@ -1790,18 +1404,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public void shuffleList(final int[] input, final Bytes32 seed) {
   spec: |
-    <spec fn="compute_shuffled_permutation" fork="phase0" hash="48fcb874">
-    def compute_shuffled_permutation(index_count: uint64, seed: Bytes32) -> Sequence[uint64]:
+    <spec fn="compute_shuffled_permutation" fork="phase0" hash="067c0a89">
+    def compute_shuffled_permutation(index_count: Uint64, seed: Bytes32) -> Sequence[Uint64]:
         """
         Return the full shuffled permutation corresponding to ``seed`` (and ``index_count``).
         """
         # Swap or not (https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf)
         # See the 'generalized domain' algorithm on page 3
-        indices = [uint64(i) for i in range(index_count)]
+        indices = [Uint64(i) for i in range(index_count)]
         for current_round in range(SHUFFLE_ROUND_COUNT):
             round_bytes = current_round.to_bytes(1, "little")
             pivot = int.from_bytes(hash(seed + round_bytes)[0:8], "little") % index_count
-            source_by_bucket: Dict[uint64, Bytes32] = {}
+            source_by_bucket: Dict[Uint64, Bytes32] = {}
             for i in range(index_count):
                 flip = (pivot + index_count - indices[i]) % index_count
                 position = max(indices[i], flip)
@@ -1881,15 +1495,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
       search: public int computeSubnetForAttestation(
   spec: |
-    <spec fn="compute_subnet_for_attestation" fork="phase0" hash="2e9cf65d">
+    <spec fn="compute_subnet_for_attestation" fork="phase0" hash="f68bbbac">
     def compute_subnet_for_attestation(
-        committees_per_slot: uint64, slot: Slot, committee_index: CommitteeIndex
+        committees_per_slot: Uint64, slot: Slot, committee_index: CommitteeIndex
     ) -> SubnetID:
         """
         Compute the correct subnet for an attestation for Phase 0.
         Note, this mimics expected future behavior where attestations will be mapped to their shard subnet.
         """
-        slots_since_epoch_start = uint64(slot % SLOTS_PER_EPOCH)
+        slots_since_epoch_start = Uint64(slot % SLOTS_PER_EPOCH)
         committees_since_epoch_start = committees_per_slot * slots_since_epoch_start
 
         return SubnetID((committees_since_epoch_start + committee_index) % ATTESTATION_SUBNET_COUNT)
@@ -1957,13 +1571,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: protected UInt64 computeSubscribedSubnet(
   spec: |
-    <spec fn="compute_subscribed_subnet" fork="phase0" hash="83f860b8">
+    <spec fn="compute_subscribed_subnet" fork="phase0" hash="5618c1df">
     def compute_subscribed_subnet(node_id: NodeID, epoch: Epoch, index: int) -> SubnetID:
         prefix_bits = int(compute_attestation_subnet_prefix_bits())
-        node_id_prefix = node_id >> (NODE_ID_BITS - prefix_bits)
-        node_offset = node_id % EPOCHS_PER_SUBNET_SUBSCRIPTION
+        node_id_prefix = node_id >> int(NODE_ID_BITS - prefix_bits)
+        node_offset = Uint64(node_id % Uint256(EPOCHS_PER_SUBNET_SUBSCRIPTION))
         permutation_seed = hash(
-            uint_to_bytes(uint64((epoch + node_offset) // EPOCHS_PER_SUBNET_SUBSCRIPTION))
+            uint_to_bytes(Uint64((epoch + node_offset) // EPOCHS_PER_SUBNET_SUBSCRIPTION))
         )
         permutated_prefix = compute_shuffled_index(
             node_id_prefix,
@@ -1988,8 +1602,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public UInt64 computeSyncCommitteePeriod(
   spec: |
-    <spec fn="compute_sync_committee_period" fork="altair" hash="c5bb031f">
-    def compute_sync_committee_period(epoch: Epoch) -> uint64:
+    <spec fn="compute_sync_committee_period" fork="altair" hash="13b7b958">
+    def compute_sync_committee_period(epoch: Epoch) -> Uint64:
         return epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
     </spec>
 
@@ -1998,8 +1612,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/LightClientUtil.java
       search: private UInt64 syncCommitteePeriodAtSlot(
   spec: |
-    <spec fn="compute_sync_committee_period_at_slot" fork="altair" hash="6ad449b8">
-    def compute_sync_committee_period_at_slot(slot: Slot) -> uint64:
+    <spec fn="compute_sync_committee_period_at_slot" fork="altair" hash="610ba396">
+    def compute_sync_committee_period_at_slot(slot: Slot) -> Uint64:
         return compute_sync_committee_period(compute_epoch_at_slot(slot))
     </spec>
 
@@ -2008,10 +1622,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeTimeAtSlot(
   spec: |
-    <spec fn="compute_time_at_slot" fork="phase0" hash="70962a0c">
-    def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
+    <spec fn="compute_time_at_slot" fork="phase0" hash="c654b2ca">
+    def compute_time_at_slot(state: BeaconState, slot: Slot) -> Uint64:
         slots_since_genesis = slot - GENESIS_SLOT
-        return uint64(state.genesis_time + slots_since_genesis * SLOT_DURATION_MS // 1000)
+        return Uint64(state.genesis_time + slots_since_genesis * SLOT_DURATION_MS // 1000)
     </spec>
 
 - name: compute_time_at_slot_ms#phase0
@@ -2019,46 +1633,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public UInt64 computeTimeMillisAtSlot(
   spec: |
-    <spec fn="compute_time_at_slot_ms" fork="phase0" hash="9e51db2a">
-    def compute_time_at_slot_ms(state: BeaconState, slot: Slot) -> uint64:
+    <spec fn="compute_time_at_slot_ms" fork="phase0" hash="1ec2646a">
+    def compute_time_at_slot_ms(state: BeaconState, slot: Slot) -> Uint64:
         """
         Return the time in milliseconds at the start of the given slot.
         """
         slots_since_genesis = slot - GENESIS_SLOT
-        return uint64(state.genesis_time * 1000 + slots_since_genesis * SLOT_DURATION_MS)
-    </spec>
-
-- name: compute_verify_cell_kzg_proof_batch_challenge#fulu
-  sources: []
-  spec: |
-    <spec fn="compute_verify_cell_kzg_proof_batch_challenge" fork="fulu" hash="8d3b11a0">
-    def compute_verify_cell_kzg_proof_batch_challenge(
-        commitments: Sequence[KZGCommitment],
-        commitment_indices: Sequence[CommitmentIndex],
-        cell_indices: Sequence[CellIndex],
-        cosets_evals: Sequence[CosetEvals],
-        proofs: Sequence[KZGProof],
-    ) -> BLSFieldElement:
-        """
-        Compute a random challenge ``r`` used in the universal verification equation. To compute the
-        challenge, ``RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN`` and all data that can influence the
-        verification is hashed together to deterministically generate a "random" field element via
-        the Fiat-Shamir heuristic.
-        """
-        hashinput = RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN
-        hashinput += int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 8, KZG_ENDIANNESS)
-        hashinput += int.to_bytes(FIELD_ELEMENTS_PER_CELL, 8, KZG_ENDIANNESS)
-        hashinput += int.to_bytes(len(commitments), 8, KZG_ENDIANNESS)
-        hashinput += int.to_bytes(len(cell_indices), 8, KZG_ENDIANNESS)
-        for commitment in commitments:
-            hashinput += commitment
-        for k, coset_evals in enumerate(cosets_evals):
-            hashinput += int.to_bytes(commitment_indices[k], 8, KZG_ENDIANNESS)
-            hashinput += int.to_bytes(cell_indices[k], 8, KZG_ENDIANNESS)
-            for coset_eval in coset_evals:
-                hashinput += bls_field_to_bytes(coset_eval)
-            hashinput += proofs[k]
-        return hash_to_bls_field(hashinput)
+        return Uint64(state.genesis_time * 1000 + slots_since_genesis * SLOT_DURATION_MS)
     </spec>
 
 - name: compute_weak_subjectivity_period#phase0
@@ -2066,8 +1647,8 @@
     - file: ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
       search: public UInt64 computeWeakSubjectivityPeriod(
   spec: |
-    <spec fn="compute_weak_subjectivity_period" fork="phase0" hash="d151e9de">
-    def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
+    <spec fn="compute_weak_subjectivity_period" fork="phase0" hash="73699619">
+    def compute_weak_subjectivity_period(state: BeaconState) -> Uint64:
         """
         Returns the weak subjectivity period for the current ``state``.
         This computation takes into account the effect of:
@@ -2101,7 +1682,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/weaksubjectivity/WeakSubjectivityCalculatorElectra.java
       search: public UInt64 computeWeakSubjectivityPeriod(
   spec: |
-    <spec fn="compute_weak_subjectivity_period" fork="electra" style="diff" hash="8d95104c">
+    <spec fn="compute_weak_subjectivity_period" fork="electra" style="diff" hash="58b3e6e0">
     --- phase0
     +++ electra
     @@ -2,26 +2,11 @@
@@ -2144,8 +1725,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/weaksubjectivity/WeakSubjectivityCalculatorGloas.java
       search: public UInt64 computeWeakSubjectivityPeriod(
   spec: |
-    <spec fn="compute_weak_subjectivity_period" fork="gloas" hash="8b1ddc92">
-    def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
+    <spec fn="compute_weak_subjectivity_period" fork="gloas" hash="687b7a35">
+    def compute_weak_subjectivity_period(state: BeaconState) -> Uint64:
         """
         Returns the weak subjectivity period for the current ``state``.
         This computation takes into account the effect of:
@@ -2162,40 +1743,6 @@
         )
         epochs_for_validator_set_churn = SAFETY_DECAY * t // (2 * delta * 100)
         return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
-    </spec>
-
-- name: construct_vanishing_polynomial#fulu
-  sources: []
-  spec: |
-    <spec fn="construct_vanishing_polynomial" fork="fulu" hash="4ab9e55a">
-    def construct_vanishing_polynomial(
-        missing_cell_indices: Sequence[CellIndex],
-    ) -> Sequence[BLSFieldElement]:
-        """
-        Given the cells indices that are missing from the data, compute the polynomial that vanishes at every point that
-        corresponds to a missing field element.
-
-        This method assumes that all of the cells cannot be missing. In this case the vanishing polynomial
-        could be computed as Z(x) = x^n - 1, where `n` is FIELD_ELEMENTS_PER_EXT_BLOB.
-
-        We never encounter this case however because this method is used solely for recovery and recovery only
-        works if at least half of the cells are available.
-        """
-        # Get the small domain
-        roots_of_unity_reduced = compute_roots_of_unity(CELLS_PER_EXT_BLOB)
-
-        # Compute polynomial that vanishes at all the missing cells (over the small domain)
-        short_zero_poly = vanishing_polynomialcoeff([
-            roots_of_unity_reduced[reverse_bits(missing_cell_index, CELLS_PER_EXT_BLOB)]
-            for missing_cell_index in missing_cell_indices
-        ])
-
-        # Extend vanishing polynomial to full domain using the closed form of the vanishing polynomial over a coset
-        zero_poly_coeff = [BLSFieldElement(0)] * FIELD_ELEMENTS_PER_EXT_BLOB
-        for i, coeff in enumerate(short_zero_poly):
-            zero_poly_coeff[i * FIELD_ELEMENTS_PER_CELL] = coeff
-
-        return zero_poly_coeff
     </spec>
 
 - name: convert_builder_index_to_validator_index#gloas
@@ -2216,101 +1763,6 @@
     <spec fn="convert_validator_index_to_builder_index" fork="gloas" hash="2fea5b47">
     def convert_validator_index_to_builder_index(validator_index: ValidatorIndex) -> BuilderIndex:
         return BuilderIndex(validator_index & ~BUILDER_INDEX_FLAG)
-    </spec>
-
-- name: coset_evals_to_cell#fulu
-  sources: []
-  spec: |
-    <spec fn="coset_evals_to_cell" fork="fulu" hash="394b0ba9">
-    def coset_evals_to_cell(coset_evals: CosetEvals) -> Cell:
-        """
-        Convert a trusted ``CosetEval`` into an untrusted ``Cell``.
-        """
-        cell = []
-        for i in range(FIELD_ELEMENTS_PER_CELL):
-            cell += bls_field_to_bytes(coset_evals[i])
-        return Cell(cell)
-    </spec>
-
-- name: coset_fft_field#fulu
-  sources: []
-  spec: |
-    <spec fn="coset_fft_field" fork="fulu" hash="2e32df99">
-    def coset_fft_field(
-        vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement], inv: bool = False
-    ) -> Sequence[BLSFieldElement]:
-        """
-        Computes an FFT/IFFT over a coset of the roots of unity.
-        This is useful for when one wants to divide by a polynomial which
-        vanishes on one or more elements in the domain.
-        """
-        vals = list(vals)  # copy
-
-        def shift_vals(
-            vals: Sequence[BLSFieldElement], factor: BLSFieldElement
-        ) -> Sequence[BLSFieldElement]:
-            """
-            Multiply each entry in `vals` by succeeding powers of `factor`
-            i.e., [vals[0] * factor^0, vals[1] * factor^1, ..., vals[n] * factor^n]
-            """
-            updated_vals: List[BLSFieldElement] = []
-            shift = BLSFieldElement(1)
-            for i in range(len(vals)):
-                updated_vals.append(vals[i] * shift)
-                shift = shift * factor
-            return updated_vals
-
-        # This is the coset generator; it is used to compute a FFT/IFFT over a coset of
-        # the roots of unity.
-        shift_factor = BLSFieldElement(PRIMITIVE_ROOT_OF_UNITY)
-        if inv:
-            vals = fft_field(vals, roots_of_unity, inv)
-            return shift_vals(vals, shift_factor.inverse())
-        else:
-            vals = shift_vals(vals, shift_factor)
-            return fft_field(vals, roots_of_unity, inv)
-    </spec>
-
-- name: coset_for_cell#fulu
-  sources: []
-  spec: |
-    <spec fn="coset_for_cell" fork="fulu" hash="9462c88f">
-    def coset_for_cell(cell_index: CellIndex) -> Coset:
-        """
-        Get the coset for a given ``cell_index``.
-        Precisely, consider the group of roots of unity of order FIELD_ELEMENTS_PER_CELL * CELLS_PER_EXT_BLOB.
-        Let G = {1, g, g^2, ...} denote its subgroup of order FIELD_ELEMENTS_PER_CELL.
-        Then, the coset is defined as h * G = {h, hg, hg^2, ...}.
-        This function, returns the coset.
-        """
-        assert cell_index < CELLS_PER_EXT_BLOB
-        roots_of_unity_brp = bit_reversal_permutation(
-            compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
-        )
-        return Coset(
-            roots_of_unity_brp[
-                FIELD_ELEMENTS_PER_CELL * cell_index : FIELD_ELEMENTS_PER_CELL * (cell_index + 1)
-            ]
-        )
-    </spec>
-
-- name: coset_shift_for_cell#fulu
-  sources: []
-  spec: |
-    <spec fn="coset_shift_for_cell" fork="fulu" hash="c8359618">
-    def coset_shift_for_cell(cell_index: CellIndex) -> BLSFieldElement:
-        """
-        Get the shift that determines the coset for a given ``cell_index``.
-        Precisely, consider the group of roots of unity of order FIELD_ELEMENTS_PER_CELL * CELLS_PER_EXT_BLOB.
-        Let G = {1, g, g^2, ...} denote its subgroup of order FIELD_ELEMENTS_PER_CELL.
-        Then, the coset is defined as h * G = {h, hg, hg^2, ...} for an element h.
-        This function returns h.
-        """
-        assert cell_index < CELLS_PER_EXT_BLOB
-        roots_of_unity_brp = bit_reversal_permutation(
-            compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
-        )
-        return roots_of_unity_brp[FIELD_ELEMENTS_PER_CELL * cell_index]
     </spec>
 
 - name: create_light_client_bootstrap#altair
@@ -2473,29 +1925,6 @@
         state.balances[index] = 0 if delta > state.balances[index] else state.balances[index] - delta
     </spec>
 
-- name: divide_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="divide_polynomialcoeff" fork="fulu" hash="7cf7d709">
-    def divide_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoeff:
-        """
-        Long polynomial division for two coefficient form polynomials ``a`` and ``b``.
-        """
-        a = PolynomialCoeff(a[:])  # copy
-        o = PolynomialCoeff([])
-        apos = len(a) - 1
-        bpos = len(b) - 1
-        diff = apos - bpos
-        while diff >= 0:
-            quot = a[apos] / b[bpos]
-            o.insert(0, quot)
-            for i in range(bpos, -1, -1):
-                a[diff + i] = a[diff + i] - b[i] * quot
-            apos -= 1
-            diff -= 1
-        return o
-    </spec>
-
 - name: estimate_committee_weight_between_slots#phase0
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
@@ -2586,76 +2015,6 @@
         if len(pubkeys) == 0 and signature == G2_POINT_AT_INFINITY:
             return True
         return bls.FastAggregateVerify(pubkeys, message, signature)
-    </spec>
-
-- name: evaluate_polynomial_in_evaluation_form#deneb
-  sources: []
-  spec: |
-    <spec fn="evaluate_polynomial_in_evaluation_form" fork="deneb" hash="7c1a70aa">
-    def evaluate_polynomial_in_evaluation_form(
-        polynomial: Polynomial, z: BLSFieldElement
-    ) -> BLSFieldElement:
-        """
-        Evaluate a polynomial (in evaluation form) at an arbitrary point ``z``.
-        - When ``z`` is in the domain, the evaluation can be found by indexing the polynomial at the
-        position that ``z`` is in the domain.
-        - When ``z`` is not in the domain, the barycentric formula is used:
-           f(z) = (z**WIDTH - 1) / WIDTH  *  sum_(i=0)^(WIDTH-1) (f(DOMAIN[i]) * DOMAIN[i]) / (z - DOMAIN[i])
-        """
-        width = len(polynomial)
-        assert width == FIELD_ELEMENTS_PER_BLOB
-        inverse_width = BLSFieldElement(width).inverse()
-
-        roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB))
-
-        # If we are asked to evaluate within the domain, we already know the answer
-        if z in roots_of_unity_brp:
-            eval_index = roots_of_unity_brp.index(z)
-            return polynomial[eval_index]
-
-        result = BLSFieldElement(0)
-        for i in range(width):
-            a = polynomial[i] * roots_of_unity_brp[i]
-            b = z - roots_of_unity_brp[i]
-            result += a / b
-        r = z.pow(BLSFieldElement(width)) - BLSFieldElement(1)
-        result = result * r * inverse_width
-        return result
-    </spec>
-
-- name: evaluate_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="evaluate_polynomialcoeff" fork="fulu" hash="629b29c4">
-    def evaluate_polynomialcoeff(
-        polynomial_coeff: PolynomialCoeff, z: BLSFieldElement
-    ) -> BLSFieldElement:
-        """
-        Evaluate a coefficient form polynomial at ``z`` using Horner's schema.
-        """
-        y = BLSFieldElement(0)
-        for coef in polynomial_coeff[::-1]:
-            y = y * z + coef
-        return y
-    </spec>
-
-- name: fft_field#fulu
-  sources: []
-  spec: |
-    <spec fn="fft_field" fork="fulu" hash="6568b8ab">
-    def fft_field(
-        vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement], inv: bool = False
-    ) -> Sequence[BLSFieldElement]:
-        if inv:
-            # Inverse FFT
-            invlen = BLSFieldElement(len(vals)).pow(BLSFieldElement(BLS_MODULUS - 2))
-            return [
-                x * invlen
-                for x in _fft_field(vals, list(roots_of_unity[0:1]) + list(roots_of_unity[:0:-1]))
-            ]
-        else:
-            # Regular FFT
-            return _fft_field(vals, roots_of_unity)
     </spec>
 
 - name: filter_block_tree#phase0
@@ -2831,29 +2190,6 @@
         return confirmed_root
     </spec>
 
-- name: g1_lincomb#deneb
-  sources: []
-  spec: |
-    <spec fn="g1_lincomb" fork="deneb" hash="3928091d">
-    def g1_lincomb(
-        points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElement]
-    ) -> KZGCommitment:
-        """
-        BLS multiscalar multiplication in G1. This can be naively implemented using double-and-add.
-        """
-        assert len(points) == len(scalars)
-
-        if len(points) == 0:
-            return bls.G1_to_bytes48(bls.G1.identity())
-
-        points_g1 = []
-        for point in points:
-            points_g1.append(bls.bytes48_to_G1(point))
-
-        result = bls.multi_exp(points_g1, scalars)
-        return KZGCommitment(bls.G1_to_bytes48(result))
-    </spec>
-
 - name: get_activation_churn_limit#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
@@ -2961,8 +2297,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public int getAggregateDueMillis(
   spec: |
-    <spec fn="get_aggregate_due_ms" fork="phase0" hash="fe8c736c">
-    def get_aggregate_due_ms() -> uint64:
+    <spec fn="get_aggregate_due_ms" fork="phase0" hash="f04ecc41">
+    def get_aggregate_due_ms() -> Uint64:
         return get_slot_component_duration_ms(AGGREGATE_DUE_BPS)
     </spec>
 
@@ -2973,8 +2309,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloasImpl.java
       search: private final int aggregateDueBps;
   spec: |
-    <spec fn="get_aggregate_due_ms" fork="gloas" hash="c3dccba7">
-    def get_aggregate_due_ms() -> uint64:
+    <spec fn="get_aggregate_due_ms" fork="gloas" hash="055e3209">
+    def get_aggregate_due_ms() -> Uint64:
         # [Modified in Gloas]
         return get_slot_component_duration_ms(AGGREGATE_DUE_BPS_GLOAS)
     </spec>
@@ -3053,7 +2389,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
       search: public void applyAttestationComponentDelta(
   spec: |
-    <spec fn="get_attestation_component_deltas" fork="phase0" hash="c6d7c444">
+    <spec fn="get_attestation_component_deltas" fork="phase0" hash="dffb146e">
     def get_attestation_component_deltas(
         state: BeaconState, attestations: Sequence[PendingAttestation]
     ) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
@@ -3067,7 +2403,7 @@
         attesting_balance = get_total_balance(state, unslashed_attesting_indices)
         for index in get_eligible_validator_indices(state):
             if index in unslashed_attesting_indices:
-                increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid uint64 overflow
+                increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid Uint64 overflow
                 if is_in_inactivity_leak(state):
                     # Since full base reward will be canceled out by inactivity penalty deltas,
                     # optimal participation receives full base reward compensation here.
@@ -3116,8 +2452,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public int getAttestationDueMillis(
   spec: |
-    <spec fn="get_attestation_due_ms" fork="phase0" hash="e611ff37">
-    def get_attestation_due_ms() -> uint64:
+    <spec fn="get_attestation_due_ms" fork="phase0" hash="acadb6c3">
+    def get_attestation_due_ms() -> Uint64:
         return get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
     </spec>
 
@@ -3128,8 +2464,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloasImpl.java
       search: private final int attestationDueBps;
   spec: |
-    <spec fn="get_attestation_due_ms" fork="gloas" hash="90627c02">
-    def get_attestation_due_ms() -> uint64:
+    <spec fn="get_attestation_due_ms" fork="gloas" hash="6bfa8f84">
+    def get_attestation_due_ms() -> Uint64:
         # [Modified in Gloas]
         return get_slot_component_duration_ms(ATTESTATION_DUE_BPS_GLOAS)
     </spec>
@@ -3139,9 +2475,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: // get_attestation_participation_flag_indices
   spec: |
-    <spec fn="get_attestation_participation_flag_indices" fork="altair" hash="d697ae39">
+    <spec fn="get_attestation_participation_flag_indices" fork="altair" hash="28f72fdf">
     def get_attestation_participation_flag_indices(
-        state: BeaconState, data: AttestationData, inclusion_delay: uint64
+        state: BeaconState, data: AttestationData, inclusion_delay: Uint64
     ) -> Sequence[int]:
         """
         Return the flag indices that are satisfied by an attestation.
@@ -3183,9 +2519,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
       search: protected boolean shouldSetTargetTimelinessFlag(
   spec: |
-    <spec fn="get_attestation_participation_flag_indices" fork="deneb" hash="7b46fd38">
+    <spec fn="get_attestation_participation_flag_indices" fork="deneb" hash="5a59415f">
     def get_attestation_participation_flag_indices(
-        state: BeaconState, data: AttestationData, inclusion_delay: uint64
+        state: BeaconState, data: AttestationData, inclusion_delay: Uint64
     ) -> Sequence[int]:
         """
         Return the flag indices that are satisfied by an attestation.
@@ -3228,9 +2564,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: protected boolean computeIsMatchingHead(
   spec: |
-    <spec fn="get_attestation_participation_flag_indices" fork="gloas" hash="aeb30d51">
+    <spec fn="get_attestation_participation_flag_indices" fork="gloas" hash="6c629ef4">
     def get_attestation_participation_flag_indices(
-        state: BeaconState, data: AttestationData, inclusion_delay: uint64
+        state: BeaconState,
+        data: AttestationData,
+        inclusion_delay: Uint64,
+        # [New in Gloas:EIP7732]
+        parent_slot: Slot,
     ) -> Sequence[int]:
         """
         Return the flag indices that are satisfied by an attestation.
@@ -3252,7 +2592,7 @@
             assert data.index == 0
             payload_matches = True
         else:
-            slot_index = data.slot % SLOTS_PER_HISTORICAL_ROOT
+            slot_index = parent_slot % SLOTS_PER_HISTORICAL_ROOT
             payload_index = state.execution_payload_availability[slot_index]
             payload_matches = data.index == payload_index
 
@@ -3283,33 +2623,6 @@
       search: private static void computeDelta(
   spec: |
     <spec fn="get_attestation_score" fork="phase0" hash="0a9ceb6e">
-    def get_attestation_score(store: Store, node: ForkChoiceNode, state: BeaconState) -> Gwei:
-        unslashed_and_active_indices = [
-            i
-            for i in get_active_validator_indices(state, get_current_epoch(state))
-            if not state.validators[i].slashed
-        ]
-        return Gwei(
-            sum(
-                state.validators[i].effective_balance
-                for i in unslashed_and_active_indices
-                if (
-                    i in store.latest_messages
-                    and i not in store.equivocating_indices
-                    and is_ancestor(store, get_supported_node(store, store.latest_messages[i]), node)
-                )
-            )
-        )
-    </spec>
-
-- name: get_attestation_score#gloas
-  sources:
-    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
-      search: public Optional<ForkChoiceNode> getSupportedNode(
-    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayScoreCalculator.java
-      search: private static void computeDelta(
-  spec: |
-    <spec fn="get_attestation_score" fork="gloas" hash="0a9ceb6e">
     def get_attestation_score(store: Store, node: ForkChoiceNode, state: BeaconState) -> Gwei:
         unslashed_and_active_indices = [
             i
@@ -3736,14 +3049,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateAccessorsGloas.java
       search: public UInt64 getBuilderPaymentQuorumThreshold(
   spec: |
-    <spec fn="get_builder_payment_quorum_threshold" fork="gloas" hash="a64b7ffb">
-    def get_builder_payment_quorum_threshold(state: BeaconState) -> uint64:
+    <spec fn="get_builder_payment_quorum_threshold" fork="gloas" hash="cd87415a">
+    def get_builder_payment_quorum_threshold(state: BeaconState) -> Uint64:
         """
         Calculate the quorum threshold for builder payments.
         """
         per_slot_balance = get_total_active_balance(state) // SLOTS_PER_EPOCH
         quorum = per_slot_balance * BUILDER_PAYMENT_THRESHOLD_NUMERATOR
-        return uint64(quorum // BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
+        return Uint64(quorum // BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
     </spec>
 
 - name: get_builder_withdrawals#gloas
@@ -3751,16 +3064,16 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected int processBuilderWithdrawals(
   spec: |
-    <spec fn="get_builder_withdrawals" fork="gloas" hash="d54dd146">
+    <spec fn="get_builder_withdrawals" fork="gloas" hash="e816787f">
     def get_builder_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
         prior_withdrawals: Sequence[Withdrawal],
-    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, Uint64]:
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
         assert len(prior_withdrawals) <= withdrawals_limit
 
-        processed_count: uint64 = 0
+        processed_count: Uint64 = 0
         withdrawals: List[Withdrawal] = []
         for withdrawal in state.builder_pending_withdrawals:
             all_withdrawals = prior_withdrawals + withdrawals
@@ -3788,18 +3101,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected int processBuildersSweepWithdrawals(
   spec: |
-    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="04c1cb10">
+    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="67af411a">
     def get_builders_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
         prior_withdrawals: Sequence[Withdrawal],
-    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, Uint64]:
         epoch = get_current_epoch(state)
         builders_limit = min(len(state.builders), MAX_BUILDERS_PER_WITHDRAWALS_SWEEP)
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
         assert len(prior_withdrawals) <= withdrawals_limit
 
-        processed_count: uint64 = 0
+        processed_count: Uint64 = 0
         withdrawals: List[Withdrawal] = []
         builder_index = state.next_withdrawal_builder_index
         for _ in range(builders_limit):
@@ -3909,16 +3222,16 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getCommitteeCountPerSlot(final BeaconState state, final UInt64 epoch)
   spec: |
-    <spec fn="get_committee_count_per_slot" fork="phase0" hash="3238e1ea">
-    def get_committee_count_per_slot(state: BeaconState, epoch: Epoch) -> uint64:
+    <spec fn="get_committee_count_per_slot" fork="phase0" hash="3968cc71">
+    def get_committee_count_per_slot(state: BeaconState, epoch: Epoch) -> Uint64:
         """
         Return the number of committees in each slot for the given ``epoch``.
         """
         return max(
-            uint64(1),
+            Uint64(1),
             min(
                 MAX_COMMITTEES_PER_SLOT,
-                uint64(len(get_active_validator_indices(state, epoch)))
+                Uint64(len(get_active_validator_indices(state, epoch)))
                 // SLOTS_PER_EPOCH
                 // TARGET_COMMITTEE_SIZE,
             ),
@@ -3930,8 +3243,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/electra/AttestationElectra.java
       search: public Optional<List<UInt64>> getCommitteeIndices()
   spec: |
-    <spec fn="get_committee_indices" fork="electra" hash="fa701795">
-    def get_committee_indices(committee_bits: Bitvector) -> Sequence[CommitteeIndex]:
+    <spec fn="get_committee_indices" fork="electra" hash="33edfd80">
+    def get_committee_indices(committee_bits: BitVector) -> Sequence[CommitteeIndex]:
         return [CommitteeIndex(index) for index, bit in enumerate(committee_bits) if bit]
     </spec>
 
@@ -4010,8 +3323,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public int getContributionDueMillis(
   spec: |
-    <spec fn="get_contribution_due_ms" fork="altair" hash="34ba156a">
-    def get_contribution_due_ms() -> uint64:
+    <spec fn="get_contribution_due_ms" fork="altair" hash="05255480">
+    def get_contribution_due_ms() -> Uint64:
         return get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS)
     </spec>
 
@@ -4022,8 +3335,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloasImpl.java
       search: private final int contributionDueBps;
   spec: |
-    <spec fn="get_contribution_due_ms" fork="gloas" hash="9d9baa98">
-    def get_contribution_due_ms() -> uint64:
+    <spec fn="get_contribution_due_ms" fork="gloas" hash="31d7c1c3">
+    def get_contribution_due_ms() -> Uint64:
         # [Modified in Gloas]
         return get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS_GLOAS)
     </spec>
@@ -4125,15 +3438,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public Set<UInt64> computeCustodyColumnIndices(
   spec: |
-    <spec fn="get_custody_groups" fork="fulu" hash="2e6b71d3">
-    def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence[CustodyIndex]:
+    <spec fn="get_custody_groups" fork="fulu" hash="aad37e2f">
+    def get_custody_groups(node_id: NodeID, custody_group_count: Uint64) -> Sequence[CustodyIndex]:
         assert custody_group_count <= NUMBER_OF_CUSTODY_GROUPS
 
         # Skip computation if all groups are custodied
         if custody_group_count == NUMBER_OF_CUSTODY_GROUPS:
             return [CustodyIndex(i) for i in range(NUMBER_OF_CUSTODY_GROUPS)]
 
-        current_id = uint256(node_id)
+        current_id = Uint256(node_id)
         custody_groups: List[CustodyIndex] = []
         while len(custody_groups) < custody_group_count:
             custody_group = CustodyIndex(
@@ -4143,7 +3456,7 @@
                 custody_groups.append(custody_group)
             if current_id == UINT256_MAX:
                 # Overflow prevention
-                current_id = uint256(0)
+                current_id = Uint256(0)
             else:
                 current_id += 1
 
@@ -4434,15 +3747,15 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
       search: protected void verifyOutstandingDepositsAreProcessed(
   spec: |
-    <spec fn="get_eth1_pending_deposit_count" fork="electra" hash="5dc54930">
-    def get_eth1_pending_deposit_count(state: BeaconState) -> uint64:
+    <spec fn="get_eth1_pending_deposit_count" fork="electra" hash="3418399a">
+    def get_eth1_pending_deposit_count(state: BeaconState) -> Uint64:
         eth1_deposit_index_limit = min(
             state.eth1_data.deposit_count, state.deposit_requests_start_index
         )
         if state.eth1_deposit_index < eth1_deposit_index_limit:
             return min(MAX_DEPOSITS, eth1_deposit_index_limit - state.eth1_deposit_index)
         else:
-            return uint64(0)
+            return Uint64(0)
     </spec>
 
 - name: get_eth1_vote#phase0
@@ -4886,8 +4199,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getFinalityDelay(
   spec: |
-    <spec fn="get_finality_delay" fork="phase0" hash="df3ca52e">
-    def get_finality_delay(state: BeaconState) -> uint64:
+    <spec fn="get_finality_delay" fork="phase0" hash="475d0afa">
+    def get_finality_delay(state: BeaconState) -> Uint64:
         return get_previous_epoch(state) - state.finalized_checkpoint.epoch
     </spec>
 
@@ -4931,7 +4244,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
       search: public static OnDiskStoreData forkChoiceStoreBuilder(
   spec: |
-    <spec fn="get_forkchoice_store" fork="phase0" hash="1c381b74">
+    <spec fn="get_forkchoice_store" fork="phase0" hash="8e0e5f17">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4940,7 +4253,7 @@
         finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
         proposer_boost_root = Root()
         return Store(
-            time=uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000),
+            time=Uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000),
             genesis_time=anchor_state.genesis_time,
             justified_checkpoint=justified_checkpoint,
             finalized_checkpoint=finalized_checkpoint,
@@ -4960,7 +4273,7 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
       search: public static OnDiskStoreData forkChoiceStoreBuilder(
   spec: |
-    <spec fn="get_forkchoice_store" fork="gloas" hash="91d69dde">
+    <spec fn="get_forkchoice_store" fork="gloas" hash="94300183">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4969,7 +4282,7 @@
         finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
         proposer_boost_root = Root()
         return Store(
-            time=uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000),
+            time=Uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000),
             genesis_time=anchor_state.genesis_time,
             justified_checkpoint=justified_checkpoint,
             finalized_checkpoint=finalized_checkpoint,
@@ -5383,43 +4696,6 @@
          return Root()
     </spec>
 
-- name: get_lc_execution_root#electra
-  sources: []
-  spec: |
-    <spec fn="get_lc_execution_root" fork="electra" style="diff" hash="311e3c71">
-    --- capella
-    +++ electra
-    @@ -1,7 +1,27 @@
-     def get_lc_execution_root(header: LightClientHeader) -> Root:
-         epoch = compute_epoch_at_slot(header.beacon.slot)
-
-    -    if epoch >= CAPELLA_FORK_EPOCH:
-    +    if epoch >= DENEB_FORK_EPOCH:
-             return hash_tree_root(header.execution)
-
-    +    if epoch >= CAPELLA_FORK_EPOCH:
-    +        execution_header = capella.ExecutionPayloadHeader(
-    +            parent_hash=header.execution.parent_hash,
-    +            fee_recipient=header.execution.fee_recipient,
-    +            state_root=header.execution.state_root,
-    +            receipts_root=header.execution.receipts_root,
-    +            logs_bloom=header.execution.logs_bloom,
-    +            prev_randao=header.execution.prev_randao,
-    +            block_number=header.execution.block_number,
-    +            gas_limit=header.execution.gas_limit,
-    +            gas_used=header.execution.gas_used,
-    +            timestamp=header.execution.timestamp,
-    +            extra_data=header.execution.extra_data,
-    +            base_fee_per_gas=header.execution.base_fee_per_gas,
-    +            block_hash=header.execution.block_hash,
-    +            transactions_root=header.execution.transactions_root,
-    +            withdrawals_root=header.execution.withdrawals_root,
-    +        )
-    +        return hash_tree_root(execution_header)
-    +
-         return Root()
-    </spec>
-
 - name: get_matching_head_attestations#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/ValidatorStatusFactoryPhase0.java
@@ -5506,7 +4782,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
       search: public IntList getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="altair" hash="29891ee8">
+    <spec fn="get_next_sync_committee_indices" fork="altair" hash="6ed6661f">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
@@ -5515,16 +4791,16 @@
 
         MAX_RANDOM_BYTE = 2**8 - 1
         active_validator_indices = get_active_validator_indices(state, epoch)
-        active_validator_count = uint64(len(active_validator_indices))
+        active_validator_count = Uint64(len(active_validator_indices))
         seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
         i = 0
         sync_committee_indices: List[ValidatorIndex] = []
         while len(sync_committee_indices) < SYNC_COMMITTEE_SIZE:
             shuffled_index = compute_shuffled_index(
-                uint64(i % active_validator_count), active_validator_count, seed
+                Uint64(i % active_validator_count), active_validator_count, seed
             )
             candidate_index = active_validator_indices[shuffled_index]
-            random_byte = hash(seed + uint_to_bytes(uint64(i // 32)))[i % 32]
+            random_byte = hash(seed + uint_to_bytes(Uint64(i // 32)))[i % 32]
             effective_balance = state.validators[candidate_index].effective_balance
             if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
                 sync_committee_indices.append(candidate_index)
@@ -5537,7 +4813,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
       search: public IntList getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="electra" hash="2ecaf5da">
+    <spec fn="get_next_sync_committee_indices" fork="electra" hash="41a80dac">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
@@ -5547,13 +4823,13 @@
         # [Modified in Electra]
         MAX_RANDOM_VALUE = 2**16 - 1
         active_validator_indices = get_active_validator_indices(state, epoch)
-        active_validator_count = uint64(len(active_validator_indices))
+        active_validator_count = Uint64(len(active_validator_indices))
         seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
-        i = uint64(0)
+        i = Uint64(0)
         sync_committee_indices: List[ValidatorIndex] = []
         while len(sync_committee_indices) < SYNC_COMMITTEE_SIZE:
             shuffled_index = compute_shuffled_index(
-                uint64(i % active_validator_count), active_validator_count, seed
+                Uint64(i % active_validator_count), active_validator_count, seed
             )
             candidate_index = active_validator_indices[shuffled_index]
             # [Modified in Electra]
@@ -5666,8 +4942,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloasImpl.java
       search: private final int payloadAttestationDueBps;
   spec: |
-    <spec fn="get_payload_attestation_due_ms" fork="gloas" hash="cab71114">
-    def get_payload_attestation_due_ms() -> uint64:
+    <spec fn="get_payload_attestation_due_ms" fork="gloas" hash="268cc3e0">
+    def get_payload_attestation_due_ms() -> Uint64:
         return get_slot_component_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)
     </spec>
 
@@ -5690,8 +4966,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
       search: public Optional<Integer> getPayloadDueMillis()
   spec: |
-    <spec fn="get_payload_due_ms" fork="gloas" hash="6ccf7f5c">
-    def get_payload_due_ms() -> uint64:
+    <spec fn="get_payload_due_ms" fork="gloas" hash="492ee49c">
+    def get_payload_due_ms() -> Uint64:
         return get_slot_component_duration_ms(PAYLOAD_DUE_BPS)
     </spec>
 
@@ -5700,8 +4976,8 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: private int computePayloadStatusTiebreaker(
   spec: |
-    <spec fn="get_payload_status_tiebreaker" fork="gloas" hash="55e656e3">
-    def get_payload_status_tiebreaker(store: Store, node: ForkChoiceNode) -> uint8:
+    <spec fn="get_payload_status_tiebreaker" fork="gloas" hash="68bd690c">
+    def get_payload_status_tiebreaker(store: Store, node: ForkChoiceNode) -> Uint8:
         if is_previous_slot_payload_decision(store, node):
             # To decide on a payload from the previous slot, choose
             # between FULL and EMPTY based on `should_extend_payload`
@@ -5753,12 +5029,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
       search: protected int processPendingPartialWithdrawals(
   spec: |
-    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="306047e9">
+    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="31f145b3">
     def get_pending_partial_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
         prior_withdrawals: Sequence[Withdrawal],
-    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, Uint64]:
         epoch = get_current_epoch(state)
         withdrawals_limit = min(
             len(prior_withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
@@ -5766,7 +5042,7 @@
         )
         assert len(prior_withdrawals) <= withdrawals_limit
 
-        processed_count: uint64 = 0
+        processed_count: Uint64 = 0
         withdrawals: List[Withdrawal] = []
         for withdrawal in state.pending_partial_withdrawals:
             all_withdrawals = prior_withdrawals + withdrawals
@@ -5967,8 +5243,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public int getProposerReorgCutoffMillis(
   spec: |
-    <spec fn="get_proposer_reorg_cutoff_ms" fork="phase0" hash="cf363b52">
-    def get_proposer_reorg_cutoff_ms() -> uint64:
+    <spec fn="get_proposer_reorg_cutoff_ms" fork="phase0" hash="3dae8607">
+    def get_proposer_reorg_cutoff_ms() -> Uint64:
         return get_slot_component_duration_ms(PROPOSER_REORG_CUTOFF_BPS)
     </spec>
 
@@ -6073,8 +5349,8 @@
 - name: get_safety_threshold#altair
   sources: []
   spec: |
-    <spec fn="get_safety_threshold" fork="altair" hash="72f3d7ff">
-    def get_safety_threshold(store: LightClientStore) -> uint64:
+    <spec fn="get_safety_threshold" fork="altair" hash="4444150c">
+    def get_safety_threshold(store: LightClientStore) -> Uint64:
         return (
             max(
                 store.previous_max_active_participants,
@@ -6161,7 +5437,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
       search: public SafeFuture<BLSSignature> signProposerPreferences(
   spec: |
-    <spec fn="get_signed_proposer_preferences" fork="gloas" hash="7298817d">
+    <spec fn="get_signed_proposer_preferences" fork="gloas" hash="c1833478">
     def get_signed_proposer_preferences(
         store: Store,
         state: BeaconState,
@@ -6169,7 +5445,7 @@
         proposal_slot: Slot,
         validator_index: ValidatorIndex,
         fee_recipient: ExecutionAddress,
-        target_gas_limit: uint64,
+        target_gas_limit: Uint64,
         privkey: int,
     ) -> SignedProposerPreferences:
         proposal_epoch = compute_epoch_at_slot(proposal_slot)
@@ -6211,8 +5487,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: int getSlotComponentDurationMillis(
   spec: |
-    <spec fn="get_slot_component_duration_ms" fork="phase0" hash="b81504df">
-    def get_slot_component_duration_ms(basis_points: uint64) -> uint64:
+    <spec fn="get_slot_component_duration_ms" fork="phase0" hash="9decf51d">
+    def get_slot_component_duration_ms(basis_points: Uint64) -> Uint64:
         """
         Calculate the duration of a slot component in milliseconds.
         """
@@ -6262,9 +5538,9 @@
 - name: get_subtree_index#altair
   sources: []
   spec: |
-    <spec fn="get_subtree_index" fork="altair" hash="74962089">
-    def get_subtree_index(generalized_index: GeneralizedIndex) -> uint64:
-        return uint64(generalized_index % 2 ** (floorlog2(generalized_index)))
+    <spec fn="get_subtree_index" fork="altair" hash="78c851f8">
+    def get_subtree_index(generalized_index: GeneralizedIndex) -> Uint64:
+        return Uint64(generalized_index % 2 ** (floorlog2(generalized_index)))
     </spec>
 
 - name: get_support_discount#phase0
@@ -6349,9 +5625,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public Bytes getSyncAggregatorSelectionDataSigningRoot(
   spec: |
-    <spec fn="get_sync_committee_selection_proof" fork="altair" hash="fa4e7704">
+    <spec fn="get_sync_committee_selection_proof" fork="altair" hash="7e3c59ba">
     def get_sync_committee_selection_proof(
-        state: BeaconState, slot: Slot, subcommittee_index: uint64, privkey: int
+        state: BeaconState, slot: Slot, subcommittee_index: Uint64, privkey: int
     ) -> BLSSignature:
         domain = get_domain(state, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, compute_epoch_at_slot(slot))
         signing_data = SyncAggregatorSelectionData(
@@ -6369,8 +5645,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public int getSyncMessageDueMillis(
   spec: |
-    <spec fn="get_sync_message_due_ms" fork="altair" hash="0b972849">
-    def get_sync_message_due_ms() -> uint64:
+    <spec fn="get_sync_message_due_ms" fork="altair" hash="6d2c769f">
+    def get_sync_message_due_ms() -> Uint64:
         return get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)
     </spec>
 
@@ -6381,8 +5657,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigGloasImpl.java
       search: private final int syncMessageDueBps;
   spec: |
-    <spec fn="get_sync_message_due_ms" fork="gloas" hash="e66d68bc">
-    def get_sync_message_due_ms() -> uint64:
+    <spec fn="get_sync_message_due_ms" fork="gloas" hash="74a07556">
+    def get_sync_message_due_ms() -> Uint64:
         # [Modified in Gloas]
         return get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS_GLOAS)
     </spec>
@@ -6392,9 +5668,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
       search: public SyncSubcommitteeAssignments getSubcommitteeAssignments(
   spec: |
-    <spec fn="get_sync_subcommittee_pubkeys" fork="altair" hash="772addda">
+    <spec fn="get_sync_subcommittee_pubkeys" fork="altair" hash="fda27f73">
     def get_sync_subcommittee_pubkeys(
-        state: BeaconState, subcommittee_index: uint64
+        state: BeaconState, subcommittee_index: Uint64
     ) -> Sequence[BLSPubkey]:
         # Committees assigned to `slot` sign for `slot - 1`
         # This creates the exceptional logic below when transitioning between sync committee periods
@@ -6466,12 +5742,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getTotalBalance(
   spec: |
-    <spec fn="get_total_balance" fork="phase0" hash="32fd5ad7">
+    <spec fn="get_total_balance" fork="phase0" hash="8227088d">
     def get_total_balance(state: BeaconState, indices: Set[ValidatorIndex]) -> Gwei:
         """
         Return the combined effective balance of the ``indices``.
         ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
-        Math safe up to ~10B ETH, after which this overflows uint64.
+        Math safe up to ~10B ETH, after which this overflows Uint64.
         """
         return Gwei(
             max(
@@ -6551,8 +5827,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getValidatorActivationChurnLimit(
   spec: |
-    <spec fn="get_validator_activation_churn_limit" fork="deneb" hash="cfc9e54a">
-    def get_validator_activation_churn_limit(state: BeaconState) -> uint64:
+    <spec fn="get_validator_activation_churn_limit" fork="deneb" hash="4b6d6bb5">
+    def get_validator_activation_churn_limit(state: BeaconState) -> Uint64:
         """
         Return the validator activation churn limit for the current epoch.
         """
@@ -6564,14 +5840,14 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
       search: public UInt64 getValidatorChurnLimit(final BeaconState state)
   spec: |
-    <spec fn="get_validator_churn_limit" fork="phase0" hash="76f815b3">
-    def get_validator_churn_limit(state: BeaconState) -> uint64:
+    <spec fn="get_validator_churn_limit" fork="phase0" hash="1aaf615c">
+    def get_validator_churn_limit(state: BeaconState) -> Uint64:
         """
         Return the validator churn limit for the current epoch.
         """
         active_validator_indices = get_active_validator_indices(state, get_current_epoch(state))
         return max(
-            MIN_PER_EPOCH_CHURN_LIMIT, uint64(len(active_validator_indices)) // CHURN_LIMIT_QUOTIENT
+            MIN_PER_EPOCH_CHURN_LIMIT, Uint64(len(active_validator_indices)) // CHURN_LIMIT_QUOTIENT
         )
     </spec>
 
@@ -6580,9 +5856,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public Validator getValidatorFromDeposit(
   spec: |
-    <spec fn="get_validator_from_deposit" fork="phase0" hash="d267aa31">
+    <spec fn="get_validator_from_deposit" fork="phase0" hash="4de4438c">
     def get_validator_from_deposit(
-        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
     ) -> Validator:
         effective_balance = min(amount - amount % EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE)
 
@@ -6603,9 +5879,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public Validator getValidatorFromDeposit(
   spec: |
-    <spec fn="get_validator_from_deposit" fork="electra" hash="b1164a28">
+    <spec fn="get_validator_from_deposit" fork="electra" hash="ca05d992">
     def get_validator_from_deposit(
-        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64
     ) -> Validator:
         validator = Validator(
             pubkey=pubkey,
@@ -6632,10 +5908,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public UInt64 getValidatorsCustodyRequirement(
   spec: |
-    <spec fn="get_validators_custody_requirement" fork="fulu" hash="b2f47d03">
+    <spec fn="get_validators_custody_requirement" fork="fulu" hash="0f12230b">
     def get_validators_custody_requirement(
         state: BeaconState, validator_indices: Sequence[ValidatorIndex]
-    ) -> uint64:
+    ) -> Uint64:
         total_node_balance = sum(
             state.validators[index].effective_balance for index in validator_indices
         )
@@ -6648,19 +5924,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/withdrawals/WithdrawalsHelpersCapella.java
       search: protected int processValidatorsSweepWithdrawals(
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="59563c2a">
+    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="63669fe1">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
         prior_withdrawals: Sequence[Withdrawal],
-    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, Uint64]:
         epoch = get_current_epoch(state)
         validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
         # There must be at least one space reserved for validator sweep withdrawals
         assert len(prior_withdrawals) < withdrawals_limit
 
-        processed_count: uint64 = 0
+        processed_count: Uint64 = 0
         withdrawals: List[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
@@ -6707,19 +5983,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/MiscHelpersElectra.java
       search: public UInt64 getMaxEffectiveBalance(
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="034093ad">
+    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="9d487c12">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
         prior_withdrawals: Sequence[Withdrawal],
-    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, Uint64]:
         epoch = get_current_epoch(state)
         validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
         # There must be at least one space reserved for validator sweep withdrawals
         assert len(prior_withdrawals) < withdrawals_limit
 
-        processed_count: uint64 = 0
+        processed_count: Uint64 = 0
         withdrawals: List[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
@@ -6894,19 +6170,6 @@
         return flags & flag == flag
     </spec>
 
-- name: hash_to_bls_field#deneb
-  sources: []
-  spec: |
-    <spec fn="hash_to_bls_field" fork="deneb" hash="0856ac0c">
-    def hash_to_bls_field(data: bytes) -> BLSFieldElement:
-        """
-        Hash ``data`` and convert the output to a BLS scalar field element.
-        The output is not uniform over the BLS field.
-        """
-        hashed_data = hash(data)
-        return BLSFieldElement(int.from_bytes(hashed_data, KZG_ENDIANNESS) % BLS_MODULUS)
-    </spec>
-
 - name: increase_balance#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -6925,9 +6188,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
       search: public BeaconState initializeBeaconStateFromEth1(
   spec: |
-    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="7c0b0251">
+    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="af20d2eb">
     def initialize_beacon_state_from_eth1(
-        eth1_block_hash: Hash32, eth1_timestamp: uint64, deposits: Sequence[Deposit]
+        eth1_block_hash: Hash32, eth1_timestamp: Uint64, deposits: Sequence[Deposit]
     ) -> BeaconState:
         fork = Fork(
             previous_version=GENESIS_FORK_VERSION,
@@ -6937,7 +6200,7 @@
         state = BeaconState(
             genesis_time=eth1_timestamp + GENESIS_DELAY,
             fork=fork,
-            eth1_data=Eth1Data(deposit_count=uint64(len(deposits)), block_hash=eth1_block_hash),
+            eth1_data=Eth1Data(deposit_count=Uint64(len(deposits)), block_hash=eth1_block_hash),
             latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
             randao_mixes=[eth1_block_hash]
             * EPOCHS_PER_HISTORICAL_VECTOR,  # Seed RANDAO with Eth1 entropy
@@ -7112,8 +6375,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MathHelpers.java
       search: public static UInt64 integerSquareRoot(
   spec: |
-    <spec fn="integer_squareroot" fork="phase0" hash="f99da6e7">
-    def integer_squareroot(n: uint64) -> uint64:
+    <spec fn="integer_squareroot" fork="phase0" hash="1c1fe0a6">
+    def integer_squareroot(n: Uint64) -> Uint64:
         """
         Return the largest integer ``x`` such that ``x**2 <= n``.
         """
@@ -7125,32 +6388,6 @@
             x = y
             y = (x + n // x) // 2
         return x
-    </spec>
-
-- name: interpolate_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="interpolate_polynomialcoeff" fork="fulu" hash="73875a16">
-    def interpolate_polynomialcoeff(
-        xs: Sequence[BLSFieldElement], ys: Sequence[BLSFieldElement]
-    ) -> PolynomialCoeff:
-        """
-        Lagrange interpolation: Finds the lowest degree polynomial that takes the value ``ys[i]`` at ``x[i]`` for all i.
-        Outputs a coefficient form polynomial. Leading coefficients may be zero.
-        """
-        assert len(xs) == len(ys)
-
-        r = PolynomialCoeff([BLSFieldElement(0)])
-        for i in range(len(xs)):
-            summand = PolynomialCoeff([ys[i]])
-            for j in range(len(ys)):
-                if j != i:
-                    weight_adjustment = (xs[i] - xs[j]).inverse()
-                    summand = multiply_polynomialcoeff(
-                        summand, PolynomialCoeff([-weight_adjustment * xs[j], weight_adjustment])
-                    )
-            r = add_polynomialcoeff(r, summand)
-        return r
     </spec>
 
 - name: is_active_builder#gloas
@@ -7326,6 +6563,35 @@
         return new_update.signature_slot < old_update.signature_slot
     </spec>
 
+- name: is_bid_compatible_with_head#gloas
+  sources: []
+  spec: |
+    <spec fn="is_bid_compatible_with_head" fork="gloas" hash="8918e061">
+    def is_bid_compatible_with_head(store: Store, bid: ExecutionPayloadBid) -> bool:
+        """
+        Check if ``bid`` is compatible with the head branch.
+        """
+        head_node = get_head(store)
+        head_block = store.blocks[head_node.root]
+        head_bid = head_block.body.signed_execution_payload_bid.message
+
+        builds_on_parent_block = bid.parent_block_root == head_block.parent_root
+        builds_on_parent_payload = bid.parent_block_hash == head_bid.parent_block_hash
+
+        if builds_on_parent_block and builds_on_parent_payload:
+            return True
+
+        if bid.parent_block_root != head_node.root:
+            return False
+
+        builds_on_head_payload = bid.parent_block_hash == head_bid.block_hash
+
+        if should_build_on_full(store, head_node, bid.slot):
+            return builds_on_head_payload
+
+        return builds_on_parent_payload
+    </spec>
+
 - name: is_builder_index#gloas
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/PredicatesGloas.java
@@ -7355,8 +6621,8 @@
     - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1DataCache.java
       search: private NavigableMap<UInt64, Eth1Data> getVotesToConsider(
   spec: |
-    <spec fn="is_candidate_block" fork="phase0" hash="c588dc0a">
-    def is_candidate_block(block: Eth1Block, period_start: uint64) -> bool:
+    <spec fn="is_candidate_block" fork="phase0" hash="781fcefe">
+    def is_candidate_block(block: Eth1Block, period_start: Uint64) -> bool:
         return (
             block.timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE <= period_start
             and block.timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE * 2 >= period_start
@@ -7417,16 +6683,36 @@
         )
     </spec>
 
+- name: is_current_or_previous_epoch#deneb
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
+      search: boolean isAttestationSlotInCurrentOrPreviousEpoch(
+  spec: |
+    <spec fn="is_current_or_previous_epoch" fork="deneb" hash="b9a9edf6">
+    def is_current_or_previous_epoch(
+        state: BeaconState,
+        epoch: Epoch,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given epoch is the current or previous epoch
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        is_current = is_within_epoch(state, epoch, current_time_ms)
+        is_previous = is_within_epoch(state, Epoch(epoch + 1), current_time_ms)
+        return is_current or is_previous
+    </spec>
+
 - name: is_current_slot#altair
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
       search: public boolean isSlotCurrent(final UInt64 slot) {
   spec: |
-    <spec fn="is_current_slot" fork="altair" hash="cc76de78">
+    <spec fn="is_current_slot" fork="altair" hash="8748e6f0">
     def is_current_slot(
         state: BeaconState,
         slot: Slot,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> bool:
         """
         Check if the given slot is the current slot
@@ -7439,7 +6725,7 @@
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/BlobSidecarsAvailabilityChecker.java
   spec: |
-    <spec fn="is_data_available" fork="deneb" hash="98ad45cf">
+    <spec fn="is_data_available" fork="deneb" hash="120fd761">
     def is_data_available(
         beacon_block_root: Root, blob_kzg_commitments: Sequence[KZGCommitment]
     ) -> bool:
@@ -7449,7 +6735,7 @@
         # `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`
         blobs, proofs = retrieve_blobs_and_proofs(beacon_block_root)
 
-        return verify_blob_kzg_proof_batch(blobs, blob_kzg_commitments, proofs)
+        return kzg.verify_blob_kzg_proof_batch(blobs, blob_kzg_commitments, proofs)
     </spec>
 
 - name: is_data_available#fulu
@@ -7621,13 +6907,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationRuleUtil.java
       search: static boolean isFullValidatorSetCovered(
   spec: |
-    <spec fn="is_full_validator_set_covered" fork="phase0" hash="d83c05cd">
+    <spec fn="is_full_validator_set_covered" fork="phase0" hash="a9e47901">
     def is_full_validator_set_covered(start_slot: Slot, end_slot: Slot) -> bool:
         """
         Return ``True`` if the range between ``start_slot`` and ``end_slot`` (inclusive of both) includes an entire epoch.
         """
-        start_full_epoch = compute_epoch_at_slot(start_slot + (SLOTS_PER_EPOCH - 1))
-        end_full_epoch = compute_epoch_at_slot(Slot(end_slot + 1))
+        start_full_epoch = compute_epoch_at_slot(start_slot + SLOTS_PER_EPOCH - Slot(1))
+        end_full_epoch = compute_epoch_at_slot(end_slot + Slot(1))
         return start_full_epoch < end_full_epoch
     </spec>
 
@@ -7671,9 +6957,9 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
       search: static boolean isGasLimitTargetCompatible(
   spec: |
-    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="3fa22023">
+    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="6dffbd1d">
     def is_gas_limit_target_compatible(
-        parent_gas_limit: uint64, gas_limit: uint64, target_gas_limit: uint64
+        parent_gas_limit: Uint64, gas_limit: Uint64, target_gas_limit: Uint64
     ) -> bool:
         """
         Check if ``gas_limit`` is compatible with ``target_gas_limit`` under the
@@ -7715,20 +7001,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public boolean isHeadWeak(
   spec: |
-    <spec fn="is_head_weak" fork="phase0" hash="ac0fb917">
-    def is_head_weak(store: Store, head_root: Root) -> bool:
-        justified_state = store.checkpoint_states[store.justified_checkpoint]
-        reorg_threshold = calculate_committee_fraction(justified_state, REORG_HEAD_WEIGHT_THRESHOLD)
-        head_weight = get_weight(store, ForkChoiceNode(root=head_root))
-        return head_weight < reorg_threshold
-    </spec>
-
-- name: is_head_weak#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
-      search: public boolean isHeadWeak(
-  spec: |
-    <spec fn="is_head_weak" fork="gloas" hash="a763a3db">
+    <spec fn="is_head_weak" fork="phase0" hash="08f7dac6">
     def is_head_weak(store: Store, head_root: Root) -> bool:
         # Calculate weight threshold for weak head
         justified_state = store.checkpoint_states[store.justified_checkpoint]
@@ -7738,6 +7011,37 @@
         head_state = store.block_states[head_root]
         head_block = store.blocks[head_root]
         epoch = compute_epoch_at_slot(head_block.slot)
+        head_node = ForkChoiceNode(root=head_root)
+        head_weight = get_attestation_score(store, head_node, justified_state)
+        for index in range(get_committee_count_per_slot(head_state, epoch)):
+            committee = get_beacon_committee(head_state, head_block.slot, CommitteeIndex(index))
+            head_weight += Gwei(
+                sum(
+                    justified_state.validators[i].effective_balance
+                    for i in committee
+                    if i in store.equivocating_indices
+                )
+            )
+
+        return head_weight < reorg_threshold
+    </spec>
+
+- name: is_head_weak#gloas
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/util/ForkChoiceUtilGloas.java
+      search: public boolean isHeadWeak(
+  spec: |
+    <spec fn="is_head_weak" fork="gloas" hash="5b81945a">
+    def is_head_weak(store: Store, head_root: Root) -> bool:
+        # Calculate weight threshold for weak head
+        justified_state = store.checkpoint_states[store.justified_checkpoint]
+        reorg_threshold = calculate_committee_fraction(justified_state, REORG_HEAD_WEIGHT_THRESHOLD)
+
+        # Compute head weight including equivocations
+        head_state = store.block_states[head_root]
+        head_block = store.blocks[head_root]
+        epoch = compute_epoch_at_slot(head_block.slot)
+        # [Modified in Gloas:EIP7732]
         head_node = ForkChoiceNode(root=head_root, payload_status=PAYLOAD_STATUS_PENDING)
         head_weight = get_attestation_score(store, head_node, justified_state)
         for index in range(get_committee_count_per_slot(head_state, epoch)):
@@ -7783,16 +7087,6 @@
         return state.latest_execution_payload_header != ExecutionPayloadHeader()
     </spec>
 
-- name: is_merge_transition_complete#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/helpers/MiscHelpersCapella.java
-      search: public boolean isMergeTransitionComplete(
-  spec: |
-    <spec fn="is_merge_transition_complete" fork="gloas" hash="b13c98c6">
-    def is_merge_transition_complete(state: BeaconState) -> bool:
-        return state.latest_execution_payload_header != ExecutionPayloadHeader()
-    </spec>
-
 - name: is_next_sync_committee_known#altair
   sources: []
   spec: |
@@ -7808,10 +7102,10 @@
     - file: infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitSet.java
       search: default boolean isSuperSetOf(final SszBitSet other) {
   spec: |
-    <spec fn="is_non_strict_superset" fork="phase0" hash="636b4456">
+    <spec fn="is_non_strict_superset" fork="phase0" hash="7cb1d56e">
     def is_non_strict_superset(
-        seen_bits_set: Set[Tuple[boolean, ...]],
-        new_bits: Tuple[boolean, ...],
+        seen_bits_set: Set[Tuple[Boolean, ...]],
+        new_bits: Tuple[Boolean, ...],
     ) -> bool:
         """
         Return True if any prior bitset in ``seen_bits_set`` is a non-strict
@@ -7843,11 +7137,11 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
       search: public boolean isSlotFromFuture(
   spec: |
-    <spec fn="is_not_from_future_slot" fork="phase0" hash="7e35ef32">
+    <spec fn="is_not_from_future_slot" fork="phase0" hash="04d389ee">
     def is_not_from_future_slot(
         state: BeaconState,
         slot: Slot,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> bool:
         """
         Check if the given slot is not from the future
@@ -7915,13 +7209,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public boolean isParentStrong(
   spec: |
-    <spec fn="is_parent_strong" fork="phase0" hash="a23d498f">
+    <spec fn="is_parent_strong" fork="phase0" hash="f7f4e624">
     def is_parent_strong(store: Store, root: Root) -> bool:
         justified_state = store.checkpoint_states[store.justified_checkpoint]
         parent_threshold = calculate_committee_fraction(justified_state, REORG_PARENT_WEIGHT_THRESHOLD)
         parent_root = store.blocks[root].parent_root
         parent_node = ForkChoiceNode(root=parent_root)
-        parent_weight = get_weight(store, parent_node)
+        parent_weight = get_attestation_score(store, parent_node, justified_state)
         return parent_weight > parent_threshold
     </spec>
 
@@ -8019,17 +7313,6 @@
             ):
                 return True
         return False
-    </spec>
-
-- name: is_power_of_two#deneb
-  sources: []
-  spec: |
-    <spec fn="is_power_of_two" fork="deneb" hash="9a547510">
-    def is_power_of_two(value: int) -> bool:
-        """
-        Check if ``value`` is a power of two integer.
-        """
-        return (value > 0) and (value & (value - 1) == 0)
     </spec>
 
 - name: is_previous_slot_payload_decision#gloas
@@ -8175,14 +7458,33 @@
         return bls.Verify(request.pubkey, signing_root, request.signature)
     </spec>
 
+- name: is_valid_dependent_root#gloas
+  sources: []
+  spec: |
+    <spec fn="is_valid_dependent_root" fork="gloas" hash="2b049531">
+    def is_valid_dependent_root(store: Store, root: Root, epoch: Epoch) -> bool:
+        """
+        Check if the block with the given ``root`` is a possible dependent block
+        for the given ``epoch``, meaning that on some branch it is, or could
+        become, the latest block prior to the start of the epoch.
+        """
+        epoch_start_slot = compute_start_slot_at_epoch(epoch)
+        if store.blocks[root].slot >= epoch_start_slot:
+            return False
+        for block in store.blocks.values():
+            if block.parent_root == root and block.slot >= epoch_start_slot:
+                return True
+        return root == get_head(store).root
+    </spec>
+
 - name: is_valid_deposit_signature#electra
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
       search: public boolean isValidDepositSignature(
   spec: |
-    <spec fn="is_valid_deposit_signature" fork="electra" hash="7347b754">
+    <spec fn="is_valid_deposit_signature" fork="electra" hash="3d27f174">
     def is_valid_deposit_signature(
-        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64, signature: BLSSignature
+        pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: Uint64, signature: BLSSignature
     ) -> bool:
         deposit_message = DepositMessage(
             pubkey=pubkey,
@@ -8327,7 +7629,7 @@
 - name: is_valid_light_client_header#deneb
   sources: []
   spec: |
-    <spec fn="is_valid_light_client_header" fork="deneb" style="diff" hash="f458ba78">
+    <spec fn="is_valid_light_client_header" fork="deneb" style="diff" hash="89259a0e">
     --- capella
     +++ deneb
     @@ -1,5 +1,11 @@
@@ -8335,9 +7637,9 @@
          epoch = compute_epoch_at_slot(header.beacon.slot)
     +
     +    if epoch < DENEB_FORK_EPOCH:
-    +        if header.execution.blob_gas_used != uint64(0):
+    +        if header.execution.blob_gas_used != Uint64(0):
     +            return False
-    +        if header.execution.excess_blob_gas != uint64(0):
+    +        if header.execution.excess_blob_gas != Uint64(0):
     +            return False
 
          if epoch < CAPELLA_FORK_EPOCH:
@@ -8349,9 +7651,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
       search: public boolean isValidMerkleBranch(
   spec: |
-    <spec fn="is_valid_merkle_branch" fork="phase0" hash="19db92a5">
+    <spec fn="is_valid_merkle_branch" fork="phase0" hash="356dc6b1">
     def is_valid_merkle_branch(
-        leaf: Bytes32, branch: Sequence[Bytes32], depth: uint64, index: uint64, root: Root
+        leaf: Bytes32, branch: Sequence[Bytes32], depth: Uint64, index: Uint64, root: Root
     ) -> bool:
         """
         Check if ``leaf`` at ``index`` verifies against the Merkle ``root`` and ``branch``.
@@ -8453,17 +7755,40 @@
         return is_total_difficulty_reached and is_parent_total_difficulty_valid
     </spec>
 
+- name: is_within_epoch#deneb
+  sources:
+    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/util/AttestationUtilDeneb.java
+      search: boolean isAttestationSlotInCurrentOrPreviousEpoch(
+  spec: |
+    <spec fn="is_within_epoch" fork="deneb" hash="276fb799">
+    def is_within_epoch(
+        state: BeaconState,
+        epoch: Epoch,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the current time is within the given epoch
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance on both ends).
+        """
+        return is_within_slot_range(
+            state,
+            compute_start_slot_at_epoch(epoch),
+            SLOTS_PER_EPOCH - 1,
+            current_time_ms,
+        )
+    </spec>
+
 - name: is_within_slot_range#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
       search: public Optional<SlotInclusionGossipValidationResult> performSlotInclusionGossipValidation(
   spec: |
-    <spec fn="is_within_slot_range" fork="phase0" hash="7a6f6f51">
+    <spec fn="is_within_slot_range" fork="phase0" hash="9e470870">
     def is_within_slot_range(
         state: BeaconState,
         slot: Slot,
-        slot_range: uint64,
-        current_time_ms: uint64,
+        slot_range: Uint64,
+        current_time_ms: Uint64,
     ) -> bool:
         """
         Check if the current time is within the inclusive slot range ``[slot, slot + slot_range]``
@@ -8539,11 +7864,11 @@
     - file: networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
       search: private static int maxCompressedLength(
   spec: |
-    <spec fn="max_compressed_len" fork="phase0" hash="2e531709">
-    def max_compressed_len(n: uint64) -> uint64:
+    <spec fn="max_compressed_len" fork="phase0" hash="8dfe50b2">
+    def max_compressed_len(n: Uint64) -> Uint64:
         # Worst-case compressed length for a given payload of size n when using snappy:
         # https://github.com/google/snappy/blob/32ded457c0b1fe78ceb8397632c416568d6714a0/snappy.cc#L218C1-L218C47
-        return uint64(32 + n + n / 6)
+        return Uint64(32 + n + n / 6)
     </spec>
 
 - name: max_message_size#phase0
@@ -8551,27 +7876,10 @@
     - file: networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
       search: private static int maxMessageSize(
   spec: |
-    <spec fn="max_message_size" fork="phase0" hash="8abedfdb">
-    def max_message_size() -> uint64:
+    <spec fn="max_message_size" fork="phase0" hash="ae51ac93">
+    def max_message_size() -> Uint64:
         # Allow 1024 bytes for framing and encoding overhead but at least 1MiB in case MAX_PAYLOAD_SIZE is small.
         return max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1024 * 1024)
-    </spec>
-
-- name: multiply_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="multiply_polynomialcoeff" fork="fulu" hash="c2ba13ea">
-    def multiply_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoeff:
-        """
-        Multiplies the coefficient form polynomials ``a`` and ``b``.
-        """
-        assert len(a) + len(b) <= FIELD_ELEMENTS_PER_EXT_BLOB
-
-        r = PolynomialCoeff([BLSFieldElement(0)])
-        for power, coef in enumerate(a):
-            summand = PolynomialCoeff([BLSFieldElement(0)] * power + [coef * x for x in b])
-            r = add_polynomialcoeff(r, summand)
-        return r
     </spec>
 
 - name: next_sync_committee_gindex_at_slot#altair
@@ -8693,9 +8001,15 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="phase0" hash="36ebb320">
+    <spec fn="on_block" fork="phase0" hash="fd507f39">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         block = signed_block.message
+        block_root = hash_tree_root(block)
+
+        # Return early if the block is already known
+        if block_root in store.blocks:
+            return
+
         # Parent block must be known
         assert block.parent_root in store.block_states
         # Make a copy of the state to avoid mutability issues
@@ -8716,7 +8030,6 @@
 
         # Check the block is valid and compute the post-state
         state = pre_state.copy()
-        block_root = hash_tree_root(block)
         state_transition(state, signed_block, validate_result=True)
 
         # Compute head before applying the block
@@ -8741,7 +8054,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="bellatrix" hash="317c8053">
+    <spec fn="on_block" fork="bellatrix" hash="12ce22a6">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
@@ -8750,6 +8063,12 @@
         consider scheduling it for later processing in such case.
         """
         block = signed_block.message
+        block_root = hash_tree_root(block)
+
+        # Return early if the block is already known
+        if block_root in store.blocks:
+            return
+
         # Parent block must be known
         assert block.parent_root in store.block_states
         # Make a copy of the state to avoid mutability issues
@@ -8770,7 +8089,6 @@
 
         # Check the block is valid and compute the post-state
         state = pre_state.copy()
-        block_root = hash_tree_root(block)
         state_transition(state, signed_block, validate_result=True)
 
         # [New in Bellatrix]
@@ -8799,12 +8117,18 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="capella" hash="7e879033">
+    <spec fn="on_block" fork="capella" hash="3f558bc8">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
         """
         block = signed_block.message
+        block_root = hash_tree_root(block)
+
+        # Return early if the block is already known
+        if block_root in store.blocks:
+            return
+
         # Parent block must be known
         assert block.parent_root in store.block_states
         # Blocks cannot be in the future. If they are, their consideration must be delayed until they are in the past.
@@ -8824,7 +8148,6 @@
         # Check the block is valid and compute the post-state
         # Make a copy of the state to avoid mutability issues
         state = copy(store.block_states[block.parent_root])
-        block_root = hash_tree_root(block)
         state_transition(state, signed_block, validate_result=True)
 
         # Compute head before applying the block
@@ -8849,12 +8172,18 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="deneb" hash="12aa50be">
+    <spec fn="on_block" fork="deneb" hash="e7ccb392">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
         """
         block = signed_block.message
+        block_root = hash_tree_root(block)
+
+        # Return early if the block is already known
+        if block_root in store.blocks:
+            return
+
         # Parent block must be known
         assert block.parent_root in store.block_states
         # Blocks cannot be in the future. If they are, their consideration must be delayed until they are in the past.
@@ -8874,12 +8203,11 @@
         # [New in Deneb:EIP4844]
         # Check if blob data is available
         # If not, this payload MAY be queued and subsequently considered when blob data becomes available
-        assert is_data_available(hash_tree_root(block), block.body.blob_kzg_commitments)
+        assert is_data_available(block_root, block.body.blob_kzg_commitments)
 
         # Check the block is valid and compute the post-state
         # Make a copy of the state to avoid mutability issues
         state = copy(store.block_states[block.parent_root])
-        block_root = hash_tree_root(block)
         state_transition(state, signed_block, validate_result=True)
 
         # Compute head before applying the block
@@ -8904,12 +8232,18 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
       search: private SafeFuture<BlockImportResult> onBlock(
   spec: |
-    <spec fn="on_block" fork="fulu" hash="7a1448fc">
+    <spec fn="on_block" fork="fulu" hash="86d1a522">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
         """
         block = signed_block.message
+        block_root = hash_tree_root(block)
+
+        # Return early if the block is already known
+        if block_root in store.blocks:
+            return
+
         # Parent block must be known
         assert block.parent_root in store.block_states
         # Make a copy of the state to avoid mutability issues
@@ -8931,10 +8265,9 @@
         # [Modified in Fulu:EIP7594]
         # Check if blob data is available
         # If not, this payload MAY be queued and subsequently considered when blob data becomes available
-        assert is_data_available(hash_tree_root(block))
+        assert is_data_available(block_root)
 
         # Check the block is valid and compute the post-state
-        block_root = hash_tree_root(block)
         state_transition(state, signed_block, validate_result=True)
 
         # Compute head before applying the block
@@ -8963,12 +8296,18 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public UInt64 executionProcessing(
   spec: |
-    <spec fn="on_block" fork="gloas" hash="c370389d">
+    <spec fn="on_block" fork="gloas" hash="dfd77120">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
         """
         Run ``on_block`` upon receiving a new block.
         """
         block = signed_block.message
+        block_root = hash_tree_root(block)
+
+        # Return early if the block is already known
+        if block_root in store.blocks:
+            return
+
         # Parent block must be known
         assert block.parent_root in store.block_states
 
@@ -8996,7 +8335,6 @@
         state = copy(store.block_states[block.parent_root])
 
         # Check the block is valid and compute the post-state
-        block_root = hash_tree_root(block)
         state_transition(state, signed_block, validate_result=True)
 
         # Compute head before applying the block
@@ -9120,8 +8458,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: public void onTick(
   spec: |
-    <spec fn="on_tick" fork="phase0" hash="741c4913">
-    def on_tick(store: Store, time: uint64) -> None:
+    <spec fn="on_tick" fork="phase0" hash="8ec6b435">
+    def on_tick(store: Store, time: Uint64) -> None:
         # If the ``store.time`` falls behind, while loop catches up slot by slot
         # to ensure that every previous slot is processed with ``on_tick_per_slot``
         tick_slot = (time - store.genesis_time) * 1000 // SLOT_DURATION_MS
@@ -9138,8 +8476,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
       search: private void processOnTick(final MutableStore store, final UInt64 timeMillis) {
   spec: |
-    <spec fn="on_tick_per_slot" fork="phase0" hash="ae9ef172">
-    def on_tick_per_slot(store: Store, time: uint64) -> None:
+    <spec fn="on_tick_per_slot" fork="phase0" hash="8bda5b76">
+    def on_tick_per_slot(store: Store, time: Uint64) -> None:
         previous_slot = get_current_slot(store)
 
         # Update store time
@@ -9264,20 +8602,6 @@
         return sum(vote == timely for vote in votes) > PAYLOAD_TIMELY_THRESHOLD
     </spec>
 
-- name: polynomial_eval_to_coeff#fulu
-  sources: []
-  spec: |
-    <spec fn="polynomial_eval_to_coeff" fork="fulu" hash="f13ead66">
-    def polynomial_eval_to_coeff(polynomial: Polynomial) -> PolynomialCoeff:
-        """
-        Interpolates a polynomial (given in evaluation form) to a polynomial in coefficient form.
-        """
-        roots_of_unity = compute_roots_of_unity(FIELD_ELEMENTS_PER_BLOB)
-        return PolynomialCoeff(
-            fft_field(bit_reversal_permutation(polynomial), roots_of_unity, inv=True)
-        )
-    </spec>
-
 - name: prepare_execution_payload#bellatrix
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -9400,28 +8724,6 @@
              head_block_hash=parent_hash,
     </spec>
 
-- name: prepare_execution_payload#electra
-  sources:
-    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
-      search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
-    - file: ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
-      search: public static Optional<PayloadAttributesV3> fromInternalPayloadBuildingAttributesV3(
-    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
-      search: executionLayer.engineForkChoiceUpdated(forkChoiceState, payloadBuildingAttributes)
-  spec: |
-    <spec fn="prepare_execution_payload" fork="electra" style="diff" hash="c617aa1b">
-    --- capella
-    +++ electra
-    @@ -12,6 +12,7 @@
-             prev_randao=get_randao_mix(state, get_current_epoch(state)),
-             suggested_fee_recipient=suggested_fee_recipient,
-             withdrawals=get_expected_withdrawals(state).withdrawals,
-    +        parent_beacon_block_root=hash_tree_root(state.latest_block_header),
-         )
-         return execution_engine.notify_forkchoice_updated(
-             head_block_hash=parent_hash,
-    </spec>
-
 - name: prepare_execution_payload#gloas
   sources:
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -9429,7 +8731,7 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
       search: private SafeFuture<Optional<PayloadBuildingAttributes>> calculatePayloadBuildingAttributes(
   spec: |
-    <spec fn="prepare_execution_payload" fork="gloas" hash="193044fa">
+    <spec fn="prepare_execution_payload" fork="gloas" hash="e25f2d5e">
     def prepare_execution_payload(
         # [New in Gloas:EIP7732]
         store: Store,
@@ -9440,12 +8742,12 @@
         finalized_block_hash: Hash32,
         suggested_fee_recipient: ExecutionAddress,
         # [New in Gloas]
-        target_gas_limit: uint64,
+        target_gas_limit: Uint64,
         execution_engine: ExecutionEngine,
     ) -> Optional[PayloadId]:
         # [New in Gloas:EIP7732]
         parent_bid = state.latest_execution_payload_bid
-        if should_build_on_full(store, head):
+        if should_build_on_full(store, head, get_current_slot(store)):
             envelope = store.payloads[head.root]
             # Make a copy of the state to avoid mutability issues
             state = copy(state)
@@ -9684,8 +8986,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void consumeAttestationProcessingResult(
   spec: |
-    <spec fn="process_attestation" fork="gloas" hash="169ef683">
-    def process_attestation(state: BeaconState, attestation: Attestation) -> None:
+    <spec fn="process_attestation" fork="gloas" hash="788ac81e">
+    def process_attestation(
+        state: BeaconState,
+        attestation: Attestation,
+        # [New in Gloas:EIP7732]
+        parent_slot: Slot,
+    ) -> None:
         data = attestation.data
         assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
         assert data.target.epoch == compute_epoch_at_slot(data.slot)
@@ -9710,8 +9017,9 @@
         assert len(attestation.aggregation_bits) == committee_offset
 
         # Participation flag indices
+        # [Modified in Gloas:EIP7732]
         participation_flag_indices = get_attestation_participation_flag_indices(
-            state, data, state.slot - data.slot
+            state, data, state.slot - data.slot, parent_slot
         )
 
         # Verify signature
@@ -9898,7 +9206,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: public UInt64 executionProcessing(
   spec: |
-    <spec fn="process_block" fork="gloas" hash="7d98b5a3">
+    <spec fn="process_block" fork="gloas" hash="fda2f095">
     def process_block(state: BeaconState, block: BeaconBlock) -> None:
         # [New in Gloas:EIP7732]
         process_parent_execution_payload(state, block)
@@ -9908,11 +9216,11 @@
         # [Modified in Gloas:EIP7732]
         # Removed `process_execution_payload`
         # [New in Gloas:EIP7732]
-        process_execution_payload_bid(state, block.body.signed_execution_payload_bid)
+        parent_slot = process_execution_payload_bid(state, block.body.signed_execution_payload_bid)
         process_randao(state, block.body)
         process_eth1_data(state, block.body)
         # [Modified in Gloas:EIP7732]
-        process_operations(state, block.body)
+        process_operations(state, block.body, parent_slot)
         process_sync_aggregate(state, block.body.sync_aggregate)
     </spec>
 
@@ -10239,12 +9547,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processEffectiveBalanceUpdates(
   spec: |
-    <spec fn="process_effective_balance_updates" fork="phase0" hash="678d0327">
+    <spec fn="process_effective_balance_updates" fork="phase0" hash="bd6c1c47">
     def process_effective_balance_updates(state: BeaconState) -> None:
         # Update effective balances with hysteresis
         for index, validator in enumerate(state.validators):
             balance = state.balances[index]
-            HYSTERESIS_INCREMENT = uint64(EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT)
+            HYSTERESIS_INCREMENT = Uint64(EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT)
             DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_DOWNWARD_MULTIPLIER
             UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER
             if (
@@ -10261,12 +9569,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processEffectiveBalanceUpdates(
   spec: |
-    <spec fn="process_effective_balance_updates" fork="electra" hash="6b447363">
+    <spec fn="process_effective_balance_updates" fork="electra" hash="838d8754">
     def process_effective_balance_updates(state: BeaconState) -> None:
         # Update effective balances with hysteresis
         for index, validator in enumerate(state.validators):
             balance = state.balances[index]
-            HYSTERESIS_INCREMENT = uint64(EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT)
+            HYSTERESIS_INCREMENT = Uint64(EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT)
             DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_DOWNWARD_MULTIPLIER
             UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER
             # [Modified in Electra:EIP7251]
@@ -10329,65 +9637,12 @@
         process_sync_committee_updates(state)
     </spec>
 
-- name: process_epoch#bellatrix
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
-      search: public BeaconState processEpoch(
-  spec: |
-    <spec fn="process_epoch" fork="bellatrix" hash="3ce6242b">
-    def process_epoch(state: BeaconState) -> None:
-        # [Modified in Altair]
-        process_justification_and_finalization(state)
-        # [New in Altair]
-        process_inactivity_updates(state)
-        # [Modified in Altair]
-        process_rewards_and_penalties(state)
-        process_registry_updates(state)
-        # [Modified in Altair]
-        process_slashings(state)
-        process_eth1_data_reset(state)
-        process_effective_balance_updates(state)
-        process_slashings_reset(state)
-        process_randao_mixes_reset(state)
-        process_historical_roots_update(state)
-        # [Modified in Altair]
-        # Removed `process_participation_record_updates`
-        # [New in Altair]
-        process_participation_flag_updates(state)
-        # [New in Altair]
-        process_sync_committee_updates(state)
-    </spec>
-
 - name: process_epoch#capella
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public BeaconState processEpoch(
   spec: |
     <spec fn="process_epoch" fork="capella" hash="b96e20df">
-    def process_epoch(state: BeaconState) -> None:
-        process_justification_and_finalization(state)
-        process_inactivity_updates(state)
-        process_rewards_and_penalties(state)
-        process_registry_updates(state)
-        process_slashings(state)
-        process_eth1_data_reset(state)
-        process_effective_balance_updates(state)
-        process_slashings_reset(state)
-        process_randao_mixes_reset(state)
-        # [Modified in Altair]
-        # Removed `process_historical_roots_update`
-        # [New in Capella]
-        process_historical_summaries_update(state)
-        process_participation_flag_updates(state)
-        process_sync_committee_updates(state)
-    </spec>
-
-- name: process_epoch#deneb
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
-      search: public BeaconState processEpoch(
-  spec: |
-    <spec fn="process_epoch" fork="deneb" hash="b96e20df">
     def process_epoch(state: BeaconState) -> None:
         process_justification_and_finalization(state)
         process_inactivity_updates(state)
@@ -10742,10 +9997,10 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: // process_execution_payload_bid
   spec: |
-    <spec fn="process_execution_payload_bid" fork="gloas" hash="ba18a784">
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="ccd70022">
     def process_execution_payload_bid(
         state: BeaconState, signed_bid: SignedExecutionPayloadBid
-    ) -> None:
+    ) -> Slot:
         bid = signed_bid.message
         builder_index = bid.builder_index
         amount = bid.value
@@ -10793,8 +10048,13 @@
                 pending_payment
             )
 
+        # Cache the parent block's slot before overwriting the bid
+        parent_slot = state.latest_execution_payload_bid.slot
+
         # Cache the signed execution payload bid
         state.latest_execution_payload_bid = bid
+
+        return parent_slot
     </spec>
 
 - name: process_historical_roots_update#phase0
@@ -11141,13 +10401,19 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/block/BlockProcessorGloas.java
       search: protected void processOperationsNoValidation(
   spec: |
-    <spec fn="process_operations" fork="gloas" hash="5009f53b">
-    def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
+    <spec fn="process_operations" fork="gloas" hash="52aee81b">
+    def process_operations(
+        state: BeaconState,
+        body: BeaconBlockBody,
+        # [New in Gloas:EIP7732]
+        parent_slot: Slot,
+    ) -> None:
         assert len(body.deposits) == 0
 
-        def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
+        # [Modified in Gloas:EIP7732]
+        def for_ops(operations: Sequence[Any], fn: Callable[..., None], *args: Any) -> None:
             for operation in operations:
-                fn(state, operation)
+                fn(state, operation, *args)
 
         # [New in Gloas:EIP7688]
         assert len(body.proposer_slashings) <= MAX_PROPOSER_SLASHINGS
@@ -11161,7 +10427,7 @@
         for_ops(body.proposer_slashings, process_proposer_slashing)
         for_ops(body.attester_slashings, process_attester_slashing)
         # [Modified in Gloas:EIP7732]
-        for_ops(body.attestations, process_attestation)
+        for_ops(body.attestations, process_attestation, parent_slot)
         for_ops(body.voluntary_exits, process_voluntary_exit)
         for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
         # [Modified in Gloas:EIP7732]
@@ -11744,7 +11010,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="phase0" hash="a18a9045">
+    <spec fn="process_slashings" fork="phase0" hash="cec229a2">
     def process_slashings(state: BeaconState) -> None:
         epoch = get_current_epoch(state)
         total_balance = get_total_active_balance(state)
@@ -11756,7 +11022,7 @@
                 validator.slashed
                 and epoch + EPOCHS_PER_SLASHINGS_VECTOR // 2 == validator.withdrawable_epoch
             ):
-                increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from penalty numerator to avoid uint64 overflow
+                increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from penalty numerator to avoid Uint64 overflow
                 penalty_numerator = (
                     validator.effective_balance // increment * adjusted_total_slashing_balance
                 )
@@ -11769,7 +11035,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="altair" style="diff" hash="96cce87d">
+    <spec fn="process_slashings" fork="altair" style="diff" hash="acf32b34">
     --- phase0
     +++ altair
     @@ -2,7 +2,7 @@
@@ -11788,7 +11054,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="bellatrix" style="diff" hash="0c8f6e6e">
+    <spec fn="process_slashings" fork="bellatrix" style="diff" hash="4880d29b">
     --- altair
     +++ bellatrix
     @@ -2,7 +2,9 @@
@@ -11809,7 +11075,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
       search: public void processSlashings(
   spec: |
-    <spec fn="process_slashings" fork="electra" hash="a948faff">
+    <spec fn="process_slashings" fork="electra" hash="d3b2c93b">
     def process_slashings(state: BeaconState) -> None:
         epoch = get_current_epoch(state)
         total_balance = get_total_active_balance(state)
@@ -11817,7 +11083,7 @@
             sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX, total_balance
         )
         increment = (
-            EFFECTIVE_BALANCE_INCREMENT  # Factored out from total balance to avoid uint64 overflow
+            EFFECTIVE_BALANCE_INCREMENT  # Factored out from total balance to avoid Uint64 overflow
         )
         penalty_per_effective_balance_increment = adjusted_total_slashing_balance // (
             total_balance // increment
@@ -12295,49 +11561,6 @@
         ]
     </spec>
 
-- name: recover_cells_and_kzg_proofs#fulu
-  sources: []
-  spec: |
-    <spec fn="recover_cells_and_kzg_proofs" fork="fulu" hash="1a56b010">
-    def recover_cells_and_kzg_proofs(
-        cell_indices: Sequence[CellIndex], cells: Sequence[Cell]
-    ) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
-        """
-        Given at least 50% of cells for a blob, recover all the cells/proofs.
-        This algorithm uses FFTs to recover cells faster than using Lagrange
-        implementation, as can be seen here:
-        https://ethresear.ch/t/reed-solomon-erasure-code-recovery-in-n-log-2-n-time-with-ffts/3039
-
-        A faster version thanks to Qi Zhou can be found here:
-        https://github.com/ethereum/research/blob/51b530a53bd4147d123ab3e390a9d08605c2cdb8/polynomial_reconstruction/polynomial_reconstruction_danksharding.py
-
-        Public method.
-        """
-        # Check we have the same number of cells and indices
-        assert len(cell_indices) == len(cells)
-        # Check we have enough cells to be able to perform the reconstruction
-        assert CELLS_PER_EXT_BLOB // 2 <= len(cell_indices) <= CELLS_PER_EXT_BLOB
-        # Check for duplicates
-        assert len(cell_indices) == len(set(cell_indices))
-        # Check that indices are in ascending order
-        assert cell_indices == sorted(cell_indices)
-        # Check that the cell indices are within bounds
-        for cell_index in cell_indices:
-            assert cell_index < CELLS_PER_EXT_BLOB
-        # Check that each cell is the correct length
-        for cell in cells:
-            assert len(cell) == BYTES_PER_CELL
-
-        # Convert cells to coset evaluations
-        cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
-
-        # Given the coset evaluations, recover the polynomial in coefficient form
-        polynomial_coeff = recover_polynomialcoeff(cell_indices, cosets_evals)
-
-        # Recompute all cells/proofs
-        return compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff)
-    </spec>
-
 - name: recover_matrix#fulu
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
@@ -12345,21 +11568,21 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/helpers/MiscHelpersFulu.java
       search: public List<List<MatrixEntry>> recoverMatrix(
   spec: |
-    <spec fn="recover_matrix" fork="fulu" hash="d21e29e7">
+    <spec fn="recover_matrix" fork="fulu" hash="7876eaca">
     def recover_matrix(
-        partial_matrix: Sequence[MatrixEntry], blob_count: uint64
+        partial_matrix: Sequence[MatrixEntry], blob_count: Uint64
     ) -> Sequence[MatrixEntry]:
         """
         Recover the full, flattened sequence of matrix entries.
 
-        This helper demonstrates how to apply ``recover_cells_and_kzg_proofs``.
+        This helper demonstrates how to apply ``kzg.recover_cells_and_kzg_proofs``.
         The data structure for storing cells/proofs is implementation-dependent.
         """
         matrix = []
         for blob_index in range(blob_count):
             cell_indices = [e.column_index for e in partial_matrix if e.row_index == blob_index]
             cells = [e.cell for e in partial_matrix if e.row_index == blob_index]
-            recovered_cells, recovered_proofs = recover_cells_and_kzg_proofs(cell_indices, cells)
+            recovered_cells, recovered_proofs = kzg.recover_cells_and_kzg_proofs(cell_indices, cells)
             for cell_index, (cell, proof) in enumerate(
                 zip(recovered_cells, recovered_proofs, strict=True)
             ):
@@ -12374,101 +11597,13 @@
         return matrix
     </spec>
 
-- name: recover_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="recover_polynomialcoeff" fork="fulu" hash="d5344462">
-    def recover_polynomialcoeff(
-        cell_indices: Sequence[CellIndex], cosets_evals: Sequence[CosetEvals]
-    ) -> PolynomialCoeff:
-        """
-        Recover the polynomial in coefficient form that when evaluated at the roots of unity will give the extended blob.
-        """
-        # Get the extended domain. This will be referred to as the FFT domain.
-        roots_of_unity_extended = compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
-
-        # Flatten the cosets evaluations.
-        # If a cell is missing, then its evaluation is zero.
-        # We let E(x) be a polynomial of degree FIELD_ELEMENTS_PER_EXT_BLOB - 1
-        # that interpolates the evaluations including the zeros for missing ones.
-        extended_evaluation_rbo = [BLSFieldElement(0)] * FIELD_ELEMENTS_PER_EXT_BLOB
-        for cell_index, cell in zip(cell_indices, cosets_evals, strict=True):
-            start = cell_index * FIELD_ELEMENTS_PER_CELL
-            end = (cell_index + 1) * FIELD_ELEMENTS_PER_CELL
-            extended_evaluation_rbo[start:end] = cell
-        extended_evaluation = bit_reversal_permutation(extended_evaluation_rbo)
-
-        # Compute the vanishing polynomial Z(x) in coefficient form.
-        # Z(x) is the polynomial which vanishes on all of the evaluations which are missing.
-        missing_cell_indices = [
-            CellIndex(cell_index)
-            for cell_index in range(CELLS_PER_EXT_BLOB)
-            if cell_index not in cell_indices
-        ]
-        zero_poly_coeff = construct_vanishing_polynomial(missing_cell_indices)
-
-        # Convert Z(x) to evaluation form over the FFT domain
-        zero_poly_eval = fft_field(zero_poly_coeff, roots_of_unity_extended)
-
-        # Compute (E*Z)(x) = E(x) * Z(x) in evaluation form over the FFT domain
-        # Note: over the FFT domain, the polynomials (E*Z)(x) and (P*Z)(x) agree, where
-        # P(x) is the polynomial we want to reconstruct (degree FIELD_ELEMENTS_PER_BLOB - 1).
-        extended_evaluation_times_zero = [
-            a * b for a, b in zip(zero_poly_eval, extended_evaluation, strict=True)
-        ]
-
-        # We know that (E*Z)(x) and (P*Z)(x) agree over the FFT domain,
-        # and we know that (P*Z)(x) has degree at most FIELD_ELEMENTS_PER_EXT_BLOB - 1.
-        # Thus, an inverse FFT of the evaluations of (E*Z)(x) (= evaluations of (P*Z)(x))
-        # yields the coefficient form of (P*Z)(x).
-        extended_evaluation_times_zero_coeffs = fft_field(
-            extended_evaluation_times_zero, roots_of_unity_extended, inv=True
-        )
-
-        # Next step is to divide the polynomial (P*Z)(x) by polynomial Z(x) to get P(x).
-        # We do this in evaluation form over a coset of the FFT domain to avoid division by 0.
-
-        # Convert (P*Z)(x) to evaluation form over a coset of the FFT domain
-        extended_evaluations_over_coset = coset_fft_field(
-            extended_evaluation_times_zero_coeffs, roots_of_unity_extended
-        )
-
-        # Convert Z(x) to evaluation form over a coset of the FFT domain
-        zero_poly_over_coset = coset_fft_field(zero_poly_coeff, roots_of_unity_extended)
-
-        # Compute P(x) = (P*Z)(x) / Z(x) in evaluation form over a coset of the FFT domain
-        reconstructed_poly_over_coset = [
-            a / b for a, b in zip(extended_evaluations_over_coset, zero_poly_over_coset, strict=True)
-        ]
-
-        # Convert P(x) to coefficient form
-        reconstructed_poly_coeff = coset_fft_field(
-            reconstructed_poly_over_coset, roots_of_unity_extended, inv=True
-        )
-
-        return PolynomialCoeff(reconstructed_poly_coeff[:FIELD_ELEMENTS_PER_BLOB])
-    </spec>
-
-- name: reverse_bits#deneb
-  sources: []
-  spec: |
-    <spec fn="reverse_bits" fork="deneb" hash="ea345856">
-    def reverse_bits(n: int, order: int) -> int:
-        """
-        Reverse the bit order of an integer ``n``.
-        """
-        assert is_power_of_two(order)
-        # Convert n to binary with the same number of bits as "order" - 1, then reverse its bit order
-        return int(("{:0" + str(order.bit_length() - 1) + "b}").format(n)[::-1], 2)
-    </spec>
-
 - name: seconds_to_milliseconds#phase0
   sources:
     - file: infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/TimeUtilities.java
       search: public static UInt64 secondsToMillis(final UInt64 timeInSeconds) {
   spec: |
-    <spec fn="seconds_to_milliseconds" fork="phase0" hash="b2cc9743">
-    def seconds_to_milliseconds(seconds: uint64) -> uint64:
+    <spec fn="seconds_to_milliseconds" fork="phase0" hash="3eff10ea">
+    def seconds_to_milliseconds(seconds: Uint64) -> Uint64:
         """
         Convert seconds to milliseconds with overflow protection.
         Returns ``UINT64_MAX`` if the result would overflow.
@@ -12496,8 +11631,8 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/BeaconStateMutatorsGloas.java
       search: public void settleBuilderPayment(
   spec: |
-    <spec fn="settle_builder_payment" fork="gloas" hash="42ebaa70">
-    def settle_builder_payment(state: BeaconState, payment_index: uint64) -> None:
+    <spec fn="settle_builder_payment" fork="gloas" hash="2e5e5de6">
+    def settle_builder_payment(state: BeaconState, payment_index: Uint64) -> None:
         assert payment_index < len(state.builder_pending_payments)
         payment = state.builder_pending_payments[payment_index]
         if payment.withdrawal.amount > 0:
@@ -12549,10 +11684,10 @@
     - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceModelGloas.java
       search: public boolean shouldBuildOnFull(
   spec: |
-    <spec fn="should_build_on_full" fork="gloas" hash="c93c17f0">
-    def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
+    <spec fn="should_build_on_full" fork="gloas" hash="759005a1">
+    def should_build_on_full(store: Store, head: ForkChoiceNode, slot: Slot) -> bool:
         assert head.payload_status != PAYLOAD_STATUS_PENDING
-        if store.blocks[head.root].slot + 1 != get_current_slot(store):
+        if store.blocks[head.root].slot + 1 != slot:
             return head.payload_status == PAYLOAD_STATUS_FULL
         if head.payload_status == PAYLOAD_STATUS_EMPTY:
             return False
@@ -12821,9 +11956,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected void updateBuilderPendingWithdrawals(
   spec: |
-    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="0cbba9bd">
+    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="d9882622">
     def update_builder_pending_withdrawals(
-        state: BeaconState, processed_builder_withdrawals_count: uint64
+        state: BeaconState, processed_builder_withdrawals_count: Uint64
     ) -> None:
         state.builder_pending_withdrawals = state.builder_pending_withdrawals[
             processed_builder_withdrawals_count:
@@ -12935,9 +12070,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/withdrawals/WithdrawalsHelpersGloas.java
       search: protected void updateNextWithdrawalBuilderIndex(
   spec: |
-    <spec fn="update_next_withdrawal_builder_index" fork="gloas" hash="652c72b5">
+    <spec fn="update_next_withdrawal_builder_index" fork="gloas" hash="be78d479">
     def update_next_withdrawal_builder_index(
-        state: BeaconState, processed_builders_sweep_count: uint64
+        state: BeaconState, processed_builders_sweep_count: Uint64
     ) -> None:
         if len(state.builders) > 0:
             # Update the next builder index to start the next withdrawal sweep
@@ -12999,9 +12134,9 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/withdrawals/WithdrawalsHelpersElectra.java
       search: protected void updatePendingPartialWithdrawals(
   spec: |
-    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="dcdd6c8f">
+    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="ab8f3216">
     def update_pending_partial_withdrawals(
-        state: BeaconState, processed_partial_withdrawals_count: uint64
+        state: BeaconState, processed_partial_withdrawals_count: Uint64
     ) -> None:
         state.pending_partial_withdrawals = state.pending_partial_withdrawals[
             processed_partial_withdrawals_count:
@@ -13175,7 +12310,7 @@
 - name: upgrade_lc_header_to_deneb#deneb
   sources: []
   spec: |
-    <spec fn="upgrade_lc_header_to_deneb" fork="deneb" hash="7dc12b61">
+    <spec fn="upgrade_lc_header_to_deneb" fork="deneb" hash="e7b827f1">
     def upgrade_lc_header_to_deneb(pre: capella.LightClientHeader) -> LightClientHeader:
         return LightClientHeader(
             beacon=pre.beacon,
@@ -13196,9 +12331,9 @@
                 transactions_root=pre.execution.transactions_root,
                 withdrawals_root=pre.execution.withdrawals_root,
                 # [New in Deneb:EIP4844]
-                blob_gas_used=uint64(0),
+                blob_gas_used=Uint64(0),
                 # [New in Deneb:EIP4844]
-                excess_blob_gas=uint64(0),
+                excess_blob_gas=Uint64(0),
             ),
             execution_branch=pre.execution_branch,
         )
@@ -13373,7 +12508,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/forktransition/AltairStateUpgrade.java
       search: public BeaconStateAltair upgrade(
   spec: |
-    <spec fn="upgrade_to_altair" fork="altair" hash="45bb04f7">
+    <spec fn="upgrade_to_altair" fork="altair" hash="10e7fa01">
     def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:
         epoch = phase0.get_current_epoch(pre)
         post = BeaconState(
@@ -13407,7 +12542,7 @@
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
-            inactivity_scores=[uint64(0) for _ in range(len(pre.validators))],
+            inactivity_scores=[Uint64(0) for _ in range(len(pre.validators))],
         )
         # Fill in previous epoch participation from the pre state's pending attestations
         translate_participation(post, pre.previous_epoch_attestations)
@@ -13537,7 +12672,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/forktransition/DenebStateUpgrade.java
       search: public BeaconStateDeneb upgrade(
   spec: |
-    <spec fn="upgrade_to_deneb" fork="deneb" hash="0c371849">
+    <spec fn="upgrade_to_deneb" fork="deneb" hash="9eecb1a3">
     def upgrade_to_deneb(pre: capella.BeaconState) -> BeaconState:
         epoch = capella.get_current_epoch(pre)
         latest_execution_payload_header = ExecutionPayloadHeader(
@@ -13557,9 +12692,9 @@
             transactions_root=pre.latest_execution_payload_header.transactions_root,
             withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
             # [New in Deneb:EIP4844]
-            blob_gas_used=uint64(0),
+            blob_gas_used=Uint64(0),
             # [New in Deneb:EIP4844]
-            excess_blob_gas=uint64(0),
+            excess_blob_gas=Uint64(0),
         )
         post = BeaconState(
             genesis_time=pre.genesis_time,
@@ -13773,7 +12908,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/forktransition/GloasStateUpgrade.java
       search: public BeaconStateGloas upgrade(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="571abe9a">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="013b8366">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -13813,7 +12948,7 @@
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
             # [Modified in Gloas:EIP7688]
-            inactivity_scores=ProgressiveList[uint64](list(pre.inactivity_scores)),
+            inactivity_scores=ProgressiveList[Uint64](list(pre.inactivity_scores)),
             current_sync_committee=pre.current_sync_committee,
             next_sync_committee=pre.next_sync_committee,
             # [Modified in Gloas:EIP7732]
@@ -13934,13 +13069,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="phase0" hash="dd1babcc">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="phase0" hash="8a8eed9d">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_aggregate_and_proof: SignedAggregateAndProof,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedAggregateAndProof for gossip propagation.
@@ -14050,13 +13185,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="ec1dcf12">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="4a576fc4">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_aggregate_and_proof: SignedAggregateAndProof,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedAggregateAndProof for gossip propagation.
@@ -14081,20 +13216,8 @@
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
-        is_previous_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        is_current_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(attestation_epoch),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
-            raise GossipIgnore("aggregate epoch is not previous or current epoch")
+        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+            raise GossipIgnore("aggregate epoch is not current or previous epoch")
 
         # [REJECT] The aggregate attestation's epoch matches its target
         if aggregate.data.target.epoch != compute_epoch_at_slot(aggregate.data.slot):
@@ -14183,13 +13306,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
       search: validate(final ValidatableAttestation attestation)
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="fd4d3e8f">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="573a95ef">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_aggregate_and_proof: SignedAggregateAndProof,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedAggregateAndProof for gossip propagation.
@@ -14223,20 +13346,8 @@
 
         # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
-        is_previous_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        is_current_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(attestation_epoch),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
-            raise GossipIgnore("aggregate epoch is not previous or current epoch")
+        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+            raise GossipIgnore("aggregate epoch is not current or previous epoch")
 
         # [REJECT] The aggregate attestation's epoch matches its target
         if aggregate.data.target.epoch != compute_epoch_at_slot(aggregate.data.slot):
@@ -14327,13 +13438,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="phase0" hash="b7375ab1">
+    <spec fn="validate_beacon_attestation_gossip" fork="phase0" hash="cbf9fcf3">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         attestation: Attestation,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         subnet_id: SubnetID,
     ) -> None:
         """
@@ -14419,13 +13530,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="bc9dda54">
+    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="e75305a8">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         attestation: Attestation,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         subnet_id: SubnetID,
     ) -> None:
         """
@@ -14458,20 +13569,8 @@
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(data.slot)
-        is_previous_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        is_current_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(attestation_epoch),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
-            raise GossipIgnore("attestation epoch is not previous or current epoch")
+        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+            raise GossipIgnore("attestation epoch is not current or previous epoch")
 
         # [REJECT] The attestation's epoch matches its target
         if target_epoch != compute_epoch_at_slot(data.slot):
@@ -14528,14 +13627,14 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="214a283d">
+    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="3b002df3">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         # [Modified in Electra:EIP7549]
         attestation: SingleAttestation,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         subnet_id: SubnetID,
     ) -> None:
         """
@@ -14572,20 +13671,8 @@
 
         # [IGNORE] The attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(data.slot)
-        is_previous_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        is_current_epoch_attestation = is_within_slot_range(
-            state,
-            compute_start_slot_at_epoch(attestation_epoch),
-            SLOTS_PER_EPOCH - 1,
-            current_time_ms,
-        )
-        if not (is_previous_epoch_attestation or is_current_epoch_attestation):
-            raise GossipIgnore("attestation epoch is not previous or current epoch")
+        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+            raise GossipIgnore("attestation epoch is not current or previous epoch")
 
         # [REJECT] The attestation's epoch matches its target
         if target_epoch != compute_epoch_at_slot(data.slot):
@@ -14641,13 +13728,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="1368bba8">
+    <spec fn="validate_beacon_block_gossip" fork="phase0" hash="31f56a5c">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedBeaconBlock for gossip propagation.
@@ -14719,13 +13806,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="6b2b6629">
+    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="31da1c6c">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         # [New in Bellatrix]
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
     ) -> None:
@@ -14780,15 +13867,15 @@
 
             if block.parent_root not in store.block_states:
                 if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
-                    # [REJECT] The block's parent passes validation
-                    raise GossipReject("block's parent is invalid and EL result is unknown")
+                    # [REJECT] The block's parent failed validation and its execution payload is optimistic
+                    raise GossipReject("block's parent is invalid and its payload is optimistic")
 
-                # [IGNORE] The block's parent passes validation
-                raise GossipIgnore("block's parent is invalid and EL result is known")
+                # [IGNORE] The block's parent failed validation and its execution payload is processed
+                raise GossipIgnore("block's parent is invalid and its payload is processed")
 
-            # [IGNORE] The block's parent's execution payload passes validation
+            # [IGNORE] The block's parent passed validation but its execution payload is invalid
             if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
-                raise GossipIgnore("block's parent is valid and EL result is invalid")
+                raise GossipIgnore("block's parent is valid and its payload is invalid")
 
         # [REJECT] The block's parent passes validation
         elif block.parent_root not in store.block_states:
@@ -14823,13 +13910,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="capella" hash="18ed1bc4">
+    <spec fn="validate_beacon_block_gossip" fork="capella" hash="9d2a397e">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
     ) -> None:
         """
@@ -14881,15 +13968,15 @@
 
         if block.parent_root not in store.block_states:
             if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
-                # [REJECT] The block's parent passes validation
-                raise GossipReject("block's parent is invalid and EL result is unknown")
+                # [REJECT] The block's parent failed validation and its execution payload is optimistic
+                raise GossipReject("block's parent is invalid and its payload is optimistic")
 
-            # [IGNORE] The block's parent passes validation
-            raise GossipIgnore("block's parent is invalid and EL result is known")
+            # [IGNORE] The block's parent failed validation and its execution payload is processed
+            raise GossipIgnore("block's parent is invalid and its payload is processed")
 
-        # [IGNORE] The block's parent's execution payload passes validation
+        # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
-            raise GossipIgnore("block's parent is valid and EL result is invalid")
+            raise GossipIgnore("block's parent is valid and its payload is invalid")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -14919,13 +14006,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="679f5b63">
+    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="85275293">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
     ) -> None:
         """
@@ -14977,15 +14064,15 @@
 
         if block.parent_root not in store.block_states:
             if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
-                # [REJECT] The block's parent passes validation
-                raise GossipReject("block's parent is invalid and EL result is unknown")
+                # [REJECT] The block's parent failed validation and its execution payload is optimistic
+                raise GossipReject("block's parent is invalid and its payload is optimistic")
 
-            # [IGNORE] The block's parent passes validation
-            raise GossipIgnore("block's parent is invalid and EL result is known")
+            # [IGNORE] The block's parent failed validation and its execution payload is processed
+            raise GossipIgnore("block's parent is invalid and its payload is processed")
 
-        # [IGNORE] The block's parent's execution payload passes validation
+        # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
-            raise GossipIgnore("block's parent is valid and EL result is invalid")
+            raise GossipIgnore("block's parent is valid and its payload is invalid")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -15020,13 +14107,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="electra" hash="b4939435">
+    <spec fn="validate_beacon_block_gossip" fork="electra" hash="b5e31e17">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         block_payload_statuses: Dict[Root, PayloadValidationStatus],
     ) -> None:
         """
@@ -15078,15 +14165,15 @@
 
         if block.parent_root not in store.block_states:
             if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
-                # [REJECT] The block's parent passes validation
-                raise GossipReject("block's parent is invalid and EL result is unknown")
+                # [REJECT] The block's parent failed validation and its execution payload is optimistic
+                raise GossipReject("block's parent is invalid and its payload is optimistic")
 
-            # [IGNORE] The block's parent passes validation
-            raise GossipIgnore("block's parent is invalid and EL result is known")
+            # [IGNORE] The block's parent failed validation and its execution payload is processed
+            raise GossipIgnore("block's parent is invalid and its payload is processed")
 
-        # [IGNORE] The block's parent's execution payload passes validation
+        # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
-            raise GossipIgnore("block's parent is valid and EL result is invalid")
+            raise GossipIgnore("block's parent is valid and its payload is invalid")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -15121,13 +14208,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="58934408">
+    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="aeb637f6">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         block_payload_statuses: Optional[Dict[Root, PayloadValidationStatus]] = None,
     ) -> None:
         """
@@ -15181,15 +14268,15 @@
 
         if block.parent_root not in store.block_states:
             if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
-                # [REJECT] The block's parent passes validation
-                raise GossipReject("block's parent is invalid and EL result is unknown")
+                # [REJECT] The block's parent failed validation and its execution payload is optimistic
+                raise GossipReject("block's parent is invalid and its payload is optimistic")
 
-            # [IGNORE] The block's parent passes validation
-            raise GossipIgnore("block's parent is invalid and EL result is known")
+            # [IGNORE] The block's parent failed validation and its execution payload is processed
+            raise GossipIgnore("block's parent is invalid and its payload is processed")
 
-        # [IGNORE] The block's parent's execution payload passes validation
+        # [IGNORE] The block's parent passed validation but its execution payload is invalid
         if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
-            raise GossipIgnore("block's parent is valid and EL result is invalid")
+            raise GossipIgnore("block's parent is valid and its payload is invalid")
 
         # [REJECT] The block is from a higher slot than its parent
         if block.slot <= store.blocks[block.parent_root].slot:
@@ -15225,13 +14312,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="2a9319ce">
+    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="2ad40697">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         blob_sidecar: BlobSidecar,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         subnet_id: SubnetID,
     ) -> None:
         """
@@ -15294,7 +14381,7 @@
             raise GossipReject("invalid blob sidecar inclusion proof")
 
         # [REJECT] The sidecar's blob is valid as verified by verify_blob_kzg_proof
-        if not verify_blob_kzg_proof(
+        if not kzg.verify_blob_kzg_proof(
             blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
         ):
             raise GossipReject("invalid blob kzg proof")
@@ -15322,13 +14409,13 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final BlobSidecar blobSidecar)
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="2240dacc">
+    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="23259565">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         blob_sidecar: BlobSidecar,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         subnet_id: SubnetID,
     ) -> None:
         """
@@ -15392,7 +14479,7 @@
             raise GossipReject("invalid blob sidecar inclusion proof")
 
         # [REJECT] The sidecar's blob is valid as verified by verify_blob_kzg_proof
-        if not verify_blob_kzg_proof(
+        if not kzg.verify_blob_kzg_proof(
             blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
         ):
             raise GossipReject("invalid blob kzg proof")
@@ -15422,12 +14509,12 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/BlsToExecutionChangesValidator.java
       search: public Optional<OperationInvalidReason> validate(
   spec: |
-    <spec fn="validate_bls_to_execution_change_gossip" fork="capella" hash="dc7d042d">
+    <spec fn="validate_bls_to_execution_change_gossip" fork="capella" hash="1e6b274d">
     def validate_bls_to_execution_change_gossip(
         seen: Seen,
         state: BeaconState,
         signed_bls_to_execution_change: SignedBLSToExecutionChange,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedBLSToExecutionChange for gossip propagation.
@@ -15487,13 +14574,13 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/fulu/util/DataColumnSidecarUtilFulu.java
       search: public SafeFuture<Optional<DataColumnSidecarValidationError>> validateWithState(
   spec: |
-    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="57a6f229">
+    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="ec896133">
     def validate_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         sidecar: DataColumnSidecar,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         subnet_id: SubnetID,
     ) -> None:
         """
@@ -15575,20 +14662,6 @@
 
         # Mark this data column sidecar as seen
         seen.data_column_sidecar_tuples.add(sidecar_tuple)
-    </spec>
-
-- name: validate_kzg_g1#deneb
-  sources: []
-  spec: |
-    <spec fn="validate_kzg_g1" fork="deneb" hash="865bd0c2">
-    def validate_kzg_g1(b: Bytes48) -> None:
-        """
-        Perform BLS validation required by the types `KZGProof` and `KZGCommitment`.
-        """
-        if b == G1_POINT_AT_INFINITY:
-            return
-
-        assert bls.KeyValidate(b)
     </spec>
 
 - name: validate_light_client_update#altair
@@ -15710,36 +14783,6 @@
         assert is_valid_terminal_pow_block(pow_block, pow_parent)
     </spec>
 
-- name: validate_merge_block#gloas
-  sources:
-    - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/BellatrixTransitionHelpers.java
-      search: public SafeFuture<PayloadStatus> validateMergeBlock(
-  spec: |
-    <spec fn="validate_merge_block" fork="gloas" hash="6553dd1d">
-    def validate_merge_block(block: BeaconBlock) -> None:
-        """
-        Check the parent PoW block of execution payload is a valid terminal PoW block.
-
-        Note: Unavailable PoW block(s) may later become available,
-        and a client software MAY delay a call to ``validate_merge_block``
-        until the PoW block(s) become available.
-        """
-        if TERMINAL_BLOCK_HASH != EMPTY_BLOCK_HASH:
-            # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
-            assert compute_epoch_at_slot(block.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
-            assert block.body.execution_payload.parent_hash == TERMINAL_BLOCK_HASH
-            return
-
-        pow_block = get_pow_block(block.body.execution_payload.parent_hash)
-        # Check if `pow_block` is available
-        assert pow_block is not None
-        pow_parent = get_pow_block(pow_block.parent_hash)
-        # Check if `pow_parent` is available
-        assert pow_parent is not None
-        # Check if `pow_block` is a valid terminal PoW block
-        assert is_valid_terminal_pow_block(pow_block, pow_parent)
-    </spec>
-
 - name: validate_on_attestation#phase0
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -15831,13 +14874,13 @@
 - name: validate_partial_data_column_sidecar_gossip#fulu
   sources: []
   spec: |
-    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="aaad7df2">
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="53eac7ee">
     def validate_partial_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         sidecar: PartialDataColumnSidecar,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         group_id: PartialDataColumnGroupID,
         column_index: ColumnIndex,
     ) -> None:
@@ -16027,12 +15070,12 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
       search: public SafeFuture<InternalValidationResult> validate(final SignedContributionAndProof proof) {
   spec: |
-    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="36521201">
+    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="6dd060ef">
     def validate_sync_committee_contribution_and_proof_gossip(
         seen: Seen,
         state: BeaconState,
         signed_contribution_and_proof: SignedContributionAndProof,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
     ) -> None:
         """
         Validate a SignedContributionAndProof for gossip propagation.
@@ -16137,12 +15180,12 @@
     - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
       search: public SafeFuture<InternalValidationResult> validate(
   spec: |
-    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="f3ed28bd">
+    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="01f56b45">
     def validate_sync_committee_message_gossip(
         seen: Seen,
         state: BeaconState,
         sync_committee_message: SyncCommitteeMessage,
-        current_time_ms: uint64,
+        current_time_ms: Uint64,
         subnet_id: SubnetID,
     ) -> None:
         """
@@ -16318,80 +15361,6 @@
         seen.voluntary_exit_indices.add(validator_index)
     </spec>
 
-- name: vanishing_polynomialcoeff#fulu
-  sources: []
-  spec: |
-    <spec fn="vanishing_polynomialcoeff" fork="fulu" hash="e2c3fb1b">
-    def vanishing_polynomialcoeff(xs: Sequence[BLSFieldElement]) -> PolynomialCoeff:
-        """
-        Compute the vanishing polynomial on ``xs`` (in coefficient form).
-        """
-        p = PolynomialCoeff([BLSFieldElement(1)])
-        for x in xs:
-            p = multiply_polynomialcoeff(p, PolynomialCoeff([-x, BLSFieldElement(1)]))
-        return p
-    </spec>
-
-- name: verify_blob_kzg_proof#deneb
-  sources: []
-  spec: |
-    <spec fn="verify_blob_kzg_proof" fork="deneb" hash="1e0e92e6">
-    def verify_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes48, proof_bytes: Bytes48) -> bool:
-        """
-        Given a blob and a KZG proof, verify that the blob data corresponds to the provided commitment.
-
-        Public method.
-        """
-        assert len(blob) == BYTES_PER_BLOB
-        assert len(commitment_bytes) == BYTES_PER_COMMITMENT
-        assert len(proof_bytes) == BYTES_PER_PROOF
-
-        commitment = bytes_to_kzg_commitment(commitment_bytes)
-
-        polynomial = blob_to_polynomial(blob)
-        evaluation_challenge = compute_challenge(blob, commitment)
-
-        # Evaluate polynomial at `evaluation_challenge`
-        y = evaluate_polynomial_in_evaluation_form(polynomial, evaluation_challenge)
-
-        # Verify proof
-        proof = bytes_to_kzg_proof(proof_bytes)
-        return verify_kzg_proof_impl(commitment, evaluation_challenge, y, proof)
-    </spec>
-
-- name: verify_blob_kzg_proof_batch#deneb
-  sources: []
-  spec: |
-    <spec fn="verify_blob_kzg_proof_batch" fork="deneb" hash="16a55ea7">
-    def verify_blob_kzg_proof_batch(
-        blobs: Sequence[Blob], commitments_bytes: Sequence[Bytes48], proofs_bytes: Sequence[Bytes48]
-    ) -> bool:
-        """
-        Given a list of blobs and blob KZG proofs, verify that they correspond to the provided commitments.
-        Will return True if there are zero blobs/commitments/proofs.
-        Public method.
-        """
-
-        assert len(blobs) == len(commitments_bytes) == len(proofs_bytes)
-
-        commitments, evaluation_challenges, ys, proofs = [], [], [], []
-        for blob, commitment_bytes, proof_bytes in zip(
-            blobs, commitments_bytes, proofs_bytes, strict=True
-        ):
-            assert len(blob) == BYTES_PER_BLOB
-            assert len(commitment_bytes) == BYTES_PER_COMMITMENT
-            assert len(proof_bytes) == BYTES_PER_PROOF
-            commitment = bytes_to_kzg_commitment(commitment_bytes)
-            commitments.append(commitment)
-            polynomial = blob_to_polynomial(blob)
-            evaluation_challenge = compute_challenge(blob, commitment)
-            evaluation_challenges.append(evaluation_challenge)
-            ys.append(evaluate_polynomial_in_evaluation_form(polynomial, evaluation_challenge))
-            proofs.append(bytes_to_kzg_proof(proof_bytes))
-
-        return verify_kzg_proof_batch(commitments, evaluation_challenges, ys, proofs)
-    </spec>
-
 - name: verify_blob_sidecar_inclusion_proof#deneb
   sources:
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -16423,168 +15392,6 @@
             signed_block.message, get_domain(state, DOMAIN_BEACON_PROPOSER)
         )
         return bls.Verify(proposer.pubkey, signing_root, signed_block.signature)
-    </spec>
-
-- name: verify_cell_kzg_proof_batch#fulu
-  sources: []
-  spec: |
-    <spec fn="verify_cell_kzg_proof_batch" fork="fulu" hash="2005f095">
-    def verify_cell_kzg_proof_batch(
-        commitments_bytes: Sequence[Bytes48],
-        cell_indices: Sequence[CellIndex],
-        cells: Sequence[Cell],
-        proofs_bytes: Sequence[Bytes48],
-    ) -> bool:
-        """
-        Verify that a set of cells belong to their corresponding commitments.
-
-        Given four lists representing tuples of (``commitment``, ``cell_index``, ``cell``, ``proof``),
-        the function verifies ``proof`` which shows that ``cell`` are the evaluations of the polynomial
-        associated with ``commitment``, evaluated over the domain specified by ``cell_index``.
-
-        This function implements the universal verification equation that has been introduced here:
-        https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240
-
-        Public method.
-        """
-
-        assert len(commitments_bytes) == len(cells) == len(proofs_bytes) == len(cell_indices)
-        for commitment_bytes in commitments_bytes:
-            assert len(commitment_bytes) == BYTES_PER_COMMITMENT
-        for cell_index in cell_indices:
-            assert cell_index < CELLS_PER_EXT_BLOB
-        for cell in cells:
-            assert len(cell) == BYTES_PER_CELL
-        for proof_bytes in proofs_bytes:
-            assert len(proof_bytes) == BYTES_PER_PROOF
-
-        # Create the list of deduplicated commitments we are dealing with
-        deduplicated_commitments = [
-            bytes_to_kzg_commitment(commitment_bytes)
-            for index, commitment_bytes in enumerate(commitments_bytes)
-            if commitments_bytes.index(commitment_bytes) == index
-        ]
-        # Create indices list mapping initial commitments (that may contain duplicates) to the deduplicated commitments
-        commitment_indices = [
-            CommitmentIndex(deduplicated_commitments.index(commitment_bytes))
-            for commitment_bytes in commitments_bytes
-        ]
-
-        cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
-        proofs = [bytes_to_kzg_proof(proof_bytes) for proof_bytes in proofs_bytes]
-
-        # Do the actual verification
-        return verify_cell_kzg_proof_batch_impl(
-            deduplicated_commitments, commitment_indices, cell_indices, cosets_evals, proofs
-        )
-    </spec>
-
-- name: verify_cell_kzg_proof_batch_impl#fulu
-  sources: []
-  spec: |
-    <spec fn="verify_cell_kzg_proof_batch_impl" fork="fulu" hash="23b55caf">
-    def verify_cell_kzg_proof_batch_impl(
-        commitments: Sequence[KZGCommitment],
-        commitment_indices: Sequence[CommitmentIndex],
-        cell_indices: Sequence[CellIndex],
-        cosets_evals: Sequence[CosetEvals],
-        proofs: Sequence[KZGProof],
-    ) -> bool:
-        """
-        Helper: Verify that a set of cells belong to their corresponding commitment.
-
-        Given a list of ``commitments`` (which contains no duplicates) and four lists representing
-        tuples of (``commitment_index``, ``cell_index``, ``evals``, ``proof``), the function
-        verifies ``proof`` which shows that ``evals`` are the evaluations of the polynomial associated
-        with ``commitments[commitment_index]``, evaluated over the domain specified by ``cell_index``.
-
-        This function is the internal implementation of ``verify_cell_kzg_proof_batch``.
-        """
-        assert len(commitment_indices) == len(cell_indices) == len(cosets_evals) == len(proofs)
-        assert len(commitments) == len(set(commitments))
-        for commitment_index in commitment_indices:
-            assert commitment_index < len(commitments)
-
-        # The verification equation that we will check is pairing (LL, LR) = pairing (RL, [1]), where
-        # LL = sum_k r^k proofs[k],
-        # LR = [s^n]
-        # RL = RLC - RLI + RLP, where
-        #   RLC = sum_i weights[i] commitments[i]
-        #   RLI = [sum_k r^k interpolation_poly_k(s)]
-        #   RLP = sum_k (r^k * h_k^n) proofs[k]
-        #
-        # Here, the variables have the following meaning:
-        # - k < len(cell_indices) is an index iterating over all cells in the input
-        # - r is a random coefficient, derived from hashing all data provided by the prover
-        # - s is the secret embedded in the KZG setup
-        # - n = FIELD_ELEMENTS_PER_CELL is the size of the evaluation domain
-        # - i ranges over all provided commitments
-        # - weights[i] is a weight computed for commitment i
-        #   - It depends on r and on which cells are associated with commitment i
-        # - interpolation_poly_k is the interpolation polynomial for the kth cell
-        # - h_k is the coset shift specifying the evaluation domain of the kth cell
-
-        # Preparation
-        num_cells = len(cell_indices)
-        n = FIELD_ELEMENTS_PER_CELL
-        num_commitments = len(commitments)
-
-        # Step 1: Compute a challenge r and its powers r^0, ..., r^{num_cells-1}
-        r = compute_verify_cell_kzg_proof_batch_challenge(
-            commitments, commitment_indices, cell_indices, cosets_evals, proofs
-        )
-        r_powers = compute_powers(r, num_cells)
-
-        # Step 2: Compute LL = sum_k r^k proofs[k]
-        ll = bls.bytes48_to_G1(g1_lincomb(proofs, r_powers))
-
-        # Step 3: Compute LR = [s^n]
-        lr = bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[n])
-
-        # Step 4: Compute RL = RLC - RLI + RLP
-        # Step 4.1: Compute RLC = sum_i weights[i] commitments[i]
-        # Step 4.1a: Compute weights[i]: the sum of all r^k for which cell k is associated with commitment i.
-        # Note: we do that by iterating over all k and updating the correct weights[i] accordingly
-        weights = [BLSFieldElement(0)] * num_commitments
-        for k in range(num_cells):
-            i = commitment_indices[k]
-            weights[i] += r_powers[k]
-        # Step 4.1b: Linearly combine the weights with the commitments to get RLC
-        rlc = bls.bytes48_to_G1(g1_lincomb(commitments, weights))
-
-        # Step 4.2: Compute RLI = [sum_k r^k interpolation_poly_k(s)]
-        # Note: an efficient implementation would use the IDFT based method explained in the blog post
-        sum_interp_polys_coeff = PolynomialCoeff([BLSFieldElement(0)] * n)
-        for k in range(num_cells):
-            interp_poly_coeff = interpolate_polynomialcoeff(
-                coset_for_cell(cell_indices[k]), cosets_evals[k]
-            )
-            interp_poly_scaled_coeff = multiply_polynomialcoeff(
-                PolynomialCoeff([r_powers[k]]), interp_poly_coeff
-            )
-            sum_interp_polys_coeff = add_polynomialcoeff(
-                sum_interp_polys_coeff, interp_poly_scaled_coeff
-            )
-        rli = bls.bytes48_to_G1(g1_lincomb(KZG_SETUP_G1_MONOMIAL[:n], sum_interp_polys_coeff))
-
-        # Step 4.3: Compute RLP = sum_k (r^k * h_k^n) proofs[k]
-        weighted_r_powers = []
-        for k in range(num_cells):
-            h_k = coset_shift_for_cell(cell_indices[k])
-            h_k_pow = h_k.pow(BLSFieldElement(n))
-            wrp = r_powers[k] * h_k_pow
-            weighted_r_powers.append(wrp)
-        rlp = bls.bytes48_to_G1(g1_lincomb(proofs, weighted_r_powers))
-
-        # Step 4.4: Compute RL = RLC - RLI + RLP
-        rl = bls.add(rlc, bls.neg(rli))
-        rl = bls.add(rl, rlp)
-
-        # Step 5: Check pairing (LL, LR) = pairing (RL, [1])
-        return bls.pairing_check([
-            [ll, lr],
-            [rl, bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[0]))],
-        ])
     </spec>
 
 - name: verify_data_column_sidecar#fulu
@@ -16677,7 +15484,7 @@
       search: public boolean verifyDataColumnSidecarKzgProofs\(\s*final DataColumnSidecar dataColumnSidecar, final SszList<SszKZGCommitment> kzgCommitments\) \{
       regex: true
   spec: |
-    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="fulu" hash="1cd21395">
+    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="fulu" hash="34fa68b5">
     def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
         """
         Verify if the KZG proofs are correct.
@@ -16686,7 +15493,7 @@
         cell_indices = [CellIndex(sidecar.index)] * len(sidecar.column)
 
         # Batch verify that the cells match the corresponding commitments and proofs
-        return verify_cell_kzg_proof_batch(
+        return kzg.verify_cell_kzg_proof_batch(
             commitments_bytes=sidecar.kzg_commitments,
             cell_indices=cell_indices,
             cells=sidecar.column,
@@ -16699,7 +15506,7 @@
     - file: ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/gloas/helpers/MiscHelpersGloas.java
       search: public boolean verifyDataColumnSidecarKzgProofs(
   spec: |
-    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="19a51c0d">
+    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="401fafe6">
     def verify_data_column_sidecar_kzg_proofs(
         sidecar: DataColumnSidecar,
         # [New in Gloas:EIP7732]
@@ -16712,7 +15519,7 @@
         cell_indices = [CellIndex(sidecar.index)] * len(sidecar.column)
 
         # Batch verify that the cells match the corresponding commitments and proofs
-        return verify_cell_kzg_proof_batch(
+        return kzg.verify_cell_kzg_proof_batch(
             # [Modified in Gloas:EIP7732]
             commitments_bytes=kzg_commitments,
             cell_indices=cell_indices,
@@ -16808,114 +15615,13 @@
         return bls.Verify(pubkey, signing_root, signed_envelope.signature)
     </spec>
 
-- name: verify_kzg_proof#deneb
-  sources: []
-  spec: |
-    <spec fn="verify_kzg_proof" fork="deneb" hash="900aa92d">
-    def verify_kzg_proof(
-        commitment_bytes: Bytes48, z_bytes: Bytes32, y_bytes: Bytes32, proof_bytes: Bytes48
-    ) -> bool:
-        """
-        Verify KZG proof that ``p(z) == y`` where ``p(z)`` is the polynomial represented by ``polynomial_kzg``.
-        Receives inputs as bytes.
-        Public method.
-        """
-        assert len(commitment_bytes) == BYTES_PER_COMMITMENT
-        assert len(z_bytes) == BYTES_PER_FIELD_ELEMENT
-        assert len(y_bytes) == BYTES_PER_FIELD_ELEMENT
-        assert len(proof_bytes) == BYTES_PER_PROOF
-
-        return verify_kzg_proof_impl(
-            bytes_to_kzg_commitment(commitment_bytes),
-            bytes_to_bls_field(z_bytes),
-            bytes_to_bls_field(y_bytes),
-            bytes_to_kzg_proof(proof_bytes),
-        )
-    </spec>
-
-- name: verify_kzg_proof_batch#deneb
-  sources: []
-  spec: |
-    <spec fn="verify_kzg_proof_batch" fork="deneb" hash="4756dd78">
-    def verify_kzg_proof_batch(
-        commitments: Sequence[KZGCommitment],
-        zs: Sequence[BLSFieldElement],
-        ys: Sequence[BLSFieldElement],
-        proofs: Sequence[KZGProof],
-    ) -> bool:
-        """
-        Verify multiple KZG proofs efficiently.
-        """
-
-        assert len(commitments) == len(zs) == len(ys) == len(proofs)
-
-        # Compute a random challenge. Note that it does not have to be computed from a hash,
-        # r just has to be random.
-        degree_poly = int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 8, KZG_ENDIANNESS)
-        num_commitments = int.to_bytes(len(commitments), 8, KZG_ENDIANNESS)
-        data = RANDOM_CHALLENGE_KZG_BATCH_DOMAIN + degree_poly + num_commitments
-
-        # Append all inputs to the transcript before we hash
-        for commitment, z, y, proof in zip(commitments, zs, ys, proofs, strict=True):
-            data += commitment + bls_field_to_bytes(z) + bls_field_to_bytes(y) + proof
-
-        r = hash_to_bls_field(data)
-        r_powers = compute_powers(r, len(commitments))
-
-        # Verify: e(sum r^i proof_i, [s]) ==
-        # e(sum r^i (commitment_i - [y_i]) + sum r^i z_i proof_i, [1])
-        proof_lincomb = g1_lincomb(proofs, r_powers)
-        proof_z_lincomb = g1_lincomb(
-            proofs, [z * r_power for z, r_power in zip(zs, r_powers, strict=True)]
-        )
-        C_minus_ys = [
-            bls.add(bls.bytes48_to_G1(commitment), bls.multiply(bls.G1(), -y))
-            for commitment, y in zip(commitments, ys, strict=True)
-        ]
-        C_minus_y_as_KZGCommitments = [KZGCommitment(bls.G1_to_bytes48(x)) for x in C_minus_ys]
-        C_minus_y_lincomb = g1_lincomb(C_minus_y_as_KZGCommitments, r_powers)
-
-        return bls.pairing_check([
-            [
-                bls.bytes48_to_G1(proof_lincomb),
-                bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[1])),
-            ],
-            [
-                bls.add(bls.bytes48_to_G1(C_minus_y_lincomb), bls.bytes48_to_G1(proof_z_lincomb)),
-                bls.G2(),
-            ],
-        ])
-    </spec>
-
-- name: verify_kzg_proof_impl#deneb
-  sources: []
-  spec: |
-    <spec fn="verify_kzg_proof_impl" fork="deneb" hash="08b53a7a">
-    def verify_kzg_proof_impl(
-        commitment: KZGCommitment, z: BLSFieldElement, y: BLSFieldElement, proof: KZGProof
-    ) -> bool:
-        """
-        Verify KZG proof that ``p(z) == y`` where ``p(z)`` is the polynomial represented by ``polynomial_kzg``.
-        """
-        # Verify: P - y = Q * (X - z)
-        X_minus_z = bls.add(
-            bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[1]),
-            bls.multiply(bls.G2(), -z),
-        )
-        P_minus_y = bls.add(bls.bytes48_to_G1(commitment), bls.multiply(bls.G1(), -y))
-        return bls.pairing_check([
-            [P_minus_y, bls.neg(bls.G2())],
-            [bls.bytes48_to_G1(proof), X_minus_z],
-        ])
-    </spec>
-
 - name: voting_period_start_time#phase0
   sources:
     - file: beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1VotingPeriod.java
       search: private UInt64 getVotingPeriodStartTime(
   spec: |
-    <spec fn="voting_period_start_time" fork="phase0" hash="4eb8d0ca">
-    def voting_period_start_time(state: BeaconState) -> uint64:
+    <spec fn="voting_period_start_time" fork="phase0" hash="3d2f8ab7">
+    def voting_period_start_time(state: BeaconState) -> Uint64:
         eth1_voting_period_start_slot = Slot(
             state.slot - state.slot % (EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)
         )

--- a/specrefs/presets.yml
+++ b/specrefs/presets.yml
@@ -3,8 +3,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "BASE_REWARD_FACTOR:"
   spec: |
-    <spec preset_var="BASE_REWARD_FACTOR" fork="phase0" hash="ba06d7ce">
-    BASE_REWARD_FACTOR: uint64 = 64
+    <spec preset_var="BASE_REWARD_FACTOR" fork="phase0" hash="645b9c83">
+    BASE_REWARD_FACTOR: Uint64 = 64
     </spec>
 
 - name: BYTES_PER_LOGS_BLOOM#bellatrix
@@ -12,8 +12,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "BYTES_PER_LOGS_BLOOM:"
   spec: |
-    <spec preset_var="BYTES_PER_LOGS_BLOOM" fork="bellatrix" hash="97101cb2">
-    BYTES_PER_LOGS_BLOOM: uint64 = 256
+    <spec preset_var="BYTES_PER_LOGS_BLOOM" fork="bellatrix" hash="c8d28fff">
+    BYTES_PER_LOGS_BLOOM: Uint64 = 256
     </spec>
 
 - name: CELLS_PER_EXT_BLOB#fulu
@@ -39,8 +39,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "EPOCHS_PER_ETH1_VOTING_PERIOD:"
   spec: |
-    <spec preset_var="EPOCHS_PER_ETH1_VOTING_PERIOD" fork="phase0" hash="6b6a0053">
-    EPOCHS_PER_ETH1_VOTING_PERIOD: uint64 = 64
+    <spec preset_var="EPOCHS_PER_ETH1_VOTING_PERIOD" fork="phase0" hash="517f1025">
+    EPOCHS_PER_ETH1_VOTING_PERIOD: Epoch = 64
     </spec>
 
 - name: EPOCHS_PER_HISTORICAL_VECTOR#phase0
@@ -48,8 +48,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "EPOCHS_PER_HISTORICAL_VECTOR:"
   spec: |
-    <spec preset_var="EPOCHS_PER_HISTORICAL_VECTOR" fork="phase0" hash="6156dc33">
-    EPOCHS_PER_HISTORICAL_VECTOR: uint64 = 65536
+    <spec preset_var="EPOCHS_PER_HISTORICAL_VECTOR" fork="phase0" hash="f2819dc7">
+    EPOCHS_PER_HISTORICAL_VECTOR: Epoch = 65536
     </spec>
 
 - name: EPOCHS_PER_SLASHINGS_VECTOR#phase0
@@ -57,8 +57,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "EPOCHS_PER_SLASHINGS_VECTOR:"
   spec: |
-    <spec preset_var="EPOCHS_PER_SLASHINGS_VECTOR" fork="phase0" hash="c237469a">
-    EPOCHS_PER_SLASHINGS_VECTOR: uint64 = 8192
+    <spec preset_var="EPOCHS_PER_SLASHINGS_VECTOR" fork="phase0" hash="1adb9280">
+    EPOCHS_PER_SLASHINGS_VECTOR: Epoch = 8192
     </spec>
 
 - name: EPOCHS_PER_SYNC_COMMITTEE_PERIOD#altair
@@ -66,8 +66,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "EPOCHS_PER_SYNC_COMMITTEE_PERIOD:"
   spec: |
-    <spec preset_var="EPOCHS_PER_SYNC_COMMITTEE_PERIOD" fork="altair" hash="f02bdf72">
-    EPOCHS_PER_SYNC_COMMITTEE_PERIOD: uint64 = 256
+    <spec preset_var="EPOCHS_PER_SYNC_COMMITTEE_PERIOD" fork="altair" hash="a76512fd">
+    EPOCHS_PER_SYNC_COMMITTEE_PERIOD: Epoch = 256
     </spec>
 
 - name: FIELD_ELEMENTS_PER_BLOB#deneb
@@ -75,8 +75,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/deneb.yaml
       search: "FIELD_ELEMENTS_PER_BLOB:"
   spec: |
-    <spec preset_var="FIELD_ELEMENTS_PER_BLOB" fork="deneb" hash="a86948eb">
-    FIELD_ELEMENTS_PER_BLOB: uint64 = 4096
+    <spec preset_var="FIELD_ELEMENTS_PER_BLOB" fork="deneb" hash="20b047a6">
+    FIELD_ELEMENTS_PER_BLOB: Uint64 = 4096
     </spec>
 
 - name: FIELD_ELEMENTS_PER_CELL#fulu
@@ -84,8 +84,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "FIELD_ELEMENTS_PER_CELL:"
   spec: |
-    <spec preset_var="FIELD_ELEMENTS_PER_CELL" fork="fulu" hash="6af85ab8">
-    FIELD_ELEMENTS_PER_CELL: uint64 = 64
+    <spec preset_var="FIELD_ELEMENTS_PER_CELL" fork="fulu" hash="99f9c55d">
+    FIELD_ELEMENTS_PER_CELL: Uint64 = 64
     </spec>
 
 - name: FIELD_ELEMENTS_PER_EXT_BLOB#fulu
@@ -102,8 +102,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HISTORICAL_ROOTS_LIMIT:"
   spec: |
-    <spec preset_var="HISTORICAL_ROOTS_LIMIT" fork="phase0" hash="498b6597">
-    HISTORICAL_ROOTS_LIMIT: uint64 = 16777216
+    <spec preset_var="HISTORICAL_ROOTS_LIMIT" fork="phase0" hash="f8803117">
+    HISTORICAL_ROOTS_LIMIT: Uint64 = 16777216
     </spec>
 
 - name: HYSTERESIS_DOWNWARD_MULTIPLIER#phase0
@@ -111,8 +111,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HYSTERESIS_DOWNWARD_MULTIPLIER:"
   spec: |
-    <spec preset_var="HYSTERESIS_DOWNWARD_MULTIPLIER" fork="phase0" hash="95d603c9">
-    HYSTERESIS_DOWNWARD_MULTIPLIER: uint64 = 1
+    <spec preset_var="HYSTERESIS_DOWNWARD_MULTIPLIER" fork="phase0" hash="17b794e0">
+    HYSTERESIS_DOWNWARD_MULTIPLIER: Uint64 = 1
     </spec>
 
 - name: HYSTERESIS_QUOTIENT#phase0
@@ -120,8 +120,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HYSTERESIS_QUOTIENT:"
   spec: |
-    <spec preset_var="HYSTERESIS_QUOTIENT" fork="phase0" hash="c3849917">
-    HYSTERESIS_QUOTIENT: uint64 = 4
+    <spec preset_var="HYSTERESIS_QUOTIENT" fork="phase0" hash="1bfc462c">
+    HYSTERESIS_QUOTIENT: Uint64 = 4
     </spec>
 
 - name: HYSTERESIS_UPWARD_MULTIPLIER#phase0
@@ -129,8 +129,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "HYSTERESIS_UPWARD_MULTIPLIER:"
   spec: |
-    <spec preset_var="HYSTERESIS_UPWARD_MULTIPLIER" fork="phase0" hash="34607474">
-    HYSTERESIS_UPWARD_MULTIPLIER: uint64 = 5
+    <spec preset_var="HYSTERESIS_UPWARD_MULTIPLIER" fork="phase0" hash="41a9e35c">
+    HYSTERESIS_UPWARD_MULTIPLIER: Uint64 = 5
     </spec>
 
 - name: INACTIVITY_PENALTY_QUOTIENT#phase0
@@ -138,8 +138,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "INACTIVITY_PENALTY_QUOTIENT:"
   spec: |
-    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT" fork="phase0" hash="5d82db62">
-    INACTIVITY_PENALTY_QUOTIENT: uint64 = 67108864
+    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT" fork="phase0" hash="70b32ea0">
+    INACTIVITY_PENALTY_QUOTIENT: Uint64 = 67108864
     </spec>
 
 - name: INACTIVITY_PENALTY_QUOTIENT_ALTAIR#altair
@@ -147,8 +147,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "INACTIVITY_PENALTY_QUOTIENT_ALTAIR:"
   spec: |
-    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT_ALTAIR" fork="altair" hash="d0d3c505">
-    INACTIVITY_PENALTY_QUOTIENT_ALTAIR: uint64 = 50331648
+    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT_ALTAIR" fork="altair" hash="e164e59c">
+    INACTIVITY_PENALTY_QUOTIENT_ALTAIR: Uint64 = 50331648
     </spec>
 
 - name: INACTIVITY_PENALTY_QUOTIENT_BELLATRIX#bellatrix
@@ -156,8 +156,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "INACTIVITY_PENALTY_QUOTIENT_BELLATRIX:"
   spec: |
-    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT_BELLATRIX" fork="bellatrix" hash="33fd626d">
-    INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: uint64 = 16777216
+    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT_BELLATRIX" fork="bellatrix" hash="e7e75029">
+    INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: Uint64 = 16777216
     </spec>
 
 - name: INCLUSION_LIST_COMMITTEE_SIZE#heze
@@ -165,8 +165,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/heze.yaml
       search: "INCLUSION_LIST_COMMITTEE_SIZE:"
   spec: |
-    <spec preset_var="INCLUSION_LIST_COMMITTEE_SIZE" fork="heze" hash="780fb63c">
-    INCLUSION_LIST_COMMITTEE_SIZE: uint64 = 16
+    <spec preset_var="INCLUSION_LIST_COMMITTEE_SIZE" fork="heze" hash="514829ec">
+    INCLUSION_LIST_COMMITTEE_SIZE: Uint64 = 16
     </spec>
 
 - name: KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH#fulu
@@ -174,8 +174,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH:"
   spec: |
-    <spec preset_var="KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH" fork="fulu" hash="22280638">
-    KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH: uint64 = 4
+    <spec preset_var="KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH" fork="fulu" hash="12f9ffd8">
+    KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH: Uint64 = 4
     </spec>
 
 - name: KZG_COMMITMENT_INCLUSION_PROOF_DEPTH#deneb
@@ -183,8 +183,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/deneb.yaml
       search: "KZG_COMMITMENT_INCLUSION_PROOF_DEPTH:"
   spec: |
-    <spec preset_var="KZG_COMMITMENT_INCLUSION_PROOF_DEPTH" fork="deneb" hash="79db011d">
-    KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: uint64 = 17
+    <spec preset_var="KZG_COMMITMENT_INCLUSION_PROOF_DEPTH" fork="deneb" hash="f9f066ac">
+    KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: Uint64 = 17
     </spec>
 
 - name: MAX_ATTESTATIONS#phase0
@@ -192,8 +192,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_ATTESTATIONS:"
   spec: |
-    <spec preset_var="MAX_ATTESTATIONS" fork="phase0" hash="8ee7f084">
-    MAX_ATTESTATIONS: uint64 = 128
+    <spec preset_var="MAX_ATTESTATIONS" fork="phase0" hash="2f56fca0">
+    MAX_ATTESTATIONS: Uint64 = 128
     </spec>
 
 - name: MAX_ATTESTATIONS_ELECTRA#electra
@@ -201,8 +201,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_ATTESTATIONS_ELECTRA:"
   spec: |
-    <spec preset_var="MAX_ATTESTATIONS_ELECTRA" fork="electra" hash="f5ced7c7">
-    MAX_ATTESTATIONS_ELECTRA: uint64 = 8
+    <spec preset_var="MAX_ATTESTATIONS_ELECTRA" fork="electra" hash="0eb0ffa5">
+    MAX_ATTESTATIONS_ELECTRA: Uint64 = 8
     </spec>
 
 - name: MAX_ATTESTER_SLASHINGS#phase0
@@ -210,8 +210,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_ATTESTER_SLASHINGS:"
   spec: |
-    <spec preset_var="MAX_ATTESTER_SLASHINGS" fork="phase0" hash="a026f81c">
-    MAX_ATTESTER_SLASHINGS: uint64 = 2
+    <spec preset_var="MAX_ATTESTER_SLASHINGS" fork="phase0" hash="a8262e02">
+    MAX_ATTESTER_SLASHINGS: Uint64 = 2
     </spec>
 
 - name: MAX_ATTESTER_SLASHINGS_ELECTRA#electra
@@ -219,8 +219,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_ATTESTER_SLASHINGS_ELECTRA:"
   spec: |
-    <spec preset_var="MAX_ATTESTER_SLASHINGS_ELECTRA" fork="electra" hash="cb7ff972">
-    MAX_ATTESTER_SLASHINGS_ELECTRA: uint64 = 1
+    <spec preset_var="MAX_ATTESTER_SLASHINGS_ELECTRA" fork="electra" hash="a6c8acd1">
+    MAX_ATTESTER_SLASHINGS_ELECTRA: Uint64 = 1
     </spec>
 
 - name: MAX_BLOB_COMMITMENTS_PER_BLOCK#deneb
@@ -228,8 +228,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/deneb.yaml
       search: "MAX_BLOB_COMMITMENTS_PER_BLOCK:"
   spec: |
-    <spec preset_var="MAX_BLOB_COMMITMENTS_PER_BLOCK" fork="deneb" hash="0ad15e8f">
-    MAX_BLOB_COMMITMENTS_PER_BLOCK: uint64 = 4096
+    <spec preset_var="MAX_BLOB_COMMITMENTS_PER_BLOCK" fork="deneb" hash="f1bbc4a0">
+    MAX_BLOB_COMMITMENTS_PER_BLOCK: Uint64 = 4096
     </spec>
 
 - name: MAX_BLS_TO_EXECUTION_CHANGES#capella
@@ -237,8 +237,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
       search: "MAX_BLS_TO_EXECUTION_CHANGES:"
   spec: |
-    <spec preset_var="MAX_BLS_TO_EXECUTION_CHANGES" fork="capella" hash="a7430c88">
-    MAX_BLS_TO_EXECUTION_CHANGES: uint64 = 16
+    <spec preset_var="MAX_BLS_TO_EXECUTION_CHANGES" fork="capella" hash="2139bb1e">
+    MAX_BLS_TO_EXECUTION_CHANGES: Uint64 = 16
     </spec>
 
 - name: MAX_BUILDERS_PER_WITHDRAWALS_SWEEP#gloas
@@ -246,8 +246,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "MAX_BUILDERS_PER_WITHDRAWALS_SWEEP:"
   spec: |
-    <spec preset_var="MAX_BUILDERS_PER_WITHDRAWALS_SWEEP" fork="gloas" hash="ab42a68a">
-    MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: uint64 = 16384
+    <spec preset_var="MAX_BUILDERS_PER_WITHDRAWALS_SWEEP" fork="gloas" hash="fc60d90e">
+    MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: Uint64 = 16384
     </spec>
 
 - name: MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD#gloas
@@ -255,8 +255,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD:"
   spec: |
-    <spec preset_var="MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="fdb8276d">
-    MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD: uint64 = 64
+    <spec preset_var="MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="1da1bc35">
+    MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD: Uint64 = 64
     </spec>
 
 - name: MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD#gloas
@@ -264,8 +264,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD:"
   spec: |
-    <spec preset_var="MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="d461f12d">
-    MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD: uint64 = 16
+    <spec preset_var="MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD" fork="gloas" hash="d46cb337">
+    MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD: Uint64 = 16
     </spec>
 
 - name: MAX_BYTES_PER_TRANSACTION#bellatrix
@@ -273,8 +273,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MAX_BYTES_PER_TRANSACTION:"
   spec: |
-    <spec preset_var="MAX_BYTES_PER_TRANSACTION" fork="bellatrix" hash="3684e68f">
-    MAX_BYTES_PER_TRANSACTION: uint64 = 1073741824
+    <spec preset_var="MAX_BYTES_PER_TRANSACTION" fork="bellatrix" hash="7f83b3d2">
+    MAX_BYTES_PER_TRANSACTION: Uint64 = 1073741824
     </spec>
 
 - name: MAX_COMMITTEES_PER_SLOT#phase0
@@ -282,8 +282,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_COMMITTEES_PER_SLOT:"
   spec: |
-    <spec preset_var="MAX_COMMITTEES_PER_SLOT" fork="phase0" hash="0442c4b7">
-    MAX_COMMITTEES_PER_SLOT: uint64 = 64
+    <spec preset_var="MAX_COMMITTEES_PER_SLOT" fork="phase0" hash="3f755ce5">
+    MAX_COMMITTEES_PER_SLOT: Uint64 = 64
     </spec>
 
 - name: MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD#electra
@@ -291,8 +291,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD:"
   spec: |
-    <spec preset_var="MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD" fork="electra" hash="59ec80e5">
-    MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: uint64 = 2
+    <spec preset_var="MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD" fork="electra" hash="04089975">
+    MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: Uint64 = 2
     </spec>
 
 - name: MAX_DEPOSITS#phase0
@@ -300,8 +300,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_DEPOSITS:"
   spec: |
-    <spec preset_var="MAX_DEPOSITS" fork="phase0" hash="8c07fc09">
-    MAX_DEPOSITS: uint64 = 16
+    <spec preset_var="MAX_DEPOSITS" fork="phase0" hash="10422f62">
+    MAX_DEPOSITS: Uint64 = 16
     </spec>
 
 - name: MAX_DEPOSIT_REQUESTS_PER_PAYLOAD#electra
@@ -309,8 +309,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_DEPOSIT_REQUESTS_PER_PAYLOAD:"
   spec: |
-    <spec preset_var="MAX_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="electra" hash="6c60ff83">
-    MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: uint64 = 8192
+    <spec preset_var="MAX_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="electra" hash="ea0610b5">
+    MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: Uint64 = 8192
     </spec>
 
 - name: MAX_EFFECTIVE_BALANCE#phase0
@@ -336,8 +336,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MAX_EXTRA_DATA_BYTES:"
   spec: |
-    <spec preset_var="MAX_EXTRA_DATA_BYTES" fork="bellatrix" hash="a37eed77">
-    MAX_EXTRA_DATA_BYTES: uint64 = 32
+    <spec preset_var="MAX_EXTRA_DATA_BYTES" fork="bellatrix" hash="03a5eec2">
+    MAX_EXTRA_DATA_BYTES: Uint64 = 32
     </spec>
 
 - name: MAX_PAYLOAD_ATTESTATIONS#gloas
@@ -345,8 +345,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "MAX_PAYLOAD_ATTESTATIONS:"
   spec: |
-    <spec preset_var="MAX_PAYLOAD_ATTESTATIONS" fork="gloas" hash="c91cfe07">
-    MAX_PAYLOAD_ATTESTATIONS: uint64 = 4
+    <spec preset_var="MAX_PAYLOAD_ATTESTATIONS" fork="gloas" hash="60a6ba31">
+    MAX_PAYLOAD_ATTESTATIONS: Uint64 = 4
     </spec>
 
 - name: MAX_PENDING_DEPOSITS_PER_EPOCH#electra
@@ -354,8 +354,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_PENDING_DEPOSITS_PER_EPOCH:"
   spec: |
-    <spec preset_var="MAX_PENDING_DEPOSITS_PER_EPOCH" fork="electra" hash="f532a46f">
-    MAX_PENDING_DEPOSITS_PER_EPOCH: uint64 = 16
+    <spec preset_var="MAX_PENDING_DEPOSITS_PER_EPOCH" fork="electra" hash="7f4802cf">
+    MAX_PENDING_DEPOSITS_PER_EPOCH: Uint64 = 16
     </spec>
 
 - name: MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP#electra
@@ -363,8 +363,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP:"
   spec: |
-    <spec preset_var="MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP" fork="electra" hash="e7b2f394">
-    MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: uint64 = 8
+    <spec preset_var="MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP" fork="electra" hash="59b59180">
+    MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: Uint64 = 8
     </spec>
 
 - name: MAX_PROPOSER_SLASHINGS#phase0
@@ -372,8 +372,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_PROPOSER_SLASHINGS:"
   spec: |
-    <spec preset_var="MAX_PROPOSER_SLASHINGS" fork="phase0" hash="26182947">
-    MAX_PROPOSER_SLASHINGS: uint64 = 16
+    <spec preset_var="MAX_PROPOSER_SLASHINGS" fork="phase0" hash="0398dfd4">
+    MAX_PROPOSER_SLASHINGS: Uint64 = 16
     </spec>
 
 - name: MAX_SEED_LOOKAHEAD#phase0
@@ -381,8 +381,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_SEED_LOOKAHEAD:"
   spec: |
-    <spec preset_var="MAX_SEED_LOOKAHEAD" fork="phase0" hash="b7ae8929">
-    MAX_SEED_LOOKAHEAD: uint64 = 4
+    <spec preset_var="MAX_SEED_LOOKAHEAD" fork="phase0" hash="78b09fe1">
+    MAX_SEED_LOOKAHEAD: Epoch = 4
     </spec>
 
 - name: MAX_TRANSACTIONS_PER_PAYLOAD#bellatrix
@@ -390,8 +390,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MAX_TRANSACTIONS_PER_PAYLOAD:"
   spec: |
-    <spec preset_var="MAX_TRANSACTIONS_PER_PAYLOAD" fork="bellatrix" hash="1088e3b2">
-    MAX_TRANSACTIONS_PER_PAYLOAD: uint64 = 1048576
+    <spec preset_var="MAX_TRANSACTIONS_PER_PAYLOAD" fork="bellatrix" hash="1017dbb7">
+    MAX_TRANSACTIONS_PER_PAYLOAD: Uint64 = 1048576
     </spec>
 
 - name: MAX_VALIDATORS_PER_COMMITTEE#phase0
@@ -399,8 +399,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_VALIDATORS_PER_COMMITTEE:"
   spec: |
-    <spec preset_var="MAX_VALIDATORS_PER_COMMITTEE" fork="phase0" hash="900abcb2">
-    MAX_VALIDATORS_PER_COMMITTEE: uint64 = 2048
+    <spec preset_var="MAX_VALIDATORS_PER_COMMITTEE" fork="phase0" hash="b8578caa">
+    MAX_VALIDATORS_PER_COMMITTEE: Uint64 = 2048
     </spec>
 
 - name: MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP#capella
@@ -408,8 +408,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
       search: "MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP:"
   spec: |
-    <spec preset_var="MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP" fork="capella" hash="1becfc15">
-    MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: uint64 = 16384
+    <spec preset_var="MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP" fork="capella" hash="adeefd90">
+    MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: Uint64 = 16384
     </spec>
 
 - name: MAX_VOLUNTARY_EXITS#phase0
@@ -417,8 +417,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MAX_VOLUNTARY_EXITS:"
   spec: |
-    <spec preset_var="MAX_VOLUNTARY_EXITS" fork="phase0" hash="8fdacd5d">
-    MAX_VOLUNTARY_EXITS: uint64 = 16
+    <spec preset_var="MAX_VOLUNTARY_EXITS" fork="phase0" hash="f318373b">
+    MAX_VOLUNTARY_EXITS: Uint64 = 16
     </spec>
 
 - name: MAX_WITHDRAWALS_PER_PAYLOAD#capella
@@ -426,8 +426,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
       search: "MAX_WITHDRAWALS_PER_PAYLOAD:"
   spec: |
-    <spec preset_var="MAX_WITHDRAWALS_PER_PAYLOAD" fork="capella" hash="c406effb">
-    MAX_WITHDRAWALS_PER_PAYLOAD: uint64 = 16
+    <spec preset_var="MAX_WITHDRAWALS_PER_PAYLOAD" fork="capella" hash="c743caf6">
+    MAX_WITHDRAWALS_PER_PAYLOAD: Uint64 = 16
     </spec>
 
 - name: MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD#electra
@@ -435,8 +435,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD:"
   spec: |
-    <spec preset_var="MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD" fork="electra" hash="9f04de0d">
-    MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: uint64 = 16
+    <spec preset_var="MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD" fork="electra" hash="87a3320f">
+    MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: Uint64 = 16
     </spec>
 
 - name: MIN_ACTIVATION_BALANCE#electra
@@ -453,8 +453,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_ATTESTATION_INCLUSION_DELAY:"
   spec: |
-    <spec preset_var="MIN_ATTESTATION_INCLUSION_DELAY" fork="phase0" hash="2e9435aa">
-    MIN_ATTESTATION_INCLUSION_DELAY: uint64 = 1
+    <spec preset_var="MIN_ATTESTATION_INCLUSION_DELAY" fork="phase0" hash="eeec80c7">
+    MIN_ATTESTATION_INCLUSION_DELAY: Slot = 1
     </spec>
 
 - name: MIN_DEPOSIT_AMOUNT#phase0
@@ -471,8 +471,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_EPOCHS_TO_INACTIVITY_PENALTY:"
   spec: |
-    <spec preset_var="MIN_EPOCHS_TO_INACTIVITY_PENALTY" fork="phase0" hash="339d14c4">
-    MIN_EPOCHS_TO_INACTIVITY_PENALTY: uint64 = 4
+    <spec preset_var="MIN_EPOCHS_TO_INACTIVITY_PENALTY" fork="phase0" hash="e94e8023">
+    MIN_EPOCHS_TO_INACTIVITY_PENALTY: Epoch = 4
     </spec>
 
 - name: MIN_SEED_LOOKAHEAD#phase0
@@ -480,8 +480,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_SEED_LOOKAHEAD:"
   spec: |
-    <spec preset_var="MIN_SEED_LOOKAHEAD" fork="phase0" hash="48a0462b">
-    MIN_SEED_LOOKAHEAD: uint64 = 1
+    <spec preset_var="MIN_SEED_LOOKAHEAD" fork="phase0" hash="fc1f1b5b">
+    MIN_SEED_LOOKAHEAD: Epoch = 1
     </spec>
 
 - name: MIN_SLASHING_PENALTY_QUOTIENT#phase0
@@ -489,8 +489,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT:"
   spec: |
-    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT" fork="phase0" hash="0204123d">
-    MIN_SLASHING_PENALTY_QUOTIENT: uint64 = 128
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT" fork="phase0" hash="e5d6470c">
+    MIN_SLASHING_PENALTY_QUOTIENT: Uint64 = 128
     </spec>
 
 - name: MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR#altair
@@ -498,8 +498,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR:"
   spec: |
-    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR" fork="altair" hash="4845bc05">
-    MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: uint64 = 64
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR" fork="altair" hash="1927bfc7">
+    MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: Uint64 = 64
     </spec>
 
 - name: MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX#bellatrix
@@ -507,8 +507,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX:"
   spec: |
-    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX" fork="bellatrix" hash="2a5af13c">
-    MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: uint64 = 32
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX" fork="bellatrix" hash="a51ca4d6">
+    MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: Uint64 = 32
     </spec>
 
 - name: MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA#electra
@@ -516,8 +516,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA:"
   spec: |
-    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA" fork="electra" hash="03888289">
-    MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: uint64 = 4096
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA" fork="electra" hash="6fdc6bdf">
+    MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: Uint64 = 4096
     </spec>
 
 - name: MIN_SYNC_COMMITTEE_PARTICIPANTS#altair
@@ -525,8 +525,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "MIN_SYNC_COMMITTEE_PARTICIPANTS:"
   spec: |
-    <spec preset_var="MIN_SYNC_COMMITTEE_PARTICIPANTS" fork="altair" hash="7ca6fd1f">
-    MIN_SYNC_COMMITTEE_PARTICIPANTS = 1
+    <spec preset_var="MIN_SYNC_COMMITTEE_PARTICIPANTS" fork="altair" hash="cecedeab">
+    MIN_SYNC_COMMITTEE_PARTICIPANTS: Uint64 = 1
     </spec>
 
 - name: NUMBER_OF_COLUMNS#fulu
@@ -534,8 +534,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/fulu.yaml
       search: "NUMBER_OF_COLUMNS:"
   spec: |
-    <spec preset_var="NUMBER_OF_COLUMNS" fork="fulu" hash="8b6dad29">
-    NUMBER_OF_COLUMNS = 128
+    <spec preset_var="NUMBER_OF_COLUMNS" fork="fulu" hash="1a549032">
+    NUMBER_OF_COLUMNS: Uint64 = 128
     </spec>
 
 - name: PENDING_CONSOLIDATIONS_LIMIT#electra
@@ -543,8 +543,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "PENDING_CONSOLIDATIONS_LIMIT:"
   spec: |
-    <spec preset_var="PENDING_CONSOLIDATIONS_LIMIT" fork="electra" hash="f28398d0">
-    PENDING_CONSOLIDATIONS_LIMIT: uint64 = 262144
+    <spec preset_var="PENDING_CONSOLIDATIONS_LIMIT" fork="electra" hash="72b496bb">
+    PENDING_CONSOLIDATIONS_LIMIT: Uint64 = 262144
     </spec>
 
 - name: PENDING_DEPOSITS_LIMIT#electra
@@ -552,8 +552,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "PENDING_DEPOSITS_LIMIT:"
   spec: |
-    <spec preset_var="PENDING_DEPOSITS_LIMIT" fork="electra" hash="8f7ed296">
-    PENDING_DEPOSITS_LIMIT: uint64 = 134217728
+    <spec preset_var="PENDING_DEPOSITS_LIMIT" fork="electra" hash="89565720">
+    PENDING_DEPOSITS_LIMIT: Uint64 = 134217728
     </spec>
 
 - name: PENDING_PARTIAL_WITHDRAWALS_LIMIT#electra
@@ -561,8 +561,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "PENDING_PARTIAL_WITHDRAWALS_LIMIT:"
   spec: |
-    <spec preset_var="PENDING_PARTIAL_WITHDRAWALS_LIMIT" fork="electra" hash="9ae3fe56">
-    PENDING_PARTIAL_WITHDRAWALS_LIMIT: uint64 = 134217728
+    <spec preset_var="PENDING_PARTIAL_WITHDRAWALS_LIMIT" fork="electra" hash="90dada04">
+    PENDING_PARTIAL_WITHDRAWALS_LIMIT: Uint64 = 134217728
     </spec>
 
 - name: PROPORTIONAL_SLASHING_MULTIPLIER#phase0
@@ -570,8 +570,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "PROPORTIONAL_SLASHING_MULTIPLIER:"
   spec: |
-    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER" fork="phase0" hash="7675c5ad">
-    PROPORTIONAL_SLASHING_MULTIPLIER: uint64 = 1
+    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER" fork="phase0" hash="e2e3101c">
+    PROPORTIONAL_SLASHING_MULTIPLIER: Uint64 = 1
     </spec>
 
 - name: PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR#altair
@@ -579,8 +579,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR:"
   spec: |
-    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR" fork="altair" hash="5e6aedb9">
-    PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: uint64 = 2
+    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR" fork="altair" hash="89f426f4">
+    PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: Uint64 = 2
     </spec>
 
 - name: PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX#bellatrix
@@ -588,8 +588,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/bellatrix.yaml
       search: "PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX:"
   spec: |
-    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX" fork="bellatrix" hash="e36837df">
-    PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: uint64 = 3
+    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX" fork="bellatrix" hash="733e0a42">
+    PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: Uint64 = 3
     </spec>
 
 - name: PROPOSER_REWARD_QUOTIENT#phase0
@@ -597,8 +597,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "PROPOSER_REWARD_QUOTIENT:"
   spec: |
-    <spec preset_var="PROPOSER_REWARD_QUOTIENT" fork="phase0" hash="a60dab3e">
-    PROPOSER_REWARD_QUOTIENT: uint64 = 8
+    <spec preset_var="PROPOSER_REWARD_QUOTIENT" fork="phase0" hash="500f9dec">
+    PROPOSER_REWARD_QUOTIENT: Uint64 = 8
     </spec>
 
 - name: PTC_SIZE#gloas
@@ -606,8 +606,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/gloas.yaml
       search: "PTC_SIZE:"
   spec: |
-    <spec preset_var="PTC_SIZE" fork="gloas" hash="d61c5930">
-    PTC_SIZE: uint64 = 512
+    <spec preset_var="PTC_SIZE" fork="gloas" hash="fab28199">
+    PTC_SIZE: Uint64 = 512
     </spec>
 
 - name: SHUFFLE_ROUND_COUNT#phase0
@@ -615,8 +615,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "SHUFFLE_ROUND_COUNT:"
   spec: |
-    <spec preset_var="SHUFFLE_ROUND_COUNT" fork="phase0" hash="ed107076">
-    SHUFFLE_ROUND_COUNT: uint64 = 90
+    <spec preset_var="SHUFFLE_ROUND_COUNT" fork="phase0" hash="b83cce2d">
+    SHUFFLE_ROUND_COUNT: Uint64 = 90
     </spec>
 
 - name: SLOTS_PER_EPOCH#phase0
@@ -624,8 +624,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "SLOTS_PER_EPOCH:"
   spec: |
-    <spec preset_var="SLOTS_PER_EPOCH" fork="phase0" hash="cb41af43">
-    SLOTS_PER_EPOCH: uint64 = 32
+    <spec preset_var="SLOTS_PER_EPOCH" fork="phase0" hash="622edf20">
+    SLOTS_PER_EPOCH: Slot = 32
     </spec>
 
 - name: SLOTS_PER_HISTORICAL_ROOT#phase0
@@ -633,8 +633,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "SLOTS_PER_HISTORICAL_ROOT:"
   spec: |
-    <spec preset_var="SLOTS_PER_HISTORICAL_ROOT" fork="phase0" hash="1d0bdd1d">
-    SLOTS_PER_HISTORICAL_ROOT: uint64 = 8192
+    <spec preset_var="SLOTS_PER_HISTORICAL_ROOT" fork="phase0" hash="b91377a4">
+    SLOTS_PER_HISTORICAL_ROOT: Slot = 8192
     </spec>
 
 - name: SYNC_COMMITTEE_SIZE#altair
@@ -642,8 +642,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "SYNC_COMMITTEE_SIZE:"
   spec: |
-    <spec preset_var="SYNC_COMMITTEE_SIZE" fork="altair" hash="d31740c9">
-    SYNC_COMMITTEE_SIZE: uint64 = 512
+    <spec preset_var="SYNC_COMMITTEE_SIZE" fork="altair" hash="fd74420c">
+    SYNC_COMMITTEE_SIZE: Uint64 = 512
     </spec>
 
 - name: TARGET_COMMITTEE_SIZE#phase0
@@ -651,8 +651,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "TARGET_COMMITTEE_SIZE:"
   spec: |
-    <spec preset_var="TARGET_COMMITTEE_SIZE" fork="phase0" hash="d56fdb68">
-    TARGET_COMMITTEE_SIZE: uint64 = 128
+    <spec preset_var="TARGET_COMMITTEE_SIZE" fork="phase0" hash="7ecde123">
+    TARGET_COMMITTEE_SIZE: Uint64 = 128
     </spec>
 
 - name: UPDATE_TIMEOUT#altair
@@ -660,8 +660,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/altair.yaml
       search: "UPDATE_TIMEOUT:"
   spec: |
-    <spec preset_var="UPDATE_TIMEOUT" fork="altair" hash="e633d57e">
-    UPDATE_TIMEOUT = 8192
+    <spec preset_var="UPDATE_TIMEOUT" fork="altair" hash="b04876fe">
+    UPDATE_TIMEOUT: Slot = 8192
     </spec>
 
 - name: VALIDATOR_REGISTRY_LIMIT#phase0
@@ -669,8 +669,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "VALIDATOR_REGISTRY_LIMIT:"
   spec: |
-    <spec preset_var="VALIDATOR_REGISTRY_LIMIT" fork="phase0" hash="8fa5412c">
-    VALIDATOR_REGISTRY_LIMIT: uint64 = 1099511627776
+    <spec preset_var="VALIDATOR_REGISTRY_LIMIT" fork="phase0" hash="4457cfd6">
+    VALIDATOR_REGISTRY_LIMIT: Uint64 = 1099511627776
     </spec>
 
 - name: WHISTLEBLOWER_REWARD_QUOTIENT#phase0
@@ -678,8 +678,8 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/phase0.yaml
       search: "WHISTLEBLOWER_REWARD_QUOTIENT:"
   spec: |
-    <spec preset_var="WHISTLEBLOWER_REWARD_QUOTIENT" fork="phase0" hash="62962c52">
-    WHISTLEBLOWER_REWARD_QUOTIENT: uint64 = 512
+    <spec preset_var="WHISTLEBLOWER_REWARD_QUOTIENT" fork="phase0" hash="281e1017">
+    WHISTLEBLOWER_REWARD_QUOTIENT: Uint64 = 512
     </spec>
 
 - name: WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA#electra
@@ -687,6 +687,6 @@
     - file: ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
       search: "WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA:"
   spec: |
-    <spec preset_var="WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA" fork="electra" hash="8021dedf">
-    WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA: uint64 = 4096
+    <spec preset_var="WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA" fork="electra" hash="160af83f">
+    WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA: Uint64 = 4096
     </spec>


### PR DESCRIPTION
There has been several refactoring in alpha.13 that required to be addressed

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spec reference and ethspecify config updates; no runtime Java changes in this diff.
> 
> **Overview**
> Updates Teku **specrefs** to match **ethspecify v1.7.0-alpha.13** formatting and coverage after upstream refactors.
> 
> **Type and notation:** Spec snippets now use explicit `Name: Type = value` (e.g. `Uint64`, `Epoch`, `Slot`, `Uint256`) instead of bare assignments or lowercase `uint64` / `boolean`. SSZ-style names are normalized (`BitList` / `BitVector`, `Boolean`).
> 
> **Configs:** Adds deposit-related entries (`DEPOSIT_CHAIN_ID`, `DEPOSIT_CONTRACT_ADDRESS`, `DEPOSIT_NETWORK_ID`) and heze `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` (empty `sources`, spec-only). Many config hashes change with the new typing; numeric values are unchanged.
> 
> **Constants / functions:** Drops inlined **KZG library** constants and Deneb/Fulu KZG helper **function** spec entries from the YAML (coverage is expected from the KZG dependency). Removes a mistaken `BLS_MODULUS` constant block tied to an unrelated Java search.
> 
> **Exceptions (`.ethspecify.yml`):** Adds heze config exception for `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS`, gloas **not implemented** exceptions for `is_bid_compatible_with_head` and `is_valid_dependent_root`, and narrows KZG constant exceptions to `G2_POINT_AT_INFINITY` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34eca2d8fef63f6fe7cf8db1ae955d98b038ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->