### PR TITLE
Change default values of builder circuit breaker options

### DIFF
--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -30,9 +30,9 @@ public class ExecutionLayerConfiguration {
   private static final Logger LOG = LogManager.getLogger();
 
   public static final boolean DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED = true;
-  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW = 32;
-  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS = 5;
-  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS = 3;
+  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW = 8;
+  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS = 2;
+  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS = 2;
   public static final int BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP = 64;
   public static final UInt64 DEFAULT_BUILDER_BID_COMPARE_FACTOR = UInt64.valueOf(90);
   public static final boolean DEFAULT_BUILDER_SET_USER_AGENT_HEADER = true;


### PR DESCRIPTION
## Fixed Issue(s)
https://github.com/Consensys/teku/issues/10940

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default block-production behavior for builder users who do not override circuit breaker flags, which can increase local-EL fallback frequency on marginal builder issues.
> 
> **Overview**
> Tightens the **default** builder circuit breaker settings in `ExecutionLayerConfiguration` so nodes that rely on defaults (including hidden CLI flags wired to those constants) trip the breaker sooner on builder faults.
> 
> **Window** goes from 32 to **8** slots; **allowed faults** from 5 to **2**; **allowed consecutive faults** from 3 to **2**. Operators who already set `--Xbuilder-circuit-breaker-*` explicitly are unchanged; only unset defaults shift toward faster fallback to locally built payloads when the external builder misbehaves (issue #10940).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb651270d9729271c46c66e220bccaa363d908c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->