### PR TITLE
ci: bind workflow inputs via env before shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,12 +671,15 @@ jobs:
           echo "args=$GRADLE_ARGS" >> "$GITHUB_OUTPUT"
       - name: Run ReferenceTests (shard)
         if: steps.shard.outputs.args != ''
+        env:
+          GRADLE_ARGS: ${{ inputs.gradle_args }}
+          SHARD_ARGS: ${{ steps.shard.outputs.args }}
         run: |
           ./gradlew --no-daemon --parallel --info \
             -x generateReferenceTestClasses \
             -x processReferenceTestResources \
             -x cleanReferenceTestClasses \
-            referenceTest ${{ inputs.gradle_args }} ${{ steps.shard.outputs.args }}
+            referenceTest ${GRADLE_ARGS} ${SHARD_ARGS}
       - name: Upload JUnit XML + HTML for ReferenceTests
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -51,13 +51,20 @@ jobs:
       - name: get workflow_details
         id: jdkDetails
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          JDK_VERSION: ${{ inputs.jdk_version }}
+          INCLUDE_HASH_IN_DOCKER: ${{ inputs.include_hash_in_docker }}
+          GIT_SHA: ${{ github.sha }}
         run: |
           # on a release tag also add `latest` and `maj.min` version tags if it's not an `rc`
-          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_type }}" == "tag" ]; then
-            echo "buildVersion=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-            dockertags="consensys/teku:${{ github.ref_name }},consensys/teku:${{ github.ref_name }}-${{ inputs.jdk_version }}"
+          if [ "$EVENT_NAME" == "push" ] && [ "$REF_TYPE" == "tag" ]; then
+            echo "buildVersion=${REF_NAME}" >> $GITHUB_OUTPUT
+            dockertags="consensys/teku:${REF_NAME},consensys/teku:${REF_NAME}-${JDK_VERSION}"
             
-            semver=${{ github.ref_name }}
+            semver=${REF_NAME}
             if [[ ${semver,,} != *"-rc"* ]]; then
               echo "It's not an rc version, proceeding with extra tags..."
               # Extract major.minor 
@@ -67,27 +74,29 @@ jobs:
               else
                 echo "Invalid semver string"
               fi              
-              dockertags="${dockertags},consensys/teku:${major_minor},consensys/teku:${major_minor}-${{ inputs.jdk_version }}"
-              dockertags="${dockertags},consensys/teku:latest,consensys/teku:latest-${{ inputs.jdk_version }}"
+              dockertags="${dockertags},consensys/teku:${major_minor},consensys/teku:${major_minor}-${JDK_VERSION}"
+              dockertags="${dockertags},consensys/teku:latest,consensys/teku:latest-${JDK_VERSION}"
             fi
             echo "dockertags=${dockertags}" >> $GITHUB_OUTPUT
 
           else
             echo "buildVersion=develop" >> $GITHUB_OUTPUT
-            dockertags="consensys/teku:develop-${{ inputs.jdk_version }}"
-            if [ "${{ inputs.jdk_version }}" = "jdk25" ]; then
+            dockertags="consensys/teku:develop-${JDK_VERSION}"
+            if [ "$JDK_VERSION" = "jdk25" ]; then
               dockertags="$dockertags,consensys/teku:develop"
             fi
-            if [ "${{ inputs.include_hash_in_docker }}" = "true" ]; then
-              dockertags="$dockertags,consensys/teku:${{ github.sha }}"
+            if [ "$INCLUDE_HASH_IN_DOCKER" = "true" ]; then
+              dockertags="$dockertags,consensys/teku:${GIT_SHA}"
             fi
             echo "dockertags=${dockertags}" >> $GITHUB_OUTPUT
           fi
       - name: Get the artifacts in one place
+        env:
+          JDK_VERSION: ${{ inputs.jdk_version }}
         run: |
           mkdir -p build/docker-teku/
           ./gradlew dockerDistUntar
-          cp docker/${{ inputs.jdk_version }}/Dockerfile build/docker-teku/
+          cp "docker/${JDK_VERSION}/Dockerfile" build/docker-teku/
           echo "Creating buildVersion: ${{ steps.jdkDetails.outputs.buildVersion }}"
           echo "Creating dockertags: ${{ steps.jdkDetails.outputs.dockertags }}"
           # tree build/docker-teku/


### PR DESCRIPTION
## Summary
- Bind `inputs.gradle_args` / shard args through `env:` before the ReferenceTests gradle shell step in `ci.yml`.
- Bind `inputs.jdk_version`, `include_hash_in_docker`, and related github context through `env:` before docker tag / Dockerfile path shell steps in `publish-docker.yml`.
- Same class as GitHub’s documented script-injection guidance for interpolating caller-controlled workflow inputs into `run:` scripts.

## Test plan
- [ ] ReferenceTests shard job still forwards gradle args correctly
- [ ] Docker publish tag construction for develop / release tags unchanged for trusted inputs


Made with [Cursor](https://cursor.com)