### PR TITLE
update gossip validation logs

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidator.java
@@ -22,6 +22,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.saveForFuture;
 
+import com.google.errorprone.annotations.FormatMethod;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -76,18 +77,16 @@ public class ExecutionPayloadBidGossipValidator {
      */
     final UInt64 executionPayment = bid.getExecutionPayment();
     if (!executionPayment.isZero()) {
-      LOG.trace("Bid's execution payment should be 0 but was {}", executionPayment);
       return completedFuture(
-          reject("Bid's execution payment should be 0 but was %s", executionPayment));
+          rejectBid(bid, "execution payment should be 0 but was %s", executionPayment));
     }
 
     /*
      * [IGNORE] bid.slot is the current slot or the next slot.
      */
     if (!gossipValidationHelper.isSlotCurrentOrNext(bid.getSlot())) {
-      LOG.trace("Bid must be for current or next slot but was for slot {}", bid.getSlot());
       return completedFuture(
-          ignore("Bid must be for current or next slot but was for slot %s", bid.getSlot()));
+          ignoreBid(bid, "must be for current or next slot but was for slot %s", bid.getSlot()));
     }
 
     /*
@@ -97,14 +96,8 @@ public class ExecutionPayloadBidGossipValidator {
     final Optional<ProposerPreferences> proposerPreferences =
         proposerPreferencesManager.getProposerPreferences(bid.getSlot());
     if (proposerPreferences.isEmpty()) {
-      LOG.trace(
-          "No proposer preferences available at slot {}. The bid from the builder with index {} will be saved for future processing.",
-          bid.getSlot(),
-          bid.getBuilderIndex());
       return completedFuture(
-          saveForFuture(
-              "No proposer preferences available at slot %s. The bid from the builder with index %s will be saved for future processing.",
-              bid.getSlot(), bid.getBuilderIndex()));
+          saveBidForFuture(bid, "no proposer preferences available; saving for future processing"));
     }
 
     /*
@@ -112,14 +105,12 @@ public class ExecutionPayloadBidGossipValidator {
      * SignedProposerPreferences associated with bid.slot
      */
     if (!bid.getFeeRecipient().equals(proposerPreferences.get().getFeeRecipient())) {
-      LOG.trace(
-          "Bid fee recipient {} does not match proposer preferences fee recipient {}",
-          bid.getFeeRecipient(),
-          proposerPreferences.get().getFeeRecipient());
       return completedFuture(
-          ignore(
-              "Bid fee recipient %s does not match proposer preferences fee recipient %s",
-              bid.getFeeRecipient(), proposerPreferences.get().getFeeRecipient()));
+          ignoreBid(
+              bid,
+              "fee recipient %s does not match proposer preferences fee recipient %s",
+              bid.getFeeRecipient(),
+              proposerPreferences.get().getFeeRecipient()));
     }
 
     /*
@@ -130,16 +121,12 @@ public class ExecutionPayloadBidGossipValidator {
         new BuilderAndParent(
             bid.getBuilderIndex(), bid.getParentBlockHash(), bid.getParentBlockRoot());
     if (seenExecutionPayloadBids.getOrDefault(bid.getSlot(), Set.of()).contains(builderAndParent)) {
-      LOG.trace(
-          "Already received a bid from builder with index {} at slot {} for parent hash {} and parent root {}",
-          bid.getBuilderIndex(),
-          bid.getSlot(),
-          bid.getParentBlockHash(),
-          bid.getParentBlockRoot());
       return completedFuture(
-          ignore(
-              "Already received a bid from builder with index %s at slot %s",
-              bid.getBuilderIndex(), bid.getSlot()));
+          ignoreBid(
+              bid,
+              "already received for parent block hash %s and parent block root %s",
+              bid.getParentBlockHash(),
+              bid.getParentBlockRoot()));
     }
 
     /*
@@ -159,16 +146,10 @@ public class ExecutionPayloadBidGossipValidator {
       final UInt64 minRequiredBid = calculateMinimumRequiredBid(existingBidValue);
 
       if (bid.getValue().isLessThan(minRequiredBid)) {
-        LOG.trace(
-            "Bid value {} ETH does not meet minimum increment threshold ({}%). Current highest: {} ETH, minimum required: {} ETH",
-            () -> gweiToEth(bid.getValue()),
-            () -> minBidIncrementPercentage,
-            () -> gweiToEth(existingBidValue),
-            () -> gweiToEth(minRequiredBid));
         return completedFuture(
-            ignore(
-                "Bid value %s ETH does not meet minimum increment threshold (%s%%). Current highest: %s ETH, minimum required: %s ETH",
-                gweiToEth(bid.getValue()),
+            ignoreBid(
+                bid,
+                "does not meet minimum increment threshold (%s%%); current highest is %s ETH and minimum required is %s ETH",
                 minBidIncrementPercentage,
                 gweiToEth(existingBidValue),
                 gweiToEth(minRequiredBid)));
@@ -184,26 +165,22 @@ public class ExecutionPayloadBidGossipValidator {
         gossipValidationHelper.getGasLimitForExecutionPayload(
             bid.getParentBlockRoot(), bid.getParentBlockHash());
     if (maybeParentGasLimit.isEmpty()) {
-      LOG.trace(
-          "Gas limit for parent execution payload with block hash {} is unavailable. It will be saved for future processing",
-          bid.getParentBlockHash());
       return completedFuture(
-          saveForFuture(
-              "Gas limit for parent execution payload with block hash %s is unavailable. The bid will be saved for future processing",
+          saveBidForFuture(
+              bid,
+              "parent execution payload gas limit is unavailable for parent block hash %s; saving for future processing",
               bid.getParentBlockHash()));
     }
     final UInt64 parentGasLimit = maybeParentGasLimit.get();
     final UInt64 targetGasLimit = proposerPreferences.get().getTargetGasLimit();
     if (!isGasLimitTargetCompatible(parentGasLimit, bid.getGasLimit(), targetGasLimit)) {
-      LOG.trace(
-          "Bid gas limit {} is not compatible with parent gas limit {} and proposer preferences target gas limit {}",
-          bid.getGasLimit(),
-          parentGasLimit,
-          targetGasLimit);
       return completedFuture(
-          ignore(
-              "Bid gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
-              bid.getGasLimit(), parentGasLimit, targetGasLimit));
+          ignoreBid(
+              bid,
+              "gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
+              bid.getGasLimit(),
+              parentGasLimit,
+              targetGasLimit));
     }
 
     /*
@@ -211,8 +188,12 @@ public class ExecutionPayloadBidGossipValidator {
      * is_bid_compatible_with_head(store, bid) returns True.
      */
     if (!gossipValidationHelper.isBidCompatibleWithHead(bid)) {
-      LOG.trace("Bid is not compatible with the current head branch");
-      return completedFuture(ignore("Bid is not compatible with the current head branch"));
+      return completedFuture(
+          ignoreBid(
+              bid,
+              "is not compatible with the current head branch (parent block hash %s, parent block root %s)",
+              bid.getParentBlockHash(),
+              bid.getParentBlockRoot()));
     }
 
     /*
@@ -221,12 +202,10 @@ public class ExecutionPayloadBidGossipValidator {
     final Optional<UInt64> maybeParentBlockSlot =
         gossipValidationHelper.getSlotForBlockRoot(bid.getParentBlockRoot());
     if (maybeParentBlockSlot.isEmpty()) {
-      LOG.trace(
-          "Bid's parent block with root {} is unknown. The bid will be saved for future processing",
-          bid.getParentBlockRoot());
       return completedFuture(
-          saveForFuture(
-              "Bid's parent block with root %s is unknown. The bid will be saved for future processing",
+          saveBidForFuture(
+              bid,
+              "parent block with root %s is unknown; saving for future processing",
               bid.getParentBlockRoot()));
     }
     final UInt64 parentBlockSlot = maybeParentBlockSlot.get();
@@ -235,12 +214,12 @@ public class ExecutionPayloadBidGossipValidator {
      * [REJECT] The bid is for a higher slot than its parent block.
      */
     if (!bid.getSlot().isGreaterThan(parentBlockSlot)) {
-      LOG.trace(
-          "Bid slot {} is not greater than parent block slot {}", bid.getSlot(), parentBlockSlot);
       return completedFuture(
-          reject(
-              "Bid slot %s is not greater than parent block slot %s",
-              bid.getSlot(), parentBlockSlot));
+          rejectBid(
+              bid,
+              "slot %s is not greater than parent block slot %s",
+              bid.getSlot(),
+              parentBlockSlot));
     }
 
     return gossipValidationHelper
@@ -248,13 +227,11 @@ public class ExecutionPayloadBidGossipValidator {
         .thenApply(
             maybeState -> {
               if (maybeState.isEmpty()) {
-                LOG.trace(
-                    "State for block root {} and slot {} is unavailable.",
+                return saveBidForFuture(
+                    bid,
+                    "state for parent block root %s at slot %s is unavailable; saving for future processing",
                     bid.getParentBlockRoot(),
                     parentBlockSlot);
-                return saveForFuture(
-                    "State for block root %s and slot %s is unavailable. The bid will be saved for future processing.",
-                    bid.getParentBlockRoot(), parentBlockSlot);
               }
               final BeaconState state = maybeState.get();
 
@@ -265,13 +242,11 @@ public class ExecutionPayloadBidGossipValidator {
               final Bytes32 expectedRandaoMix =
                   gossipValidationHelper.getRandaoMixForCurrentEpoch(state, bid.getSlot());
               if (!bid.getPrevRandao().equals(expectedRandaoMix)) {
-                LOG.trace(
-                    "Bid prev randao {} does not match expected RANDAO mix {}",
+                return rejectBid(
+                    bid,
+                    "prev randao %s does not match expected RANDAO mix %s",
                     bid.getPrevRandao(),
                     expectedRandaoMix);
-                return reject(
-                    "Bid prev randao %s does not match expected RANDAO mix %s",
-                    bid.getPrevRandao(), expectedRandaoMix);
               }
 
               /*
@@ -279,11 +254,9 @@ public class ExecutionPayloadBidGossipValidator {
                */
               if (!gossipValidationHelper.isActiveBuilder(
                   bid.getBuilderIndex(), state, bid.getSlot())) {
-                LOG.trace(
-                    "Invalid builder index {}. Builder should be valid, active and non-slashed.",
-                    bid.getBuilderIndex());
-                return reject(
-                    "Invalid builder index %s. Builder should be valid, active and non-slashed.",
+                return rejectBid(
+                    bid,
+                    "builder index %s is not valid, active, and non-slashed",
                     bid.getBuilderIndex());
               }
 
@@ -293,35 +266,24 @@ public class ExecutionPayloadBidGossipValidator {
                */
               if (!gossipValidationHelper.builderHasEnoughBalanceForBid(
                   bid.getValue(), bid.getBuilderIndex(), state, bid.getSlot())) {
-                LOG.trace(
-                    "Bid value {} ETH exceeds builder with index {} excess balance",
-                    () -> gweiToEth(bid.getValue()),
-                    bid::getBuilderIndex);
-                return ignore(
-                    "Bid value %s ETH exceeds builder with index %s excess balance",
-                    gweiToEth(bid.getValue()), bid.getBuilderIndex());
+                return ignoreBid(bid, "value exceeds the builder's excess balance");
               }
 
               /*
                * [REJECT] signed_execution_payload_bid.signature is valid with respect to the bid.builder_index.
                */
               if (!isSignatureValid(signedExecutionPayloadBid, state)) {
-                LOG.trace("Invalid payload execution bid signature");
-                return reject("Invalid payload execution bid signature");
+                return rejectBid(bid, "invalid execution payload bid signature");
               }
 
               if (!seenExecutionPayloadBids
                   .computeIfAbsent(bid.getSlot(), __ -> ConcurrentHashMap.newKeySet())
                   .add(builderAndParent)) {
-                LOG.trace(
-                    "Another payload execution bid from Builder with index {} already processed while validating bid for slot {}, parent hash {}, and parent root {}",
-                    bid.getBuilderIndex(),
-                    bid.getSlot(),
+                return ignoreBid(
+                    bid,
+                    "another bid for parent block hash %s and parent block root %s was processed concurrently",
                     bid.getParentBlockHash(),
                     bid.getParentBlockRoot());
-                return ignore(
-                    "Another payload execution bid from Builder with index %s already processed while validating bid for slot %s",
-                    bid.getBuilderIndex(), bid.getSlot());
               }
 
               // Atomically check threshold and update the highest bid
@@ -338,22 +300,58 @@ public class ExecutionPayloadBidGossipValidator {
               // Check if our bid was actually accepted
               if (!wasBidAccepted(bidValue, existingBidRef.get(), actualHighestBid)) {
                 final UInt64 minRequired = calculateMinimumRequiredBid(actualHighestBid);
-                LOG.trace(
-                    "Bid value {} ETH does not meet minimum increment threshold ({}%) due to concurrent update. Current highest: {} ETH, minimum required: {} ETH",
-                    () -> gweiToEth(bidValue),
-                    () -> minBidIncrementPercentage,
-                    () -> gweiToEth(actualHighestBid),
-                    () -> gweiToEth(minRequired));
-                return ignore(
-                    "Bid value %s ETH does not meet minimum increment threshold (%s%%) due to concurrent update. Current highest: %s ETH, minimum required: %s ETH",
-                    gweiToEth(bidValue),
+                return ignoreBid(
+                    bid,
+                    "does not meet minimum increment threshold (%s%%) after a concurrent update; current highest is %s ETH and minimum required is %s ETH",
                     minBidIncrementPercentage,
                     gweiToEth(actualHighestBid),
                     gweiToEth(minRequired));
               }
 
-              return ACCEPT;
+              return acceptBid(bid);
             });
+  }
+
+  private InternalValidationResult acceptBid(final ExecutionPayloadBid bid) {
+    LOG.trace(
+        "ExecutionPayloadBid Gossip Validation Result: ACCEPT, context: {}", formatBidContext(bid));
+    return ACCEPT;
+  }
+
+  @FormatMethod
+  private InternalValidationResult rejectBid(
+      final ExecutionPayloadBid bid, final String descriptionTemplate, final Object... args) {
+    final String message = formatBidMessage(bid, descriptionTemplate, args);
+    LOG.trace("ExecutionPayloadBid Gossip Validation Result: REJECT, reason: {}", message);
+    return reject("%s", message);
+  }
+
+  @FormatMethod
+  private InternalValidationResult ignoreBid(
+      final ExecutionPayloadBid bid, final String descriptionTemplate, final Object... args) {
+    final String message = formatBidMessage(bid, descriptionTemplate, args);
+    LOG.trace("ExecutionPayloadBid Gossip Validation Result: IGNORE, reason: {}", message);
+    return ignore("%s", message);
+  }
+
+  @FormatMethod
+  private InternalValidationResult saveBidForFuture(
+      final ExecutionPayloadBid bid, final String descriptionTemplate, final Object... args) {
+    final String message = formatBidMessage(bid, descriptionTemplate, args);
+    LOG.trace("ExecutionPayloadBid Gossip Validation Result: SAVE_FOR_FUTURE, reason: {}", message);
+    return saveForFuture("%s", message);
+  }
+
+  @FormatMethod
+  private String formatBidMessage(
+      final ExecutionPayloadBid bid, final String descriptionTemplate, final Object... args) {
+    return String.format("%s: %s", formatBidContext(bid), String.format(descriptionTemplate, args));
+  }
+
+  private String formatBidContext(final ExecutionPayloadBid bid) {
+    return String.format(
+        "Execution payload bid (builder index %s, slot %s, value %s ETH)",
+        bid.getBuilderIndex(), bid.getSlot(), gweiToEth(bid.getValue()));
   }
 
   /**

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidator.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.saveForFuture;
 
+import com.google.errorprone.annotations.FormatMethod;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -49,7 +50,7 @@ public class ProposerPreferencesGossipValidator {
   private final SigningRootUtil signingRootUtil;
   private final RecentChainData recentChainData;
 
-  private final Set<DedupKey> seenProposerPreferences =
+  private final Set<ProposerPreferencesDedupKey> seenProposerPreferences =
       LimitedSet.createSynchronizedLRU(RECENT_SEEN_PROPOSER_PREFERENCES_CACHE_SIZE);
 
   public ProposerPreferencesGossipValidator(
@@ -74,13 +75,10 @@ public class ProposerPreferencesGossipValidator {
      * [compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + MIN_SEED_LOOKAHEAD]`.
      */
     if (!gossipValidationHelper.isSlotInCurrentEpochWithMinSeedLookaheadTolerance(proposalSlot)) {
-      LOG.trace(
-          "Proposer preferences proposal slot {} is not in the current or within lookahead epoch",
-          proposalSlot);
       return completedFuture(
-          ignore(
-              "Proposer preferences proposal slot %s is not in the current or within lookahead epoch",
-              proposalSlot));
+          ignorePreferences(
+              proposerPreferences,
+              "proposal slot is not in the current or within the lookahead epoch"));
     }
 
     /*
@@ -88,9 +86,8 @@ public class ProposerPreferencesGossipValidator {
      */
     if (!gossipValidationHelper.isSlotFromFuture(proposalSlot)
         && !gossipValidationHelper.isSlotCurrent(proposalSlot)) {
-      LOG.trace("Proposer preferences proposal slot {} has already passed", proposalSlot);
       return completedFuture(
-          ignore("Proposer preferences proposal slot %s has already passed", proposalSlot));
+          ignorePreferences(proposerPreferences, "proposal slot has already passed"));
     }
 
     /*
@@ -98,23 +95,21 @@ public class ProposerPreferencesGossipValidator {
      * (a client MAY queue preferences for processing once the block is retrieved).
      */
     if (!gossipValidationHelper.isBlockAvailable(dependentRoot)) {
-      LOG.trace(
-          "Proposer preferences dependent root {} has not been seen. Saving for future processing",
-          dependentRoot);
       return completedFuture(
-          saveForFuture(
-              "Proposer preferences dependent root %s has not been seen. Saving for future processing",
-              dependentRoot));
+          savePreferencesForFuture(
+              proposerPreferences,
+              "dependent root has not been seen; saving for future processing"));
     }
 
     /*
      * [IGNORE] The signed_proposer_preferences is the first valid message for the tuple
      * (preferences.dependent_root, preferences.proposal_slot, preferences.validator_index)
      */
-    final DedupKey dedupKey =
-        new DedupKey(dependentRoot, proposalSlot, proposerPreferences.getValidatorIndex());
+    final ProposerPreferencesDedupKey dedupKey =
+        new ProposerPreferencesDedupKey(
+            dependentRoot, proposalSlot, proposerPreferences.getValidatorIndex());
     if (seenProposerPreferences.contains(dedupKey)) {
-      return completedFuture(ignoreAlreadySeen(dedupKey));
+      return completedFuture(ignoreAlreadySeen(proposerPreferences));
     }
 
     /*
@@ -137,15 +132,12 @@ public class ProposerPreferencesGossipValidator {
     if (maybeDependentRootSlot.isPresent()) {
       final UInt64 dependentRootSlot = maybeDependentRootSlot.get();
       if (!dependentRootSlot.isLessThan(checkpointBoundarySlot)) {
-        LOG.trace(
-            "Proposer preferences dependent root {} is at slot {}, but must be before checkpoint boundary slot {}",
-            dependentRoot,
-            dependentRootSlot,
-            checkpointBoundarySlot);
         return completedFuture(
-            reject(
-                "Proposer preferences dependent root %s is at slot %s, but must be before checkpoint boundary slot %s",
-                dependentRoot, dependentRootSlot, checkpointBoundarySlot));
+            rejectPreferences(
+                proposerPreferences,
+                "dependent root is at slot %s but must be before checkpoint boundary slot %s",
+                dependentRootSlot,
+                checkpointBoundarySlot));
       }
     }
     return recentChainData
@@ -153,13 +145,10 @@ public class ProposerPreferencesGossipValidator {
         .thenApply(
             maybeState -> {
               if (maybeState.isEmpty()) {
-                LOG.trace(
-                    "Could not retrieve checkpoint state for ({}, {}). Saving for future processing",
-                    checkpointEpoch,
-                    dependentRoot);
-                return saveForFuture(
-                    "Could not retrieve checkpoint state for (%s, %s). Saving proposer preferences for future processing",
-                    checkpointEpoch, dependentRoot);
+                return savePreferencesForFuture(
+                    proposerPreferences,
+                    "checkpoint state for checkpoint epoch %s is unavailable; saving for future processing",
+                    checkpointEpoch);
               }
               final BeaconState state = maybeState.get();
 
@@ -174,14 +163,10 @@ public class ProposerPreferencesGossipValidator {
               final UInt64 expectedValidatorIndex =
                   BeaconStateFulu.required(state).getProposerLookahead().getElement(lookaheadIndex);
               if (!expectedValidatorIndex.equals(proposerPreferences.getValidatorIndex())) {
-                LOG.trace(
-                    "Proposer preferences validator index {} does not match expected proposer {} for slot {}",
-                    proposerPreferences.getValidatorIndex(),
-                    expectedValidatorIndex,
-                    proposalSlot);
-                return reject(
-                    "Proposer preferences validator index %s does not match expected proposer %s for slot %s",
-                    proposerPreferences.getValidatorIndex(), expectedValidatorIndex, proposalSlot);
+                return rejectPreferences(
+                    proposerPreferences,
+                    "validator index does not match expected proposer %s",
+                    expectedValidatorIndex);
               }
 
               /*
@@ -189,27 +174,95 @@ public class ProposerPreferencesGossipValidator {
                * the validator's public key
                */
               if (!isSignatureValid(signedProposerPreferences, state)) {
-                LOG.trace("Invalid proposer preferences signature");
-                return reject("Invalid proposer preferences signature");
+                return rejectPreferences(proposerPreferences, "invalid signature");
               }
 
               if (!seenProposerPreferences.add(dedupKey)) {
-                return ignoreAlreadySeen(dedupKey);
+                return ignoreAlreadySeen(proposerPreferences);
               }
 
-              return ACCEPT;
+              return acceptPreferences(proposerPreferences);
             })
         .exceptionally(
             error -> {
-              LOG.trace(
-                  "Unable to generate proposer preferences checkpoint state for checkpoint epoch {} and dependent root {}",
-                  checkpointEpoch,
-                  dependentRoot,
-                  error);
-              return reject(
-                  "Unable to generate proposer preferences checkpoint state for checkpoint epoch %s and dependent root %s",
-                  checkpointEpoch, dependentRoot);
+              return rejectPreferencesWithError(
+                  proposerPreferences,
+                  error,
+                  "unable to generate checkpoint state for checkpoint epoch %s",
+                  checkpointEpoch);
             });
+  }
+
+  private InternalValidationResult acceptPreferences(
+      final ProposerPreferences proposerPreferences) {
+    LOG.trace(
+        "ProposerPreferences Gossip Validation Result: ACCEPT, context: {}",
+        formatProposerPreferencesContext(proposerPreferences));
+    return ACCEPT;
+  }
+
+  @FormatMethod
+  private InternalValidationResult rejectPreferences(
+      final ProposerPreferences proposerPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    final String message =
+        formatProposerPreferencesMessage(proposerPreferences, descriptionTemplate, args);
+    LOG.trace("ProposerPreferences Gossip Validation Result: REJECT, reason: {}", message);
+    return reject("%s", message);
+  }
+
+  @FormatMethod
+  private InternalValidationResult rejectPreferencesWithError(
+      final ProposerPreferences proposerPreferences,
+      final Throwable error,
+      final String descriptionTemplate,
+      final Object... args) {
+    final String message =
+        formatProposerPreferencesMessage(proposerPreferences, descriptionTemplate, args);
+    LOG.trace("ProposerPreferences Gossip Validation Result: REJECT, reason: {}", message, error);
+    return reject("%s", message);
+  }
+
+  @FormatMethod
+  private InternalValidationResult ignorePreferences(
+      final ProposerPreferences proposerPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    final String message =
+        formatProposerPreferencesMessage(proposerPreferences, descriptionTemplate, args);
+    LOG.trace("ProposerPreferences Gossip Validation Result: IGNORE, reason: {}", message);
+    return ignore("%s", message);
+  }
+
+  @FormatMethod
+  private InternalValidationResult savePreferencesForFuture(
+      final ProposerPreferences proposerPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    final String message =
+        formatProposerPreferencesMessage(proposerPreferences, descriptionTemplate, args);
+    LOG.trace("ProposerPreferences Gossip Validation Result: SAVE_FOR_FUTURE, reason: {}", message);
+    return saveForFuture("%s", message);
+  }
+
+  @FormatMethod
+  private String formatProposerPreferencesMessage(
+      final ProposerPreferences proposerPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    return String.format(
+        "%s: %s",
+        formatProposerPreferencesContext(proposerPreferences),
+        String.format(descriptionTemplate, args));
+  }
+
+  private String formatProposerPreferencesContext(final ProposerPreferences proposerPreferences) {
+    return String.format(
+        "Proposer preferences (validator index %s, proposal slot %s, dependent root %s)",
+        proposerPreferences.getValidatorIndex(),
+        proposerPreferences.getProposalSlot(),
+        proposerPreferences.getDependentRoot());
   }
 
   private boolean isSignatureValid(
@@ -224,16 +277,11 @@ public class ProposerPreferencesGossipValidator {
         state);
   }
 
-  private InternalValidationResult ignoreAlreadySeen(final DedupKey dedupKey) {
-    LOG.trace(
-        "Already received proposer preferences for tuple ({}, {}, {})",
-        dedupKey.dependentRoot(),
-        dedupKey.proposalSlot(),
-        dedupKey.validatorIndex());
-    return ignore(
-        "Already received proposer preferences for tuple (%s, %s, %s)",
-        dedupKey.dependentRoot(), dedupKey.proposalSlot(), dedupKey.validatorIndex());
+  private InternalValidationResult ignoreAlreadySeen(
+      final ProposerPreferences proposerPreferences) {
+    return ignorePreferences(proposerPreferences, "already received");
   }
 
-  private record DedupKey(Bytes32 dependentRoot, UInt64 proposalSlot, UInt64 validatorIndex) {}
+  private record ProposerPreferencesDedupKey(
+      Bytes32 dependentRoot, UInt64 proposalSlot, UInt64 validatorIndex) {}
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ExecutionPayloadBidGossipValidatorTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.validation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
@@ -27,12 +28,15 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.saveForFuture;
 
+import com.google.errorprone.annotations.FormatMethod;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Optional;
+import org.apache.logging.log4j.Level;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -134,7 +138,14 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
   @TestTemplate
   void shouldAccept() {
-    assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(ACCEPT);
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ExecutionPayloadBidGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(ACCEPT);
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(
+              "ExecutionPayloadBid Gossip Validation Result: ACCEPT, context: "
+                  + formatBidContext(bid));
+    }
   }
 
   @TestTemplate
@@ -143,8 +154,9 @@ public class ExecutionPayloadBidGossipValidatorTest {
         dataStructureUtil.randomSignedExecutionPayloadBid(UInt64.ONE);
     assertThatSafeFuture(bidValidator.validate(bidWithPayment))
         .isCompletedWithValue(
-            reject(
-                "Bid's execution payment should be 0 but was %s",
+            rejectBid(
+                bidWithPayment,
+                "execution payment should be 0 but was %s",
                 bidWithPayment.getMessage().getExecutionPayment()));
   }
 
@@ -153,7 +165,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.isSlotCurrentOrNext(slot)).thenReturn(false);
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            ignore("Bid must be for current or next slot but was for slot %s", slot));
+            ignoreBid(signedBid, "must be for current or next slot but was for slot %s", slot));
   }
 
   @TestTemplate
@@ -161,9 +173,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(proposerPreferencesManager.getProposerPreferences(slot)).thenReturn(Optional.empty());
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            saveForFuture(
-                "No proposer preferences available at slot %s. The bid from the builder with index %s will be saved for future processing.",
-                slot, builderIndex));
+            saveBidForFuture(
+                signedBid, "no proposer preferences available; saving for future processing"));
   }
 
   @TestTemplate
@@ -176,9 +187,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            ignore(
-                "Bid fee recipient %s does not match proposer preferences fee recipient %s",
-                bid.getFeeRecipient(), mismatchedPreferences.getFeeRecipient()));
+            ignoreBid(
+                signedBid,
+                "fee recipient %s does not match proposer preferences fee recipient %s",
+                bid.getFeeRecipient(),
+                mismatchedPreferences.getFeeRecipient()));
   }
 
   @TestTemplate
@@ -193,9 +206,12 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
     assertThatSafeFuture(bidValidator.validate(bidWithGasLimit))
         .isCompletedWithValue(
-            ignore(
-                "Bid gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
-                bidWithGasLimit.getMessage().getGasLimit(), parentGasLimit, targetGasLimit));
+            ignoreBid(
+                bidWithGasLimit,
+                "gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
+                bidWithGasLimit.getMessage().getGasLimit(),
+                parentGasLimit,
+                targetGasLimit));
   }
 
   @TestTemplate
@@ -223,9 +239,12 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
     assertThatSafeFuture(bidValidator.validate(bidWithGasLimit))
         .isCompletedWithValue(
-            ignore(
-                "Bid gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
-                bidGasLimit, parentGasLimit, targetGasLimit));
+            ignoreBid(
+                bidWithGasLimit,
+                "gas limit %s is not compatible with parent gas limit %s and proposer preferences target gas limit %s",
+                bidGasLimit,
+                parentGasLimit,
+                targetGasLimit));
   }
 
   @TestTemplate
@@ -246,11 +265,17 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.getGasLimitForExecutionPayload(parentBlockRoot, parentBlockHash))
         .thenReturn(Optional.empty());
 
-    assertThatSafeFuture(bidValidator.validate(signedBid))
-        .isCompletedWithValue(
-            saveForFuture(
-                "Gas limit for parent execution payload with block hash %s is unavailable. The bid will be saved for future processing",
-                parentBlockHash));
+    final InternalValidationResult expectedResult =
+        saveBidForFuture(
+            signedBid,
+            "parent execution payload gas limit is unavailable for parent block hash %s; saving for future processing",
+            parentBlockHash);
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ExecutionPayloadBidGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(expectedResult);
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(formatBidValidationLog(expectedResult));
+    }
   }
 
   @TestTemplate
@@ -258,9 +283,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
     assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(ACCEPT);
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            ignore(
-                "Already received a bid from builder with index %s at slot %s",
-                builderIndex, slot));
+            ignoreBid(
+                signedBid,
+                "already received for parent block hash %s and parent block root %s",
+                parentBlockHash,
+                parentBlockRoot));
   }
 
   @TestTemplate
@@ -323,7 +350,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
         .thenReturn(false);
 
     assertThatSafeFuture(bidValidator.validate(higherValueInvalidBid))
-        .isCompletedWithValue(reject("Invalid payload execution bid signature"));
+        .isCompletedWithValue(
+            rejectBid(higherValueInvalidBid, "invalid execution payload bid signature"));
 
     final UInt64 intermediateValue =
         lowerValue.times(200 + (3 * MIN_BID_INCREMENT_PERCENTAGE)).dividedBy(200);
@@ -342,8 +370,9 @@ public class ExecutionPayloadBidGossipValidatorTest {
         .thenReturn(Optional.empty());
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            saveForFuture(
-                "Gas limit for parent execution payload with block hash %s is unavailable. The bid will be saved for future processing",
+            saveBidForFuture(
+                signedBid,
+                "parent execution payload gas limit is unavailable for parent block hash %s; saving for future processing",
                 parentBlockHash));
   }
 
@@ -351,8 +380,19 @@ public class ExecutionPayloadBidGossipValidatorTest {
   void shouldIgnore_whenBidIsNotCompatibleWithHead() {
     when(gossipValidationHelper.isBidCompatibleWithHead(bid)).thenReturn(false);
 
-    assertThatSafeFuture(bidValidator.validate(signedBid))
-        .isCompletedWithValue(ignore("Bid is not compatible with the current head branch"));
+    final String expectedMessage =
+        formatBidMessage(
+            signedBid,
+            "is not compatible with the current head branch (parent block hash %s, parent block root %s)",
+            parentBlockHash,
+            parentBlockRoot);
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ExecutionPayloadBidGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(bidValidator.validate(signedBid))
+          .isCompletedWithValue(ignore(expectedMessage));
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(formatBidValidationLog(ignore(expectedMessage)));
+    }
   }
 
   @TestTemplate
@@ -360,8 +400,9 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.getSlotForBlockRoot(parentBlockRoot)).thenReturn(Optional.empty());
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            saveForFuture(
-                "Bid's parent block with root %s is unknown. The bid will be saved for future processing",
+            saveBidForFuture(
+                signedBid,
+                "parent block with root %s is unknown; saving for future processing",
                 parentBlockRoot));
   }
 
@@ -371,7 +412,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            reject("Bid slot %s is not greater than parent block slot %s", slot, slot));
+            rejectBid(signedBid, "slot %s is not greater than parent block slot %s", slot, slot));
   }
 
   @TestTemplate
@@ -380,9 +421,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            saveForFuture(
-                "State for block root %s and slot %s is unavailable. The bid will be saved for future processing.",
-                parentBlockRoot, slot.decrement()));
+            saveBidForFuture(
+                signedBid,
+                "state for parent block root %s at slot %s is unavailable; saving for future processing",
+                parentBlockRoot,
+                slot.decrement()));
   }
 
   @TestTemplate
@@ -392,9 +435,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
         .thenReturn(incorrectRandaoMix);
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            reject(
-                "Bid prev randao %s does not match expected RANDAO mix %s",
-                bid.getPrevRandao(), incorrectRandaoMix));
+            rejectBid(
+                signedBid,
+                "prev randao %s does not match expected RANDAO mix %s",
+                bid.getPrevRandao(),
+                incorrectRandaoMix));
   }
 
   @TestTemplate
@@ -402,9 +447,8 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.isActiveBuilder(builderIndex, postState, slot)).thenReturn(false);
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            reject(
-                "Invalid builder index %s. Builder should be valid, active and non-slashed.",
-                builderIndex));
+            rejectBid(
+                signedBid, "builder index %s is not valid, active, and non-slashed", builderIndex));
   }
 
   @TestTemplate
@@ -417,9 +461,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
         .thenReturn(false);
     assertThatSafeFuture(bidValidator.validate(insufficientBalanceBid))
         .isCompletedWithValue(
-            ignore(
-                "Bid value %s ETH exceeds builder with index %s excess balance",
-                gweiToEth(bidValue), builderIndex));
+            ignoreBid(insufficientBalanceBid, "value exceeds the builder's excess balance"));
   }
 
   @TestTemplate
@@ -427,8 +469,14 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.isSignatureValidWithRespectToBuilderIndex(
             any(), any(), any(), any()))
         .thenReturn(false);
-    assertThatSafeFuture(bidValidator.validate(signedBid))
-        .isCompletedWithValue(reject("Invalid payload execution bid signature"));
+    final InternalValidationResult expectedResult =
+        rejectBid(signedBid, "invalid execution payload bid signature");
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ExecutionPayloadBidGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(bidValidator.validate(signedBid)).isCompletedWithValue(expectedResult);
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(formatBidValidationLog(expectedResult));
+    }
   }
 
   @TestTemplate
@@ -442,9 +490,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
 
     assertThatSafeFuture(bidValidator.validate(signedBid))
         .isCompletedWithValue(
-            ignore(
-                "Already received a bid from builder with index %s at slot %s",
-                builderIndex, slot));
+            ignoreBid(
+                signedBid,
+                "already received for parent block hash %s and parent block root %s",
+                parentBlockHash,
+                parentBlockRoot));
   }
 
   @TestTemplate
@@ -453,7 +503,7 @@ public class ExecutionPayloadBidGossipValidatorTest {
             any(), any(), any(), any()))
         .thenReturn(false);
     assertThatSafeFuture(bidValidator.validate(signedBid))
-        .isCompletedWithValue(reject("Invalid payload execution bid signature"));
+        .isCompletedWithValue(rejectBid(signedBid, "invalid execution payload bid signature"));
 
     // Fix the signature mock and try again
     when(gossipValidationHelper.isSignatureValidWithRespectToBuilderIndex(
@@ -495,9 +545,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
     // First bid should be ignored because builder was added by second bid
     assertThatSafeFuture(firstBidResult)
         .isCompletedWithValue(
-            ignore(
-                "Another payload execution bid from Builder with index %s already processed while validating bid for slot %s",
-                bid.getBuilderIndex(), bid.getSlot()));
+            ignoreBid(
+                signedBid,
+                "another bid for parent block hash %s and parent block root %s was processed concurrently",
+                parentBlockHash,
+                parentBlockRoot));
   }
 
   @TestTemplate
@@ -537,9 +589,11 @@ public class ExecutionPayloadBidGossipValidatorTest {
     mockBidValidation(bidForCachedSlot, sameBuilder, UInt64.valueOf(3000));
     assertThatSafeFuture(bidValidator.validate(bidForCachedSlot))
         .isCompletedWithValue(
-            ignore(
-                "Already received a bid from builder with index %s at slot %s",
-                sameBuilder, cachedSlot));
+            ignoreBid(
+                bidForCachedSlot,
+                "already received for parent block hash %s and parent block root %s",
+                parentBlockHash,
+                parentBlockRoot));
   }
 
   @TestTemplate
@@ -584,9 +638,9 @@ public class ExecutionPayloadBidGossipValidatorTest {
     mockBidValidation(secondBid, differentBuilderIndex, secondBidValue);
     assertThatSafeFuture(bidValidator.validate(secondBid))
         .isCompletedWithValue(
-            ignore(
-                "Bid value %s ETH does not meet minimum increment threshold (%s%%). Current highest: %s ETH, minimum required: %s ETH",
-                gweiToEth(secondBidValue),
+            ignoreBid(
+                secondBid,
+                "does not meet minimum increment threshold (%s%%); current highest is %s ETH and minimum required is %s ETH",
                 MIN_BID_INCREMENT_PERCENTAGE,
                 gweiToEth(firstBidValue),
                 gweiToEth(minRequiredBid)));
@@ -636,6 +690,54 @@ public class ExecutionPayloadBidGossipValidatorTest {
     when(gossipValidationHelper.builderHasEnoughBalanceForBid(
             bidValue, builderIndex, postState, slot))
         .thenReturn(true);
+  }
+
+  @FormatMethod
+  private InternalValidationResult rejectBid(
+      final SignedExecutionPayloadBid signedBid,
+      final String descriptionTemplate,
+      final Object... args) {
+    return reject("%s", formatBidMessage(signedBid, descriptionTemplate, args));
+  }
+
+  @FormatMethod
+  private InternalValidationResult ignoreBid(
+      final SignedExecutionPayloadBid signedBid,
+      final String descriptionTemplate,
+      final Object... args) {
+    return ignore(formatBidMessage(signedBid, descriptionTemplate, args));
+  }
+
+  @FormatMethod
+  private InternalValidationResult saveBidForFuture(
+      final SignedExecutionPayloadBid signedBid,
+      final String descriptionTemplate,
+      final Object... args) {
+    return saveForFuture(formatBidMessage(signedBid, descriptionTemplate, args));
+  }
+
+  @FormatMethod
+  private String formatBidMessage(
+      final SignedExecutionPayloadBid signedBid,
+      final String descriptionTemplate,
+      final Object... args) {
+    return String.format(
+        "%s: %s",
+        formatBidContext(signedBid.getMessage()), String.format(descriptionTemplate, args));
+  }
+
+  private String formatBidContext(final ExecutionPayloadBid executionPayloadBid) {
+    return String.format(
+        "Execution payload bid (builder index %s, slot %s, value %s ETH)",
+        executionPayloadBid.getBuilderIndex(),
+        executionPayloadBid.getSlot(),
+        gweiToEth(executionPayloadBid.getValue()));
+  }
+
+  private String formatBidValidationLog(final InternalValidationResult validationResult) {
+    return String.format(
+        "ExecutionPayloadBid Gossip Validation Result: %s, reason: %s",
+        validationResult.code(), validationResult.getDescription().orElseThrow());
   }
 
   private void mockBidValidation(final SignedExecutionPayloadBid bid) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerPreferencesGossipValidatorTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.validation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -25,10 +26,13 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.saveForFuture;
 
+import com.google.errorprone.annotations.FormatMethod;
 import java.util.Optional;
+import org.apache.logging.log4j.Level;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.infrastructure.logging.LogCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -97,8 +101,15 @@ public class ProposerPreferencesGossipValidatorTest {
 
   @TestTemplate
   void shouldAccept() {
-    assertThatSafeFuture(validator.validate(signedProposerPreferences))
-        .isCompletedWithValue(ACCEPT);
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ProposerPreferencesGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(validator.validate(signedProposerPreferences))
+          .isCompletedWithValue(ACCEPT);
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(
+              "ProposerPreferences Gossip Validation Result: ACCEPT, context: "
+                  + formatProposerPreferencesContext(signedProposerPreferences));
+    }
   }
 
   @TestTemplate
@@ -107,9 +118,9 @@ public class ProposerPreferencesGossipValidatorTest {
         .thenReturn(false);
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
         .isCompletedWithValue(
-            ignore(
-                "Proposer preferences proposal slot %s is not in the current or within lookahead epoch",
-                proposalSlot));
+            ignorePreferences(
+                signedProposerPreferences,
+                "proposal slot is not in the current or within the lookahead epoch"));
     verify(recentChainData, never()).retrieveCheckpointState(any(Checkpoint.class));
   }
 
@@ -119,18 +130,24 @@ public class ProposerPreferencesGossipValidatorTest {
     when(gossipValidationHelper.isSlotCurrent(proposalSlot)).thenReturn(false);
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
         .isCompletedWithValue(
-            ignore("Proposer preferences proposal slot %s has already passed", proposalSlot));
+            ignorePreferences(signedProposerPreferences, "proposal slot has already passed"));
     verify(recentChainData, never()).retrieveCheckpointState(any(Checkpoint.class));
   }
 
   @TestTemplate
   void shouldSaveForFuture_whenDependentRootBlockNotSeen() {
     when(gossipValidationHelper.isBlockAvailable(dependentRoot)).thenReturn(false);
-    assertThatSafeFuture(validator.validate(signedProposerPreferences))
-        .isCompletedWithValue(
-            saveForFuture(
-                "Proposer preferences dependent root %s has not been seen. Saving for future processing",
-                dependentRoot));
+    final InternalValidationResult expectedResult =
+        savePreferencesForFuture(
+            signedProposerPreferences,
+            "dependent root has not been seen; saving for future processing");
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ProposerPreferencesGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(validator.validate(signedProposerPreferences))
+          .isCompletedWithValue(expectedResult);
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(formatProposerPreferencesValidationLog(expectedResult));
+    }
     verify(recentChainData, never()).retrieveCheckpointState(any(Checkpoint.class));
   }
 
@@ -145,9 +162,11 @@ public class ProposerPreferencesGossipValidatorTest {
 
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
         .isCompletedWithValue(
-            reject(
-                "Proposer preferences dependent root %s is at slot %s, but must be before checkpoint boundary slot %s",
-                dependentRoot, checkpointBoundarySlot, checkpointBoundarySlot));
+            rejectPreferences(
+                signedProposerPreferences,
+                "dependent root is at slot %s but must be before checkpoint boundary slot %s",
+                checkpointBoundarySlot,
+                checkpointBoundarySlot));
     verify(recentChainData, never()).retrieveCheckpointState(any(Checkpoint.class));
   }
 
@@ -160,9 +179,10 @@ public class ProposerPreferencesGossipValidatorTest {
         spec.computeEpochAtSlot(proposalSlot).minusMinZero(minSeedLookahead);
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
         .isCompletedWithValue(
-            reject(
-                "Unable to generate proposer preferences checkpoint state for checkpoint epoch %s and dependent root %s",
-                checkpointEpoch, dependentRoot));
+            rejectPreferences(
+                signedProposerPreferences,
+                "unable to generate checkpoint state for checkpoint epoch %s",
+                checkpointEpoch));
     verify(gossipValidationHelper, never())
         .isSignatureValidWithRespectToProposerIndex(any(), any(), any(), any());
   }
@@ -172,13 +192,15 @@ public class ProposerPreferencesGossipValidatorTest {
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
         .isCompletedWithValue(ACCEPT);
 
-    assertThatSafeFuture(validator.validate(signedProposerPreferences))
-        .isCompletedWithValue(
-            ignore(
-                "Already received proposer preferences for tuple (%s, %s, %s)",
-                signedProposerPreferences.getMessage().getDependentRoot(),
-                signedProposerPreferences.getMessage().getProposalSlot(),
-                signedProposerPreferences.getMessage().getValidatorIndex()));
+    final InternalValidationResult expectedResult =
+        ignorePreferences(signedProposerPreferences, "already received");
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ProposerPreferencesGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(validator.validate(signedProposerPreferences))
+          .isCompletedWithValue(expectedResult);
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(formatProposerPreferencesValidationLog(expectedResult));
+    }
     verify(recentChainData, times(1)).retrieveCheckpointState(any(Checkpoint.class));
   }
 
@@ -190,11 +212,10 @@ public class ProposerPreferencesGossipValidatorTest {
 
     assertThatSafeFuture(validator.validate(wrongIndexPreferences))
         .isCompletedWithValue(
-            reject(
-                "Proposer preferences validator index %s does not match expected proposer %s for slot %s",
-                wrongIndexPreferences.getMessage().getValidatorIndex(),
-                validatorIndex,
-                proposalSlot));
+            rejectPreferences(
+                wrongIndexPreferences,
+                "validator index does not match expected proposer %s",
+                validatorIndex));
     verify(gossipValidationHelper, never())
         .isSignatureValidWithRespectToProposerIndex(any(), any(), any(), any());
   }
@@ -205,8 +226,15 @@ public class ProposerPreferencesGossipValidatorTest {
             any(), any(), any(), any()))
         .thenReturn(false);
 
-    assertThatSafeFuture(validator.validate(signedProposerPreferences))
-        .isCompletedWithValue(reject("Invalid proposer preferences signature"));
+    final String expectedMessage =
+        formatProposerPreferencesMessage(signedProposerPreferences, "invalid signature");
+    try (final LogCaptor logCaptor =
+        LogCaptor.forClass(ProposerPreferencesGossipValidator.class, Level.TRACE)) {
+      assertThatSafeFuture(validator.validate(signedProposerPreferences))
+          .isCompletedWithValue(reject("%s", expectedMessage));
+      assertThat(logCaptor.getTraceLogs().getFirst())
+          .isEqualTo(formatProposerPreferencesValidationLog(reject("%s", expectedMessage)));
+    }
   }
 
   @TestTemplate
@@ -216,7 +244,7 @@ public class ProposerPreferencesGossipValidatorTest {
         .thenReturn(false);
 
     assertThatSafeFuture(validator.validate(signedProposerPreferences))
-        .isCompletedWithValue(reject("Invalid proposer preferences signature"));
+        .isCompletedWithValue(rejectPreferences(signedProposerPreferences, "invalid signature"));
 
     // Fix the signature mock
     when(gossipValidationHelper.isSignatureValidWithRespectToProposerIndex(
@@ -251,12 +279,62 @@ public class ProposerPreferencesGossipValidatorTest {
     // Now complete first validation - should be ignored due to race condition
     slowStateFuture.complete(Optional.of(state));
     assertThatSafeFuture(firstResult)
-        .isCompletedWithValue(
-            ignore(
-                "Already received proposer preferences for tuple (%s, %s, %s)",
-                signedProposerPreferences.getMessage().getDependentRoot(),
-                signedProposerPreferences.getMessage().getProposalSlot(),
-                signedProposerPreferences.getMessage().getValidatorIndex()));
+        .isCompletedWithValue(ignorePreferences(signedProposerPreferences, "already received"));
+  }
+
+  @FormatMethod
+  private InternalValidationResult rejectPreferences(
+      final SignedProposerPreferences signedPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    return reject(
+        "%s", formatProposerPreferencesMessage(signedPreferences, descriptionTemplate, args));
+  }
+
+  @FormatMethod
+  private InternalValidationResult ignorePreferences(
+      final SignedProposerPreferences signedPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    return ignore(
+        "%s", formatProposerPreferencesMessage(signedPreferences, descriptionTemplate, args));
+  }
+
+  @FormatMethod
+  private InternalValidationResult savePreferencesForFuture(
+      final SignedProposerPreferences signedPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    return saveForFuture(
+        "%s", formatProposerPreferencesMessage(signedPreferences, descriptionTemplate, args));
+  }
+
+  @FormatMethod
+  private String formatProposerPreferencesMessage(
+      final SignedProposerPreferences signedPreferences,
+      final String descriptionTemplate,
+      final Object... args) {
+    return String.format(
+        "%s: %s",
+        formatProposerPreferencesContext(signedPreferences),
+        String.format(descriptionTemplate, args));
+  }
+
+  private String formatProposerPreferencesContext(
+      final SignedProposerPreferences signedPreferences) {
+    final ProposerPreferences preferences = signedPreferences.getMessage();
+    return String.format(
+        "Proposer preferences (validator index %s, proposal slot %s, dependent root %s)",
+        preferences.getValidatorIndex(),
+        preferences.getProposalSlot(),
+        preferences.getDependentRoot());
+  }
+
+  private String formatProposerPreferencesValidationLog(
+      final InternalValidationResult validationResult) {
+    return String.format(
+        "ProposerPreferences Gossip Validation Result: %s, reason: %s",
+        validationResult.code(), validationResult.getDescription().orElseThrow());
   }
 
   private SignedProposerPreferences createSignedProposerPreferences(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update proposer preferences and execution payload bid gossip validation logs

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and message-text changes only; validation branches and outcomes are unchanged aside from clearer duplicate-bid wording.
> 
> **Overview**
> Standardizes **TRACE** logging and **validation result descriptions** for execution payload bid and proposer preferences gossip validators.
> 
> Both validators now route every outcome through small helpers (`acceptBid` / `rejectBid` / `ignoreBid` / `saveBidForFuture` and the proposer-preferences equivalents) that prefix messages with structured context (builder index, slot, value for bids; validator index, proposal slot, dependent root for preferences) and emit a single log line per result (`ACCEPT`, `REJECT`, `IGNORE`, `SAVE_FOR_FUTURE`). Scattered per-branch `LOG.trace` calls are removed in favor of this pattern.
> 
> Several **human-readable rejection/ignore strings** are reworded for clarity (e.g. duplicate-bid cases cite parent block hash/root instead of builder index only; head-incompatibility and concurrent-bid paths include parent identifiers). Checkpoint-state failure logging in proposer preferences now attaches the throwable on TRACE via `rejectPreferencesWithError`.
> 
> Tests are updated to expect the new description format and, in several cases, assert TRACE output with `LogCaptor`. `ProposerPreferencesGossipValidator` renames the dedup cache key type from `DedupKey` to `ProposerPreferencesDedupKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c572a51eb9f08e35faae2a4f420bd157a611074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->