### PR TITLE
allign to master

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultProposerPreferencesManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/execution/DefaultProposerPreferencesManager.java
@@ -13,17 +13,15 @@
 
 package tech.pegasys.teku.statetransition.execution;
 
-import static tech.pegasys.teku.spec.config.Constants.MAX_SLOTS_TO_TRACK_PROPOSER_PREFERENCES;
-
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -42,8 +40,8 @@ public class DefaultProposerPreferencesManager
 
   private final ProposerPreferencesGossipValidator proposerPreferencesGossipValidator;
   private final PendingPool<PendingProposerPreferences> pendingProposerPreferences;
-  private final Map<UInt64, ProposerPreferences> acceptedProposerPreferences =
-      LimitedMap.createSynchronizedLRU(MAX_SLOTS_TO_TRACK_PROPOSER_PREFERENCES);
+  private final ConcurrentNavigableMap<UInt64, ProposerPreferences> acceptedProposerPreferences =
+      new ConcurrentSkipListMap<>();
   private final Subscribers<OperationAddedSubscriber<SignedProposerPreferences>> subscribers =
       Subscribers.create(true);
 
@@ -79,6 +77,7 @@ public class DefaultProposerPreferencesManager
 
   @Override
   public void onSlot(final UInt64 slot) {
+    acceptedProposerPreferences.headMap(slot, false).clear();
     pendingProposerPreferences.onSlot(slot);
     pendingProposerPreferences.removeItemsMatching(
         pendingPreferences ->

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -52,10 +54,11 @@ import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
  */
 class FastConfirmationCalculator {
 
+  private static final Logger LOG = LogManager.getLogger();
+
   private final Spec spec;
   private final ForkChoiceUtil forkChoiceUtil;
 
-  @SuppressWarnings({"UnusedVariable"})
   private final FastConfirmationStore fcrStore;
 
   private final ReadOnlyStore store;
@@ -394,6 +397,247 @@ class FastConfirmationCalculator {
   }
 
   /**
+   * Implements {@code compute_honest_ffg_support_for_current_target}: the minimum honest FFG
+   * support the current-epoch target can be assured of, assuming synchrony and {@code
+   * CONFIRMATION_BYZANTINE_THRESHOLD}.
+   */
+  UInt64 computeHonestFfgSupportForCurrentTarget() {
+    final BeaconState balanceSource = getPulledUpHeadState();
+    final UInt64 totalActiveBalance = spec.getTotalActiveBalance(balanceSource);
+    final UInt64 ffgSupportForCheckpoint = getCurrentTargetScore();
+    final UInt64 epochStart = spec.computeStartSlotAtEpoch(currentEpoch);
+    final UInt64 lastSlot = currentSlot.minus(1);
+
+    // Total FFG weight already assigned up to, but excluding, the current slot.
+    final UInt64 ffgWeightTillNow =
+        FastConfirmationRuleUtil.estimateCommitteeWeightBetweenSlots(
+            spec, totalActiveBalance, epochStart, lastSlot);
+    final UInt64 remainingFfgWeight = totalActiveBalance.minusMinZero(ffgWeightTillNow);
+    final UInt64 remainingHonestFfgWeight =
+        remainingFfgWeight
+            .dividedBy(100)
+            .times(100 - FastConfirmationRuleUtil.CONFIRMATION_BYZANTINE_THRESHOLD);
+
+    final UInt64 adversarialWeight = computeAdversarialWeight(balanceSource, epochStart, lastSlot);
+    // ffg_support - min(adversarial_weight, ffg_support)
+    final UInt64 minHonestFfgSupport = ffgSupportForCheckpoint.minusMinZero(adversarialWeight);
+
+    return minHonestFfgSupport.plus(remainingHonestFfgWeight);
+  }
+
+  /**
+   * Implements {@code will_no_conflicting_checkpoint_be_justified}: whether no checkpoint
+   * conflicting with the current target can ever be justified.
+   */
+  boolean willNoConflictingCheckpointBeJustified() {
+    // If the target is already the greatest unrealized justified checkpoint, nothing can conflict.
+    if (getCurrentTarget().equals(getStoreUnrealizedJustifiedCheckpoint())) {
+      return true;
+    }
+    final UInt64 totalActiveBalance = spec.getTotalActiveBalance(getPulledUpHeadState());
+    return computeHonestFfgSupportForCurrentTarget().times(3).isGreaterThan(totalActiveBalance);
+  }
+
+  /**
+   * Implements {@code will_current_target_be_justified}: whether the current target will eventually
+   * be justified.
+   */
+  boolean willCurrentTargetBeJustified() {
+    final UInt64 totalActiveBalance = spec.getTotalActiveBalance(getPulledUpHeadState());
+    return computeHonestFfgSupportForCurrentTarget()
+        .times(3)
+        .isGreaterThanOrEqualTo(totalActiveBalance.times(2));
+  }
+
+  /**
+   * Implements {@code is_confirmed_chain_safe}: whether every block of the confirmed chain, from
+   * the current-epoch observed justified checkpoint up to {@code confirmedRoot}, is LMD-GHOST safe
+   * against the previous balance source. Run at the start of each epoch to relax the synchrony
+   * assumption (reconfirmation).
+   */
+  boolean isConfirmedChainSafe(final Bytes32 confirmedRoot) {
+    final Checkpoint observedJustified = fcrStore.currentEpochObservedJustifiedCheckpoint();
+    // The observed justified checkpoint must be on the confirmed chain.
+    if (!observedJustified.equals(
+        getCheckpointForBlock(confirmedRoot, observedJustified.getEpoch()))) {
+      return false;
+    }
+
+    final Bytes32 startRootExclusive;
+    if (observedJustified.getEpoch().plus(1).isGreaterThanOrEqualTo(currentEpoch)) {
+      // Exclude the justified checkpoint block: from the previous epoch it is always canonical.
+      startRootExclusive = observedJustified.getRoot();
+    } else {
+      // Limit reconfirmation to the first block of the previous epoch; confirming it implies its
+      // ancestors.
+      final Bytes32 ancestorAtPreviousEpochStart =
+          getAncestorRoot(confirmedRoot, spec.computeStartSlotAtEpoch(currentEpoch.minus(1)));
+      startRootExclusive =
+          getBlockEpoch(ancestorAtPreviousEpochStart).plus(1).equals(currentEpoch)
+              ? getBlockParentRoot(ancestorAtPreviousEpochStart)
+              : ancestorAtPreviousEpochStart;
+    }
+
+    final BeaconState previousBalanceSource =
+        states
+            .previousBalanceSource()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Previous balance source is required for reconfirmation"));
+    return getAncestorRoots(confirmedRoot, startRootExclusive).stream()
+        .allMatch(root -> isOneConfirmed(previousBalanceSource, root));
+  }
+
+  /**
+   * Implements {@code find_latest_confirmed_descendant}: the most recent confirmed block in the
+   * canonical suffix starting from {@code latestConfirmedRoot}. It first tries to advance across
+   * previous-epoch blocks (relying on the previous slot head), then further into the current epoch
+   * (gated on the current target being justifiable), keeping the result only if it cannot be
+   * reorged out in the current or next epoch.
+   */
+  Bytes32 findLatestConfirmedDescendant(final Bytes32 latestConfirmedRoot) {
+    final boolean atEpochStart = FastConfirmationRuleUtil.isStartSlotAtEpoch(spec, currentSlot);
+    final Bytes32 previousSlotHead = fcrStore.previousSlotHead();
+    final BeaconState currentBalanceSource = states.currentBalanceSource();
+    Bytes32 confirmedRoot = latestConfirmedRoot;
+
+    // The previous slot head is a root persisted in the FCR store across slots, so it may have been
+    // pruned from fork choice (protoarray only keeps finalized-onward blocks, while the spec
+    // assumes
+    // every block stays in store.blocks). When it is gone we cannot rely on it, so skip the
+    // previous-epoch advance rather than dereferencing it — mirrors the guard get_latest_confirmed
+    // applies to its other persisted roots.
+    if (forkChoice.contains(previousSlotHead)
+        && getBlockEpoch(confirmedRoot).plus(1).equals(currentEpoch)
+        && epochPlusIsAtLeastCurrent(getVotingSource(previousSlotHead).getEpoch(), 2)
+        && (atEpochStart
+            || (willNoConflictingCheckpointBeJustified()
+                && (epochPlusIsAtLeastCurrent(
+                        getUnrealizedJustification(previousSlotHead).getEpoch(), 1)
+                    || epochPlusIsAtLeastCurrent(
+                        getUnrealizedJustification(head).getEpoch(), 1))))) {
+      // Advance towards the head over previous-epoch blocks; stop at the first unconfirmed one.
+      for (final Bytes32 blockRoot : getAncestorRoots(head, confirmedRoot)) {
+        // Only meant to confirm previous-epoch blocks.
+        if (getBlockEpoch(blockRoot).equals(currentEpoch)) {
+          break;
+        }
+        // Can only rely on the previous head if it descends from the block being confirmed.
+        if (!isAncestor(previousSlotHead, blockRoot)) {
+          break;
+        }
+        if (!isOneConfirmed(currentBalanceSource, blockRoot)) {
+          break;
+        }
+        confirmedRoot = blockRoot;
+      }
+    }
+
+    if (atEpochStart || epochPlusIsAtLeastCurrent(getUnrealizedJustification(head).getEpoch(), 1)) {
+      Bytes32 tentativeConfirmedRoot = confirmedRoot;
+      for (final Bytes32 blockRoot : getAncestorRoots(head, confirmedRoot)) {
+        // Only true the first time the walk advances into the current epoch.
+        if (getBlockEpoch(blockRoot).isGreaterThan(getBlockEpoch(tentativeConfirmedRoot))
+            && !willCurrentTargetBeJustified()) {
+          break;
+        }
+        if (!isOneConfirmed(currentBalanceSource, blockRoot)) {
+          break;
+        }
+        tentativeConfirmedRoot = blockRoot;
+      }
+
+      // Only keep the advance if the block cannot be reorged out this epoch or the next.
+      if (getBlockEpoch(tentativeConfirmedRoot).equals(currentEpoch)
+          || (epochPlusIsAtLeastCurrent(getVotingSource(tentativeConfirmedRoot).getEpoch(), 2)
+              && (atEpochStart || willNoConflictingCheckpointBeJustified()))) {
+        confirmedRoot = tentativeConfirmedRoot;
+      }
+    }
+
+    return confirmedRoot;
+  }
+
+  /**
+   * Implements {@code get_latest_confirmed}: the FCR entry point. Reverts {@code confirmed_root} to
+   * the finalized block when it is too old, no longer canonical, or (at an epoch boundary) fails
+   * reconfirmation; optionally restarts the chain from the observed justified checkpoint; then
+   * advances via {@link #findLatestConfirmedDescendant}.
+   */
+  Bytes32 getLatestConfirmed() {
+    final boolean atEpochStart = FastConfirmationRuleUtil.isStartSlotAtEpoch(spec, currentSlot);
+    Bytes32 confirmedRoot = fcrStore.confirmedRoot();
+
+    // Revert to the finalized block if the confirmed block is no longer tracked by fork choice
+    // (pruned below the finalized anchor as finality advanced — the spec assumes every block stays
+    // in store.blocks, but Teku's protoarray only keeps finalized-onward), is more than one epoch
+    // old, no longer an ancestor of the head, or (at an epoch boundary) its chain can no longer be
+    // reconfirmed. The fork-choice-presence check is first so the epoch/ancestry lookups below
+    // never
+    // run on a pruned root.
+    if (!forkChoice.contains(confirmedRoot)
+        || getBlockEpoch(confirmedRoot).plus(1).isLessThan(currentEpoch)
+        || !isAncestor(head, confirmedRoot)
+        || (atEpochStart && !isConfirmedChainSafe(confirmedRoot))) {
+      confirmedRoot = store.getFinalizedCheckpoint().getRoot();
+    }
+
+    // Restart the confirmation chain from the observed justified checkpoint when, at an epoch
+    // boundary, that checkpoint is from the previous epoch, equals the head's unrealized
+    // justification, and the confirmed block is older than it. Skip when the checkpoint block has
+    // been pruned from fork choice.
+    final Checkpoint observedJustified = fcrStore.currentEpochObservedJustifiedCheckpoint();
+    if (atEpochStart && forkChoice.contains(observedJustified.getRoot())) {
+      final UInt64 observedJustifiedBlockSlot = getBlockSlot(observedJustified.getRoot());
+      if (spec.computeEpochAtSlot(observedJustifiedBlockSlot).plus(1).equals(currentEpoch)
+          && observedJustified.equals(getUnrealizedJustification(head))
+          && getBlockSlot(confirmedRoot).isLessThan(observedJustifiedBlockSlot)) {
+        confirmedRoot = observedJustified.getRoot();
+      }
+    }
+
+    // Attempt to advance the confirmed block further; only meaningful while it is recent.
+    final boolean advanceRan =
+        getBlockEpoch(confirmedRoot).plus(1).isGreaterThanOrEqualTo(currentEpoch);
+    final Bytes32 result =
+        advanceRan ? findLatestConfirmedDescendant(confirmedRoot) : confirmedRoot;
+
+    if (LOG.isTraceEnabled()) {
+      final Object headUnrealizedJustifiedEpoch =
+          forkChoice.getBlockData(head).isPresent()
+              ? getUnrealizedJustification(head).getEpoch()
+              : "n/a";
+      LOG.trace(
+          "FCR getLatestConfirmed slot={} epoch={} atEpochStart={} headFullyValidated={} finalizedEpoch={} observedJustifiedEpoch={} headUnrealizedJustifiedEpoch={} confirmedEpochBeforeAdvance={} advanceRan={} resultEpoch={}",
+          currentSlot,
+          currentEpoch,
+          atEpochStart,
+          forkChoice.isFullyValidated(head),
+          getBlockEpoch(store.getFinalizedCheckpoint().getRoot()),
+          observedJustified.getEpoch(),
+          headUnrealizedJustifiedEpoch,
+          getBlockEpoch(confirmedRoot),
+          advanceRan,
+          getBlockEpoch(result));
+    }
+    return result;
+  }
+
+  /**
+   * Returns {@code epoch + offset >= currentEpoch} (spec pattern {@code checkpoint.epoch + n >=
+   * current_epoch}).
+   */
+  private boolean epochPlusIsAtLeastCurrent(final UInt64 epoch, final long offset) {
+    return epoch.plus(offset).isGreaterThanOrEqualTo(currentEpoch);
+  }
+
+  /** Reconstructs {@code store.unrealized_justified_checkpoint} (the store-level greatest). */
+  private Checkpoint getStoreUnrealizedJustifiedCheckpoint() {
+    return FastConfirmationRuleUtil.getGreatestUnrealizedJustifiedCheckpoint(store);
+  }
+
+  /**
    * Union of {@code get_slot_committee} over the inclusive slot range {@code [startSlot, endSlot]}.
    */
   private IntSet getCommitteeBetweenSlots(final UInt64 startSlot, final UInt64 endSlot) {
@@ -418,6 +662,33 @@ class FastConfirmationCalculator {
       }
     }
     return headState;
+  }
+
+  /**
+   * Implements {@code get_voting_source}: the voting source of a block is its unrealized justified
+   * checkpoint when the block is from a prior epoch (pulled up), otherwise its realized justified
+   * checkpoint. Teku's protoarray stores the block's post-state realized justified checkpoint,
+   * which equals the spec's {@code store.block_states[block_root].current_justified_checkpoint}, so
+   * no block state needs to be loaded here.
+   */
+  Checkpoint getVotingSource(final Bytes32 blockRoot) {
+    final UInt64 blockEpoch = getBlockEpoch(blockRoot);
+    if (currentEpoch.isGreaterThan(blockEpoch)) {
+      return getUnrealizedJustification(blockRoot);
+    }
+    return getCheckpoints(blockRoot).getJustifiedCheckpoint();
+  }
+
+  /**
+   * Implements {@code is_ancestor(store, get_node_for_root(descendantRoot),
+   * get_node_for_root(ancestorRoot))}: {@code true} if {@code ancestorRoot} is an ancestor of
+   * {@code descendantRoot} (a block is considered its own ancestor).
+   *
+   * <p>Delegates to the fork-choice {@code is_ancestor} rather than re-deriving ancestry, so the
+   * Gloas payload-status semantics are honoured.
+   */
+  boolean isAncestor(final Bytes32 descendantRoot, final Bytes32 ancestorRoot) {
+    return isAncestor(getNodeForRoot(descendantRoot), getNodeForRoot(ancestorRoot));
   }
 
   private boolean isAncestor(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultProposerPreferencesManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/execution/DefaultProposerPreferencesManagerTest.java
@@ -151,6 +151,50 @@ public class DefaultProposerPreferencesManagerTest {
   }
 
   @TestTemplate
+  void shouldPruneAcceptedPreferencesBeforeCurrentSlot() {
+    when(gossipValidator.validate(any())).thenReturn(SafeFuture.completedFuture(ACCEPT));
+    for (int slot = 9; slot <= 11; slot++) {
+      safeJoin(
+          manager.addRemote(
+              createSignedProposerPreferences(
+                  UInt64.valueOf(slot), dataStructureUtil.randomBytes32())));
+    }
+
+    manager.onSlot(UInt64.valueOf(10));
+
+    assertThat(manager.getProposerPreferences(UInt64.valueOf(9))).isEmpty();
+    assertThat(manager.getProposerPreferences(UInt64.valueOf(10))).isPresent();
+    assertThat(manager.getProposerPreferences(UInt64.valueOf(11))).isPresent();
+  }
+
+  @TestTemplate
+  void shouldRetainCurrentPreferencesWhenAddingNextEpochPreferences() {
+    when(gossipValidator.validate(any())).thenReturn(SafeFuture.completedFuture(ACCEPT));
+
+    for (int slot = 0; slot < 64; slot++) {
+      safeJoin(
+          manager.addRemote(
+              createSignedProposerPreferences(
+                  UInt64.valueOf(slot), dataStructureUtil.randomBytes32())));
+    }
+    for (int slot = 0; slot < 32; slot++) {
+      assertThat(manager.getProposerPreferences(UInt64.valueOf(slot))).isPresent();
+    }
+
+    manager.onSlot(UInt64.valueOf(32));
+    for (int slot = 64; slot < 96; slot++) {
+      safeJoin(
+          manager.addRemote(
+              createSignedProposerPreferences(
+                  UInt64.valueOf(slot), dataStructureUtil.randomBytes32())));
+    }
+
+    for (int slot = 32; slot < 64; slot++) {
+      assertThat(manager.getProposerPreferences(UInt64.valueOf(slot))).isPresent();
+    }
+  }
+
+  @TestTemplate
   void shouldQueuePreferencesSavedForFuture() {
     final UInt64 slot = UInt64.valueOf(10);
     final SignedProposerPreferences preferences =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculatorTest.java
@@ -32,9 +32,11 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteSnapshot;
@@ -101,6 +103,20 @@ class FastConfirmationCalculatorTest {
   }
 
   @Test
+  void shouldResolveIsAncestor() {
+    buildLinearChain(6);
+    final FastConfirmationCalculator calculator = calculator(chain.get(5), 5);
+
+    assertThat(calculator.isAncestor(chain.get(5), chain.get(2))).isTrue();
+    // A block is its own ancestor
+    assertThat(calculator.isAncestor(chain.get(3), chain.get(3))).isTrue();
+    // The descendant/ancestor relationship is not symmetric
+    assertThat(calculator.isAncestor(chain.get(2), chain.get(5))).isFalse();
+    // An unknown descendant is not a descendant of anything
+    assertThat(calculator.isAncestor(Bytes32.random(), chain.get(2))).isFalse();
+  }
+
+  @Test
   void shouldComputeCheckpointForBlockAndCurrentTarget() {
     buildLinearChain(11);
     // currentSlot 10 -> currentEpoch 1
@@ -112,6 +128,31 @@ class FastConfirmationCalculatorTest {
 
     // Current target = checkpoint for the head at the current epoch (1), start slot 8.
     assertThat(calculator.getCurrentTarget()).isEqualTo(new Checkpoint(UInt64.ONE, chain.get(8)));
+  }
+
+  @Test
+  void shouldUseUnrealizedJustificationAsVotingSourceForPriorEpochBlock() {
+    buildLinearChain(11);
+    final Checkpoint realized = checkpoint(0);
+    final Checkpoint unrealized = checkpoint(1);
+    setCheckpoints(chain.get(5), realized, unrealized);
+    // currentSlot 10 -> currentEpoch 1; block 5 is in epoch 0 (prior epoch)
+    final FastConfirmationCalculator calculator = calculator(chain.get(10), 10);
+
+    assertThat(calculator.getVotingSource(chain.get(5))).isEqualTo(unrealized);
+    assertThat(calculator.getUnrealizedJustification(chain.get(5))).isEqualTo(unrealized);
+  }
+
+  @Test
+  void shouldUseRealizedJustificationAsVotingSourceForCurrentEpochBlock() {
+    buildLinearChain(11);
+    final Checkpoint realized = checkpoint(1);
+    final Checkpoint unrealized = checkpoint(2);
+    setCheckpoints(chain.get(9), realized, unrealized);
+    // currentSlot 10 -> currentEpoch 1; block 9 is in epoch 1 (current epoch)
+    final FastConfirmationCalculator calculator = calculator(chain.get(10), 10);
+
+    assertThat(calculator.getVotingSource(chain.get(9))).isEqualTo(realized);
   }
 
   @Test
@@ -441,6 +482,176 @@ class FastConfirmationCalculatorTest {
     assertThat(calculator.getCurrentTargetScore()).isEqualTo(expected);
   }
 
+  @Test
+  void shouldComputeHonestFfgSupportFromRemainingWeightWhenNoVotes() {
+    buildLinearChain(11);
+    final BeaconState balanceSource = genesisState();
+    // No votes: honest support is just the honest fraction of the not-yet-assigned FFG weight.
+    final FastConfirmationCalculator calculator = calculator(balanceSource, chain.get(10), 12);
+
+    final UInt64 total = spec.getTotalActiveBalance(calculator.getPulledUpHeadState());
+    // epochStart(epoch 1) = 8, currentSlot - 1 = 11
+    final UInt64 ffgWeightTillNow = estimate(total, 8, 11);
+    final UInt64 expected =
+        total
+            .minusMinZero(ffgWeightTillNow)
+            .dividedBy(100)
+            .times(100 - FastConfirmationRuleUtil.CONFIRMATION_BYZANTINE_THRESHOLD);
+    assertThat(calculator.computeHonestFfgSupportForCurrentTarget()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReportNoConflictingCheckpointWhenTargetIsGreatestUnrealizedJustified() {
+    buildLinearChain(11);
+    final BeaconState balanceSource = genesisState();
+    // currentSlot 10 -> current target = checkpoint(1, chain[8]); make it the greatest unrealized.
+    final Checkpoint target = new Checkpoint(UInt64.ONE, chain.get(8));
+    final Checkpoint zero = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+    when(store.getJustifiedCheckpoint()).thenReturn(zero);
+    final ProtoNodeData blockData = mock(ProtoNodeData.class);
+    when(blockData.getCheckpoints()).thenReturn(new BlockCheckpoints(zero, zero, target, zero));
+    when(forkChoice.getBlockData()).thenReturn(List.of(blockData));
+    final FastConfirmationCalculator calculator = calculator(balanceSource, chain.get(10), 10);
+
+    assertThat(calculator.willNoConflictingCheckpointBeJustified()).isTrue();
+  }
+
+  @Test
+  void shouldExpectCurrentTargetToBeJustifiedUnderFullParticipation() {
+    buildLinearChain(11);
+    final BeaconState balanceSource = genesisState();
+    // Everyone votes for the target block (chain[8]) in the current epoch.
+    final Map<Integer, VoteTracker> allVotes = new HashMap<>();
+    for (final int index : spec.getActiveValidatorIndices(balanceSource, UInt64.ONE)) {
+      allVotes.put(index, vote(chain.get(8), 8));
+    }
+    when(store.getVoteSnapshot()).thenReturn(voteSnapshot(allVotes));
+    final FastConfirmationCalculator calculator = calculator(balanceSource, chain.get(10), 10);
+
+    assertThat(calculator.willCurrentTargetBeJustified()).isTrue();
+  }
+
+  @Test
+  void shouldNotReconfirmWhenObservedJustifiedCheckpointNotInConfirmedChain() {
+    buildLinearChain(11);
+    final BeaconState genesis = genesisState();
+    // Observed justified checkpoint references a block that is not on chain[3]'s chain.
+    final Checkpoint observed = new Checkpoint(UInt64.ZERO, Bytes32.random());
+    final FastConfirmationCalculator calculator =
+        reconfirmationCalculator(genesis, chain.get(3), observed, 5);
+
+    assertThat(calculator.isConfirmedChainSafe(chain.get(3))).isFalse();
+  }
+
+  @Test
+  void shouldReconfirmWhenEveryChainBlockIsOneConfirmed() {
+    buildLinearChain(11);
+    final BeaconState genesis = genesisState();
+    when(forkChoice.isFullyValidated(any())).thenReturn(true);
+    when(store.getVoteSnapshot())
+        .thenReturn(voteSnapshot(allValidatorsVotingFor(genesis, chain.get(3))));
+    // Observed justified checkpoint = (0, chain[0]); reconfirms chain[1..3].
+    final Checkpoint observed = new Checkpoint(UInt64.ZERO, chain.get(0));
+    final FastConfirmationCalculator calculator =
+        reconfirmationCalculator(genesis, chain.get(3), observed, 5);
+
+    assertThat(calculator.isConfirmedChainSafe(chain.get(3))).isTrue();
+  }
+
+  @Test
+  void shouldNotReconfirmWhenAChainBlockIsNotOneConfirmed() {
+    buildLinearChain(11);
+    final BeaconState genesis = genesisState();
+    when(forkChoice.isFullyValidated(any())).thenReturn(true);
+    // No votes -> zero support, so no chain block is one-confirmed.
+    final Checkpoint observed = new Checkpoint(UInt64.ZERO, chain.get(0));
+    final FastConfirmationCalculator calculator =
+        reconfirmationCalculator(genesis, chain.get(3), observed, 5);
+
+    assertThat(calculator.isConfirmedChainSafe(chain.get(3))).isFalse();
+  }
+
+  @Test
+  void shouldNotAdvanceConfirmedRootWhenItIsAlreadyTheHead() {
+    buildLinearChain(11);
+    // Head's unrealized justification (epoch 0) satisfies the phase-2 guard.
+    setCheckpoints(chain.get(10), checkpoint(0), checkpoint(0));
+    // currentSlot 10 -> currentEpoch 1; head == confirmed == chain[10].
+    final FastConfirmationCalculator calculator =
+        descendantCalculator(genesisState(), chain.get(10), chain.get(9), 10);
+
+    assertThat(calculator.findLatestConfirmedDescendant(chain.get(10))).isEqualTo(chain.get(10));
+  }
+
+  @Test
+  void shouldAdvanceConfirmedRootToHeadAtEpochStartUnderFullParticipation() {
+    buildLinearChain(11);
+    final BeaconState genesis = genesisState();
+    when(forkChoice.isFullyValidated(any())).thenReturn(true);
+    // Everyone votes for the head, supporting every ancestor.
+    when(store.getVoteSnapshot())
+        .thenReturn(voteSnapshot(allValidatorsVotingFor(genesis, chain.get(10))));
+    // Voting source of the previous slot head (chain[9]) for the phase-1 guard.
+    setCheckpoints(chain.get(9), checkpoint(0), checkpoint(0));
+    // currentSlot 8 = epoch 1 start; head=chain[10], previousSlotHead=chain[9], confirmed=chain[6].
+    final FastConfirmationCalculator calculator =
+        descendantCalculator(genesis, chain.get(10), chain.get(9), 8);
+
+    assertThat(calculator.findLatestConfirmedDescendant(chain.get(6))).isEqualTo(chain.get(10));
+  }
+
+  @Test
+  void shouldRevertToFinalizedWhenConfirmedRootIsStale() {
+    buildLinearChain(18);
+    when(store.getFinalizedCheckpoint()).thenReturn(new Checkpoint(UInt64.ZERO, chain.get(0)));
+    // confirmed = chain[0] (epoch 0); currentSlot 17 -> currentEpoch 2, so confirmed is >1 epoch
+    // old
+    // and reverts to the finalized block, which is itself too old to advance.
+    final FastConfirmationCalculator calculator =
+        latestConfirmedCalculator(genesisState(), chain.get(0), chain.get(17), 17);
+
+    assertThat(calculator.getLatestConfirmed()).isEqualTo(chain.get(0));
+  }
+
+  @Test
+  void shouldKeepConfirmedRootWhenPreviousSlotHeadHasBeenPrunedFromForkChoice() {
+    buildLinearChain(18);
+    final Checkpoint zero = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+    // Head's unrealized justification is too old to trigger the current-epoch advance.
+    setCheckpoints(chain.get(17), zero, zero);
+    // Finalized at (epoch 1, chain[8]); the confirmed root starts there too.
+    when(store.getFinalizedCheckpoint()).thenReturn(new Checkpoint(UInt64.ONE, chain.get(8)));
+    // The previous slot head persisted in the FCR store is no longer tracked by fork choice
+    // (protoarray pruned it below the finalized anchor).
+    final Bytes32 prunedPreviousSlotHead = Bytes32.random();
+
+    final FastConfirmationStore fcrStore =
+        new FastConfirmationStore(
+            store, chain.get(8), zero, zero, zero, prunedPreviousSlotHead, chain.get(17));
+    final BeaconState state = genesisState();
+    final FastConfirmationStates states =
+        new FastConfirmationStates(Optional.of(state), state, state);
+    // currentSlot 17 -> currentEpoch 2. The previous-epoch advance would dereference the pruned
+    // previous slot head; the calculator must skip it and keep the finalized confirmed root.
+    final FastConfirmationCalculator calculator =
+        new FastConfirmationCalculator(spec, fcrStore, states, UInt64.valueOf(17));
+
+    assertThat(calculator.getLatestConfirmed()).isEqualTo(chain.get(8));
+  }
+
+  @Test
+  void shouldAdvanceRecentConfirmedRootTowardHead() {
+    buildLinearChain(11);
+    // Head's unrealized justification (epoch 0) satisfies find_latest_confirmed_descendant phase 2.
+    setCheckpoints(chain.get(10), checkpoint(0), checkpoint(0));
+    when(store.getFinalizedCheckpoint()).thenReturn(new Checkpoint(UInt64.ZERO, chain.get(0)));
+    // confirmed == head == chain[10]; currentSlot 10 -> currentEpoch 1, not an epoch start.
+    final FastConfirmationCalculator calculator =
+        latestConfirmedCalculator(genesisState(), chain.get(10), chain.get(10), 10);
+
+    assertThat(calculator.getLatestConfirmed()).isEqualTo(chain.get(10));
+  }
+
   private UInt64 estimate(
       final UInt64 totalActiveBalance, final long startSlot, final long endSlot) {
     return FastConfirmationRuleUtil.estimateCommitteeWeightBetweenSlots(
@@ -472,6 +683,48 @@ class FastConfirmationCalculatorTest {
         new FastConfirmationStates(Optional.empty(), mock(BeaconState.class), headState);
     return new FastConfirmationCalculator(
         spec, fcrStore(head), states, UInt64.valueOf(currentSlot));
+  }
+
+  private FastConfirmationCalculator reconfirmationCalculator(
+      final BeaconState state,
+      final Bytes32 head,
+      final Checkpoint currentObservedJustified,
+      final long currentSlot) {
+    // The state doubles as the previous balance source and the committee shuffling source.
+    final FastConfirmationStates states =
+        new FastConfirmationStates(Optional.of(state), mock(BeaconState.class), state);
+    return new FastConfirmationCalculator(
+        spec, fcrStore(head, currentObservedJustified), states, UInt64.valueOf(currentSlot));
+  }
+
+  private FastConfirmationCalculator descendantCalculator(
+      final BeaconState state,
+      final Bytes32 head,
+      final Bytes32 previousSlotHead,
+      final long currentSlot) {
+    // The state doubles as the current balance source and the committee shuffling source.
+    final Checkpoint zero = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+    final FastConfirmationStore fcrStore =
+        new FastConfirmationStore(store, Bytes32.ZERO, zero, zero, zero, previousSlotHead, head);
+    final FastConfirmationStates states =
+        new FastConfirmationStates(Optional.empty(), state, state);
+    return new FastConfirmationCalculator(spec, fcrStore, states, UInt64.valueOf(currentSlot));
+  }
+
+  private FastConfirmationCalculator latestConfirmedCalculator(
+      final BeaconState state,
+      final Bytes32 confirmedRoot,
+      final Bytes32 head,
+      final long currentSlot) {
+    final Checkpoint zero = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+    // The observed justified checkpoint root must be an in-tree block; get_latest_confirmed reads
+    // its slot unconditionally. chain[0] exists in every test chain.
+    final Checkpoint observedJustified = new Checkpoint(UInt64.ZERO, chain.get(0));
+    final FastConfirmationStore fcrStore =
+        new FastConfirmationStore(store, confirmedRoot, zero, observedJustified, zero, head, head);
+    final FastConfirmationStates states =
+        new FastConfirmationStates(Optional.of(state), state, state);
+    return new FastConfirmationCalculator(spec, fcrStore, states, UInt64.valueOf(currentSlot));
   }
 
   private FastConfirmationStore fcrStore(final Bytes32 head) {
@@ -549,6 +802,19 @@ class FastConfirmationCalculatorTest {
       i--;
     }
     return Optional.of(i);
+  }
+
+  private void setCheckpoints(
+      final Bytes32 root, final Checkpoint justified, final Checkpoint unrealizedJustified) {
+    final Checkpoint zero = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+    final ProtoNodeData data = mock(ProtoNodeData.class);
+    when(data.getCheckpoints())
+        .thenReturn(new BlockCheckpoints(justified, zero, unrealizedJustified, zero));
+    when(forkChoice.getBlockData(root)).thenReturn(Optional.of(data));
+  }
+
+  private Checkpoint checkpoint(final int epoch) {
+    return new Checkpoint(UInt64.valueOf(epoch), Bytes32.random());
   }
 
   private VoteSnapshot voteSnapshot(final Map<Integer, VoteTracker> votesByIndex) {

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -138,15 +138,9 @@ specrefs:
       - upgrade_lc_update_to_gloas#gloas
 
       # Not implemented: fast confirmation
-      - compute_honest_ffg_support_for_current_target#phase0
-      - find_latest_confirmed_descendant#phase0
       - get_current_balance_source#phase0
-      - get_latest_confirmed#phase0
       - get_previous_balance_source#phase0
-      - is_confirmed_chain_safe#phase0
       - on_fast_confirmation#phase0
-      - will_current_target_be_justified#phase0
-      - will_no_conflicting_checkpoint_be_justified#phase0
       - get_safe_execution_block_hash#bellatrix
       - get_safe_execution_block_hash#gloas
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1001,7 +1001,9 @@
     </spec>
 
 - name: compute_honest_ffg_support_for_current_target#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+      search: UInt64 computeHonestFfgSupportForCurrentTarget() {
   spec: |
     <spec fn="compute_honest_ffg_support_for_current_target" fork="phase0" hash="3aa9e6a2">
     def compute_honest_ffg_support_for_current_target(store: Store) -> Gwei:
@@ -2092,7 +2094,9 @@
     </spec>
 
 - name: find_latest_confirmed_descendant#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+      search: Bytes32 findLatestConfirmedDescendant(final Bytes32 latestConfirmedRoot) {
   spec: |
     <spec fn="find_latest_confirmed_descendant" fork="phase0" hash="f38db29f">
     def find_latest_confirmed_descendant(
@@ -4562,7 +4566,9 @@
     </spec>
 
 - name: get_latest_confirmed#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+      search: Bytes32 getLatestConfirmed() {
   spec: |
     <spec fn="get_latest_confirmed" fork="phase0" hash="32f11e2b">
     def get_latest_confirmed(fcr_store: FastConfirmationStore) -> Root:
@@ -6640,7 +6646,9 @@
     </spec>
 
 - name: is_confirmed_chain_safe#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+      search: boolean isConfirmedChainSafe(final Bytes32 confirmedRoot) {
   spec: |
     <spec fn="is_confirmed_chain_safe" fork="phase0" hash="7e4d7c51">
     def is_confirmed_chain_safe(fcr_store: FastConfirmationStore, confirmed_root: Root) -> bool:
@@ -15677,7 +15685,9 @@
     </spec>
 
 - name: will_current_target_be_justified#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+      search: boolean willCurrentTargetBeJustified() {
   spec: |
     <spec fn="will_current_target_be_justified" fork="phase0" hash="c3ddf941">
     def will_current_target_be_justified(store: Store) -> bool:
@@ -15691,7 +15701,9 @@
     </spec>
 
 - name: will_no_conflicting_checkpoint_be_justified#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationCalculator.java
+      search: boolean willNoConflictingCheckpointBeJustified() {
   spec: |
     <spec fn="will_no_conflicting_checkpoint_be_justified" fork="phase0" hash="5dbf7eb2">
     def will_no_conflicting_checkpoint_be_justified(store: Store) -> bool:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> FCR drives the safe/confirmed head used for execution safety; incorrect confirmation or reversion logic could misreport safe blocks. Proposer-preferences storage changes are narrower but affect Gloas proposal metadata lookup.
> 
> **Overview**
> Adds the **fast confirmation rule (FCR)** logic that was still missing from `FastConfirmationCalculator`: honest FFG support, justification guards, epoch reconfirmation (`is_confirmed_chain_safe`), advancing the confirmed block (`find_latest_confirmed_descendant`), and the main entry point **`get_latest_confirmed`** (revert to finalized when stale/pruned, optional restart from observed justified, then advance). Includes **Teku-specific guards** when persisted roots (e.g. previous slot head) are no longer in fork choice, plus trace logging.
> 
> **`DefaultProposerPreferencesManager`** stops using a fixed-size LRU for accepted preferences and uses a **`ConcurrentSkipListMap`** instead, **dropping entries for slots strictly before the current slot** on each `onSlot` so preferences for the current and future slots are not evicted when many future slots are added.
> 
> Unit tests cover the new FCR paths and proposer-preference pruning/retention. **specrefs** now point at the new Java implementations and remove several FCR functions from the “not implemented” list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85810f1c25e4460dcf90e8847ed822646f5e68fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->