### PR TITLE
Fast confirmation: tracker scaffolding (disabled by default)

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -113,19 +113,10 @@ public class ForkChoiceUtil {
    * <p>Returns whether {@code ancestor} is an ancestor of {@code node}, i.e. {@code ancestor} lies
    * on the chain from {@code node} at {@code ancestor}'s block slot.
    *
-   * <p>This base (phase0) form is the {@code is_ancestor#phase0} spec anchor and the default that
-   * {@code ForkChoiceUtilGloas#isAncestor} overrides. It has no pre-Gloas caller by design: in the
-   * spec, {@code is_ancestor} is consumed only by {@code get_weight}, to add proposer boost when a
-   * node is an ancestor of the proposer-boost node. Teku instead computes {@code get_weight} inside
-   * protoarray, folding the proposer-boost delta into each node's stored weight during {@code
-   * ProtoArray#applyScoreChanges}. That back-propagation realizes the ancestry condition
-   * implicitly, so the weight path needs no explicit {@code is_ancestor} call. The only explicit
-   * caller is the Gloas override, which runs the check in reverse to recover the attestation-only
-   * weight (via {@code ForkChoiceUtilGloas#getNodeAttestationWeight}); pre-Gloas {@code
-   * isHeadWeak}/{@code isParentStrong} read the already-boosted protoarray weight directly and
-   * never query ancestry. Since {@code ForkChoiceUtilGloas} overrides this method, even that
-   * reverse path dispatches to the override rather than here — so this base form is retained for
-   * spec fidelity and exercised only by its unit test.
+   * <p>This base (phase0) form is the {@code is_ancestor#phase0} spec anchor and the default
+   * overridden by {@code ForkChoiceUtilGloas#isAncestor}. Fast confirmation calls it explicitly
+   * when computing attestation support. Protoarray fork-choice scoring instead realizes the same
+   * ancestry relationship by propagating node weights to parents.
    */
   public boolean isAncestor(
       final ReadOnlyForkChoiceStrategy forkChoiceStrategy,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -63,6 +63,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationMessage;
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.SignedExecutionPayloadEnvelope;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
@@ -95,6 +96,8 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsGloas;
 import tech.pegasys.teku.statetransition.attestation.DeferredAttestations;
 import tech.pegasys.teku.statetransition.attestation.VoteUpdates;
 import tech.pegasys.teku.statetransition.block.BlockImportPerformance;
+import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
+import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.ForkChoiceFastConfirmation;
 import tech.pegasys.teku.statetransition.payloadattestation.ValidatablePayloadAttestationMessage;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.AttestationStateSelector;
@@ -125,6 +128,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   private final Subscribers<OptimisticHeadSubscriber> optimisticSyncSubscribers =
       Subscribers.create(true);
   private final TickProcessor tickProcessor;
+  private final FastConfirmationTracker fastConfirmationTracker;
   private final boolean forkChoiceLateBlockReorgEnabled;
   private final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler;
   private Optional<Boolean> optimisticSyncing = Optional.empty();
@@ -144,6 +148,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final ForkChoiceStateProvider forkChoiceStateProvider,
       final TickProcessor tickProcessor,
       final MergeTransitionBlockValidator transitionBlockValidator,
+      final FastConfirmationTracker fastConfirmationTracker,
       final boolean forkChoiceLateBlockReorgEnabled,
       final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler,
       final DebugDataDumper debugDataDumper,
@@ -158,9 +163,11 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     this.attestationStateSelector =
         new AttestationStateSelector(spec, recentChainData, metricsSystem);
     this.tickProcessor = tickProcessor;
+    this.fastConfirmationTracker = fastConfirmationTracker;
     this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
     this.lateBlockReorgPreparationHandler = lateBlockReorgPreparationHandler;
     this.lastProcessHeadSlot.set(UInt64.ZERO);
+    LOG.debug("fastConfirmationEnabled is set to {}", fastConfirmationTracker.isEnabled());
     LOG.debug("forkChoiceLateBlockReorgEnabled is set to {}", forkChoiceLateBlockReorgEnabled);
     this.debugDataDumper = debugDataDumper;
     this.signatureVerifier = signatureVerifier;
@@ -170,7 +177,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             "get_proposer_head_selection_total",
             "when late_block_reorg is enabled, counts based on the proposer parent being based on fork choice, head, or parent of head.",
             "selected_source");
-    recentChainData.subscribeStoreInitialized(this::initializeProtoArrayForkChoice);
+    recentChainData.subscribeStoreInitialized(this::onStoreInitialized);
     forkChoiceNotifier.subscribeToForkChoiceUpdatedResult(this);
   }
 
@@ -190,6 +197,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         new ForkChoiceStateProvider(forkChoiceExecutor, recentChainData),
         new TickProcessor(spec, recentChainData),
         transitionBlockValidator,
+        FastConfirmationTracker.NOOP,
         false,
         LateBlockReorgPreparationHandler.NOOP,
         DebugDataDumper.NOOP,
@@ -402,9 +410,23 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     performanceRecord.ifPresent(TickProcessingPerformance::tickProcessorComplete);
     final UInt64 currentSlot = spec.getCurrentSlot(store);
     if (currentSlot.isGreaterThan(slotAtStartOfTick)) {
-      applyDeferredAttestations(currentSlot).finishStackTrace();
+      final SafeFuture<Void> deferredAttestationsFuture = applyDeferredAttestations(currentSlot);
+      // When fast confirmation is disabled this is exactly the master behaviour. When enabled, the
+      // slot-start work runs entirely off the fork-choice thread (on the fast confirmation runner)
+      // with no blocking join; it never gates tick processing.
+      if (fastConfirmationTracker.isEnabled()) {
+        ForkChoiceFastConfirmation.processForSlot(
+            fastConfirmationTracker, currentSlot, deferredAttestationsFuture, this::processHead);
+      } else {
+        deferredAttestationsFuture.finishStackTrace();
+      }
     }
     performanceRecord.ifPresent(TickProcessingPerformance::deferredAttestationsApplied);
+  }
+
+  private void onStoreInitialized() {
+    fastConfirmationTracker.initialize(recentChainData.getStore());
+    initializeProtoArrayForkChoice();
   }
 
   private void initializeProtoArrayForkChoice() {
@@ -1292,6 +1314,16 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
   public UInt64 getLastProcessHeadSlot() {
     return lastProcessHeadSlot.get();
+  }
+
+  @VisibleForTesting
+  boolean isFastConfirmationEnabled() {
+    return fastConfirmationTracker.isEnabled();
+  }
+
+  @VisibleForTesting
+  Optional<FastConfirmationStore> getFastConfirmationStore() {
+    return fastConfirmationTracker.getFastConfirmationStore();
   }
 
   SafeFuture<ChainHead> prepareForBlockProduction(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceStateProvider.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
@@ -24,10 +26,25 @@ public class ForkChoiceStateProvider {
   private final EventThread forkChoiceExecutor;
   private final RecentChainData recentChainData;
 
+  /**
+   * Supplies the fast confirmation {@code confirmed_root} to use as the FCU {@code safe_block_hash}
+   * source ({@code get_safe_execution_block_hash}), or empty when fast confirmation is disabled (in
+   * which case the safe hash defaults to the justified block, as before).
+   */
+  private final Supplier<Optional<Bytes32>> fastConfirmationSafeBlockRootSupplier;
+
   public ForkChoiceStateProvider(
       final EventThread forkChoiceExecutor, final RecentChainData recentChainData) {
+    this(forkChoiceExecutor, recentChainData, Optional::empty);
+  }
+
+  public ForkChoiceStateProvider(
+      final EventThread forkChoiceExecutor,
+      final RecentChainData recentChainData,
+      final Supplier<Optional<Bytes32>> fastConfirmationSafeBlockRootSupplier) {
     this.forkChoiceExecutor = forkChoiceExecutor;
     this.recentChainData = recentChainData;
+    this.fastConfirmationSafeBlockRootSupplier = fastConfirmationSafeBlockRootSupplier;
   }
 
   public SafeFuture<ForkChoiceState> getForkChoiceStateAsync() {
@@ -47,6 +64,7 @@ public class ForkChoiceStateProvider {
             proposingOnHead,
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
-            recentChainData.getFinalizedCheckpoint().orElseThrow());
+            recentChainData.getFinalizedCheckpoint().orElseThrow(),
+            fastConfirmationSafeBlockRootSupplier.get());
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationEventChannel.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationEventChannel.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Fired once per slot after the fast confirmation algorithm ({@code on_fast_confirmation}) has run,
+ * regardless of whether the confirmed block changed. Backs the {@code fast_confirmation} Beacon API
+ * event stream topic.
+ */
+public interface FastConfirmationEventChannel extends VoidReturningChannelInterface {
+
+  FastConfirmationEventChannel NOOP = (confirmedRoot, confirmedSlot, currentSlot) -> {};
+
+  /**
+   * @param confirmedRoot root of the most recent confirmed block
+   * @param confirmedSlot slot of the most recent confirmed block
+   * @param currentSlot wall-clock slot at which the algorithm was executed
+   */
+  void onFastConfirmation(Bytes32 confirmedRoot, UInt64 confirmedSlot, UInt64 currentSlot);
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationInput.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationInput.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/**
+ * Per-slot snapshot captured on the fork-choice thread and handed to the fast confirmation runner.
+ * Only the head root and slot are pinned here; all remaining inputs (epoch-boundary flags, greatest
+ * unrealized justified checkpoint, source states) are derived on the runner to keep work off the
+ * latency-critical fork-choice thread.
+ */
+record FastConfirmationInput(UInt64 slot, Bytes32 headRoot) {}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+/**
+ * Retrieves the source states the Fast Confirmation Rule needs for a slot.
+ *
+ * <p>The three retrievals run concurrently on the store's own runners and are composed
+ * asynchronously, so no state load ever blocks the (single-thread) fast confirmation runner. If any
+ * required state is unavailable (e.g. pruned), the result is empty and the caller skips the slot.
+ */
+final class FastConfirmationStateLoader {
+
+  private FastConfirmationStateLoader() {}
+
+  /**
+   * @param includePreviousBalanceSource whether to also retrieve {@code
+   *     get_previous_balance_source}. It is only read by reconfirmation, which runs at epoch-start
+   *     slots, so callers pass {@code is_start_slot_at_epoch(currentSlot)} to avoid an unnecessary
+   *     (and often uncached) fetch of the previous epoch's checkpoint state on other slots.
+   */
+  static SafeFuture<Optional<FastConfirmationStates>> load(
+      final FastConfirmationStore fcrStore,
+      final Bytes32 head,
+      final boolean includePreviousBalanceSource) {
+    final ReadOnlyStore store = fcrStore.store();
+    final SafeFuture<Optional<BeaconState>> previousBalanceSource =
+        includePreviousBalanceSource
+            ? store.retrieveCheckpointState(fcrStore.previousEpochObservedJustifiedCheckpoint())
+            : SafeFuture.completedFuture(Optional.empty());
+    final SafeFuture<Optional<BeaconState>> currentBalanceSource =
+        store.retrieveCheckpointState(fcrStore.currentEpochObservedJustifiedCheckpoint());
+    final SafeFuture<Optional<BeaconState>> headBlockState = store.retrieveBlockState(head);
+
+    // The futures are already running; compose (rather than join) so the runner is not blocked
+    // while they complete.
+    return previousBalanceSource.thenCompose(
+        previous ->
+            currentBalanceSource.thenCompose(
+                current ->
+                    headBlockState.thenApply(
+                        headState ->
+                            combine(includePreviousBalanceSource, previous, current, headState))));
+  }
+
+  private static Optional<FastConfirmationStates> combine(
+      final boolean includePreviousBalanceSource,
+      final Optional<BeaconState> previousBalanceSource,
+      final Optional<BeaconState> currentBalanceSource,
+      final Optional<BeaconState> headBlockState) {
+    // The mandatory sources must be present; the previous balance source only when requested.
+    if (currentBalanceSource.isEmpty()
+        || headBlockState.isEmpty()
+        || (includePreviousBalanceSource && previousBalanceSource.isEmpty())) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new FastConfirmationStates(
+            previousBalanceSource, currentBalanceSource.get(), headBlockState.get()));
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationTracker.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
+
+public class FastConfirmationTracker {
+  private static final Logger LOG = LogManager.getLogger();
+
+  public static final FastConfirmationTracker NOOP =
+      new FastConfirmationTracker(
+          false,
+          null,
+          Optional.empty(),
+          FastConfirmationEventChannel.NOOP,
+          new NoOpMetricsSystem(),
+          () -> UInt64.ZERO);
+
+  private final boolean enabled;
+  private final Spec spec;
+  private final FastConfirmationEventChannel fastConfirmationEventChannel;
+
+  /** Slot of the most recent confirmed block * */
+  private final AtomicInteger latestConfirmedSlot = new AtomicInteger(0);
+
+  /** Total number of confirmed block reorganizations */
+  private final Counter reorgsCounter;
+
+  /** Total number of fallbacks to finality */
+  private final Counter fallbacksCounter;
+
+  /** Total number of restarts from a safe unrealized justified block */
+  private final Counter restartsCounter;
+
+  /** Wall-clock duration of a single per-slot fast confirmation run; {@code null} when disabled. */
+  private final MetricsHistogram calculationTimer;
+
+  /** Incremented when a per-slot run does not finish within {@link #updateTimeout}. */
+  private final Counter timeoutCounter;
+
+  private final AtomicReference<FastConfirmationStore> fastConfirmationStore =
+      new AtomicReference<>();
+
+  /**
+   * Slot of the most recently applied update. Guards against stale or duplicate async tasks
+   * clobbering a newer store: {@code update_fast_confirmation_variables} MUST run exactly once per
+   * slot and slot heads rotate in slot order, so an update is applied only when its slot is
+   * strictly greater than this value. {@code null} until the first update after (re)initialization.
+   */
+  private final AtomicReference<UInt64> lastProcessedSlot = new AtomicReference<>();
+
+  private final Optional<AsyncRunner> asyncRunner;
+
+  private FastConfirmationTracker(
+      final boolean enabled,
+      final Spec spec,
+      final Optional<AsyncRunner> asyncRunner,
+      final FastConfirmationEventChannel fastConfirmationEventChannel,
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider) {
+    this.enabled = enabled;
+    this.spec = spec;
+    this.asyncRunner = asyncRunner;
+    this.fastConfirmationEventChannel = fastConfirmationEventChannel;
+
+    // Setting up metrics
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.BEACON,
+        "fast_confirmation_slot",
+        "Slot of the most recent confirmed block",
+        latestConfirmedSlot::get);
+    this.reorgsCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.BEACON,
+            "fast_confirmation_reorgs_total",
+            "Total number of confirmed block reorganizations");
+    this.fallbacksCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.BEACON,
+            "fast_confirmation_fallbacks_total",
+            "Total number of fallbacks to finality");
+    this.restartsCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.BEACON,
+            "fast_confirmation_restarts_total",
+            "Total number of restarts from a safe unrealized justified block");
+    this.calculationTimer =
+        new MetricsHistogram(
+            metricsSystem,
+            timeProvider,
+            TekuMetricCategory.BEACON,
+            "fast_confirmation_calculation_seconds",
+            "Time taken to run the fast confirmation algorithm (incl. source-state loading) each slot");
+    this.timeoutCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.BEACON,
+            "fast_confirmation_timeout_total",
+            "Number of slots where the fast confirmation update did not complete within its timeout");
+  }
+
+  public static FastConfirmationTracker create(
+      final Spec spec,
+      final Optional<AsyncRunner> asyncRunner,
+      final FastConfirmationEventChannel fastConfirmationEventChannel,
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider) {
+    return new FastConfirmationTracker(
+        true, spec, asyncRunner, fastConfirmationEventChannel, metricsSystem, timeProvider);
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void initialize(final ReadOnlyStore store) {
+    if (!enabled) {
+      return;
+    }
+    lastProcessedSlot.set(null);
+    fastConfirmationStore.set(FastConfirmationStore.create(store));
+  }
+
+  /**
+   * Hands off the per-slot head snapshot to the dedicated runner. Only the head root is captured on
+   * the (latency-critical) fork-choice thread; the epoch-boundary flags, greatest unrealized
+   * justified checkpoint, source states and the confirmation computation are all derived on the
+   * runner.
+   */
+  public SafeFuture<Void> onSlot(final UInt64 slot, final Bytes32 headRoot) {
+    if (!enabled) {
+      return SafeFuture.COMPLETE;
+    }
+
+    if (fastConfirmationStore.get() == null) {
+      LOG.debug("Skipping fast confirmation update because store is not initialized");
+      return SafeFuture.COMPLETE;
+    }
+
+    if (asyncRunner.isEmpty()) {
+      LOG.warn("Skipping fast confirmation update because no async runner is configured");
+      return SafeFuture.COMPLETE;
+    }
+
+    final FastConfirmationInput input = new FastConfirmationInput(slot, headRoot);
+    final Duration updateTimeout = updateTimeout(slot);
+    return asyncRunner
+        .orElseThrow()
+        .runAsync(() -> processFastConfirmationInput(input))
+        .orTimeout(updateTimeout)
+        .exceptionallyCompose(
+            error -> {
+              // A timeout means the side computation is lagging (e.g. slow state retrieval): log it
+              // and move on rather than failing the fork-choice tick. Real errors still propagate.
+              if (ExceptionUtil.hasCause(error, TimeoutException.class)) {
+                timeoutCounter.inc();
+                LOG.warn(
+                    "Fast confirmation update for slot {} timed out after {}", slot, updateTimeout);
+                return SafeFuture.COMPLETE;
+              }
+              return SafeFuture.failedFuture(error);
+            });
+  }
+
+  /**
+   * Whether the head is too far behind for {@code get_latest_confirmed} to do anything but revert
+   * to finalized: {@code true} when the head block is two or more epochs behind the current epoch,
+   * i.e. {@code head_epoch + 1 < current_epoch}. In that case the confirmed block (an ancestor of
+   * the head) is more than one epoch old (reverts), the observed-justified checkpoint is at most
+   * the head's epoch (no restart), and the advance gate (confirmed within one epoch of current)
+   * cannot pass — so the result is always the finalized block. One epoch of lag is tolerated so the
+   * rule keeps confirming through slow-following and non-finality. Treats a head not in fork choice
+   * as stale.
+   */
+  private boolean isHeadStale(
+      final UInt64 slot, final Bytes32 headRoot, final FastConfirmationStore store) {
+    final UInt64 currentEpoch = spec.computeEpochAtSlot(slot);
+    return store
+        .store()
+        .getForkChoiceStrategy()
+        .blockSlot(headRoot)
+        .map(headSlot -> spec.computeEpochAtSlot(headSlot).plus(1).isLessThan(currentEpoch))
+        .orElse(true);
+  }
+
+  /**
+   * Upper bound for a single per-slot update: half a slot. The confirmation computation should
+   * finish well within a slot; this only guards against a hung or very slow state retrieval
+   * monopolizing the dedicated single-thread runner. Applied via the default scheduler so it fires
+   * independently of that runner thread.
+   */
+  private Duration updateTimeout(final UInt64 slot) {
+    return Duration.ofMillis(spec.getSlotDurationMillis(slot) / 2L);
+  }
+
+  private void processFastConfirmationInput(final FastConfirmationInput input) {
+    final FastConfirmationStore currentStore = fastConfirmationStore.get();
+    if (currentStore == null) {
+      LOG.debug("Skipping fast confirmation update because store is not initialized");
+      return;
+    }
+
+    // Drop stale or duplicate updates. Tasks run on a dedicated single-thread runner so this
+    // read-modify-write is serialized; the guard additionally ensures that an out-of-order or
+    // repeated slot never overwrites a newer store (and enforces the spec's once-per-slot rule for
+    // update_fast_confirmation_variables).
+    final UInt64 lastSlot = lastProcessedSlot.get();
+    if (lastSlot != null && input.slot().isLessThanOrEqualTo(lastSlot)) {
+      LOG.debug(
+          "Skipping fast confirmation update for slot {}: already processed slot {}",
+          input.slot(),
+          lastSlot);
+      return;
+    }
+
+    // Time the actual per-slot computation (state loading + get_latest_confirmed), which is what
+    // the timeout bounds; the cheap guards above are deliberately left out of the measurement.
+    final MetricsHistogram.Timer calculationTimerContext = calculationTimer.startTimer();
+    try {
+      runFastConfirmation(input, currentStore);
+    } finally {
+      calculationTimerContext.closeUnchecked().run();
+    }
+  }
+
+  private void runFastConfirmation(
+      final FastConfirmationInput input, final FastConfirmationStore currentStore) {
+    final ReadOnlyStore store = currentStore.store();
+
+    // Stale-head short-circuit (during sync, or whenever the head stops progressing): when the head
+    // is two or more epochs behind the current epoch, get_latest_confirmed could only revert to the
+    // finalized block, so skip the whole update this slot — no source-state loads, no
+    // update_fast_confirmation_variables (including its greatest-unrealized-justified scan over all
+    // blocks), no event, no metrics churn. The store is left untouched and re-establishes itself on
+    // the first non-stale slot; the FCU safe hash falls back to the justified block while this (now
+    // stale) confirmed root is no longer in fork choice (see
+    // ForkChoiceStrategy#getForkChoiceState).
+    if (isHeadStale(input.slot(), input.headRoot(), currentStore)) {
+      LOG.debug(
+          "Fast confirmation update for slot {}: head is more than one epoch behind; skipping",
+          input.slot());
+      return;
+    }
+
+    // Derived off the fork-choice thread. The greatest unrealized justified checkpoint is only
+    // needed on the last slot of an epoch (when the next slot starts a new epoch); otherwise it is
+    // left at the finalized checkpoint and unused by update_fast_confirmation_variables.
+    final boolean currentSlotIsEpochStart =
+        FastConfirmationRuleUtil.isStartSlotAtEpoch(spec, input.slot());
+    final boolean nextSlotIsEpochStart =
+        FastConfirmationRuleUtil.isStartSlotAtEpoch(spec, input.slot().plus(1));
+    final Checkpoint greatestUnrealizedJustifiedCheckpoint =
+        nextSlotIsEpochStart
+            ? FastConfirmationRuleUtil.getGreatestUnrealizedJustifiedCheckpoint(store)
+            : store.getFinalizedCheckpoint();
+
+    final FastConfirmationStore withUpdatedVariables =
+        FastConfirmationRuleUtil.updateFastConfirmationVariables(
+            currentStore,
+            input.headRoot(),
+            greatestUnrealizedJustifiedCheckpoint,
+            currentSlotIsEpochStart,
+            nextSlotIsEpochStart);
+
+    // on_fast_confirmation: fcr_store.confirmed_root = get_latest_confirmed(fcr_store).
+    final FastConfirmationStore updatedStore =
+        updateConfirmedRoot(withUpdatedVariables, input.slot(), currentSlotIsEpochStart);
+    fastConfirmationStore.set(updatedStore);
+    lastProcessedSlot.set(input.slot());
+
+    final Bytes32 confirmedRoot = updatedStore.confirmedRoot();
+    final ReadOnlyForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
+    final UInt64 confirmedSlot = forkChoiceStrategy.blockSlot(confirmedRoot).orElse(UInt64.ZERO);
+    latestConfirmedSlot.set(confirmedSlot.intValue());
+    if (isConfirmedRootReorg(
+        input.slot(), forkChoiceStrategy, currentStore.confirmedRoot(), confirmedRoot)) {
+      reorgsCounter.inc();
+    }
+
+    LOG.info(
+        "Fast confirmation update for slot {}: head={}, confirmed_root={}, confirmed_slot={}",
+        input.slot(),
+        input.headRoot(),
+        confirmedRoot,
+        confirmedSlot);
+
+    // The fast_confirmation event is emitted every time the algorithm runs, regardless of whether
+    // the confirmed block changed (per the Beacon API event stream spec).
+    fastConfirmationEventChannel.onFastConfirmation(confirmedRoot, confirmedSlot, input.slot());
+  }
+
+  /**
+   * Runs {@code get_latest_confirmed} against the loaded source states. The state loads are
+   * composed concurrently and joined here; in practice the required states are cache-resident (the
+   * head state and the justified checkpoint state), so the join is effectively non-blocking, and
+   * the overall task is bounded by {@link #updateTimeout}. When a required state is unavailable the
+   * confirmed root is left unchanged for this slot.
+   */
+  private FastConfirmationStore updateConfirmedRoot(
+      final FastConfirmationStore fcrStore, final UInt64 slot, final boolean atEpochStart) {
+    final Optional<FastConfirmationStates> maybeStates =
+        FastConfirmationStateLoader.load(fcrStore, fcrStore.currentSlotHead(), atEpochStart).join();
+    final Bytes32 finalizedRoot = fcrStore.store().getFinalizedCheckpoint().getRoot();
+    if (maybeStates.isEmpty()) {
+      // The source states could not be loaded (e.g. the observed-justified checkpoint state has
+      // been pruned, which happens for a short window after startup before that checkpoint has
+      // advanced to a still-hot one). We cannot run get_latest_confirmed, so fall back to the
+      // finalized block: it is always safe to consider confirmed, its root is known without a state
+      // load, and this keeps confirmed_root tracking finality rather than going stale.
+      LOG.debug(
+          "Fast confirmation for slot {}: source states unavailable, falling back to finalized {}",
+          slot,
+          finalizedRoot);
+      fallbacksCounter.inc();
+      return fcrStore.withConfirmedRoot(finalizedRoot);
+    }
+
+    final Bytes32 confirmedRoot =
+        new FastConfirmationCalculator(spec, fcrStore, maybeStates.get(), slot)
+            .getLatestConfirmed();
+    recordConfirmationOutcome(fcrStore, confirmedRoot, finalizedRoot);
+
+    return fcrStore.withConfirmedRoot(confirmedRoot);
+  }
+
+  void recordConfirmationOutcome(
+      final FastConfirmationStore fcrStore,
+      final Bytes32 confirmedRoot,
+      final Bytes32 finalizedRoot) {
+    if (confirmedRoot.equals(finalizedRoot)) {
+      fallbacksCounter.inc();
+    } else if (confirmedRoot.equals(fcrStore.currentEpochObservedJustifiedCheckpoint().getRoot())) {
+      restartsCounter.inc();
+    }
+  }
+
+  /**
+   * Returns whether changing between two confirmed block roots switches chains. Advancing to a
+   * descendant or falling back to an ancestor is not a reorg.
+   *
+   * <p>Confirmed roots are resolved through {@code get_node_for_root}, which deliberately produces
+   * PENDING nodes under Gloas. Unlike an attestation latest message, a confirmed root has no vote
+   * slot or payload hint with which to call {@code get_supported_node}.
+   */
+  boolean isConfirmedRootReorg(
+      final UInt64 slot,
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy,
+      final Bytes32 previousConfirmedRoot,
+      final Bytes32 confirmedRoot) {
+    if (confirmedRoot.equals(previousConfirmedRoot)) {
+      return false;
+    }
+    return !isAncestor(slot, forkChoiceStrategy, confirmedRoot, previousConfirmedRoot)
+        && !isAncestor(slot, forkChoiceStrategy, previousConfirmedRoot, confirmedRoot);
+  }
+
+  private boolean isAncestor(
+      final UInt64 slot,
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy,
+      final Bytes32 descendantRoot,
+      final Bytes32 ancestorRoot) {
+    final ForkChoiceUtil forkChoiceUtil = spec.atSlot(slot).getForkChoiceUtil();
+    return forkChoiceUtil.isAncestor(
+        forkChoiceStrategy,
+        ForkChoiceNode.createBase(descendantRoot),
+        ForkChoiceNode.createBase(ancestorRoot));
+  }
+
+  public Optional<FastConfirmationStore> getFastConfirmationStore() {
+    return Optional.ofNullable(fastConfirmationStore.get());
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/ForkChoiceFastConfirmation.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/ForkChoiceFastConfirmation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.storage.client.ChainHead;
+
+/** Glue between {@code ForkChoice.onTick} and the fast confirmation side runner. */
+public final class ForkChoiceFastConfirmation {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private ForkChoiceFastConfirmation() {}
+
+  /**
+   * Runs the FCR slot-start work once deferred attestations have been applied, entirely without
+   * blocking the fork-choice thread. FCR is defined from the post-deferred-attestation head at slot
+   * start, so this composes {@code processHead} onto the deferred-attestation future rather than
+   * joining it. Everything after the head snapshot (epoch-boundary flags, greatest unrealized
+   * justified checkpoint, source states, and the confirmation computation) is handed to the fast
+   * confirmation runner via {@link FastConfirmationTracker#onSlot}.
+   */
+  public static void processForSlot(
+      final FastConfirmationTracker fastConfirmationTracker,
+      final UInt64 currentSlot,
+      final SafeFuture<Void> deferredAttestationsFuture,
+      final Function<UInt64, SafeFuture<Optional<ChainHead>>> processHead) {
+    deferredAttestationsFuture
+        .thenCompose(__ -> processHead.apply(currentSlot))
+        .thenCompose(
+            maybeHead ->
+                maybeHead
+                    .map(head -> fastConfirmationTracker.onSlot(currentSlot, head.getRoot()))
+                    .orElse(SafeFuture.COMPLETE))
+        .finish(error -> LOG.error("Fast confirmation update failed", error));
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -65,8 +65,10 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
@@ -82,6 +84,7 @@ import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestat
 import tech.pegasys.teku.spec.datastructures.epbs.versions.gloas.PayloadAttestationData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoicePayloadStatus;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -114,6 +117,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice.OptimisticHeadSubscriber;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
+import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationEventChannel;
+import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
 import tech.pegasys.teku.statetransition.payloadattestation.ValidatablePayloadAttestationMessage;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
@@ -192,6 +197,7 @@ class ForkChoiceTest {
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
+            FastConfirmationTracker.NOOP,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             LateBlockReorgPreparationHandler.NOOP,
             debugDataDumper,
@@ -221,6 +227,52 @@ class ForkChoiceTest {
       final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecars(2);
       setBlobSidecarsAvailabilityResult(DataAndValidationResult.validResult(blobSidecars));
     }
+  }
+
+  @Test
+  void shouldNotInitializeFastConfirmationStoreWhenDisabled() {
+    assertThat(forkChoice.isFastConfirmationEnabled()).isFalse();
+    assertThat(forkChoice.getFastConfirmationStore()).isEmpty();
+  }
+
+  @Test
+  void shouldInitializeFastConfirmationStoreWhenEnabled() {
+    recreateForkChoice(true, LateBlockReorgPreparationHandler.NOOP);
+
+    final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
+    final FastConfirmationStore fastConfirmationStore =
+        forkChoice.getFastConfirmationStore().orElseThrow();
+    assertThat(forkChoice.isFastConfirmationEnabled()).isTrue();
+    assertThat(fastConfirmationStore.store()).isSameAs(recentChainData.getStore());
+    assertThat(fastConfirmationStore.confirmedRoot()).isEqualTo(finalizedCheckpoint.getRoot());
+    assertThat(fastConfirmationStore.previousEpochObservedJustifiedCheckpoint())
+        .isEqualTo(finalizedCheckpoint);
+    assertThat(fastConfirmationStore.currentEpochObservedJustifiedCheckpoint())
+        .isEqualTo(finalizedCheckpoint);
+    assertThat(fastConfirmationStore.previousEpochGreatestUnrealizedCheckpoint())
+        .isEqualTo(finalizedCheckpoint);
+    assertThat(fastConfirmationStore.previousSlotHead()).isEqualTo(finalizedCheckpoint.getRoot());
+    assertThat(fastConfirmationStore.currentSlotHead()).isEqualTo(finalizedCheckpoint.getRoot());
+  }
+
+  @Test
+  void shouldScheduleFastConfirmationUpdateOnSlotTickWhenEnabled() {
+    final StubAsyncRunner fastConfirmationAsyncRunner = new StubAsyncRunner();
+    recreateForkChoice(
+        FastConfirmationTracker.create(
+            spec,
+            Optional.of(fastConfirmationAsyncRunner),
+            FastConfirmationEventChannel.NOOP,
+            metricsSystem,
+            StubTimeProvider.withTimeInMillis(0)),
+        LateBlockReorgPreparationHandler.NOOP);
+    final UInt64 nextSlot = recentChainData.getCurrentSlot().orElseThrow().plus(ONE);
+
+    forkChoice.onTick(
+        spec.computeTimeMillisAtSlot(nextSlot, recentChainData.getGenesisTimeMillis()),
+        Optional.empty());
+
+    assertThat(fastConfirmationAsyncRunner.countDelayedActions()).isOne();
   }
 
   @Test
@@ -469,6 +521,7 @@ class ForkChoiceTest {
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
+            FastConfirmationTracker.NOOP,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             LateBlockReorgPreparationHandler.NOOP,
             DebugDataDumper.NOOP,
@@ -1116,6 +1169,7 @@ class ForkChoiceTest {
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
+            FastConfirmationTracker.NOOP,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             LateBlockReorgPreparationHandler.NOOP,
             debugDataDumper,
@@ -1160,6 +1214,7 @@ class ForkChoiceTest {
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
+            FastConfirmationTracker.NOOP,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             LateBlockReorgPreparationHandler.NOOP,
             debugDataDumper,
@@ -1888,6 +1943,27 @@ class ForkChoiceTest {
 
   private void recreateForkChoice(
       final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler) {
+    recreateForkChoice(false, lateBlockReorgPreparationHandler);
+  }
+
+  private void recreateForkChoice(
+      final boolean fastConfirmationEnabled,
+      final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler) {
+    final FastConfirmationTracker fastConfirmationTracker =
+        fastConfirmationEnabled
+            ? FastConfirmationTracker.create(
+                spec,
+                Optional.empty(),
+                FastConfirmationEventChannel.NOOP,
+                metricsSystem,
+                StubTimeProvider.withTimeInMillis(0))
+            : FastConfirmationTracker.NOOP;
+    recreateForkChoice(fastConfirmationTracker, lateBlockReorgPreparationHandler);
+  }
+
+  private void recreateForkChoice(
+      final FastConfirmationTracker fastConfirmationTracker,
+      final LateBlockReorgPreparationHandler lateBlockReorgPreparationHandler) {
     forkChoice =
         new ForkChoice(
             spec,
@@ -1897,6 +1973,7 @@ class ForkChoiceTest {
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
+            fastConfirmationTracker,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             lateBlockReorgPreparationHandler,
             debugDataDumper,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoaderTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoaderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+class FastConfirmationStateLoaderTest {
+
+  private final ReadOnlyStore store = mock(ReadOnlyStore.class);
+  private final Checkpoint previousObserved = new Checkpoint(UInt64.valueOf(1), Bytes32.random());
+  private final Checkpoint currentObserved = new Checkpoint(UInt64.valueOf(2), Bytes32.random());
+  private final Bytes32 head = Bytes32.random();
+
+  private final BeaconState previousState = mock(BeaconState.class);
+  private final BeaconState currentState = mock(BeaconState.class);
+  private final BeaconState headState = mock(BeaconState.class);
+
+  private final FastConfirmationStore fcrStore =
+      new FastConfirmationStore(
+          store,
+          Bytes32.random(),
+          previousObserved,
+          currentObserved,
+          previousObserved,
+          Bytes32.random(),
+          head);
+
+  @Test
+  void shouldLoadAllSourceStatesAtEpochStart() {
+    stubCheckpointState(previousObserved, Optional.of(previousState));
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.of(headState));
+
+    final FastConfirmationStates states = load(true).join().orElseThrow();
+
+    assertThat(states.previousBalanceSource()).contains(previousState);
+    assertThat(states.currentBalanceSource()).isSameAs(currentState);
+    assertThat(states.headBlockState()).isSameAs(headState);
+  }
+
+  @Test
+  void shouldSkipPreviousBalanceSourceWhenNotAtEpochStart() {
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.of(headState));
+
+    final FastConfirmationStates states = load(false).join().orElseThrow();
+
+    assertThat(states.previousBalanceSource()).isEmpty();
+    assertThat(states.currentBalanceSource()).isSameAs(currentState);
+    assertThat(states.headBlockState()).isSameAs(headState);
+    // The previous epoch's checkpoint state must not be fetched off epoch-start slots.
+    verify(store, never()).retrieveCheckpointState(previousObserved);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHeadStateUnavailable() {
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.empty());
+
+    assertThat(load(false).join()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenCurrentBalanceSourceUnavailable() {
+    stubCheckpointState(currentObserved, Optional.empty());
+    stubHeadState(Optional.of(headState));
+
+    assertThat(load(false).join()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenPreviousBalanceSourceUnavailableAtEpochStart() {
+    stubCheckpointState(previousObserved, Optional.empty());
+    stubCheckpointState(currentObserved, Optional.of(currentState));
+    stubHeadState(Optional.of(headState));
+
+    assertThat(load(true).join()).isEmpty();
+  }
+
+  private SafeFuture<Optional<FastConfirmationStates>> load(
+      final boolean includePreviousBalanceSource) {
+    final SafeFuture<Optional<FastConfirmationStates>> result =
+        FastConfirmationStateLoader.load(fcrStore, head, includePreviousBalanceSource);
+    assertThatSafeFuture(result).isCompleted();
+    return result;
+  }
+
+  private void stubCheckpointState(final Checkpoint checkpoint, final Optional<BeaconState> state) {
+    when(store.retrieveCheckpointState(checkpoint)).thenReturn(SafeFuture.completedFuture(state));
+  }
+
+  private void stubHeadState(final Optional<BeaconState> state) {
+    when(store.retrieveBlockState(head)).thenReturn(SafeFuture.completedFuture(state));
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationTrackerTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice.fastconfirmation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.forkchoice.FastConfirmationStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ForkChoiceNode;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+
+class FastConfirmationTrackerTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final ReadOnlyStore store = mock(ReadOnlyStore.class);
+  private final ReadOnlyForkChoiceStrategy forkChoice = mock(ReadOnlyForkChoiceStrategy.class);
+  private final FastConfirmationEventChannel eventChannel =
+      mock(FastConfirmationEventChannel.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInMillis(0);
+  private final Checkpoint finalizedCheckpoint =
+      new Checkpoint(UInt64.valueOf(12), Bytes32.random());
+
+  @BeforeEach
+  void setUp() {
+    // No source states available: get_latest_confirmed is skipped and the confirmed root is left
+    // unchanged, so these tests exercise only update_fast_confirmation_variables and the guard.
+    when(store.retrieveCheckpointState(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    when(store.retrieveBlockState(any(Bytes32.class)))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+    // Used by the fast_confirmation event to resolve the confirmed block's slot.
+    when(store.getForkChoiceStrategy()).thenReturn(forkChoice);
+    when(forkChoice.blockSlot(any())).thenReturn(Optional.of(finalizedCheckpoint.getEpoch()));
+  }
+
+  @Test
+  void shouldNotInitializeStoreWhenDisabled() {
+    final FastConfirmationTracker tracker = FastConfirmationTracker.NOOP;
+
+    tracker.initialize(store);
+
+    assertThat(tracker.isEnabled()).isFalse();
+    assertThat(tracker.getFastConfirmationStore()).isEmpty();
+  }
+
+  @Test
+  void shouldInitializeStoreFromFinalizedCheckpointWhenEnabled() {
+    when(store.getFinalizedCheckpoint()).thenReturn(finalizedCheckpoint);
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.empty(), eventChannel, metricsSystem, timeProvider);
+
+    tracker.initialize(store);
+
+    final FastConfirmationStore fastConfirmationStore =
+        tracker.getFastConfirmationStore().orElseThrow();
+    assertThat(tracker.isEnabled()).isTrue();
+    assertThat(fastConfirmationStore.store()).isSameAs(store);
+    assertThat(fastConfirmationStore.confirmedRoot()).isEqualTo(finalizedCheckpoint.getRoot());
+    assertThat(fastConfirmationStore.previousEpochObservedJustifiedCheckpoint())
+        .isEqualTo(finalizedCheckpoint);
+    assertThat(fastConfirmationStore.currentEpochObservedJustifiedCheckpoint())
+        .isEqualTo(finalizedCheckpoint);
+    assertThat(fastConfirmationStore.previousEpochGreatestUnrealizedCheckpoint())
+        .isEqualTo(finalizedCheckpoint);
+    assertThat(fastConfirmationStore.previousSlotHead()).isEqualTo(finalizedCheckpoint.getRoot());
+    assertThat(fastConfirmationStore.currentSlotHead()).isEqualTo(finalizedCheckpoint.getRoot());
+  }
+
+  @Test
+  void shouldNotScheduleUpdateWhenDisabled() {
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+    final FastConfirmationTracker tracker = FastConfirmationTracker.NOOP;
+
+    final SafeFuture<Void> result = tracker.onSlot(UInt64.valueOf(13), Bytes32.random());
+
+    assertThatSafeFuture(result).isCompleted();
+    assertThat(asyncRunner.countDelayedActions()).isZero();
+  }
+
+  @Test
+  void shouldScheduleUpdateOnAsyncRunnerWhenEnabledAndInitialized() {
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+    when(store.getFinalizedCheckpoint()).thenReturn(finalizedCheckpoint);
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.of(asyncRunner), eventChannel, metricsSystem, timeProvider);
+    tracker.initialize(store);
+    final Bytes32 headRoot = Bytes32.random();
+
+    // Slot 13 is a mid-epoch slot (minimal SLOTS_PER_EPOCH == 8), so only the slot heads rotate.
+    final SafeFuture<Void> result = tracker.onSlot(UInt64.valueOf(13), headRoot);
+
+    assertThat(result).isNotDone();
+    assertThat(asyncRunner.countDelayedActions()).isOne();
+
+    asyncRunner.executeQueuedActions();
+
+    assertThatSafeFuture(result).isCompleted();
+    final FastConfirmationStore fastConfirmationStore =
+        tracker.getFastConfirmationStore().orElseThrow();
+    assertThat(fastConfirmationStore.previousSlotHead()).isEqualTo(finalizedCheckpoint.getRoot());
+    assertThat(fastConfirmationStore.currentSlotHead()).isEqualTo(headRoot);
+  }
+
+  @Test
+  void shouldSkipUpdateEntirelyWhenHeadIsStale() {
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+    when(store.getFinalizedCheckpoint()).thenReturn(finalizedCheckpoint);
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.of(asyncRunner), eventChannel, metricsSystem, timeProvider);
+    tracker.initialize(store);
+    final Bytes32 headRoot = Bytes32.random();
+
+    // The head block slot is stubbed at 12 (epoch 1, minimal SLOTS_PER_EPOCH == 8). Slot 24 is
+    // epoch 3, so the head is two epochs behind: get_latest_confirmed could only revert to
+    // finalized, so the whole update is skipped this slot.
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(24), headRoot);
+
+    final FastConfirmationStore fastConfirmationStore =
+        tracker.getFastConfirmationStore().orElseThrow();
+    // Nothing happens: the store is untouched (confirmed root and slot heads at their initial
+    // values), no source states are loaded, no event is emitted, and no fallback is counted.
+    assertThat(fastConfirmationStore.confirmedRoot()).isEqualTo(finalizedCheckpoint.getRoot());
+    assertThat(fastConfirmationStore.currentSlotHead()).isEqualTo(finalizedCheckpoint.getRoot());
+    verify(store, never()).retrieveCheckpointState(any());
+    verify(store, never()).retrieveBlockState(any(Bytes32.class));
+    verify(eventChannel, never()).onFastConfirmation(any(), any(), any());
+    assertThat(
+            metricsSystem.getCounterValue(
+                TekuMetricCategory.BEACON, "fast_confirmation_fallbacks_total"))
+        .isZero();
+  }
+
+  @Test
+  void shouldRunFullConfirmationWhenHeadIsWithinOneEpoch() {
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+    when(store.getFinalizedCheckpoint()).thenReturn(finalizedCheckpoint);
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.of(asyncRunner), eventChannel, metricsSystem, timeProvider);
+    tracker.initialize(store);
+
+    // Head block slot 12 (epoch 1); slot 17 is epoch 2 — one epoch behind, which is tolerated, so
+    // the full rule runs and the source states are loaded (here empty, so it falls back).
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(17), Bytes32.random());
+
+    verify(store, atLeastOnce()).retrieveCheckpointState(any());
+    verify(eventChannel).onFastConfirmation(any(), any(), any());
+  }
+
+  @Test
+  void shouldEmitFastConfirmationEventWhenAlgorithmRuns() {
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+    when(store.getFinalizedCheckpoint()).thenReturn(finalizedCheckpoint);
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.of(asyncRunner), eventChannel, metricsSystem, timeProvider);
+    tracker.initialize(store);
+
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(13), Bytes32.random());
+
+    // Emitted with the confirmed root (still the finalized root, as no source states are loaded),
+    // the confirmed block's slot, and the wall-clock slot the algorithm ran at.
+    verify(eventChannel)
+        .onFastConfirmation(
+            finalizedCheckpoint.getRoot(), finalizedCheckpoint.getEpoch(), UInt64.valueOf(13));
+    // The timeout counter is registered and unaffected by a normal (non-timed-out) run.
+    assertThat(
+            metricsSystem.getCounterValue(
+                TekuMetricCategory.BEACON, "fast_confirmation_timeout_total"))
+        .isZero();
+  }
+
+  @Test
+  void shouldIncrementFallbackCounterWhenStatesAreUnavailable() {
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+    when(store.getFinalizedCheckpoint()).thenReturn(finalizedCheckpoint);
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.of(asyncRunner), eventChannel, metricsSystem, timeProvider);
+    tracker.initialize(store);
+
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(13), Bytes32.random());
+
+    assertThat(
+            metricsSystem.getCounterValue(
+                TekuMetricCategory.BEACON, "fast_confirmation_fallbacks_total"))
+        .isEqualTo(1);
+    assertThat(
+            metricsSystem.getCounterValue(
+                TekuMetricCategory.BEACON, "fast_confirmation_restarts_total"))
+        .isZero();
+  }
+
+  @Test
+  void shouldIncrementRestartCounterForObservedJustifiedRoot() {
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.empty(), eventChannel, metricsSystem, timeProvider);
+    final Bytes32 observedJustifiedRoot = Bytes32.random();
+    final Checkpoint observedJustifiedCheckpoint =
+        new Checkpoint(UInt64.valueOf(13), observedJustifiedRoot);
+    final FastConfirmationStore fastConfirmationStore =
+        new FastConfirmationStore(
+            store,
+            finalizedCheckpoint.getRoot(),
+            finalizedCheckpoint,
+            observedJustifiedCheckpoint,
+            finalizedCheckpoint,
+            finalizedCheckpoint.getRoot(),
+            finalizedCheckpoint.getRoot());
+
+    tracker.recordConfirmationOutcome(
+        fastConfirmationStore, observedJustifiedRoot, finalizedCheckpoint.getRoot());
+
+    assertThat(
+            metricsSystem.getCounterValue(
+                TekuMetricCategory.BEACON, "fast_confirmation_restarts_total"))
+        .isEqualTo(1);
+    assertThat(
+            metricsSystem.getCounterValue(
+                TekuMetricCategory.BEACON, "fast_confirmation_fallbacks_total"))
+        .isZero();
+  }
+
+  @Test
+  void shouldSkipStaleOrDuplicateSlotUpdates() {
+    final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+    when(store.getFinalizedCheckpoint()).thenReturn(finalizedCheckpoint);
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.of(asyncRunner), eventChannel, metricsSystem, timeProvider);
+    tracker.initialize(store);
+
+    final Bytes32 headA = Bytes32.random();
+    final Bytes32 headB = Bytes32.random();
+    final Bytes32 headC = Bytes32.random();
+
+    // Slot 13: rotates current -> previous, sets current = headA
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(13), headA);
+    assertThat(currentSlotHead(tracker)).isEqualTo(headA);
+    assertThat(previousSlotHead(tracker)).isEqualTo(finalizedCheckpoint.getRoot());
+
+    // Slot 14: rotates again, previous = headA, current = headB
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(14), headB);
+    assertThat(currentSlotHead(tracker)).isEqualTo(headB);
+    assertThat(previousSlotHead(tracker)).isEqualTo(headA);
+
+    // Duplicate slot 14 must be ignored (no second rotation)
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(14), headC);
+    assertThat(currentSlotHead(tracker)).isEqualTo(headB);
+    assertThat(previousSlotHead(tracker)).isEqualTo(headA);
+
+    // Older slot 13 must be ignored as well
+    applyUpdate(tracker, asyncRunner, UInt64.valueOf(13), headC);
+    assertThat(currentSlotHead(tracker)).isEqualTo(headB);
+    assertThat(previousSlotHead(tracker)).isEqualTo(headA);
+  }
+
+  @Test
+  void shouldCompareGloasConfirmedRootsAsPendingNodes() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            gloasSpec, Optional.empty(), eventChannel, metricsSystem, timeProvider);
+    final Bytes32 previousConfirmedRoot = Bytes32.random();
+    final Bytes32 confirmedRoot = Bytes32.random();
+    final UInt64 previousConfirmedSlot = UInt64.valueOf(4);
+    final UInt64 currentSlot = UInt64.valueOf(6);
+    when(forkChoice.blockSlot(previousConfirmedRoot))
+        .thenReturn(Optional.of(previousConfirmedSlot));
+    when(forkChoice.getAncestorNode(
+            ForkChoiceNode.createBase(confirmedRoot), previousConfirmedSlot))
+        .thenReturn(Optional.of(ForkChoiceNode.createBase(previousConfirmedRoot)));
+
+    assertThat(
+            tracker.isConfirmedRootReorg(
+                currentSlot, forkChoice, previousConfirmedRoot, confirmedRoot))
+        .isFalse();
+    verify(forkChoice)
+        .getAncestorNode(ForkChoiceNode.createBase(confirmedRoot), previousConfirmedSlot);
+  }
+
+  @Test
+  void shouldReportConfirmedRootReorgWhenRootsAreOnDifferentChains() {
+    final FastConfirmationTracker tracker =
+        FastConfirmationTracker.create(
+            spec, Optional.empty(), eventChannel, metricsSystem, timeProvider);
+    final Bytes32 previousConfirmedRoot = Bytes32.random();
+    final Bytes32 confirmedRoot = Bytes32.random();
+    when(forkChoice.blockSlot(previousConfirmedRoot)).thenReturn(Optional.of(UInt64.valueOf(4)));
+    when(forkChoice.blockSlot(confirmedRoot)).thenReturn(Optional.of(UInt64.valueOf(5)));
+
+    assertThat(
+            tracker.isConfirmedRootReorg(
+                UInt64.valueOf(6), forkChoice, previousConfirmedRoot, confirmedRoot))
+        .isTrue();
+  }
+
+  private void applyUpdate(
+      final FastConfirmationTracker tracker,
+      final StubAsyncRunner asyncRunner,
+      final UInt64 slot,
+      final Bytes32 headRoot) {
+    final SafeFuture<Void> result = tracker.onSlot(slot, headRoot);
+    asyncRunner.executeQueuedActions();
+    assertThatSafeFuture(result).isCompleted();
+  }
+
+  private Bytes32 currentSlotHead(final FastConfirmationTracker tracker) {
+    return tracker.getFastConfirmationStore().orElseThrow().currentSlotHead();
+  }
+
+  private Bytes32 previousSlotHead(final FastConfirmationTracker tracker) {
+    return tracker.getFastConfirmationStore().orElseThrow().previousSlotHead();
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
+import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
 import tech.pegasys.teku.statetransition.util.DebugDataDumper;
 import tech.pegasys.teku.statetransition.validation.BlockGossipValidator.EquivocationCheckResult;
 import tech.pegasys.teku.storage.api.LateBlockReorgPreparationHandler;
@@ -109,6 +110,7 @@ public class BlockGossipValidatorTest {
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             mock(MergeTransitionBlockValidator.class),
+            FastConfirmationTracker.NOOP,
             DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED,
             LateBlockReorgPreparationHandler.NOOP,
             mock(DebugDataDumper.class),

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -229,6 +229,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.forkchoice.TerminalPowBlockMonitor;
 import tech.pegasys.teku.statetransition.forkchoice.TickProcessingPerformance;
 import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
+import tech.pegasys.teku.statetransition.forkchoice.fastconfirmation.FastConfirmationTracker;
 import tech.pegasys.teku.statetransition.payloadattestation.AggregatingPayloadAttestationPool;
 import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationMessageGossipValidator;
 import tech.pegasys.teku.statetransition.payloadattestation.PayloadAttestationPool;
@@ -352,6 +353,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   private final AsyncRunner operationPoolAsyncRunner;
   private final AsyncRunner dasAsyncRunner;
+  private final FastConfirmationTracker fastConfirmationTracker;
   protected final AtomicReference<DataColumnSidecarRecoveringCustody> dataColumnSidecarCustodyRef =
       new AtomicReference<>(DataColumnSidecarRecoveringCustody.NOOP);
 
@@ -468,6 +470,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     // larger default size. das runner should be separate to the operation pool runner as it's a
     // bunch of tasks, not just operation pool activities
     this.dasAsyncRunner = serviceConfig.createAsyncRunner("das", 4, 20_000);
+    this.fastConfirmationTracker = FastConfirmationTracker.NOOP;
     this.timeProvider = serviceConfig.getTimeProvider();
     this.eventChannels = serviceConfig.getEventChannels();
     this.metricsSystem = serviceConfig.getMetricsSystem();
@@ -1660,6 +1663,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             forkChoiceStateProvider,
             new TickProcessor(spec, recentChainData),
             new MergeTransitionBlockValidator(spec, recentChainData),
+            fastConfirmationTracker,
             beaconConfig.eth2NetworkConfig().isForkChoiceLateBlockReorgEnabled(),
             (slot, blockRoot) ->
                 beaconAsyncRunner.runAsync(

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -137,12 +137,6 @@ specrefs:
       - upgrade_lc_store_to_gloas#gloas
       - upgrade_lc_update_to_gloas#gloas
 
-      # Not implemented: fast confirmation
-      - get_current_balance_source#phase0
-      - get_previous_balance_source#phase0
-      - on_fast_confirmation#phase0
-      - get_safe_execution_block_hash#bellatrix
-      - get_safe_execution_block_hash#gloas
 
       # Not implemented: fulu
       - verify_partial_data_column_header_inclusion_proof#fulu

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3346,7 +3346,9 @@
     </spec>
 
 - name: get_current_balance_source#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
+      search: store.retrieveCheckpointState(fcrStore.currentEpochObservedJustifiedCheckpoint())
   spec: |
     <spec fn="get_current_balance_source" fork="phase0" hash="75c0851b">
     def get_current_balance_source(fcr_store: FastConfirmationStore) -> BeaconState:
@@ -5100,7 +5102,9 @@
     </spec>
 
 - name: get_previous_balance_source#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationStateLoader.java
+      search: store.retrieveCheckpointState(fcrStore.previousEpochObservedJustifiedCheckpoint())
   spec: |
     <spec fn="get_previous_balance_source" fork="phase0" hash="18421690">
     def get_previous_balance_source(fcr_store: FastConfirmationStore) -> BeaconState:
@@ -5350,6 +5354,29 @@
         Return the randao mix at a recent ``epoch``.
         """
         return state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
+    </spec>
+
+- name: get_safe_execution_block_hash#bellatrix
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: final Bytes32 safeExecutionHash
+  spec: |
+    <spec fn="get_safe_execution_block_hash" fork="bellatrix" hash="ccd5f801">
+    def get_safe_execution_block_hash(fcr_store: FastConfirmationStore) -> Hash32:
+        safe_block = fcr_store.store.blocks[fcr_store.confirmed_root]
+        return safe_block.body.execution_payload.block_hash
+    </spec>
+
+- name: get_safe_execution_block_hash#gloas
+  sources:
+    - file: storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+      search: final Bytes32 safeExecutionHash
+  spec: |
+    <spec fn="get_safe_execution_block_hash" fork="gloas" hash="4884e9d5">
+    def get_safe_execution_block_hash(fcr_store: FastConfirmationStore) -> Hash32:
+        safe_block = fcr_store.store.blocks[fcr_store.confirmed_root]
+        # [Modified in Gloas:EIP7732]
+        return safe_block.body.signed_execution_payload_bid.message.parent_block_hash
     </spec>
 
 - name: get_safety_threshold#altair
@@ -8398,7 +8425,9 @@
     </spec>
 
 - name: on_fast_confirmation#phase0
-  sources: []
+  sources:
+    - file: ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/fastconfirmation/FastConfirmationTracker.java
+      search: private void runFastConfirmation(
   spec: |
     <spec fn="on_fast_confirmation" fork="phase0" hash="f1f1a4c3">
     def on_fast_confirmation(fcr_store: FastConfirmationStore) -> None:

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -250,7 +250,8 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       final Optional<ChainHead> proposingOnHead,
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
-      final Checkpoint finalizedCheckpoint) {
+      final Checkpoint finalizedCheckpoint,
+      final Optional<Bytes32> fastConfirmationSafeBlockRoot) {
     protoArrayLock.readLock().lock();
     try {
       final ProtoNode headNode =
@@ -269,8 +270,16 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
       // Pre-Gloas has only BASE, so this is the normal execution payload block hash.
       // In Gloas, BASE/EMPTY carry the effective EL parent hash from the bid
       // parent_block_hash; FULL carries the revealed payload hash for the selected head.
+      //
+      // safe_block_hash implements get_safe_execution_block_hash(fcr_store): when fast
+      // confirmation is enabled it is the confirmed block's hash, otherwise the justified block's
+      // hash (the pre-fast-confirmation default). The BASE-node hash already matches the spec per
+      // fork: pre-Gloas the confirmed block's execution_payload.block_hash, in Gloas its
+      // signed_execution_payload_bid.message.parent_block_hash.
       final Bytes32 safeExecutionHash =
-          getBaseNodeData(justifiedCheckpoint.getRoot())
+          fastConfirmationSafeBlockRoot
+              .flatMap(this::getBaseNodeData)
+              .or(() -> getBaseNodeData(justifiedCheckpoint.getRoot()))
               .map(ProtoNodeData::getExecutionBlockHash)
               .orElse(Bytes32.ZERO);
       final Bytes32 finalizedExecutionHash =

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -208,6 +208,21 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
   }
 
   @Test
+  void getSupportedNode_shouldResolveGloasVoteVariant() {
+    final GloasPayloadDecisionFixture fixture = createGloasPayloadDecisionFixture();
+    final Bytes32 blockRoot = fixture.block().getRoot();
+    final UInt64 blockSlot = fixture.block().getSlot();
+    final UInt64 laterSlot = blockSlot.plus(ONE);
+
+    assertThat(fixture.strategy().getSupportedNode(laterSlot, blockRoot, blockSlot, true))
+        .contains(ForkChoiceNode.createBase(blockRoot));
+    assertThat(fixture.strategy().getSupportedNode(laterSlot, blockRoot, laterSlot, false))
+        .contains(ForkChoiceNode.createEmpty(blockRoot));
+    assertThat(fixture.strategy().getSupportedNode(laterSlot, blockRoot, laterSlot, true))
+        .contains(ForkChoiceNode.createFull(blockRoot));
+  }
+
+  @Test
   void shouldBuildOnFull_shouldReturnFalseWhenPtcVotesPayloadUntimely() {
     final GloasPayloadDecisionFixture fixture = createGloasPayloadDecisionFixture();
     final Bytes32 blockRoot = fixture.block().getRoot();
@@ -1110,7 +1125,8 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             Optional.empty(),
             recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
-            recentChainData.getFinalizedCheckpoint().orElseThrow());
+            recentChainData.getFinalizedCheckpoint().orElseThrow(),
+            Optional.empty());
 
     // Should have reverted to the justified checkpoint as head
     assertThat(forkChoiceState.headBlock().blockRoot()).isEqualTo(currentJustified.getRoot());
@@ -1141,7 +1157,11 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         fixture
             .strategy()
             .getForkChoiceState(
-                Optional.of(proposingHead), currentEpoch, justifiedCheckpoint, finalizedCheckpoint);
+                Optional.of(proposingHead),
+                currentEpoch,
+                justifiedCheckpoint,
+                finalizedCheckpoint,
+                Optional.empty());
 
     assertThat(proposingForkChoiceState.headBlock())
         .isEqualTo(ForkChoiceNode.createFull(fixture.block1().getRoot()));
@@ -1181,11 +1201,87 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
                 Optional.empty(),
                 fixture.spec().computeEpochAtSlot(fixture.child().getSlot()),
                 justifiedCheckpoint,
-                fixture.finalizedCheckpoint());
+                fixture.finalizedCheckpoint(),
+                Optional.empty());
 
     assertThat(boundaryBidParentBlockHash).isNotEqualTo(boundaryPayloadBlockHash);
     assertThat(forkChoiceState.safeExecutionBlockHash()).isEqualTo(boundaryBidParentBlockHash);
     assertThat(forkChoiceState.finalizedExecutionBlockHash()).isEqualTo(boundaryBidParentBlockHash);
+  }
+
+  @Test
+  void getForkChoiceState_shouldUseFastConfirmationConfirmedRootForSafeBlockHash() {
+    final GloasBoundaryFixture fixture = createGloasBoundaryFixture();
+    fixture
+        .strategy()
+        .applyUpdate(
+            List.of(
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.boundary()),
+                BlockAndCheckpoints.fromBlockAndState(fixture.spec(), fixture.child())),
+            Map.of(fixture.boundary().getRoot(), fixture.boundaryExecutionPayload()),
+            emptySet(),
+            emptyMap(),
+            fixture.finalizedCheckpoint(),
+            Optional.of(fixture.boundaryBlockAndCheckpoints()));
+
+    final Checkpoint justifiedCheckpoint = fixture.finalizedCheckpoint();
+    final UInt64 currentEpoch = fixture.spec().computeEpochAtSlot(fixture.child().getSlot());
+
+    // BASE-node execution hash is the get_safe_execution_block_hash source; boundary and child
+    // carry distinct hashes (in Gloas each is the block's bid parent_block_hash).
+    final Bytes32 boundarySafeHash =
+        fixture
+            .strategy()
+            .getBlockData(fixture.boundary().getRoot())
+            .orElseThrow()
+            .getExecutionBlockHash();
+    final Bytes32 childSafeHash =
+        fixture
+            .strategy()
+            .getBlockData(fixture.child().getRoot())
+            .orElseThrow()
+            .getExecutionBlockHash();
+    assertThat(childSafeHash).isNotEqualTo(boundarySafeHash);
+
+    // Fast confirmation disabled (no confirmed root): safe hash comes from the justified block.
+    assertThat(
+            fixture
+                .strategy()
+                .getForkChoiceState(
+                    Optional.empty(),
+                    currentEpoch,
+                    justifiedCheckpoint,
+                    fixture.finalizedCheckpoint(),
+                    Optional.empty())
+                .safeExecutionBlockHash())
+        .isEqualTo(boundarySafeHash);
+
+    // Fast confirmation confirming the child: safe hash is get_safe_execution_block_hash of the
+    // confirmed (child) block instead of the justified block.
+    assertThat(
+            fixture
+                .strategy()
+                .getForkChoiceState(
+                    Optional.empty(),
+                    currentEpoch,
+                    justifiedCheckpoint,
+                    fixture.finalizedCheckpoint(),
+                    Optional.of(fixture.child().getRoot()))
+                .safeExecutionBlockHash())
+        .isEqualTo(childSafeHash);
+
+    // If the supplied confirmed root is no longer in protoarray, use the justified block.
+    assertThat(
+            fixture
+                .strategy()
+                .getForkChoiceState(
+                    Optional.empty(),
+                    currentEpoch,
+                    justifiedCheckpoint,
+                    fixture.finalizedCheckpoint(),
+                    Optional.of(Bytes32.random()))
+                .safeExecutionBlockHash())
+        .isEqualTo(boundarySafeHash);
   }
 
   private StorageSystem initStorageSystem() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreBuilderTest.java
@@ -162,7 +162,8 @@ class StoreBuilderTest {
                 Optional.empty(),
                 finalizedCheckpoint.getEpoch(),
                 finalizedCheckpoint,
-                finalizedCheckpoint);
+                finalizedCheckpoint,
+                Optional.empty());
 
     assertThat(forkChoiceState.safeExecutionBlockHash()).isEqualTo(latestBid.getParentBlockHash());
     assertThat(forkChoiceState.finalizedExecutionBlockHash())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Another part of #10948 

Slice of the fcr-yolo branch. Introduces the fast-confirmation subsystem under forkchoice/fastconfirmation/ (FastConfirmationTracker, StateLoader, Input,
  EventChannel, ForkChoiceFastConfirmation) and wires it through ForkChoice, ForkChoiceStateProvider, and BeaconChainController.

  When enabled, the confirmed root feeds the FCU safe_block_hash (get_safe_execution_block_hash) via ForkChoiceStrategy, and slot-start confirmation runs off the fork-choice
  thread. It is injected as FastConfirmationTracker.NOOP everywhere here, so behaviour is unchanged from master. Also exposes ForkChoiceUtil.isAncestor for attestation-support
  computation and updates specrefs. Covered by new FastConfirmationTracker/StateLoader/ForkChoice tests.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fork-choice tick timing and EL FCU safe-block sourcing, but the NOOP default and async/non-blocking design limit exposure until fast confirmation is explicitly turned on.
> 
> **Overview**
> Adds **fast confirmation** plumbing under `forkchoice/fastconfirmation/` and threads it through fork choice, FCU state, and beacon chain startup. Production still injects `FastConfirmationTracker.NOOP`, so runtime behavior matches master until a later slice enables it.
> 
> **Slot tick:** When the tracker is enabled, new-slot work chains deferred attestations → `processHead` → per-slot `onSlot` on a dedicated async runner (`ForkChoiceFastConfirmation`), without blocking the fork-choice thread. Store init now also initializes the FCR store before protoarray head setup.
> 
> **FCU safe hash:** `ForkChoiceStateProvider` can supply an optional confirmed block root; `ForkChoiceStrategy.getForkChoiceState` uses it for `safeExecutionBlockHash` (spec `get_safe_execution_block_hash`), falling back to the justified block when empty or unknown in protoarray.
> 
> **Tracker behavior (when enabled):** Maintains `FastConfirmationStore`, runs `update_fast_confirmation_variables` / `get_latest_confirmed` off-thread with async state loads, timeouts, stale-head skips, finalized fallbacks, metrics, and `FastConfirmationEventChannel` events. Uses `ForkChoiceUtil.isAncestor` for confirmed-root reorg detection (Gloas-aware via pending nodes).
> 
> **Docs/tests:** Shortens `isAncestor` javadoc; updates `specrefs` for FCR-related spec functions; adds unit tests for tracker, state loader, fork choice wiring, and FCU safe-hash selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b04fdfddfe5a532c2bde74c2ac61712369fa5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->