### PR TITLE
Fix fork choice equivocating votes update

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/VoteUpdates.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/VoteUpdates.java
@@ -14,11 +14,9 @@
 package tech.pegasys.teku.statetransition.attestation;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Collections.newSetFromMap;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
@@ -26,8 +24,16 @@ import tech.pegasys.teku.storage.protoarray.DeferredVotes;
 
 public class VoteUpdates implements DeferredVotes {
   private final UInt64 slot;
-  private final Map<BlockRootAndFullPayloadHint, Collection<UInt64>>
-      votingIndicesByBlockRootAndFullPayloadHint = new ConcurrentHashMap<>();
+
+  // Keyed by validator index so that each validator holds a single vote for the slot. A validator's
+  // first vote wins (putIfAbsent), mirroring the spec's update_latest_messages, which only
+  // overwrites a latest message when the new attestation's target epoch is strictly greater (a
+  // same-epoch vote never overwrites). This is why a validator that attests to two competing blocks
+  // in one slot (equivocation) is applied to its first-received vote rather than to whichever block
+  // root a root-keyed map happened to iterate first. A navigable map keeps iteration deterministic
+  // (ordered by validator index).
+  private final NavigableMap<UInt64, BlockRootAndFullPayloadHint> voteByValidatorIndex =
+      new ConcurrentSkipListMap<>();
 
   public VoteUpdates(final UInt64 slot) {
     this.slot = slot;
@@ -40,16 +46,13 @@ public class VoteUpdates implements DeferredVotes {
 
   @Override
   public void forEachDeferredVote(final DeferredVoteConsumer consumer) {
-    votingIndicesByBlockRootAndFullPayloadHint.forEach(
-        (key, indices) ->
-            indices.forEach(
-                validatorIndex ->
-                    consumer.accept(key.blockRoot(), validatorIndex, key.fullPayloadHint())));
+    voteByValidatorIndex.forEach(
+        (validatorIndex, vote) ->
+            consumer.accept(vote.blockRoot(), validatorIndex, vote.fullPayloadHint()));
   }
 
   public boolean isEmpty() {
-    return votingIndicesByBlockRootAndFullPayloadHint.values().stream()
-        .allMatch(Collection::isEmpty);
+    return voteByValidatorIndex.isEmpty();
   }
 
   public void addAttestation(
@@ -59,21 +62,15 @@ public class VoteUpdates implements DeferredVotes {
         "Attempting to store vote update for wrong slot. Expected %s but got %s",
         slot,
         attestation.data().getSlot());
-    final Bytes32 blockRoot = attestation.data().getBeaconBlockRoot();
-    votingIndicesByBlockRootAndFullPayloadHint
-        .computeIfAbsent(
-            new BlockRootAndFullPayloadHint(blockRoot, fullPayloadHint),
-            __ -> newSetFromMap(new ConcurrentHashMap<>()))
-        .addAll(attestation.attestingIndices());
+    final BlockRootAndFullPayloadHint vote =
+        new BlockRootAndFullPayloadHint(attestation.data().getBeaconBlockRoot(), fullPayloadHint);
+    attestation.attestingIndices().forEach(index -> voteByValidatorIndex.putIfAbsent(index, vote));
   }
 
   public void addVote(
       final Bytes32 blockRoot, final UInt64 validatorIndex, final boolean fullPayloadHint) {
-    votingIndicesByBlockRootAndFullPayloadHint
-        .computeIfAbsent(
-            new BlockRootAndFullPayloadHint(blockRoot, fullPayloadHint),
-            __ -> newSetFromMap(new ConcurrentHashMap<>()))
-        .add(validatorIndex);
+    voteByValidatorIndex.putIfAbsent(
+        validatorIndex, new BlockRootAndFullPayloadHint(blockRoot, fullPayloadHint));
   }
 
   private record BlockRootAndFullPayloadHint(Bytes32 blockRoot, boolean fullPayloadHint) {}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/VoteUpdates.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/VoteUpdates.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.statetransition.attestation;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.NavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
@@ -30,10 +30,9 @@ public class VoteUpdates implements DeferredVotes {
   // overwrites a latest message when the new attestation's target epoch is strictly greater (a
   // same-epoch vote never overwrites). This is why a validator that attests to two competing blocks
   // in one slot (equivocation) is applied to its first-received vote rather than to whichever block
-  // root a root-keyed map happened to iterate first. A navigable map keeps iteration deterministic
-  // (ordered by validator index).
-  private final NavigableMap<UInt64, BlockRootAndFullPayloadHint> voteByValidatorIndex =
-      new ConcurrentSkipListMap<>();
+  // root a root-keyed map happened to iterate first.
+  private final Map<UInt64, BlockRootAndFullPayloadHint> voteByValidatorIndex =
+      new ConcurrentHashMap<>();
 
   public VoteUpdates(final UInt64 slot) {
     this.slot = slot;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/VoteUpdates.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/VoteUpdates.java
@@ -22,15 +22,14 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
 import tech.pegasys.teku.storage.protoarray.DeferredVotes;
 
+/** Deferred votes for a single slot; See {@link DeferredAttestations} for usage */
 public class VoteUpdates implements DeferredVotes {
   private final UInt64 slot;
 
-  // Keyed by validator index so that each validator holds a single vote for the slot. A validator's
-  // first vote wins (putIfAbsent), mirroring the spec's update_latest_messages, which only
-  // overwrites a latest message when the new attestation's target epoch is strictly greater (a
-  // same-epoch vote never overwrites). This is why a validator that attests to two competing blocks
-  // in one slot (equivocation) is applied to its first-received vote rather than to whichever block
-  // root a root-keyed map happened to iterate first.
+  // Holds at most one vote per validator: the first one received wins. Deferred votes must be
+  // applied exactly as they would have been on arrival, and ForkChoiceUtil#shouldUpdateVote
+  // discards a validator's second vote within the same target epoch (within the same slot, under
+  // Gloas), so a validator equivocating in this slot must not have its later vote applied.
   private final Map<UInt64, BlockRootAndFullPayloadHint> voteByValidatorIndex =
       new ConcurrentHashMap<>();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/VoteUpdatesTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/VoteUpdatesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Consensys Software Inc., 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.attestation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class VoteUpdatesTest {
+
+  private static final Bytes32 BLOCK_A =
+      Bytes32.fromHexString("0x1111111111111111111111111111111111111111111111111111111111111111");
+  private static final Bytes32 BLOCK_B =
+      Bytes32.fromHexString("0x2222222222222222222222222222222222222222222222222222222222222222");
+
+  private final VoteUpdates voteUpdates = new VoteUpdates(UInt64.valueOf(16));
+
+  @Test
+  void keepsOnlyTheFirstVoteWhenAValidatorVotesTwoBlocksInTheSameSlot() {
+    // A validator equivocating within a slot: the first vote must win, matching the spec's
+    // update_latest_messages (a same-epoch vote never overwrites the latest message).
+    voteUpdates.addVote(BLOCK_A, UInt64.ZERO, false);
+    voteUpdates.addVote(BLOCK_B, UInt64.ZERO, false);
+
+    assertThat(collectVotes()).containsExactly(new Vote(BLOCK_A, UInt64.ZERO, false));
+  }
+
+  @Test
+  void keepsFirstVoteRegardlessOfWhichBlockIsSeenFirst() {
+    voteUpdates.addVote(BLOCK_B, UInt64.ZERO, false);
+    voteUpdates.addVote(BLOCK_A, UInt64.ZERO, false);
+
+    assertThat(collectVotes()).containsExactly(new Vote(BLOCK_B, UInt64.ZERO, false));
+  }
+
+  @Test
+  void recordsDistinctValidatorsVotingDifferentBlocks() {
+    voteUpdates.addVote(BLOCK_A, UInt64.ZERO, false);
+    voteUpdates.addVote(BLOCK_B, UInt64.ONE, false);
+
+    assertThat(collectVotes())
+        .containsExactlyInAnyOrder(
+            new Vote(BLOCK_A, UInt64.ZERO, false), new Vote(BLOCK_B, UInt64.ONE, false));
+  }
+
+  private List<Vote> collectVotes() {
+    final List<Vote> votes = new ArrayList<>();
+    voteUpdates.forEachDeferredVote(
+        (blockRoot, validatorIndex, fullPayloadHint) ->
+            votes.add(new Vote(blockRoot, validatorIndex, fullPayloadHint)));
+    return votes;
+  }
+
+  private record Vote(Bytes32 blockRoot, UInt64 validatorIndex, boolean fullPayloadHint) {}
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/VoteUpdatesTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/VoteUpdatesTest.java
@@ -94,15 +94,13 @@ class VoteUpdatesTest {
 
   @Test
   void rejectsAnAttestationFromADifferentSlot() {
-    final IndexedAttestationLight wrongSlot =
-        attestation(UInt64.valueOf(99), BLOCK_A, UInt64.ZERO);
+    final IndexedAttestationLight wrongSlot = attestation(UInt64.valueOf(99), BLOCK_A, UInt64.ZERO);
     assertThatThrownBy(() -> voteUpdates.addAttestation(wrongSlot, false))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("wrong slot");
   }
 
-  private IndexedAttestationLight attestation(
-      final Bytes32 blockRoot, final UInt64... indices) {
+  private IndexedAttestationLight attestation(final Bytes32 blockRoot, final UInt64... indices) {
     return attestation(SLOT, blockRoot, indices);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/VoteUpdatesTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/VoteUpdatesTest.java
@@ -14,21 +14,27 @@
 package tech.pegasys.teku.statetransition.attestation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestationLight;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 class VoteUpdatesTest {
 
+  private static final UInt64 SLOT = UInt64.valueOf(16);
   private static final Bytes32 BLOCK_A =
       Bytes32.fromHexString("0x1111111111111111111111111111111111111111111111111111111111111111");
   private static final Bytes32 BLOCK_B =
       Bytes32.fromHexString("0x2222222222222222222222222222222222222222222222222222222222222222");
 
-  private final VoteUpdates voteUpdates = new VoteUpdates(UInt64.valueOf(16));
+  private final VoteUpdates voteUpdates = new VoteUpdates(SLOT);
 
   @Test
   void keepsOnlyTheFirstVoteWhenAValidatorVotesTwoBlocksInTheSameSlot() {
@@ -56,6 +62,56 @@ class VoteUpdatesTest {
     assertThat(collectVotes())
         .containsExactlyInAnyOrder(
             new Vote(BLOCK_A, UInt64.ZERO, false), new Vote(BLOCK_B, UInt64.ONE, false));
+  }
+
+  @Test
+  void keepsFirstVoteWhenAValidatorEquivocatesAcrossTwoAttestations() {
+    // Validator 2 appears in both attestations; its first-seen vote (BLOCK_A) must win.
+    voteUpdates.addAttestation(attestation(BLOCK_A, UInt64.ONE, UInt64.valueOf(2)), false);
+    voteUpdates.addAttestation(attestation(BLOCK_B, UInt64.valueOf(2), UInt64.valueOf(3)), false);
+
+    assertThat(collectVotes())
+        .containsExactlyInAnyOrder(
+            new Vote(BLOCK_A, UInt64.ONE, false),
+            new Vote(BLOCK_A, UInt64.valueOf(2), false),
+            new Vote(BLOCK_B, UInt64.valueOf(3), false));
+  }
+
+  @Test
+  void keepsFirstVoteWhenTheSameBlockIsAttestedWithADifferentFullPayloadHint() {
+    voteUpdates.addVote(BLOCK_A, UInt64.ZERO, false);
+    voteUpdates.addVote(BLOCK_A, UInt64.ZERO, true);
+
+    assertThat(collectVotes()).containsExactly(new Vote(BLOCK_A, UInt64.ZERO, false));
+  }
+
+  @Test
+  void isEmptyUntilAVoteIsAdded() {
+    assertThat(voteUpdates.isEmpty()).isTrue();
+    voteUpdates.addVote(BLOCK_A, UInt64.ZERO, false);
+    assertThat(voteUpdates.isEmpty()).isFalse();
+  }
+
+  @Test
+  void rejectsAnAttestationFromADifferentSlot() {
+    final IndexedAttestationLight wrongSlot =
+        attestation(UInt64.valueOf(99), BLOCK_A, UInt64.ZERO);
+    assertThatThrownBy(() -> voteUpdates.addAttestation(wrongSlot, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("wrong slot");
+  }
+
+  private IndexedAttestationLight attestation(
+      final Bytes32 blockRoot, final UInt64... indices) {
+    return attestation(SLOT, blockRoot, indices);
+  }
+
+  private IndexedAttestationLight attestation(
+      final UInt64 slot, final Bytes32 blockRoot, final UInt64... indices) {
+    final Checkpoint checkpoint = new Checkpoint(UInt64.ZERO, Bytes32.ZERO);
+    final AttestationData data =
+        new AttestationData(slot, UInt64.ZERO, blockRoot, checkpoint, checkpoint);
+    return new IndexedAttestationLight(List.of(indices), data, BLSSignature.empty());
   }
 
   private List<Vote> collectVotes() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

  Re-key `VoteUpdates`'s deferred-vote store by validator index instead of by block root. Previously votes were grouped by block root, so when a validator equivocated (attested
  to two competing blocks in one slot), the winning vote depended on block-root map iteration order and the head could diverge non-deterministically.

  Now the first vote per validator wins (putIfAbsent), matching the spec's update_latest_messages (a same-epoch vote never overwrites the latest message), and a `NavigableMap`
  keeps iteration deterministic by validator index. Adds `VoteUpdatesTest`.



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how deferred attestations feed fork-choice vote updates; incorrect behavior could affect head selection under equivocation, but scope is localized with new unit tests.
> 
> **Overview**
> **`VoteUpdates` now stores at most one deferred vote per validator**, keyed by validator index instead of grouping validator indices by block root. **`addAttestation` and `addVote` use `putIfAbsent`**, so when a validator equivocates in the same slot (two blocks or conflicting attestations), only the first-seen vote is kept—aligned with **`ForkChoiceUtil#shouldUpdateVote`** and the spec’s same-epoch latest-message rules.
> 
> This removes behavior where a validator could appear under multiple block roots and which vote “won” could depend on map iteration order, which could make deferred fork-choice application non-deterministic.
> 
> Adds **`VoteUpdatesTest`** covering first-vote wins, distinct validators, cross-attestation equivocation, `fullPayloadHint` conflicts, emptiness, and wrong-slot rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674b5b2c15e7a9864fa2bc7c4127626abc7ffd11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->