### PR TITLE
Fix ROCKSDB_TREE storage for Gloas progressive container states

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.ssz.schema.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Suppliers;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -107,6 +108,7 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
   // Progressive mode fields (null for regular containers)
   private final boolean[] activeFields;
   private final int[] fieldToTreePosition;
+  private final int[] slotToFieldIndex;
   private final LeafNode activeFieldsLeafNode;
 
   // ===== Regular (non-progressive) constructors =====
@@ -118,6 +120,7 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
     this.childrenSchemas = childrenSchemas.stream().map(NamedSchema::getSchema).toList();
     this.activeFields = null;
     this.fieldToTreePosition = null;
+    this.slotToFieldIndex = null;
     this.activeFieldsLeafNode = null;
     this.fixedPartSize = calcSszFixedPartSize();
     this.jsonTypeDefinition = SszContainerTypeDefinition.createFor(this);
@@ -133,6 +136,7 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
     this.childrenSchemas = childrenSchemas;
     this.activeFields = null;
     this.fieldToTreePosition = null;
+    this.slotToFieldIndex = null;
     this.activeFieldsLeafNode = null;
     this.fixedPartSize = calcSszFixedPartSize();
     this.jsonTypeDefinition = SszContainerTypeDefinition.createFor(this);
@@ -164,6 +168,7 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
     this.containerName = name;
     this.activeFields = activeFields.clone();
     this.fieldToTreePosition = new int[childrenSchemas.size()];
+    this.slotToFieldIndex = new int[activeFields.length];
 
     int fieldIdx = 0;
     for (int slot = 0; slot < activeFields.length; slot++) {
@@ -176,7 +181,10 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
         }
         childrenNamesToFieldIndex.put(ns.getName(), fieldIdx);
         this.fieldToTreePosition[fieldIdx] = slot;
+        this.slotToFieldIndex[slot] = fieldIdx;
         fieldIdx++;
+      } else {
+        this.slotToFieldIndex[slot] = -1;
       }
     }
 
@@ -576,20 +584,144 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
       final int maxBranchLevelsSkipped,
       final long rootGIndex,
       final TreeNode node) {
-    if (isProgressiveMode()) {
-      throw new UnsupportedOperationException(
-          "Store/load backing nodes not yet supported for progressive containers");
+    if (!isProgressiveMode()) {
+      SszContainerSchema.super.storeBackingNodes(
+          nodeStore, maxBranchLevelsSkipped, rootGIndex, node);
+      return;
     }
-    SszContainerSchema.super.storeBackingNodes(nodeStore, maxBranchLevelsSkipped, rootGIndex, node);
+    final TreeNode progressiveDataTree = node.get(GIndexUtil.LEFT_CHILD_G_INDEX);
+    final TreeNode activeFieldsNode = node.get(GIndexUtil.RIGHT_CHILD_G_INDEX);
+    final long dataRootGIndex = GIndexUtil.gIdxLeftGIndex(rootGIndex);
+    ProgressiveTreeUtil.storeProgressiveSpine(
+        nodeStore,
+        dataRootGIndex,
+        progressiveDataTree,
+        activeFields.length,
+        (levelGIndex, levelSubtree, chunksInLevel, depth) ->
+            storeContainerLevelSubtree(
+                nodeStore,
+                maxBranchLevelsSkipped,
+                levelGIndex,
+                levelSubtree,
+                chunksInLevel,
+                depth));
+    nodeStore.storeLeafNode(activeFieldsNode, GIndexUtil.gIdxRightGIndex(rootGIndex));
+    nodeStore.storeBranchNode(
+        node.hashTreeRoot(),
+        rootGIndex,
+        1,
+        new Bytes32[] {progressiveDataTree.hashTreeRoot(), activeFieldsNode.hashTreeRoot()});
+  }
+
+  private void storeContainerLevelSubtree(
+      final TreeNodeStore nodeStore,
+      final int maxBranchLevelsSkipped,
+      final long levelGIndex,
+      final TreeNode levelSubtree,
+      final int chunksInLevel,
+      final int depth) {
+    if (chunksInLevel == 0) {
+      return;
+    }
+    final int levelNum = depth / 2; // depth = 2 * level per ProgressiveTreeUtil
+    final int levelStartSlot =
+        levelNum > 0 ? (int) ProgressiveTreeUtil.cumulativeCapacity(levelNum - 1) : 0;
+    if (depth == 0) {
+      final int fieldIdx = slotToFieldIndex[levelStartSlot];
+      if (fieldIdx >= 0) {
+        getChildSchema(fieldIdx)
+            .storeBackingNodes(nodeStore, maxBranchLevelsSkipped, levelGIndex, levelSubtree);
+      }
+    } else {
+      final long lastUsefulGIndex =
+          GIndexUtil.gIdxChildGIndex(levelGIndex, chunksInLevel - 1, depth);
+      StoringUtil.storeNodesToDepth(
+          nodeStore,
+          maxBranchLevelsSkipped,
+          levelSubtree,
+          levelGIndex,
+          depth,
+          lastUsefulGIndex,
+          (targetNode, targetGIndex) -> {
+            final int posInLevel = GIndexUtil.gIdxChildIndexFromGIndex(targetGIndex, depth);
+            final int slot = levelStartSlot + posInLevel;
+            final int fieldIdx = slotToFieldIndex[slot];
+            if (fieldIdx >= 0) {
+              getChildSchema(fieldIdx)
+                  .storeBackingNodes(nodeStore, maxBranchLevelsSkipped, targetGIndex, targetNode);
+            }
+          });
+    }
   }
 
   @Override
   public TreeNode loadBackingNodes(
       final TreeNodeSource nodeSource, final Bytes32 rootHash, final long rootGIndex) {
-    if (isProgressiveMode()) {
-      throw new UnsupportedOperationException(
-          "Store/load backing nodes not yet supported for progressive containers");
+    if (!isProgressiveMode()) {
+      return SszContainerSchema.super.loadBackingNodes(nodeSource, rootHash, rootGIndex);
     }
-    return SszContainerSchema.super.loadBackingNodes(nodeSource, rootHash, rootGIndex);
+    final TreeNodeSource.CompressedBranchInfo branch =
+        nodeSource.loadBranchNode(rootHash, rootGIndex);
+    checkState(
+        branch.getChildren().length == 2, "Container root node must have exactly 2 children");
+    checkState(branch.getDepth() == 1, "Container root node must have depth of 1");
+    final Bytes32 dataHash = branch.getChildren()[0];
+    final long dataRootGIndex = GIndexUtil.gIdxLeftGIndex(rootGIndex);
+    final TreeNode progressiveDataTree =
+        ProgressiveTreeUtil.loadProgressiveSpine(
+            nodeSource,
+            dataHash,
+            dataRootGIndex,
+            activeFields.length,
+            (levelHash, levelGIndex, chunksInLevel, depth) ->
+                loadContainerLevelSubtree(
+                    nodeSource, levelHash, levelGIndex, chunksInLevel, depth));
+    return BranchNode.create(progressiveDataTree, activeFieldsLeafNode);
+  }
+
+  private TreeNode loadContainerLevelSubtree(
+      final TreeNodeSource nodeSource,
+      final Bytes32 levelHash,
+      final long levelGIndex,
+      final int chunksInLevel,
+      final int depth) {
+    final int levelNum = depth / 2;
+    final int levelStartSlot =
+        levelNum > 0 ? (int) ProgressiveTreeUtil.cumulativeCapacity(levelNum - 1) : 0;
+    if (depth == 0) {
+      final int fieldIdx = slotToFieldIndex[levelStartSlot];
+      if (fieldIdx < 0) {
+        return LeafNode.EMPTY_LEAF;
+      }
+      return loadChunkNode(nodeSource, levelHash, levelGIndex, getChildSchema(fieldIdx));
+    }
+    final long lastUsefulGIndex = GIndexUtil.gIdxChildGIndex(levelGIndex, chunksInLevel - 1, depth);
+    return LoadingUtil.loadNodesToDepth(
+        nodeSource,
+        levelHash,
+        levelGIndex,
+        depth,
+        TreeUtil.ZERO_TREES[depth],
+        lastUsefulGIndex,
+        (src, childHash, childGIndex) -> {
+          final int posInLevel = GIndexUtil.gIdxChildIndexFromGIndex(childGIndex, depth);
+          final int slot = levelStartSlot + posInLevel;
+          final int fieldIdx = slotToFieldIndex[slot];
+          if (fieldIdx < 0) {
+            return LeafNode.EMPTY_LEAF;
+          }
+          return loadChunkNode(src, childHash, childGIndex, getChildSchema(fieldIdx));
+        });
+  }
+
+  private TreeNode loadChunkNode(
+      final TreeNodeSource nodeSource,
+      final Bytes32 chunkHash,
+      final long chunkGIndex,
+      final SszSchema<?> fieldSchema) {
+    if (TreeUtil.ZERO_TREES_BY_ROOT.containsKey(chunkHash) || chunkHash.equals(Bytes32.ZERO)) {
+      return fieldSchema.getDefaultTree();
+    }
+    return fieldSchema.loadBackingNodes(nodeSource, chunkHash, chunkGIndex);
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtil.java
@@ -360,9 +360,6 @@ public class ProgressiveTreeUtil {
     if (totalChunks == 0) {
       return LeafNode.EMPTY_LEAF;
     }
-    if (TreeUtil.ZERO_TREES_BY_ROOT.containsKey(dataHash)) {
-      return LeafNode.EMPTY_LEAF;
-    }
 
     final int maxLevel = levelForIndex(totalChunks - 1);
     return loadSpineLevelRecursive(
@@ -378,9 +375,6 @@ public class ProgressiveTreeUtil {
       final int totalChunks,
       final LevelLoader levelLoader) {
     if (level > maxLevel) {
-      return LeafNode.EMPTY_LEAF;
-    }
-    if (TreeUtil.ZERO_TREES_BY_ROOT.containsKey(spineHash)) {
       return LeafNode.EMPTY_LEAF;
     }
 

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/InMemoryStoringTreeNodeStore.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/InMemoryStoringTreeNodeStore.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.infrastructure.ssz.tree.LeafDataNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeSource;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNodeStore;
-import tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil;
 
 public class InMemoryStoringTreeNodeStore implements TreeNodeStore, TreeNodeSource {
 
@@ -41,10 +40,6 @@ public class InMemoryStoringTreeNodeStore implements TreeNodeStore, TreeNodeSour
   @Override
   public void storeBranchNode(
       final Bytes32 root, final long gIndex, final int depth, final Bytes32[] children) {
-    if (TreeUtil.ZERO_TREES_BY_ROOT.containsKey(root)) {
-      // No point storing zero trees.
-      return;
-    }
     branchNodes.putIfAbsent(
         root, new CompressedBranchInfo(depth, Arrays.copyOf(children, children.length)));
   }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveContainerSchemaTest.java
@@ -15,10 +15,13 @@ package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.ssz.schema.TreeNodeAssert.assertThatTreeNode;
 
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
@@ -307,5 +310,65 @@ public class SszProgressiveContainerSchemaTest {
   void getSszLengthBounds_maxBytesShouldBePositive() {
     final SszLengthBounds bounds = MULTI_FIELD_SCHEMA.getSszLengthBounds();
     assertThat(bounds.getMaxBytes()).isPositive();
+  }
+
+  // ===== Store/Load backing nodes roundtrip tests =====
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 5, 15})
+  void storeAndLoadBackingNodes_allFixedFields(final int maxBranchLevelsSkipped) {
+    final TreeNode node =
+        MULTI_FIELD_SCHEMA.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(UInt64.valueOf(0xDEADBEEFL)),
+                SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 42),
+                SszUInt64.of(UInt64.valueOf(0xCAFEBABEL))));
+    assertStoreLoadRoundtrip(MULTI_FIELD_SCHEMA, node, maxBranchLevelsSkipped);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 5, 15})
+  void storeAndLoadBackingNodes_gappedFields(final int maxBranchLevelsSkipped) {
+    final TreeNode node =
+        GAPPED_SCHEMA.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(UInt64.valueOf(999)),
+                SszPrimitiveSchemas.BYTE_SCHEMA.boxed((byte) 7)));
+    assertStoreLoadRoundtrip(GAPPED_SCHEMA, node, maxBranchLevelsSkipped);
+  }
+
+  @Test
+  void storeAndLoadBackingNodes_defaultContainer() {
+    final TreeNode node = MULTI_FIELD_SCHEMA.getDefaultTree();
+    assertStoreLoadRoundtrip(MULTI_FIELD_SCHEMA, node, 15);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 5, 15})
+  void storeAndLoadBackingNodes_withVariableField(final int maxBranchLevelsSkipped) {
+    final SszContainerSchema<SszContainer> varSchema =
+        SszContainerSchema.createProgressive(
+            "VarContainer2",
+            new boolean[] {true, true},
+            List.of(
+                NamedSchema.of("fixed", SszPrimitiveSchemas.UINT64_SCHEMA),
+                NamedSchema.of("bits", SszBitlistSchema.create(64))));
+    final TreeNode node =
+        varSchema.createTreeFromFieldValues(
+            List.of(
+                SszUInt64.of(UInt64.valueOf(12345)), SszBitlistSchema.create(64).ofBits(10, 0, 5)));
+    assertStoreLoadRoundtrip(varSchema, node, maxBranchLevelsSkipped);
+  }
+
+  private void assertStoreLoadRoundtrip(
+      final SszContainerSchema<?> schema, final TreeNode node, final int maxBranchLevelsSkipped) {
+    final InMemoryStoringTreeNodeStore nodeStore = new InMemoryStoringTreeNodeStore();
+    final long rootGIndex = 34L;
+
+    schema.storeBackingNodes(nodeStore, maxBranchLevelsSkipped, rootGIndex, node);
+    final TreeNode result = schema.loadBackingNodes(nodeStore, node.hashTreeRoot(), rootGIndex);
+
+    assertThat(result.hashTreeRoot()).isEqualTo(node.hashTreeRoot());
+    assertThatTreeNode(result).isTreeEqual(node);
   }
 }

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/SszProgressiveListSchemaTest.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.infrastructure.ssz.schema.TreeNodeAssert.assertT
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -478,8 +479,6 @@ public class SszProgressiveListSchemaTest {
   @ParameterizedTest
   @ValueSource(ints = {1, 5, 15})
   void storeAndLoadBackingNodes_compositeList(final int maxBranchLevelsSkipped) {
-    // Use a standard (non-progressive) container as element schema since progressive containers
-    // don't support store/load yet
     final ContainerSchema2<SszContainer, SszUInt64, SszUInt64> elementSchema =
         ContainerSchema2.create(
             SszPrimitiveSchemas.UINT64_SCHEMA,
@@ -492,6 +491,31 @@ public class SszProgressiveListSchemaTest {
             (SszProgressiveListSchema<?>) SszProgressiveListSchema.create(elementSchema);
 
     assertStoreLoadRoundtrip(listSchema, maxBranchLevelsSkipped);
+  }
+
+  @Test
+  void storeAndLoadBackingNodes_allZeroByteList() {
+    // Regression: a byte list where all 32 elements are 0x00 (e.g. epoch participation at genesis)
+    // has exactly 1 chunk of all-zero bytes. That chunk's hash equals ZERO_TREES[1].hashTreeRoot(),
+    // which caused loadProgressiveSpine to return LeafNode.EMPTY_LEAF instead of a BranchNode,
+    // breaking element navigation with "Invalid root index: 2".
+    final SszProgressiveListSchema<SszByte> byteListSchema =
+        SszProgressiveListSchema.create(SszPrimitiveSchemas.BYTE_SCHEMA);
+    // 32 zero bytes fills exactly one 32-byte chunk
+    final SszList<SszByte> list =
+        byteListSchema.createFromElements(Collections.nCopies(32, SszByte.of((byte) 0)));
+
+    final InMemoryStoringTreeNodeStore nodeStore = new InMemoryStoringTreeNodeStore();
+    final long rootGIndex = 34;
+    byteListSchema.storeBackingNodes(nodeStore, 15, rootGIndex, list.getBackingNode());
+
+    final TreeNode result =
+        byteListSchema.loadBackingNodes(nodeStore, list.hashTreeRoot(), rootGIndex);
+
+    assertThatTreeNode(result).isTreeEqual(list.getBackingNode());
+    final SszList<SszByte> loaded = byteListSchema.createFromBackingNode(result);
+    assertThat(loaded.size()).isEqualTo(32);
+    assertThat(loaded.get(0).get()).isEqualTo((byte) 0);
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/tree/ProgressiveTreeUtilTest.java
@@ -238,6 +238,42 @@ class ProgressiveTreeUtilTest {
   }
 
   @Test
+  void storeAndLoadSpine_singleAllZeroChunk_roundtripsWithNavigableTree() {
+    // Regression: when chunk is all-zero, progressiveDataTree.hashTreeRoot() equals
+    // ZERO_TREES[1].hashTreeRoot(). The old code returned LeafNode.EMPTY_LEAF instead of
+    // a proper BranchNode, causing navigation errors (e.g. "Invalid root index: 2").
+    final LeafNode zeroChunk = LeafNode.create(Bytes32.ZERO);
+    final TreeNode tree = ProgressiveTreeUtil.createProgressiveTree(List.of(zeroChunk));
+
+    // Sanity check: the tree's hash collides with ZERO_TREES[1]
+    assertThat(tree.hashTreeRoot()).isEqualTo(TreeUtil.ZERO_TREES[1].hashTreeRoot());
+
+    // The tree must still be navigable after store/load (not a LeafNode)
+    final InMemoryStoringTreeNodeStore nodeStore = new InMemoryStoringTreeNodeStore();
+    final long dataRootGIndex = GIndexUtil.LEFT_CHILD_G_INDEX;
+    final Map<Bytes32, TreeNode> subtreeByHash = new HashMap<>();
+    ProgressiveTreeUtil.storeProgressiveSpine(
+        nodeStore,
+        dataRootGIndex,
+        tree,
+        1,
+        (levelGIndex, levelSubtree, chunksInLevel, depth) ->
+            subtreeByHash.put(levelSubtree.hashTreeRoot(), levelSubtree));
+
+    final TreeNode result =
+        ProgressiveTreeUtil.loadProgressiveSpine(
+            nodeStore,
+            tree.hashTreeRoot(),
+            dataRootGIndex,
+            1,
+            (levelHash, levelGIndex, chunksInLevel, depth) -> subtreeByHash.get(levelHash));
+
+    assertThat(result.hashTreeRoot()).isEqualTo(tree.hashTreeRoot());
+    // Must be a BranchNode, not a LeafNode, so navigation (e.g. get(2)) works
+    assertThat(result).isInstanceOf(BranchNode.class);
+  }
+
+  @Test
   void storeAndLoadSpine_multipleChunks_roundtrips() {
     final List<LeafNode> chunks = new ArrayList<>();
     for (int i = 0; i < 6; i++) {

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -17,15 +17,12 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
-import static tech.pegasys.teku.storage.server.DatabaseVersion.LEVELDB_TREE;
-import static tech.pegasys.teku.storage.server.DatabaseVersion.ROCKSDB_TREE;
 import static tech.pegasys.teku.storage.store.StoreAssertions.assertStoresMatch;
 
 import com.google.common.collect.Streams;
@@ -109,7 +106,6 @@ import tech.pegasys.teku.storage.archive.filesystem.FileSystemBlobSidecarsArchiv
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DatabaseContext;
-import tech.pegasys.teku.storage.server.DatabaseVersion;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.server.TestDatabaseContext;
@@ -143,7 +139,6 @@ public class DatabaseTest {
   private Checkpoint checkpoint1;
   private Checkpoint checkpoint2;
   private Checkpoint checkpoint3;
-  private DatabaseVersion databaseVersion;
   private StateStorageMode storageMode;
   private StorageSystem storageSystem;
   private Database database;
@@ -154,7 +149,6 @@ public class DatabaseTest {
 
   @BeforeEach
   public void setup(final DatabaseContext context) throws IOException {
-    databaseVersion = context.getDatabaseVersion();
     setupWithSpec(TestSpecFactory.createMinimalDeneb());
   }
 
@@ -164,13 +158,6 @@ public class DatabaseTest {
 
   private void setupWithSpec(final Spec spec, final List<BLSKeyPair> validatorKeys)
       throws IOException {
-    // TODO refer to https://github.com/Consensys/teku/issues/10978
-    assumeFalse(
-        (databaseVersion == LEVELDB_TREE || databaseVersion == ROCKSDB_TREE)
-            && spec.getGenesisSpecConfig()
-                .getMilestone()
-                .isGreaterThanOrEqualTo(SpecMilestone.GLOAS),
-        "Progressive SSZ containers do not support tree storage");
     this.spec = spec;
     this.dataStructureUtil = new DataStructureUtil(spec);
     this.chainBuilder = ChainBuilder.create(spec, validatorKeys);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/state/FinalizedStateCache.java
@@ -22,12 +22,16 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.server.Database;
 
 public class FinalizedStateCache {
+
+  private static final Logger LOG = LogManager.getLogger(FinalizedStateCache.class);
 
   private static final long MAX_REGENERATE_SLOTS = 10_000L;
 
@@ -89,6 +93,7 @@ public class FinalizedStateCache {
       if (Throwables.getRootCause(e) instanceof StateUnavailableException) {
         return Optional.empty();
       }
+      LOG.error("Error while regenerating state for slot {}", slot, e);
       throw new RuntimeException("Error while regenerating state", e);
     }
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogicTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogicTest.java
@@ -14,14 +14,19 @@
 package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.util.Collections;
 import java.util.Optional;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.BeaconStateGloas;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.gloas.MutableBeaconStateGloas;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor;
 import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor.KvStoreTransaction;
@@ -86,6 +91,82 @@ class V4FinalizedStateTreeStorageLogicTest {
     final Optional<BeaconState> loadedState =
         logic.getLatestAvailableFinalizedState(db, schema, slot);
     assertThat(loadedState).contains(expectedState);
+  }
+
+  @Test
+  void shouldRoundTripGloasState() {
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasUtil = new DataStructureUtil(gloasSpec);
+    final V6SchemaCombinedTreeState gloasSchema = new V6SchemaCombinedTreeState(gloasSpec);
+    final KvStoreAccessor gloasDb =
+        MockKvStoreInstance.createEmpty(gloasSchema.getAllColumns(), gloasSchema.getAllVariables());
+    final V4FinalizedStateTreeStorageLogic gloasLogic =
+        new V4FinalizedStateTreeStorageLogic(new NoOpMetricsSystem(), gloasSpec, 1000);
+
+    final BeaconState state = gloasUtil.randomBeaconState();
+    try (final KvStoreTransaction transaction = gloasDb.startTransaction()) {
+      gloasLogic.updater().addFinalizedState(gloasDb, transaction, gloasSchema, state);
+      transaction.commit();
+    }
+    final Optional<BeaconState> loaded =
+        gloasLogic.getLatestAvailableFinalizedState(gloasDb, gloasSchema, state.getSlot());
+    assertThat(loaded).contains(state);
+  }
+
+  @Test
+  void shouldRoundTripGloasStateWithZeroParticipation() {
+    // Regression: genesis-like states have all-zero participation lists (32 validators, all
+    // flags=0)
+    // The progressive data tree for a 1-chunk all-zero list has the same hash as ZERO_TREES[1],
+    // causing loadProgressiveSpine to return LeafNode.EMPTY_LEAF instead of a BranchNode.
+    // Accessing any element then fails with "Invalid root index: 2".
+    final Spec gloasSpec = TestSpecFactory.createMinimalGloas();
+    final DataStructureUtil gloasUtil = new DataStructureUtil(gloasSpec);
+    final V6SchemaCombinedTreeState gloasSchema = new V6SchemaCombinedTreeState(gloasSpec);
+    final KvStoreAccessor gloasDb =
+        MockKvStoreInstance.createEmpty(gloasSchema.getAllColumns(), gloasSchema.getAllVariables());
+    final V4FinalizedStateTreeStorageLogic gloasLogic =
+        new V4FinalizedStateTreeStorageLogic(new NoOpMetricsSystem(), gloasSpec, 1000);
+
+    final BeaconState randomState = gloasUtil.randomBeaconState();
+    final int validatorCount = randomState.getValidators().size();
+    final BeaconState state =
+        randomState.updated(
+            mutable -> {
+              final MutableBeaconStateGloas mutableGloas =
+                  MutableBeaconStateGloas.required(mutable);
+              final var zeros = Collections.nCopies(validatorCount, SszByte.of((byte) 0));
+              mutableGloas.setPreviousEpochParticipation(
+                  mutableGloas
+                      .getPreviousEpochParticipation()
+                      .getSchema()
+                      .createFromElements(zeros));
+              mutableGloas.setCurrentEpochParticipation(
+                  mutableGloas
+                      .getCurrentEpochParticipation()
+                      .getSchema()
+                      .createFromElements(zeros));
+            });
+
+    try (final KvStoreTransaction transaction = gloasDb.startTransaction()) {
+      gloasLogic.updater().addFinalizedState(gloasDb, transaction, gloasSchema, state);
+      transaction.commit();
+    }
+    final Optional<BeaconState> loaded =
+        gloasLogic.getLatestAvailableFinalizedState(gloasDb, gloasSchema, state.getSlot());
+    assertThat(loaded).contains(state);
+
+    // Verify elements are actually accessible (not just hash-equal), which was the failure mode:
+    // accessing participation.get(0) on a loaded Gloas state with all-zero participation threw
+    // "Invalid root index: 2" because loadProgressiveSpine returned LeafNode.EMPTY_LEAF
+    // when the progressive data tree hash collides with ZERO_TREES[1].
+    final BeaconStateGloas loadedGloas = BeaconStateGloas.required(loaded.get());
+    assertThatCode(() -> loadedGloas.getPreviousEpochParticipation().get(0))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> loadedGloas.getCurrentEpochParticipation().get(0))
+        .doesNotThrowAnyException();
+    assertThat(loadedGloas.getPreviousEpochParticipation().get(0).get()).isEqualTo((byte) 0);
+    assertThat(loadedGloas.getCurrentEpochParticipation().get(0).get()).isEqualTo((byte) 0);
   }
 
   private void storeState(final BeaconState state) {


### PR DESCRIPTION
  Problem

  BeaconStateSchemaGloas is an SSZ progressive container (EIP-7916). When using ROCKSDB_TREE database mode, storing and loading Gloas beacon states failed in two ways:

  1. Progressive containers were not supported at all. AbstractSszContainerSchema.storeBackingNodes and loadBackingNodes threw UnsupportedOperationException in progressive mode, blocking all Gloas integration tests with tree storage.

  2. All-zero participation lists caused "Invalid root index: 2" during state replay. At genesis, previous_epoch_participation and current_epoch_participation contain 32 zero bytes — exactly one chunk of all-zero data. That chunk's hash equals ZERO_TREES[1].hashTreeRoot(), which caused loadProgressiveSpine to short-circuit and return LeafNode.EMPTY_LEAF instead of a navigable BranchNode. Any subsequent access to participation.get(i) during block replay (e.g. processAttestation) would fail with "Invalid root index: 2".

  This was observed as "Error while regenerating state" at slot 828 on a live node running with Xdata-storage-create-db-version: rocksdb-tree.

  Changes

  AbstractSszContainerSchema — Implements progressive container tree storage:
  - storeBackingNodes: walks the progressive data tree's right spine level-by-level, calling each field schema's own storeBackingNodes for its slot in the balanced level subtree
  - loadBackingNodes: reconstructs the progressive data tree by loading the spine and delegating each level subtree to loadContainerLevelSubtree; the activeFieldsLeafNode is schema-fixed so it is never loaded from the database

  ProgressiveTreeUtil.loadProgressiveSpine — Removes the ZERO_TREES_BY_ROOT early-exit. The totalChunks == 0 guard already handles the empty-tree case; for non-empty trees the spine branch nodes are always written to the database and must be loaded
  rather than bypassed.

  InMemoryStoringTreeNodeStore — Removes the corresponding zero-tree skip from storeBranchNode, aligning the test double with KvStoreTreeNodeStore which always persists branches regardless of their hash.

  AbstractSszContainerSchema.loadChunkNode — Removes the erroneous isPrimitive() branch that called LeafNode.create(loadLeafNode(...)) directly, creating a 32-byte leaf from the stored hash rather than the original data. Delegating to
  fieldSchema.loadBackingNodes already handles primitives correctly.

  DatabaseTest — Removes the assumeFalse guard that was skipping all Gloas integration tests against tree database versions.

  FinalizedStateCache — Logs the root cause exception so state-regeneration failures are diagnosable from logs.

  Tests

  Three new regression tests, each targeting a different layer of the fix:

  - ProgressiveTreeUtilTest.storeAndLoadSpine_singleAllZeroChunk_roundtripsWithNavigableTree — directly asserts that a spine loaded from a zero-hash progressive data tree is a BranchNode, not EMPTY_LEAF
  - SszProgressiveListSchemaTest.storeAndLoadBackingNodes_allZeroByteList — store/load roundtrip for a 32-element all-zero byte list (the participation flag schema shape) with element access verification
  - V4FinalizedStateTreeStorageLogicTest.shouldRoundTripGloasStateWithZeroParticipation — full storage stack: a Gloas progressive-container state with all-zero participation is stored, loaded, and its participation elements are accessed without error

fixes #10989 
fixes #10978 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes SSZ tree store/load for progressive containers and spine loading—core to finalized beacon state persistence and replay in tree DB mode; incorrect behavior could corrupt or fail state regeneration.
> 
> **Overview**
> **Enables tree-database persistence for Gloas progressive SSZ containers** by replacing `UnsupportedOperationException` in `AbstractSszContainerSchema` with full `storeBackingNodes` / `loadBackingNodes`: the progressive data spine is walked via `ProgressiveTreeUtil`, field slots are mapped with a new `slotToFieldIndex` table, and each active field’s subtree is stored or loaded through the child schema.
> 
> **Fixes state replay failures on all-zero participation chunks** by removing `ZERO_TREES_BY_ROOT` short-circuits in `ProgressiveTreeUtil.loadProgressiveSpine` (and the matching skip in `InMemoryStoringTreeNodeStore.storeBranchNode`) so single-chunk trees whose root hash matches a zero tree still reload as navigable `BranchNode`s instead of `EMPTY_LEAF` (“Invalid root index: 2”).
> 
> **Integration and observability:** `DatabaseTest` no longer skips Gloas against tree DB versions; `FinalizedStateCache` logs the underlying exception on regeneration errors. Regression tests cover container/list roundtrips, zero-byte lists, Gloas finalized state storage, and zero-participation access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672fe44f796fd2627a76345d6b05d63adaec79c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->